### PR TITLE
Fix: Task classifier misclassification causing phase enforcement failures

### DIFF
--- a/src/integrations/enhanced_task_classifier.py
+++ b/src/integrations/enhanced_task_classifier.py
@@ -7,7 +7,7 @@ pattern matching, and context-aware classification for 95%+ accuracy.
 
 import re
 from dataclasses import dataclass
-from typing import Dict, List, Optional, Pattern, Tuple
+from typing import Dict, List, Pattern, Tuple
 
 from src.core.models import Task
 from src.integrations.nlp_task_utils import TaskType
@@ -400,10 +400,11 @@ class EnhancedTaskClassifier:
         ClassificationResult
             ClassificationResult with type, confidence, and reasoning
         """
-        # Combine text sources
-        text = (
-            f"{task.name} {task.description or ''} " f"{' '.join(task.labels or [])}"
-        ).lower()
+        # Separate strong signals (name, labels) from weak signals (description)
+        # This allows us to weight them appropriately
+        task_name = task.name.lower()
+        task_description = (task.description or "").lower()
+        task_labels = task.labels or []
 
         # Score each task type
         scores = {}
@@ -415,7 +416,10 @@ class EnhancedTaskClassifier:
                 continue
 
             score, keywords, patterns = self._score_task_type(
-                text, task_type, task.labels or []
+                task_name=task_name,
+                task_description=task_description,
+                task_labels=task_labels,
+                task_type=task_type,
             )
             scores[task_type] = score
             matched_keywords[task_type] = keywords
@@ -431,36 +435,13 @@ class EnhancedTaskClassifier:
                 reasoning="No matching keywords or patterns found",
             )
 
-        # Handle ambiguous cases - prefer DESIGN over IMPLEMENTATION when both
-        # have high scores
-        # and there's an explicit design keyword
-        design_score = scores.get(TaskType.DESIGN, 0)
-        impl_score = scores.get(TaskType.IMPLEMENTATION, 0)
-
-        # Track if we had an ambiguous case
+        # GH-180: Removed ambiguous case handling that artificially boosted DESIGN
+        # The new weighted scoring system (strong signals > weak signals) makes
+        # this override unnecessary and was causing misclassification.
+        # Task name and labels are now weighted more heavily than description,
+        # so a task named "Implement X" with label "implement" will correctly
+        # classify as IMPLEMENTATION even if description contains "design"
         ambiguous_case = False
-
-        if design_score > 0 and impl_score > 0:
-            # Only consider it ambiguous if the scores are reasonably close
-            if design_score / impl_score < 2.5:  # Only if scores are close
-                # Check if task contains design keywords
-                design_keywords = [
-                    "design",
-                    "architect",
-                    "plan",
-                    "planning",
-                    "mockup",
-                    "wireframe",
-                ]
-                full_text = (f"{task.name.lower()} {task.description or ''}").lower()
-                has_design_keywords = any(
-                    keyword in full_text for keyword in design_keywords
-                )
-
-                if has_design_keywords:
-                    # Boost design score to win ambiguous cases
-                    scores[TaskType.DESIGN] = max(design_score + 2.0, impl_score + 1.0)
-                    ambiguous_case = True
 
         # Defensive check: ensure scores is not empty before calling max()
         if not scores:
@@ -544,15 +525,23 @@ class EnhancedTaskClassifier:
         )
 
     def _score_task_type(
-        self, text: str, task_type: TaskType, labels: Optional[List[str]] = None
+        self,
+        task_name: str,
+        task_description: str,
+        task_labels: list[str],
+        task_type: TaskType,
     ) -> Tuple[float, List[str], List[str]]:
         """
-        Score how well text matches a task type.
+        Score how well a task matches a task type.
+
+        Uses weighted scoring where strong signals (task name, labels) have
+        higher weight than weak signals (description keywords).
 
         Args:
-            text: Combined text from task name, description, and labels
+            task_name: Task name (strong signal)
+            task_description: Task description (weak signal)
+            task_labels: Task labels (very strong signal - explicit categorization)
             task_type: TaskType to score against
-            labels: Task labels for additional context
 
         Returns
         -------
@@ -562,148 +551,190 @@ class EnhancedTaskClassifier:
         score = 0.0
         matched_keywords = []
         matched_patterns = []
-        labels = labels or []
 
         keywords_dict = self.TASK_KEYWORDS.get(task_type, {})
 
-        # Give extra weight if labels match task type directly
+        # STRONGEST SIGNAL: Explicit labels (weight: 8.0)
+        # Labels are explicit categorization by users/systems
         label_boost = 0.0
-        for label in labels:
-            if label.lower() in ["testing", "qa"] and task_type == TaskType.TESTING:
-                label_boost += 4.0  # Strong boost for testing labels
-                matched_keywords.append(label.lower())
+        for label in task_labels:
+            label_lower = label.lower()
+            # Check for direct task type matches
+            if (
+                label_lower in ["test", "testing", "qa"]
+                and task_type == TaskType.TESTING
+            ):
+                label_boost += 8.0
+                matched_keywords.append(label_lower)
             elif (
-                label.lower() in ["design", "architecture"]
+                label_lower in ["implement", "implementation"]
+                and task_type == TaskType.IMPLEMENTATION
+            ):
+                label_boost += 8.0
+                matched_keywords.append(label_lower)
+            elif (
+                label_lower in ["design", "architecture"]
                 and task_type == TaskType.DESIGN
             ):
-                label_boost += 4.0
-                matched_keywords.append(label.lower())
+                label_boost += 8.0
+                matched_keywords.append(label_lower)
             elif (
-                label.lower() in ["documentation", "docs"]
+                label_lower in ["documentation", "docs", "readme"]
                 and task_type == TaskType.DOCUMENTATION
             ):
-                label_boost += 4.0
-                matched_keywords.append(label.lower())
+                label_boost += 8.0
+                matched_keywords.append(label_lower)
+            elif (
+                label_lower in ["deploy", "deployment", "release"]
+                and task_type == TaskType.DEPLOYMENT
+            ):
+                label_boost += 8.0
+                matched_keywords.append(label_lower)
+            elif (
+                label_lower in ["infrastructure", "devops", "setup"]
+                and task_type == TaskType.INFRASTRUCTURE
+            ):
+                label_boost += 8.0
+                matched_keywords.append(label_lower)
 
         score += label_boost
 
-        # Check primary keywords (higher weight)
-        for keyword in keywords_dict.get("primary", []):
-            # Use word boundary matching for better accuracy
-            # Also check for plural forms
-            pattern = rf"\b{re.escape(keyword)}s?\b"
-            match = re.search(pattern, text)
-            if match:
-                # Give extra weight if keyword appears at the beginning
-                position_weight = 1.5 if match.start() < 10 else 1.0
+        # Combine name and description for keyword/pattern matching
+        # But track which came from name (strong) vs description (weak)
+        combined_text = f"{task_name} {task_description} {' '.join(task_labels)}"
 
-                # Give testing keywords extra weight to avoid misclassification
+        # STRONG SIGNAL: Primary keywords in task name (weight: 5.0-6.0)
+        # Medium signal: Primary keywords in description (weight: 1.5-2.0)
+        for keyword in keywords_dict.get("primary", []):
+            pattern = rf"\b{re.escape(keyword)}s?\b"
+
+            # Check task name first (strong signal)
+            name_match = re.search(pattern, task_name)
+            desc_match = re.search(pattern, task_description)
+
+            if name_match:
+                # Keyword in name is a STRONG signal
+                position_weight = 1.2 if name_match.start() < 10 else 1.0
+
+                # Special handling for certain keywords
                 if task_type == TaskType.TESTING and keyword in ["test", "testing"]:
-                    score += 3.0 * position_weight  # Higher weight
-                # Give documentation keywords high weight for specific phrases
-                elif (
-                    task_type == TaskType.DOCUMENTATION
-                    and keyword == "document"
-                    and "comment" in text
-                ):
-                    score += 3.0 * position_weight
+                    score += 6.0 * position_weight
+                elif task_type == TaskType.IMPLEMENTATION and keyword in [
+                    "implement",
+                    "build",
+                ]:
+                    score += 6.0 * position_weight
+                elif task_type == TaskType.DESIGN and keyword in ["design", "plan"]:
+                    score += 6.0 * position_weight
                 else:
-                    score += 2.0 * position_weight
+                    score += 5.0 * position_weight
+                matched_keywords.append(keyword)
+            elif desc_match:
+                # Keyword only in description is a WEAK signal
+                if task_type == TaskType.TESTING and keyword in ["test", "testing"]:
+                    score += 2.0
+                elif task_type == TaskType.DOCUMENTATION and keyword == "document":
+                    score += 2.0
+                else:
+                    score += 1.5
                 matched_keywords.append(keyword)
 
-        # Check secondary keywords
+        # Secondary keywords: moderate weight for name, low weight for description
         for keyword in keywords_dict.get("secondary", []):
-            # Use word boundary matching for better accuracy
-            # Also check for plural forms
             pattern = rf"\b{re.escape(keyword)}s?\b"
-            if re.search(pattern, text):
-                # Special handling for documentation keywords
+
+            name_match = re.search(pattern, task_name)
+            desc_match = re.search(pattern, task_description)
+
+            if name_match:
+                # Secondary keyword in name
+                score += 2.0
+                matched_keywords.append(keyword)
+            elif desc_match:
+                # Secondary keyword in description only
                 if (
                     task_type == TaskType.DOCUMENTATION
                     and keyword == "comments"
-                    and ("add" in text or "annotate" in text)
+                    and ("add" in combined_text or "annotate" in combined_text)
                 ):
-                    score += 2.5  # High score for "add comments" pattern
+                    score += 1.5
                 else:
-                    score += 1.0
-                matched_keywords.append(keyword)
-
-        # Check verb usage
-        for verb in keywords_dict.get("verbs", []):
-            if re.search(rf"\b{verb}\b", text):
-                # Special case: generic verbs need more context
-                if (
-                    verb in ["update", "create", "write", "add", "build"]
-                    and len(text.split()) <= 3
-                ):
-                    # Very short task names with generic verbs get lower scores
                     score += 0.5
-                    # Skip if the verb is the entire classification basis for testing
-                    if task_type == TaskType.TESTING and "test" in text:
-                        continue  # Don't let "write" override "test"
+                if keyword not in matched_keywords:
+                    matched_keywords.append(keyword)
+
+        # Verb usage: higher weight in name, lower in description
+        for verb in keywords_dict.get("verbs", []):
+            name_match = re.search(rf"\b{verb}\b", task_name)
+            desc_match = re.search(rf"\b{verb}\b", task_description)
+
+            if name_match:
+                # Verb in task name is a strong signal
+                # Special handling for implementation verbs
+                if task_type == TaskType.IMPLEMENTATION and verb in [
+                    "implement",
+                    "build",
+                    "create",
+                    "develop",
+                ]:
+                    score += 4.0
+                elif task_type == TaskType.TESTING and verb in [
+                    "test",
+                    "verify",
+                    "validate",
+                ]:
+                    score += 4.0
+                elif task_type == TaskType.DESIGN and verb in [
+                    "design",
+                    "plan",
+                    "architect",
+                ]:
+                    score += 4.0
                 else:
-                    # Special handling for documentation verbs
-                    if (
-                        task_type == TaskType.DOCUMENTATION
-                        and verb in ["annotate", "comment", "document"]
-                        and ("function" in text or "code" in text)
-                    ):
-                        score += 3.5  # Higher score for documentation-specific verbs
-                    # Special case for "add comments"
-                    elif (
-                        task_type == TaskType.DOCUMENTATION
-                        and verb == "add"
-                        and "comment" in text
-                    ):
-                        score += 4.0  # Very high score for adding comments
-                    # Reduce setup/configure scoring for database connections
-                    # to avoid infrastructure classification
-                    elif (
-                        task_type == TaskType.INFRASTRUCTURE
-                        and verb in ["setup", "configure"]
-                        and ("database" in text and "connection" in text)
-                    ):
-                        # Much lower score to prefer IMPLEMENTATION
-                        score += 0.3
-                    # Boost implementation scoring for database connections
-                    elif (
-                        task_type == TaskType.IMPLEMENTATION
-                        and verb in ["setup", "configure"]
-                        and ("database" in text and "connection" in text)
-                    ):
-                        # Higher score to prefer IMPLEMENTATION
-                        score += 3.0
-                    else:
-                        score += 1.5
+                    score += 3.0
+                if verb not in matched_keywords:
+                    matched_keywords.append(verb)
+            elif desc_match:
+                # Verb in description is a weak signal
+                # Generic verbs in description get very low weight
+                if verb in ["update", "create", "write", "add", "build"]:
+                    score += 0.3
+                elif task_type == TaskType.DOCUMENTATION and verb in [
+                    "annotate",
+                    "comment",
+                    "document",
+                ]:
+                    score += 1.0
+                else:
+                    score += 0.5
                 if verb not in matched_keywords:
                     matched_keywords.append(verb)
 
-        # Check patterns (highest weight)
+        # Pattern matching: higher weight in name, medium in combined
         for regex_pattern in self._compiled_patterns.get(task_type, []):
-            match = regex_pattern.search(text)
-            if match:
-                # Special case: database setup patterns get lower score
-                # for infrastructure
-                if (
-                    task_type == TaskType.INFRASTRUCTURE
-                    and "database" in text
-                    and "connection" in text
-                ):
-                    # Much lower score to prefer IMPLEMENTATION
-                    score += 1.0
-                else:
-                    score += 3.0
-                matched_patterns.append(regex_pattern.pattern)
+            name_match = regex_pattern.search(task_name)
+            combined_match = regex_pattern.search(combined_text)
 
-        # Penalty for conflicting keywords
+            if name_match:
+                # Pattern match in name is very strong
+                score += 5.0
+                matched_patterns.append(regex_pattern.pattern)
+            elif combined_match:
+                # Pattern match in description is moderate
+                score += 2.0
+                if regex_pattern.pattern not in matched_patterns:
+                    matched_patterns.append(regex_pattern.pattern)
+
+        # Reduced penalty for conflicting keywords (only in name)
+        # Description conflicts don't matter as much
         for other_type in TaskType:
             if other_type == task_type or other_type == TaskType.OTHER:
                 continue
             other_keywords = self.TASK_KEYWORDS.get(other_type, {})
-            # Only penalize if primary keywords of other types are present
+            # Only penalize if primary keywords of other types are in task NAME
             for keyword in other_keywords.get("primary", []):
-                if keyword in text and keyword not in matched_keywords:
-                    score -= 0.5
+                if keyword in task_name and keyword not in matched_keywords:
+                    score -= 0.3  # Reduced penalty
 
         return score, matched_keywords, matched_patterns
 

--- a/src/integrations/enhanced_task_classifier.py
+++ b/src/integrations/enhanced_task_classifier.py
@@ -616,8 +616,26 @@ class EnhancedTaskClassifier:
                 # Keyword in name is a STRONG signal
                 position_weight = 1.2 if name_match.start() < 10 else 1.0
 
+                # EDGE CASE: Database connections are IMPLEMENTATION
+                combined_text = f"{task_name} {task_description}".lower()
+                if (
+                    task_type == TaskType.INFRASTRUCTURE
+                    and keyword in ["setup", "configure"]
+                    and "database" in combined_text
+                    and "connection" in combined_text
+                ):
+                    # Much lower score to avoid infrastructure classification
+                    score += 0.5
+                # EDGE CASE: "code" with doc keywords is DOCUMENTATION
+                elif (
+                    task_type == TaskType.IMPLEMENTATION
+                    and keyword == "code"
+                    and ("comment" in combined_text or "document" in combined_text)
+                ):
+                    # Lower score when "code" appears with documentation keywords
+                    score += 1.0
                 # Special handling for certain keywords
-                if task_type == TaskType.TESTING and keyword in ["test", "testing"]:
+                elif task_type == TaskType.TESTING and keyword in ["test", "testing"]:
                     score += 6.0 * position_weight
                 elif task_type == TaskType.IMPLEMENTATION and keyword in [
                     "implement",
@@ -670,8 +688,43 @@ class EnhancedTaskClassifier:
 
             if name_match:
                 # Verb in task name is a strong signal
+                # EDGE CASE: Database connections are IMPLEMENTATION
+                # "Setup database connections" is implementation, not infra
+                combined_text = f"{task_name} {task_description}".lower()
+                if (
+                    task_type == TaskType.INFRASTRUCTURE
+                    and verb in ["setup", "configure"]
+                    and "database" in combined_text
+                    and "connection" in combined_text
+                ):
+                    # Much lower score to avoid infrastructure classification
+                    score += 0.3
+                elif (
+                    task_type == TaskType.IMPLEMENTATION
+                    and verb in ["setup", "configure"]
+                    and "database" in combined_text
+                    and "connection" in combined_text
+                ):
+                    # Higher score to prefer IMPLEMENTATION
+                    score += 3.0
+                # EDGE CASE: Code comments should be DOCUMENTATION not IMPLEMENTATION
+                # "Add code comments" is documentation work, not implementation
+                elif (
+                    task_type == TaskType.DOCUMENTATION
+                    and verb == "add"
+                    and "comment" in combined_text
+                ):
+                    # Very high score for adding comments
+                    score += 4.0
+                elif (
+                    task_type == TaskType.DOCUMENTATION
+                    and verb in ["document", "annotate", "comment"]
+                    and ("function" in combined_text or "code" in combined_text)
+                ):
+                    # Higher score for documentation-specific verbs with code context
+                    score += 3.5
                 # Special handling for implementation verbs
-                if task_type == TaskType.IMPLEMENTATION and verb in [
+                elif task_type == TaskType.IMPLEMENTATION and verb in [
                     "implement",
                     "build",
                     "create",

--- a/src/marcus_mcp/tools/task.py
+++ b/src/marcus_mcp/tools/task.py
@@ -2137,6 +2137,7 @@ async def _find_optimal_task_original_logic(
                             for t in state.project_tasks
                             if t.labels and set(t.labels) & set(task.labels)
                         )
+
                         if phase_exists:
                             phase_allowed = False
                             logger.info(

--- a/tests/unit/integrations/test_enhanced_task_classifier.py
+++ b/tests/unit/integrations/test_enhanced_task_classifier.py
@@ -10,10 +10,7 @@ from datetime import datetime, timezone
 import pytest
 
 from src.core.models import Priority, Task, TaskStatus
-from src.integrations.enhanced_task_classifier import (
-    ClassificationResult,
-    EnhancedTaskClassifier,
-)
+from src.integrations.enhanced_task_classifier import EnhancedTaskClassifier
 from src.integrations.nlp_task_utils import TaskType
 
 
@@ -403,9 +400,10 @@ class TestEnhancedTaskClassifier:
             labels=["implement"],
         )
         result1 = classifier.classify_with_confidence(task1)
-        assert (
-            result1.task_type == TaskType.IMPLEMENTATION
-        ), f"Expected IMPLEMENTATION but got {result1.task_type.name} (confidence: {result1.confidence:.2f})"
+        assert result1.task_type == TaskType.IMPLEMENTATION, (
+            f"Expected IMPLEMENTATION but got {result1.task_type.name} "
+            f"(confidence: {result1.confidence:.2f})"
+        )
 
         # Case 2: Design task should still be classified as DESIGN
         task2 = self.create_task(
@@ -440,3 +438,86 @@ class TestEnhancedTaskClassifier:
         assert (
             result4.task_type == TaskType.IMPLEMENTATION
         ), f"Expected IMPLEMENTATION but got {result4.task_type.name}"
+
+    def test_database_connection_as_implementation(self, classifier):
+        """
+        Test database connection tasks classify as IMPLEMENTATION.
+
+        Edge case: "Setup database connections" contains infrastructure keywords
+        ("setup", "database") but should be classified as IMPLEMENTATION because
+        setting up database connections is implementation work, not infrastructure
+        provisioning.
+        """
+        # Test case 1: Setup database connections
+        task1 = self.create_task(
+            "1",
+            "Setup database connections",
+            description="Configure database connection pool and settings",
+        )
+        result1 = classifier.classify_with_confidence(task1)
+        assert (
+            result1.task_type == TaskType.IMPLEMENTATION
+        ), f"Expected IMPLEMENTATION but got {result1.task_type.name}"
+
+        # Test case 2: Configure database connection
+        task2 = self.create_task(
+            "2",
+            "Configure API database connection",
+            description="Set up database connection for the API service",
+        )
+        result2 = classifier.classify_with_confidence(task2)
+        assert (
+            result2.task_type == TaskType.IMPLEMENTATION
+        ), f"Expected IMPLEMENTATION but got {result2.task_type.name}"
+
+        # Test case 3: Actual infrastructure should still be INFRASTRUCTURE
+        task3 = self.create_task(
+            "3",
+            "Setup database server",
+            description="Provision and configure PostgreSQL database server",
+        )
+        result3 = classifier.classify_with_confidence(task3)
+        assert (
+            result3.task_type == TaskType.INFRASTRUCTURE
+        ), f"Expected INFRASTRUCTURE but got {result3.task_type.name}"
+
+    def test_code_comments_as_documentation(self, classifier):
+        """
+        Test that adding code comments classifies as DOCUMENTATION not IMPLEMENTATION.
+
+        Edge case: "Add code comments" contains implementation keyword ("code")
+        but should be classified as DOCUMENTATION because the task is about
+        documenting code, not implementing functionality.
+        """
+        # Test case 1: Add code comments
+        task1 = self.create_task(
+            "1",
+            "Add code comments",
+            description="Document the authentication module with comments",
+        )
+        result1 = classifier.classify_with_confidence(task1)
+        assert (
+            result1.task_type == TaskType.DOCUMENTATION
+        ), f"Expected DOCUMENTATION but got {result1.task_type.name}"
+
+        # Test case 2: Document functions with comments
+        task2 = self.create_task(
+            "2",
+            "Document code with inline comments",
+            description="Add explanatory comments to complex functions",
+        )
+        result2 = classifier.classify_with_confidence(task2)
+        assert (
+            result2.task_type == TaskType.DOCUMENTATION
+        ), f"Expected DOCUMENTATION but got {result2.task_type.name}"
+
+        # Test case 3: Actual code implementation should be IMPLEMENTATION
+        task3 = self.create_task(
+            "3",
+            "Implement code review feature",
+            description="Build the code review functionality",
+        )
+        result3 = classifier.classify_with_confidence(task3)
+        assert (
+            result3.task_type == TaskType.IMPLEMENTATION
+        ), f"Expected IMPLEMENTATION but got {result3.task_type.name}"

--- a/tests/unit/integrations/test_enhanced_task_classifier.py
+++ b/tests/unit/integrations/test_enhanced_task_classifier.py
@@ -382,3 +382,61 @@ class TestEnhancedTaskClassifier:
         task = self.create_task("1", name)
         result = classifier.classify(task)
         assert result == expected_type
+
+    # GH-180: Strong signals should override weak signals
+    def test_strong_signals_override_description_keywords(self, classifier):
+        """
+        Test that strong signals (name + labels) override weak signals.
+
+        Issue #180: Tasks with "Implement" in name and "implement" label
+        were being misclassified as DESIGN when description contained
+        design keywords like "design", "plan", "architecture".
+
+        Strong signals (task name prefix + explicit labels) should take
+        precedence over weak signals (description keywords).
+        """
+        # Case 1: Implement task with design keywords in description
+        task1 = self.create_task(
+            "1",
+            "Implement Pomodoro Timer",
+            description="Design and implement the pomodoro timer feature",
+            labels=["implement"],
+        )
+        result1 = classifier.classify_with_confidence(task1)
+        assert (
+            result1.task_type == TaskType.IMPLEMENTATION
+        ), f"Expected IMPLEMENTATION but got {result1.task_type.name} (confidence: {result1.confidence:.2f})"
+
+        # Case 2: Design task should still be classified as DESIGN
+        task2 = self.create_task(
+            "2",
+            "Design Pomodoro Timer",
+            description="Plan the architecture for the pomodoro timer",
+            labels=["design", "architecture"],
+        )
+        result2 = classifier.classify_with_confidence(task2)
+        assert result2.task_type == TaskType.DESIGN
+
+        # Case 3: Test task with implementation keywords in description
+        task3 = self.create_task(
+            "3",
+            "Test Authentication Flow",
+            description="Implement tests for the authentication feature",
+            labels=["test", "qa"],
+        )
+        result3 = classifier.classify_with_confidence(task3)
+        assert (
+            result3.task_type == TaskType.TESTING
+        ), f"Expected TESTING but got {result3.task_type.name}"
+
+        # Case 4: Strong label should override conflicting description
+        task4 = self.create_task(
+            "4",
+            "Build User Dashboard",
+            description="Research and design the dashboard layout before building",
+            labels=["implement", "frontend"],
+        )
+        result4 = classifier.classify_with_confidence(task4)
+        assert (
+            result4.task_type == TaskType.IMPLEMENTATION
+        ), f"Expected IMPLEMENTATION but got {result4.task_type.name}"


### PR DESCRIPTION
## Summary
Fixes task classifier misclassification that was blocking parallel task assignment in phase enforcement (closes #180).

**Root Cause:** The classifier treated all text equally (task name, description, labels), allowing weak signals (description keywords) to override strong signals (task name and explicit labels).

**Example:** Task named "Implement Pomodoro Timer" with label `['implement']` was being classified as DESIGN when the description contained the word "design", causing phase enforcement to incorrectly block it.

## Changes
- **Weighted signal scoring system:**
  - Labels (explicit categorization): weight 8.0 - strongest signal
  - Task name keywords: weight 5.0-6.0 - strong signal  
  - Description keywords: weight 1.5-2.0 - weak signal
- Removed ambiguous case logic that artificially boosted DESIGN classification
- Added test case covering the GH-180 scenario
- Removed debug logging from task.py

## Impact
✅ Phase enforcement now works correctly - tasks are properly classified based on name/labels, not misleading description content  
✅ Parallel task assignment reliability improved  
✅ End-to-end testing confirms fix resolves the issue

## Test Plan
- [x] Added unit test for strong signal override scenario
- [x] All existing classifier tests pass
- [x] End-to-end testing with multi-agent parallelization verified
- [x] Pre-commit hooks pass (mypy, flake8, black, isort)

## Related Issues
Closes #180

🤖 Generated with [Claude Code](https://claude.com/claude-code)