### PR TITLE
fix(subtasks): prevent project_tasks overwrite after subtask migration

### DIFF
--- a/src/integrations/pipeline_tracked_nlp.py
+++ b/src/integrations/pipeline_tracked_nlp.py
@@ -400,6 +400,9 @@ async def create_project_from_natural_language_tracked(
                         await state.project_manager.get_kanban_client()
                     )
 
+                    # Reset migration flag for new project
+                    state._subtasks_migrated = False
+
                     # Add Marcus project_id to result for auto-select functionality
                     result["project_id"] = marcus_project_id
                 else:

--- a/src/marcus_mcp/server.py
+++ b/src/marcus_mcp/server.py
@@ -831,7 +831,10 @@ class MarcusServer:
 
         try:
             # Get all tasks from the board
-            if self.kanban_client is not None:
+            # CRITICAL: Skip if subtasks already migrated to avoid losing them
+            # (get_all_tasks only returns parent tasks from Planka,
+            # not migrated subtasks)
+            if self.kanban_client is not None and not self._subtasks_migrated:
                 self.project_tasks = await self.kanban_client.get_all_tasks()
 
             # Migrate subtasks from SubtaskManager to unified project_tasks storage


### PR DESCRIPTION
## Problem
In v0.1.2, agents were receiving **parent tasks** instead of **subtasks** when requesting assignments, even though subtasks existed in the system.

## Root Cause
1. `refresh_project_state()` calls `get_all_tasks()` which **REPLACES** `project_tasks` 
2. This happens on **EVERY** task request (via `request_next_task`)
3. Planka's `get_all_tasks()` only returns parent tasks, not migrated subtasks
4. Migration flag prevents re-migration, so subtasks are **permanently lost**
5. `has_subtasks()` returns False, causing parent tasks to be assigned

## Solution
- Skip `get_all_tasks()` in `refresh_project_state()` if subtasks already migrated
- Only reset `_subtasks_migrated` flag when actually switching projects
- Preserves migrated subtasks in memory across multiple refresh calls

## Changes
- **server.py:836**: Added condition to skip `get_all_tasks()` if migrated
- **pipeline_tracked_nlp.py:404**: Reset flag when switching to new project  
- **project_management.py**: Already had flag resets at lines 522, 590

## Preserved v0.1.2 Features
✅ Cross-parent dependency wiring  
✅ 50% performance improvement  
✅ Auto-select feature  
✅ Project registration  
✅ CPM scheduling  
✅ Migration flag pattern (good part of a17a607)

## Testing
Created "Recipe Manager Test" project with 4 subtasks:
- First request: `1624430881290586002_sub_1` (subtask) ✅
- Second request: `1624430881290586002_sub_2` (subtask) ✅  
- Dependencies tracked correctly ✅

## Test plan
- [ ] Verify agents receive subtasks instead of parent tasks
- [ ] Verify all v0.1.2 features still work (cross-parent wiring, auto-select, etc.)
- [ ] Verify flag resets when switching projects
- [ ] Verify no duplicate migrations occur

🤖 Generated with [Claude Code](https://claude.com/claude-code)