### PR TITLE
feat: Add soft vs hard dependency support for parallel work

### DIFF
--- a/src/core/models.py
+++ b/src/core/models.py
@@ -148,6 +148,7 @@ class Task:
     estimated_hours: float
     actual_hours: float = 0.0
     dependencies: List[str] = field(default_factory=list)
+    dependency_types: List[str] = field(default_factory=list)
     labels: List[str] = field(default_factory=list)
     project_id: Optional[str] = None
     project_name: Optional[str] = None

--- a/src/marcus_mcp/coordinator/dependency_wiring.py
+++ b/src/marcus_mcp/coordinator/dependency_wiring.py
@@ -606,8 +606,11 @@ async def wire_cross_parent_dependencies(
         for dep_id in new_deps:
             if dep_id not in task.dependencies:
                 task.dependencies.append(dep_id)
+                task.dependency_types.append("soft")
                 stats["dependencies_created"] += 1
-                logger.info(f"Added cross-parent dependency: {task.name} → {dep_id}")
+                logger.info(
+                    f"Added cross-parent dependency: {task.name} → {dep_id} (soft)"
+                )
 
     elapsed_time = time.time() - start_time
     stats["total_time_seconds"] = round(elapsed_time, 2)

--- a/src/marcus_mcp/coordinator/subtask_assignment.py
+++ b/src/marcus_mcp/coordinator/subtask_assignment.py
@@ -45,10 +45,10 @@ def _determine_task_type(task: Task) -> str:
 
 def _are_dependencies_satisfied(task: Task, all_tasks: List[Task]) -> bool:
     """
-    Check if all dependencies of a task are completed.
+    Check if all HARD dependencies of a task are completed.
 
-    This ensures that subtasks from a parent task are only available
-    after all of the parent task's dependencies are satisfied.
+    Soft dependencies are skipped - agents can start work using design specs
+    as contracts and integrate later.
 
     Parameters
     ----------
@@ -60,24 +60,53 @@ def _are_dependencies_satisfied(task: Task, all_tasks: List[Task]) -> bool:
     Returns
     -------
     bool
-        True if all dependencies are satisfied (or no dependencies exist)
+        True if all hard dependencies are satisfied (or no dependencies exist)
+
+    Notes
+    -----
+    Dependency types:
+    - "hard": Agent must wait for dependency to be DONE before starting
+    - "soft": Agent can start using design specs, integrate when ready
+    - Empty array: Defaults to all "hard" (migration behavior)
     """
     if not task.dependencies:
         return True
 
+    # Get dependency types (default to all "hard" if not specified)
+    dependency_types = task.dependency_types or []
+    if not dependency_types and task.dependencies:
+        dependency_types = ["hard"] * len(task.dependencies)
+        logger.debug(
+            f"Task '{task.name}' has no dependency_types - "
+            f"defaulting all {len(task.dependencies)} dependencies to 'hard'"
+        )
+
     # Create a mapping of task IDs to their status
     task_status_map = {t.id: t.status for t in all_tasks}
 
-    # Check if all dependencies are DONE
-    for dep_id in task.dependencies:
+    # Check each dependency based on its type
+    for idx, dep_id in enumerate(task.dependencies):
+        # Get dependency type (default to "hard" if index out of range)
+        dep_type = dependency_types[idx] if idx < len(dependency_types) else "hard"
+
+        # Skip soft dependencies - agent can use design specs
+        if dep_type == "soft":
+            logger.debug(
+                f"Task '{task.name}' has soft dependency '{dep_id}' - "
+                "can start using design specs as contract"
+            )
+            continue
+
+        # Check hard dependencies - must be DONE
         dep_status = task_status_map.get(dep_id)
         if dep_status != TaskStatus.DONE:
             logger.debug(
-                f"Parent task {task.name} has unsatisfied dependency: "
-                f"{dep_id} (status: {dep_status})"
+                f"Task '{task.name}' blocked by HARD dependency '{dep_id}' "
+                f"(status: {dep_status})"
             )
             return False
 
+    logger.debug(f"Task '{task.name}' - all hard dependencies satisfied")
     return True
 
 
@@ -206,6 +235,7 @@ def convert_subtask_to_task(subtask: Subtask, parent_task: Task) -> Task:
         due_date=parent_task.due_date,  # Inherit from parent
         estimated_hours=subtask.estimated_hours,
         dependencies=subtask.dependencies,
+        dependency_types=subtask.dependency_types,
         labels=parent_task.labels,  # Inherit labels from parent
         project_id=parent_task.project_id,
         project_name=parent_task.project_name,

--- a/tests/unit/coordinator/test_soft_dependency_support.py
+++ b/tests/unit/coordinator/test_soft_dependency_support.py
@@ -1,0 +1,320 @@
+"""
+Unit tests for soft vs hard dependency support in subtask assignment.
+
+Tests verify that:
+1. Soft dependencies don't block task assignment
+2. Hard dependencies do block task assignment
+3. Empty dependency_types defaults to hard
+4. Mixed soft/hard dependencies work correctly
+"""
+
+from datetime import datetime, timezone
+
+import pytest
+
+from src.core.models import Priority, Task, TaskStatus
+from src.marcus_mcp.coordinator.subtask_assignment import (
+    _are_dependencies_satisfied,
+)
+
+
+class TestSoftDependencySupport:
+    """Test suite for soft vs hard dependency behavior."""
+
+    def test_soft_dependencies_do_not_block_assignment(self):
+        """Test that tasks with soft dependencies can be assigned immediately."""
+        # Arrange
+        dependency_task = Task(
+            id="dep1",
+            name="Design API Specs",
+            description="Create API design",
+            status=TaskStatus.TODO,  # NOT done
+            priority=Priority.MEDIUM,
+            assigned_to=None,
+            created_at=datetime.now(timezone.utc),
+            updated_at=datetime.now(timezone.utc),
+            due_date=None,
+            estimated_hours=2.0,
+        )
+
+        main_task = Task(
+            id="main",
+            name="Implement API Endpoint",
+            description="Build the endpoint",
+            status=TaskStatus.TODO,
+            priority=Priority.MEDIUM,
+            assigned_to=None,
+            created_at=datetime.now(timezone.utc),
+            updated_at=datetime.now(timezone.utc),
+            due_date=None,
+            estimated_hours=4.0,
+            dependencies=["dep1"],
+            dependency_types=["soft"],  # Soft dependency
+        )
+
+        # Act
+        result = _are_dependencies_satisfied(main_task, [dependency_task])
+
+        # Assert - should be available despite dep being TODO
+        assert result is True, "Soft dependency should not block assignment"
+
+    def test_hard_dependencies_block_assignment(self):
+        """Test that tasks with hard dependencies must wait for completion."""
+        # Arrange
+        dependency_task = Task(
+            id="dep1",
+            name="Setup Database",
+            description="Initialize DB",
+            status=TaskStatus.TODO,  # NOT done
+            priority=Priority.HIGH,
+            assigned_to=None,
+            created_at=datetime.now(timezone.utc),
+            updated_at=datetime.now(timezone.utc),
+            due_date=None,
+            estimated_hours=1.0,
+        )
+
+        main_task = Task(
+            id="main",
+            name="Run Migrations",
+            description="Apply DB migrations",
+            status=TaskStatus.TODO,
+            priority=Priority.HIGH,
+            assigned_to=None,
+            created_at=datetime.now(timezone.utc),
+            updated_at=datetime.now(timezone.utc),
+            due_date=None,
+            estimated_hours=0.5,
+            dependencies=["dep1"],
+            dependency_types=["hard"],  # Hard dependency
+        )
+
+        # Act
+        result = _are_dependencies_satisfied(main_task, [dependency_task])
+
+        # Assert - should be blocked
+        assert result is False, "Hard dependency should block assignment"
+
+    def test_empty_dependency_types_defaults_to_hard(self):
+        """Test migration behavior: empty dependency_types means all hard."""
+        # Arrange
+        dependency_task = Task(
+            id="dep1",
+            name="Prepare Environment",
+            description="Setup",
+            status=TaskStatus.TODO,
+            priority=Priority.MEDIUM,
+            assigned_to=None,
+            created_at=datetime.now(timezone.utc),
+            updated_at=datetime.now(timezone.utc),
+            due_date=None,
+            estimated_hours=1.0,
+        )
+
+        main_task = Task(
+            id="main",
+            name="Deploy Application",
+            description="Deploy to prod",
+            status=TaskStatus.TODO,
+            priority=Priority.HIGH,
+            assigned_to=None,
+            created_at=datetime.now(timezone.utc),
+            updated_at=datetime.now(timezone.utc),
+            due_date=None,
+            estimated_hours=2.0,
+            dependencies=["dep1"],
+            dependency_types=[],  # Empty = default to hard
+        )
+
+        # Act
+        result = _are_dependencies_satisfied(main_task, [dependency_task])
+
+        # Assert - should be blocked (defaults to hard)
+        assert result is False, "Empty dependency_types should default to hard"
+
+    def test_mixed_soft_and_hard_dependencies(self):
+        """Test tasks with both soft and hard dependencies."""
+        # Arrange
+        soft_dep = Task(
+            id="soft1",
+            name="Design Specs",
+            description="Create design",
+            status=TaskStatus.TODO,
+            priority=Priority.MEDIUM,
+            assigned_to=None,
+            created_at=datetime.now(timezone.utc),
+            updated_at=datetime.now(timezone.utc),
+            due_date=None,
+            estimated_hours=2.0,
+        )
+
+        hard_dep = Task(
+            id="hard1",
+            name="Database Schema",
+            description="Create schema",
+            status=TaskStatus.TODO,
+            priority=Priority.HIGH,
+            assigned_to=None,
+            created_at=datetime.now(timezone.utc),
+            updated_at=datetime.now(timezone.utc),
+            due_date=None,
+            estimated_hours=1.0,
+        )
+
+        done_dep = Task(
+            id="done1",
+            name="Environment Setup",
+            description="Setup complete",
+            status=TaskStatus.DONE,
+            priority=Priority.HIGH,
+            assigned_to="agent1",
+            created_at=datetime.now(timezone.utc),
+            updated_at=datetime.now(timezone.utc),
+            due_date=None,
+            estimated_hours=0.5,
+        )
+
+        main_task = Task(
+            id="main",
+            name="Implement Feature",
+            description="Build feature",
+            status=TaskStatus.TODO,
+            priority=Priority.MEDIUM,
+            assigned_to=None,
+            created_at=datetime.now(timezone.utc),
+            updated_at=datetime.now(timezone.utc),
+            due_date=None,
+            estimated_hours=4.0,
+            dependencies=["soft1", "hard1", "done1"],
+            dependency_types=["soft", "hard", "soft"],
+        )
+
+        # Act
+        result = _are_dependencies_satisfied(main_task, [soft_dep, hard_dep, done_dep])
+
+        # Assert - blocked because hard1 is TODO
+        assert result is False, "Hard dependency hard1 should block"
+
+    def test_all_soft_dependencies_with_todo_status(self):
+        """Test that multiple soft dependencies don't block."""
+        # Arrange
+        dep1 = Task(
+            id="dep1",
+            name="Design Frontend",
+            description="Frontend design",
+            status=TaskStatus.TODO,
+            priority=Priority.MEDIUM,
+            assigned_to=None,
+            created_at=datetime.now(timezone.utc),
+            updated_at=datetime.now(timezone.utc),
+            due_date=None,
+            estimated_hours=3.0,
+        )
+
+        dep2 = Task(
+            id="dep2",
+            name="Design Backend",
+            description="Backend design",
+            status=TaskStatus.TODO,
+            priority=Priority.MEDIUM,
+            assigned_to=None,
+            created_at=datetime.now(timezone.utc),
+            updated_at=datetime.now(timezone.utc),
+            due_date=None,
+            estimated_hours=2.0,
+        )
+
+        main_task = Task(
+            id="main",
+            name="Implement Integration",
+            description="Connect frontend and backend",
+            status=TaskStatus.TODO,
+            priority=Priority.HIGH,
+            assigned_to=None,
+            created_at=datetime.now(timezone.utc),
+            updated_at=datetime.now(timezone.utc),
+            due_date=None,
+            estimated_hours=4.0,
+            dependencies=["dep1", "dep2"],
+            dependency_types=["soft", "soft"],
+        )
+
+        # Act
+        result = _are_dependencies_satisfied(main_task, [dep1, dep2])
+
+        # Assert - should be assignable (all soft)
+        assert result is True, "All soft dependencies should allow assignment"
+
+    def test_task_with_no_dependencies(self):
+        """Test that tasks without dependencies are always assignable."""
+        # Arrange
+        task = Task(
+            id="task1",
+            name="Independent Task",
+            description="No dependencies",
+            status=TaskStatus.TODO,
+            priority=Priority.MEDIUM,
+            assigned_to=None,
+            created_at=datetime.now(timezone.utc),
+            updated_at=datetime.now(timezone.utc),
+            due_date=None,
+            estimated_hours=2.0,
+            dependencies=[],
+            dependency_types=[],
+        )
+
+        # Act
+        result = _are_dependencies_satisfied(task, [])
+
+        # Assert
+        assert result is True, "Task with no dependencies should be assignable"
+
+    def test_dependency_types_length_mismatch_defaults_to_hard(self):
+        """Test that missing dependency_types entries default to hard."""
+        # Arrange
+        dep1 = Task(
+            id="dep1",
+            name="Task 1",
+            description="First dependency",
+            status=TaskStatus.DONE,
+            priority=Priority.MEDIUM,
+            assigned_to="agent1",
+            created_at=datetime.now(timezone.utc),
+            updated_at=datetime.now(timezone.utc),
+            due_date=None,
+            estimated_hours=1.0,
+        )
+
+        dep2 = Task(
+            id="dep2",
+            name="Task 2",
+            description="Second dependency",
+            status=TaskStatus.TODO,
+            priority=Priority.MEDIUM,
+            assigned_to=None,
+            created_at=datetime.now(timezone.utc),
+            updated_at=datetime.now(timezone.utc),
+            due_date=None,
+            estimated_hours=1.0,
+        )
+
+        main_task = Task(
+            id="main",
+            name="Main Task",
+            description="Depends on two tasks",
+            status=TaskStatus.TODO,
+            priority=Priority.MEDIUM,
+            assigned_to=None,
+            created_at=datetime.now(timezone.utc),
+            updated_at=datetime.now(timezone.utc),
+            due_date=None,
+            estimated_hours=2.0,
+            dependencies=["dep1", "dep2"],
+            dependency_types=["soft"],  # Only one type for two deps!
+        )
+
+        # Act
+        result = _are_dependencies_satisfied(main_task, [dep1, dep2])
+
+        # Assert - dep2 defaults to hard, blocks assignment
+        assert result is False, "Missing dependency_type should default to hard"


### PR DESCRIPTION
## Summary
Implements soft/hard dependency system to enable agents to start implementation work while design tasks are still in progress, using design specifications as contracts.

## Problem
Currently, all dependencies block task assignment until they are DONE. This creates unnecessary serialization:
- Agents must wait for design tasks to complete before starting implementation
- Reduces parallelism and increases agent idle time
- Design specs are often sufficient as contracts for starting implementation

## Solution
Add `dependency_types` field to distinguish between:
- **Hard dependencies**: Must be DONE before task can start (existing behavior)
- **Soft dependencies**: Can start using design specs as contracts (new behavior)

Cross-parent dependencies are marked as "soft" by default, enabling parallel work across phases.

## Changes

### 1. Data Model (`src/core/models.py`)
- Added `dependency_types: List[str]` field to `Task` dataclass
- Each dependency has a corresponding type: "hard" or "soft"

### 2. Subtask Model (`src/marcus_mcp/coordinator/subtask_manager.py`)
- Added `dependency_types: List[str]` field to `Subtask` dataclass
- Maintains consistency with Task model

### 3. Dependency Wiring (`src/marcus_mcp/coordinator/dependency_wiring.py`)
- Cross-parent dependencies are now marked as "soft"
- Allows implementation to start while design is in progress
- Logs dependency type for visibility

### 4. Assignment Logic (`src/marcus_mcp/coordinator/subtask_assignment.py`)
Enhanced `_are_dependencies_satisfied()`:
- **Soft dependencies**: Skipped - agents can use design specs
- **Hard dependencies**: Must be DONE before assignment
- **Migration-safe**: Empty `dependency_types` defaults to all "hard"
- Added detailed logging for dependency satisfaction

Updated `convert_subtask_to_task()`:
- Preserves `dependency_types` during conversion

## Testing
Created comprehensive test suite `test_soft_dependency_support.py` with 7 tests:

✅ `test_soft_dependencies_do_not_block_assignment` - Soft deps allow assignment  
✅ `test_hard_dependencies_block_assignment` - Hard deps block assignment  
✅ `test_empty_dependency_types_defaults_to_hard` - Migration safety  
✅ `test_mixed_soft_and_hard_dependencies` - Mixed scenarios  
✅ `test_all_soft_dependencies_with_todo_status` - Multiple soft deps  
✅ `test_task_with_no_dependencies` - Base case  
✅ `test_dependency_types_length_mismatch_defaults_to_hard` - Safety check  

All tests passing. Mypy type checking clean.

## Benefits
✅ Enables parallel work across design and implementation phases  
✅ Reduces agent idle time waiting for dependencies  
✅ Uses design specs as contracts (contract-based development)  
✅ Backward compatible - defaults to hard dependencies  
✅ Maintains architectural constraints from PR #155  

## Example Behavior

### Before (All Hard Dependencies)
```
Design API Specs → (DONE) → Implementation can start
     ⬆️ blocking
```
Implementation waits for design to be DONE.

### After (Soft Cross-Parent Dependencies)
```
Design API Specs → (TODO, specs available)
                          ⬇️ soft dependency
                   Implementation can start immediately
```
Implementation uses design specs as contract, integrates when ready.

## Migration Safety
- Empty or missing `dependency_types` defaults to all "hard"
- Existing tasks continue to work without changes
- Only new cross-parent dependencies use "soft" by default

## Related
- Closes #156
- Complements PR #155 (backwards dependency fix)
- Enables the parallel work pattern prevented by the circular dependency bug

## Testing Checklist
- [x] All new tests pass (7/7)
- [x] Existing tests still pass
- [x] Mypy type checking clean
- [x] Pre-commit hooks pass (black, isort)