### PR TITLE
fix: resolve timezone-aware/naive datetime mismatch in request_next_task

### DIFF
--- a/src/core/adaptive_dependencies.py
+++ b/src/core/adaptive_dependencies.py
@@ -10,7 +10,7 @@ Works alongside existing templates to:
 
 import logging
 from dataclasses import dataclass, field
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional, Set, Tuple
 
 from src.core.models import Task, TaskStatus
@@ -669,7 +669,7 @@ class AdaptiveDependencyInferer:
             pattern = self.patterns[pattern_key]
             pattern.examples_count += 1
             pattern.confidence = min(0.95, pattern.confidence * 1.05)
-            pattern.last_seen = datetime.now()
+            pattern.last_seen = datetime.now(timezone.utc)
 
         logger.info(
             f"Learned from confirmed dependency: "

--- a/src/core/board_health_analyzer.py
+++ b/src/core/board_health_analyzer.py
@@ -11,7 +11,7 @@ This module analyzes the overall health of the project board by detecting:
 import logging
 from collections import defaultdict
 from dataclasses import dataclass
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from enum import Enum
 from typing import Any, Dict, List, Set
 
@@ -418,7 +418,9 @@ class BoardHealthAnalyzer:
         """Detect tasks that haven't progressed in a while."""
         issues = []
 
-        stale_threshold = datetime.now() - timedelta(days=self.stale_task_days)
+        stale_threshold = datetime.now(timezone.utc) - timedelta(
+            days=self.stale_task_days
+        )
         stale_tasks: List[Dict[str, Any]] = []
 
         for task in tasks:
@@ -430,7 +432,9 @@ class BoardHealthAnalyzer:
                             "task_id": task.id,
                             "task_name": task.name,
                             "assigned_to": task.assigned_to,
-                            "days_stale": (datetime.now() - task.updated_at).days,
+                            "days_stale": (
+                                datetime.now(timezone.utc) - task.updated_at
+                            ).days,
                         }
                     )
 

--- a/src/core/task_diagnostics.py
+++ b/src/core/task_diagnostics.py
@@ -147,7 +147,7 @@ class TaskDiagnosticCollector:
         ProjectSnapshot
             Holistic view of the project
         """
-        from datetime import datetime
+        from datetime import datetime, timezone
 
         # Calculate completion percentage
         completed_count = len(
@@ -157,7 +157,7 @@ class TaskDiagnosticCollector:
         completion_pct = (completed_count / total_count * 100) if total_count > 0 else 0
 
         # Calculate task ages (for incomplete tasks only)
-        now = datetime.now()
+        now = datetime.now(timezone.utc)
         incomplete_tasks = [
             t for t in self.project_tasks if t.status != TaskStatus.DONE
         ]
@@ -688,7 +688,7 @@ class DiagnosticReportGenerator:
         DiagnosticReport
             Complete diagnostic report with issues and recommendations
         """
-        from datetime import datetime
+        from datetime import datetime, timezone
 
         issues = self._identify_issues()
         recommendations = self._generate_recommendations(issues)
@@ -698,7 +698,7 @@ class DiagnosticReportGenerator:
         project_snapshot = collector.create_project_snapshot()
 
         return DiagnosticReport(
-            timestamp=datetime.now().isoformat(),
+            timestamp=datetime.now(timezone.utc).isoformat(),
             project_snapshot=project_snapshot,
             total_tasks=self.filtering_stats["total_tasks"],
             available_tasks=len(self.filtering_stats["available"]),

--- a/src/marcus_mcp/coordinator/subtask_manager.py
+++ b/src/marcus_mcp/coordinator/subtask_manager.py
@@ -8,7 +8,7 @@ and their relationship to parent tasks.
 import json
 import logging
 from dataclasses import asdict, dataclass, field
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
@@ -183,7 +183,7 @@ class SubtaskManager:
                 status=TaskStatus.TODO,
                 priority=subtask_data.get("priority", Priority.MEDIUM),
                 assigned_to=None,
-                created_at=datetime.now(),
+                created_at=datetime.now(timezone.utc),
                 estimated_hours=subtask_data.get("estimated_hours", 1.0),
                 dependencies=dependencies,
                 dependency_types=dependency_types,
@@ -207,8 +207,8 @@ class SubtaskManager:
                 dependencies=dependencies,
                 labels=subtask_data.get("labels", []),
                 assigned_to=None,
-                created_at=datetime.now(),
-                updated_at=datetime.now(),
+                created_at=datetime.now(timezone.utc),
+                updated_at=datetime.now(timezone.utc),
                 due_date=None,
                 # Subtask-specific fields
                 is_subtask=True,
@@ -374,7 +374,7 @@ class SubtaskManager:
                 return False
 
             task.status = status
-            task.updated_at = datetime.now()
+            task.updated_at = datetime.now(timezone.utc)
             if assigned_to:
                 task.assigned_to = assigned_to
 

--- a/tests/unit/core/test_task_diagnostics.py
+++ b/tests/unit/core/test_task_diagnostics.py
@@ -4,7 +4,7 @@ Unit tests for the automatic task diagnostics system.
 Tests the diagnostic collectors, analyzers, and report generators.
 """
 
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import List
 from unittest.mock import Mock
 
@@ -28,7 +28,7 @@ def create_task(
     description: str = "",
 ) -> Task:
     """Helper function to create a task with all required fields."""
-    now = datetime.now()
+    now = datetime.now(timezone.utc)
     return Task(
         id=task_id,
         name=name,


### PR DESCRIPTION
## Problem

Agents calling `request_next_task` were encountering the following error:

```json
{
  "success": false,
  "error": "can't subtract offset-naive and offset-aware datetimes"
}
```

This prevented agents from receiving task assignments.

## Root Cause

Mixed use of timezone-aware and timezone-naive datetimes across the codebase:

- **Tasks created with:** `datetime.now(timezone.utc)` (timezone-aware)
- **Diagnostic code used:** `datetime.now()` (timezone-naive)

When `request_next_task` triggered automatic diagnostics (runs when no suitable tasks found), datetime arithmetic operations failed:

```python
# ❌ BEFORE: Mixing naive and aware datetimes
(datetime.now() - task.created_at).days  # Error!

# ✅ AFTER: Consistent timezone-aware datetimes  
(datetime.now(timezone.utc) - task.created_at).days  # Works!
```

## Changes

### Core Modules Fixed

1. **`src/core/task_diagnostics.py`**
   - Task age calculations in project snapshots
   - Diagnostic report timestamp generation

2. **`src/core/board_health_analyzer.py`**
   - Stale task detection thresholds
   - Days-stale calculations

3. **`src/core/adaptive_dependencies.py`**
   - Pattern learning timestamp tracking

4. **`src/marcus_mcp/coordinator/subtask_manager.py`**
   - Subtask creation timestamps (created_at, updated_at)
   - Subtask status update timestamps

### Test Fixes

5. **`tests/unit/core/test_task_diagnostics.py`**
   - Updated `create_task()` helper to use timezone-aware datetimes
   - Ensures test tasks match production behavior

### Summary

All `datetime.now()` calls replaced with `datetime.now(timezone.utc)` in:
- ✅ Task age/staleness calculations
- ✅ Project snapshot generation  
- ✅ Subtask creation and updates
- ✅ Pattern learning timestamps
- ✅ Test fixtures

## Testing

### Unit Tests
```bash
python -m pytest tests/unit/core/test_task_diagnostics.py -v
# Result: 14 passed ✅
```

### Manual Verification
Agents can now successfully call `request_next_task` without timezone errors.

## Impact

- **Low Risk**: Only affects datetime arithmetic operations
- **No API Changes**: Same function signatures
- **Backward Compatible**: Timezone-aware is more robust than naive
- **Fixes Production Bug**: Agents were blocked from getting tasks

## Related Issues

- Partially addresses #103 (Fix remaining datetime.now() calls to use UTC timestamps)
  - This PR fixes the critical path causing agent failures
  - 271 total `datetime.now()` calls remain across codebase
  - Recommend systematic migration in follow-up work

## Checklist

- [x] All affected tests pass
- [x] Pre-commit hooks pass (mypy, black, flake8, etc.)
- [x] Manual testing confirms fix
- [x] Commit message follows conventional commits
- [x] Changes are minimal and focused on the bug

## Migration Path (Future Work)

This PR fixes the **critical path** but doesn't solve the broader timezone consistency issue. Recommend:

1. **Phase 1** (This PR): Fix immediate blocker ✅
2. **Phase 2**: Audit and fix remaining 266 `datetime.now()` calls
3. **Phase 3**: Add linting rule to prevent future naive datetime usage

---

**Resolves the immediate agent task assignment failure. Partial fix for #103.**