### PR TITLE
fix: enable bundled design task creation by storing full metadata (GH-108)

### DIFF
--- a/tests/unit/ai/test_bundled_design_task_generation.py
+++ b/tests/unit/ai/test_bundled_design_task_generation.py
@@ -1,0 +1,320 @@
+"""
+Unit tests for bundled design Task object generation.
+
+Tests that bundled design tasks are properly converted from metadata dicts
+to Task objects in _generate_detailed_task (fix for bundled designs not being created).
+"""
+
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+
+from src.ai.advanced.prd.advanced_parser import (
+    AdvancedPRDParser,
+    PRDAnalysis,
+    ProjectConstraints,
+)
+from src.core.models import Priority, Task, TaskStatus
+
+
+class TestBundledDesignTaskGeneration:
+    """Test suite for bundled design Task object generation"""
+
+    @pytest.fixture
+    def parser(self):
+        """Create AdvancedPRDParser with mocked dependencies"""
+        with patch(
+            "src.ai.advanced.prd.advanced_parser.LLMAbstraction"
+        ) as mock_llm_class:
+            with patch(
+                "src.ai.advanced.prd.advanced_parser.HybridDependencyInferer"
+            ) as mock_dep_class:
+                mock_llm = Mock()
+                mock_llm.analyze = AsyncMock()
+                mock_llm_class.return_value = mock_llm
+
+                mock_dep = Mock()
+                mock_dep.infer_dependencies = AsyncMock(return_value=Mock(edges=[]))
+                mock_dep_class.return_value = mock_dep
+
+                parser = AdvancedPRDParser()
+                parser.llm_client = mock_llm
+                parser.dependency_inferer = mock_dep
+
+                # Mock _get_learned_task_duration to avoid DB access
+                parser._get_learned_task_duration = Mock(return_value=6.0)
+
+                return parser
+
+    @pytest.fixture
+    def bundled_design_metadata(self):
+        """Sample bundled design task metadata"""
+        return {
+            "original_name": "Design Task Management",
+            "type": "design",
+            "epic_id": "epic_design_architecture",
+            "domain_name": "Task Management",
+            "feature_ids": ["feature_create_task", "feature_view_tasks"],
+            "description": """Design the architecture for the Task Management \
+which encompasses the following features:
+
+1. CREATE TASK
+   Create new tasks with title and description
+
+2. VIEW TASKS
+   Display list of all tasks
+
+Your design should define:
+- Component boundaries (what components exist and their responsibilities)
+- Data flows (how data moves between components)
+- Integration points (how components communicate)
+- Shared data models (schemas, entities, etc.)
+
+Agents implementing these features will use get_task_context() to see your design
+artifacts and log_artifact() to document their specific implementation choices
+(exact API paths, field names, technologies, etc.).""",
+            "estimated_hours": 0.2,
+            "labels": ["design", "architecture", "task management"],
+            "priority": "high",
+        }
+
+    @pytest.fixture
+    def prd_analysis(self):
+        """Sample PRD analysis"""
+        return PRDAnalysis(
+            functional_requirements=[
+                {
+                    "id": "feature_create_task",
+                    "name": "Create Task",
+                    "description": "Create new tasks",
+                },
+                {
+                    "id": "feature_view_tasks",
+                    "name": "View Tasks",
+                    "description": "Display tasks",
+                },
+            ],
+            non_functional_requirements=[],
+            technical_constraints=[],
+            business_objectives=[],
+            user_personas=[],
+            success_metrics=[],
+            implementation_approach="agile",
+            complexity_assessment={},
+            risk_factors=[],
+            confidence=0.85,
+            original_description="Create a task management application",
+        )
+
+    @pytest.fixture
+    def project_constraints(self):
+        """Sample project constraints"""
+        return ProjectConstraints(team_size=1, complexity_mode="standard")
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_bundled_design_task_converted_to_task_object(
+        self, parser, bundled_design_metadata, prd_analysis, project_constraints
+    ):
+        """
+        Test that bundled design task metadata is properly converted to Task object.
+
+        This is the core fix - bundled design tasks don't have matching requirements,
+        so they need special handling in _generate_detailed_task.
+        """
+        # Arrange
+        task_id = "design_task_management"
+        epic_id = "epic_design_architecture"
+
+        # Store bundled design metadata (simulating what _create_bundled_design_tasks does)
+        parser._task_metadata = {task_id: bundled_design_metadata}
+
+        # Act
+        result_task = await parser._generate_detailed_task(
+            task_id=task_id,
+            epic_id=epic_id,
+            analysis=prd_analysis,
+            constraints=project_constraints,
+            sequence=1,
+        )
+
+        # Assert
+        assert isinstance(result_task, Task)
+        assert result_task.id == task_id
+        assert result_task.name == "Design Task Management"
+        assert "Task Management" in result_task.description
+        assert "CREATE TASK" in result_task.description
+        assert "VIEW TASKS" in result_task.description
+        assert result_task.status == TaskStatus.TODO
+        assert result_task.priority == Priority.HIGH
+        assert result_task.estimated_hours == 0.2
+        assert "design" in result_task.labels
+        assert "architecture" in result_task.labels
+        assert result_task.source_type == "bundled_design"
+        assert result_task.source_context["domain_name"] == "Task Management"
+        assert len(result_task.source_context["feature_ids"]) == 2
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_bundled_design_task_uses_stored_description(
+        self, parser, bundled_design_metadata, prd_analysis, project_constraints
+    ):
+        """
+        Test that bundled design uses the detailed description from metadata.
+
+        The description from _create_bundled_design_tasks includes all features
+        in the domain - we must preserve this, not generate a new generic one.
+        """
+        # Arrange
+        task_id = "design_task_management"
+        parser._task_metadata = {task_id: bundled_design_metadata}
+
+        # Act
+        result_task = await parser._generate_detailed_task(
+            task_id=task_id,
+            epic_id="epic_design_architecture",
+            analysis=prd_analysis,
+            constraints=project_constraints,
+            sequence=1,
+        )
+
+        # Assert - should use the exact description from metadata
+        assert result_task.description == bundled_design_metadata["description"]
+        assert "CREATE TASK" in result_task.description
+        assert "VIEW TASKS" in result_task.description
+        assert "Component boundaries" in result_task.description
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_bundled_design_task_uses_correct_estimated_hours(
+        self, parser, bundled_design_metadata, prd_analysis, project_constraints
+    ):
+        """
+        Test that bundled design uses estimated hours from metadata.
+
+        Estimated hours are scaled by number of features in the domain during
+        _create_bundled_design_tasks - we must use that value, not recalculate.
+        """
+        # Arrange
+        task_id = "design_task_management"
+        # Set custom estimated hours (scaled for 2 features)
+        bundled_design_metadata["estimated_hours"] = 0.3
+        parser._task_metadata = {task_id: bundled_design_metadata}
+
+        # Act
+        result_task = await parser._generate_detailed_task(
+            task_id=task_id,
+            epic_id="epic_design_architecture",
+            analysis=prd_analysis,
+            constraints=project_constraints,
+            sequence=1,
+        )
+
+        # Assert - should use the scaled estimated hours from metadata
+        assert result_task.estimated_hours == 0.3
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_bundled_design_task_preserves_labels(
+        self, parser, bundled_design_metadata, prd_analysis, project_constraints
+    ):
+        """Test that bundled design preserves labels from metadata"""
+        # Arrange
+        task_id = "design_task_management"
+        custom_labels = ["design", "architecture", "core", "task management"]
+        bundled_design_metadata["labels"] = custom_labels
+        parser._task_metadata = {task_id: bundled_design_metadata}
+
+        # Act
+        result_task = await parser._generate_detailed_task(
+            task_id=task_id,
+            epic_id="epic_design_architecture",
+            analysis=prd_analysis,
+            constraints=project_constraints,
+            sequence=1,
+        )
+
+        # Assert
+        assert result_task.labels == custom_labels
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_bundled_design_task_maps_priority_correctly(
+        self, parser, bundled_design_metadata, prd_analysis, project_constraints
+    ):
+        """Test that bundled design correctly maps priority string to enum"""
+        # Arrange
+        task_id = "design_task_management"
+        parser._task_metadata = {task_id: bundled_design_metadata}
+
+        # Test high priority
+        bundled_design_metadata["priority"] = "high"
+        result_high = await parser._generate_detailed_task(
+            task_id, "epic_design_architecture", prd_analysis, project_constraints, 1
+        )
+        assert result_high.priority == Priority.HIGH
+
+        # Test medium priority
+        bundled_design_metadata["priority"] = "medium"
+        result_medium = await parser._generate_detailed_task(
+            task_id, "epic_design_architecture", prd_analysis, project_constraints, 1
+        )
+        assert result_medium.priority == Priority.MEDIUM
+
+        # Test low priority
+        bundled_design_metadata["priority"] = "low"
+        result_low = await parser._generate_detailed_task(
+            task_id, "epic_design_architecture", prd_analysis, project_constraints, 1
+        )
+        assert result_low.priority == Priority.LOW
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_bundled_design_with_missing_description_uses_fallback(
+        self, parser, bundled_design_metadata, prd_analysis, project_constraints
+    ):
+        """Test bundled design with missing description gets fallback"""
+        # Arrange
+        task_id = "design_task_management"
+        # Remove description to test fallback
+        del bundled_design_metadata["description"]
+        parser._task_metadata = {task_id: bundled_design_metadata}
+
+        # Act
+        result_task = await parser._generate_detailed_task(
+            task_id=task_id,
+            epic_id="epic_design_architecture",
+            analysis=prd_analysis,
+            constraints=project_constraints,
+            sequence=1,
+        )
+
+        # Assert - should use fallback description
+        assert "Design the architecture for Task Management" in result_task.description
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_bundled_design_stores_feature_ids_in_context(
+        self, parser, bundled_design_metadata, prd_analysis, project_constraints
+    ):
+        """Test that bundled design stores feature_ids for dependency tracking"""
+        # Arrange
+        task_id = "design_task_management"
+        parser._task_metadata = {task_id: bundled_design_metadata}
+
+        # Act
+        result_task = await parser._generate_detailed_task(
+            task_id=task_id,
+            epic_id="epic_design_architecture",
+            analysis=prd_analysis,
+            constraints=project_constraints,
+            sequence=1,
+        )
+
+        # Assert
+        assert "feature_ids" in result_task.source_context
+        assert result_task.source_context["feature_ids"] == [
+            "feature_create_task",
+            "feature_view_tasks",
+        ]

--- a/tests/unit/ai/test_nfr_infrastructure_task_generation.py
+++ b/tests/unit/ai/test_nfr_infrastructure_task_generation.py
@@ -1,0 +1,319 @@
+"""
+Unit tests for NFR and infrastructure task generation.
+
+Tests that NFR and infrastructure tasks are properly converted from metadata
+to Task objects in _generate_detailed_task (regression test for #139).
+"""
+
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+
+from src.ai.advanced.prd.advanced_parser import (
+    AdvancedPRDParser,
+    PRDAnalysis,
+    ProjectConstraints,
+)
+from src.core.models import Priority, Task, TaskStatus
+
+
+class TestNFRTaskGeneration:
+    """Test suite for NFR task generation"""
+
+    @pytest.fixture
+    def parser(self):
+        """Create AdvancedPRDParser with mocked dependencies"""
+        with patch(
+            "src.ai.advanced.prd.advanced_parser.LLMAbstraction"
+        ) as mock_llm_class:
+            with patch(
+                "src.ai.advanced.prd.advanced_parser.HybridDependencyInferer"
+            ) as mock_dep_class:
+                mock_llm = Mock()
+                mock_llm.analyze = AsyncMock()
+                mock_llm_class.return_value = mock_llm
+
+                mock_dep = Mock()
+                mock_dep.infer_dependencies = AsyncMock(return_value=Mock(edges=[]))
+                mock_dep_class.return_value = mock_dep
+
+                parser = AdvancedPRDParser()
+                parser.llm_client = mock_llm
+                parser.dependency_inferer = mock_dep
+
+                # Mock _get_learned_task_duration to avoid DB access
+                parser._get_learned_task_duration = Mock(return_value=8.0)
+
+                return parser
+
+    @pytest.fixture
+    def nfr_metadata(self):
+        """Sample NFR task metadata"""
+        return {
+            "original_name": "Implement Performance Monitoring",
+            "type": "nfr",
+            "epic_id": "epic_nfr",
+            "description": "Add comprehensive performance monitoring",
+            "nfr_data": {
+                "id": "nfr_performance",
+                "name": "Performance Monitoring",
+                "description": "Monitor application performance metrics",
+            },
+        }
+
+    @pytest.fixture
+    def prd_analysis(self):
+        """Sample PRD analysis without matching NFR requirement"""
+        return PRDAnalysis(
+            functional_requirements=[
+                {
+                    "id": "feature_create_task",
+                    "name": "Create Task",
+                    "description": "Create new tasks",
+                }
+            ],
+            non_functional_requirements=[],
+            technical_constraints=[],
+            business_objectives=[],
+            user_personas=[],
+            success_metrics=[],
+            implementation_approach="agile",
+            complexity_assessment={},
+            risk_factors=[],
+            confidence=0.85,
+            original_description="Create a task management application",
+        )
+
+    @pytest.fixture
+    def project_constraints(self):
+        """Sample project constraints"""
+        return ProjectConstraints(team_size=1, complexity_mode="standard")
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_nfr_task_converted_to_task_object(
+        self, parser, nfr_metadata, prd_analysis, project_constraints
+    ):
+        """
+        Test that NFR task metadata is properly converted to Task object.
+
+        Regression test: NFR tasks don't match functional requirements,
+        so they need special handling via metadata path.
+        """
+        # Arrange
+        task_id = "nfr_task_performance"
+        epic_id = "epic_nfr"
+
+        # Store NFR metadata (simulating what _create_nfr_tasks does)
+        parser._task_metadata = {task_id: nfr_metadata}
+
+        # Mock AI description generation for NFR tasks
+        parser.llm_client.analyze = AsyncMock(
+            return_value="Enhanced: Add comprehensive performance monitoring"
+        )
+
+        # Act
+        result_task = await parser._generate_detailed_task(
+            task_id=task_id,
+            epic_id=epic_id,
+            analysis=prd_analysis,
+            constraints=project_constraints,
+            sequence=1,
+        )
+
+        # Assert
+        assert isinstance(result_task, Task)
+        assert result_task.id == task_id
+        assert result_task.name == "Implement Performance Monitoring"
+        assert result_task.status == TaskStatus.TODO
+        assert result_task.estimated_hours > 0
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_nfr_task_uses_ai_enhanced_description(
+        self, parser, nfr_metadata, prd_analysis, project_constraints
+    ):
+        """Test that NFR tasks get AI-enhanced descriptions"""
+        # Arrange
+        task_id = "nfr_task_performance"
+        parser._task_metadata = {task_id: nfr_metadata}
+
+        # Mock AI enhancement
+        enhanced_desc = "Enhanced: Monitor performance with detailed metrics"
+        parser.llm_client.analyze = AsyncMock(return_value=enhanced_desc)
+
+        # Act
+        result_task = await parser._generate_detailed_task(
+            task_id=task_id,
+            epic_id="epic_nfr",
+            analysis=prd_analysis,
+            constraints=project_constraints,
+            sequence=1,
+        )
+
+        # Assert
+        assert enhanced_desc in result_task.description
+
+
+class TestInfrastructureTaskGeneration:
+    """Test suite for infrastructure task generation"""
+
+    @pytest.fixture
+    def parser(self):
+        """Create AdvancedPRDParser with mocked dependencies"""
+        with patch(
+            "src.ai.advanced.prd.advanced_parser.LLMAbstraction"
+        ) as mock_llm_class:
+            with patch(
+                "src.ai.advanced.prd.advanced_parser.HybridDependencyInferer"
+            ) as mock_dep_class:
+                mock_llm = Mock()
+                mock_llm.analyze = AsyncMock()
+                mock_llm_class.return_value = mock_llm
+
+                mock_dep = Mock()
+                mock_dep.infer_dependencies = AsyncMock(return_value=Mock(edges=[]))
+                mock_dep_class.return_value = mock_dep
+
+                parser = AdvancedPRDParser()
+                parser.llm_client = mock_llm
+                parser.dependency_inferer = mock_dep
+
+                # Mock _get_learned_task_duration to avoid DB access
+                parser._get_learned_task_duration = Mock(return_value=8.0)
+
+                return parser
+
+    @pytest.fixture
+    def infra_metadata(self):
+        """Sample infrastructure task metadata"""
+        return {
+            "original_name": "Set up development environment",
+            "type": "setup",
+            "epic_id": "epic_infrastructure",
+        }
+
+    @pytest.fixture
+    def prd_analysis(self):
+        """Sample PRD analysis without matching infrastructure requirement"""
+        return PRDAnalysis(
+            functional_requirements=[
+                {
+                    "id": "feature_create_task",
+                    "name": "Create Task",
+                    "description": "Create new tasks",
+                }
+            ],
+            non_functional_requirements=[],
+            technical_constraints=[],
+            business_objectives=[],
+            user_personas=[],
+            success_metrics=[],
+            implementation_approach="agile",
+            complexity_assessment={},
+            risk_factors=[],
+            confidence=0.85,
+            original_description="Create a task management application",
+        )
+
+    @pytest.fixture
+    def project_constraints(self):
+        """Sample project constraints"""
+        return ProjectConstraints(team_size=1, complexity_mode="standard")
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_infrastructure_task_converted_to_task_object(
+        self, parser, infra_metadata, prd_analysis, project_constraints
+    ):
+        """
+        Test infrastructure task metadata is converted to Task object.
+
+        Regression test: Infrastructure tasks don't match functional
+        requirements, so they need special handling via metadata path.
+        """
+        # Arrange
+        task_id = "infra_setup"
+        epic_id = "epic_infrastructure"
+
+        # Store infrastructure metadata
+        parser._task_metadata = {task_id: infra_metadata}
+
+        # Act
+        result_task = await parser._generate_detailed_task(
+            task_id=task_id,
+            epic_id=epic_id,
+            analysis=prd_analysis,
+            constraints=project_constraints,
+            sequence=1,
+        )
+
+        # Assert
+        assert isinstance(result_task, Task)
+        assert result_task.id == task_id
+        assert result_task.name == "Set up development environment"
+        assert result_task.status == TaskStatus.TODO
+        assert result_task.estimated_hours > 0
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_infrastructure_task_with_no_description_gets_default(
+        self, parser, infra_metadata, prd_analysis, project_constraints
+    ):
+        """Test infrastructure task without description gets default"""
+        # Arrange
+        task_id = "infra_ci_cd"
+        # Create metadata without description
+        metadata = {
+            "original_name": "Configure CI/CD pipeline",
+            "type": "infrastructure",
+            "epic_id": "epic_infrastructure",
+        }
+        parser._task_metadata = {task_id: metadata}
+
+        # Act
+        result_task = await parser._generate_detailed_task(
+            task_id=task_id,
+            epic_id="epic_infrastructure",
+            analysis=prd_analysis,
+            constraints=project_constraints,
+            sequence=1,
+        )
+
+        # Assert
+        assert isinstance(result_task, Task)
+        assert "Configure CI/CD pipeline" in result_task.description
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_task_without_requirement_or_metadata_raises_error(
+        self, parser, prd_analysis, project_constraints
+    ):
+        """
+        Test that task without requirement OR metadata raises AIProviderError.
+
+        This is the true error case - task_id doesn't match any requirement
+        AND there's no stored metadata.
+        """
+        from src.core.error_framework import AIProviderError
+
+        # Arrange
+        task_id = "unknown_task"
+        epic_id = "epic_features"
+
+        # No metadata stored
+        parser._task_metadata = {}
+
+        # Act & Assert
+        with pytest.raises(AIProviderError) as exc_info:
+            await parser._generate_detailed_task(
+                task_id=task_id,
+                epic_id=epic_id,
+                analysis=prd_analysis,
+                constraints=project_constraints,
+                sequence=1,
+            )
+
+        # Verify it's an AIProviderError (the correct error type)
+        assert isinstance(exc_info.value, AIProviderError)


### PR DESCRIPTION
## Summary

Fixes bundled design tasks not being created after removal of fallback templates. Bundled design tasks were failing because they couldn't be matched to individual requirements in `_generate_detailed_task()`.

## Root Cause

Bundled design tasks are meta-tasks that span multiple features within a domain - they don't correspond to individual requirements. After removing fallback templates:

1. `_create_bundled_design_tasks()` created bundled design task metadata as dicts
2. `_generate_detailed_task()` tried to match them to requirements using `_find_matching_requirement()`
3. No match found → hit `AIProviderError` path → tasks never created

## Solution

1. **Store FULL metadata** in `_create_bundled_design_tasks()`:
   - Description (with all features in domain)
   - Estimated hours (scaled by feature count)
   - Labels (design, architecture, domain name)
   - Priority

2. **Add early detection** in `_generate_detailed_task()`:
   - Check if task is bundled design (type="design" + epic="epic_design_architecture")
   - Convert metadata directly to Task object
   - Bypass requirement matching entirely

3. **Preserve domain descriptions** from PR #130:
   - Use detailed descriptions that list all features
   - Maintain architecture guidance for agents

## Changes

### `src/ai/advanced/prd/advanced_parser.py`

- **Lines 955-967**: Extended metadata storage to include description, estimated_hours, labels, priority
- **Lines 1187-1246**: Added bundled design detection and direct Task object conversion
- **Lines 1295-1325**: Improved AIProviderError for unmatched tasks with detailed context
- **Lines 1739-1758**: Fixed line length violations in error message

### `tests/unit/ai/test_bundled_design_task_generation.py` (NEW)

Comprehensive test suite with 7 unit tests:

1. ✅ `test_bundled_design_task_converted_to_task_object` - Core conversion logic
2. ✅ `test_bundled_design_task_uses_stored_description` - Description preservation
3. ✅ `test_bundled_design_task_uses_correct_estimated_hours` - Scaled hours usage
4. ✅ `test_bundled_design_task_preserves_labels` - Label preservation
5. ✅ `test_bundled_design_task_maps_priority_correctly` - Priority enum mapping
6. ✅ `test_bundled_design_with_missing_description_uses_fallback` - Fallback description
7. ✅ `test_bundled_design_stores_feature_ids_in_context` - Feature ID tracking

## Testing

```bash
pytest tests/unit/ai/test_bundled_design_task_generation.py -v
```

**Result**: All 7 tests pass ✅

Manual testing confirmed bundled design tasks are now created successfully in project creation.

## Integration

This fix properly integrates with:

- **PR #130**: Preserves bundled domain-based design task descriptions
- **PR #131**: Uses `source_type="bundled_design"` for dependency tracking

## Related Issues

- References #108 (bundled domain-based design tasks)
- Builds on #130 (bundled design implementation)
- Compatible with #131 (dependency source tracking)

🤖 Generated with [Claude Code](https://claude.com/claude-code)