### PR TITLE
feat(lease): cadence-based recovery using median progress interval

### DIFF
--- a/src/config/marcus_config.py
+++ b/src/config/marcus_config.py
@@ -235,6 +235,7 @@ class TaskLeaseSettings:
     max_lease_hours: float = 24.0
     stuck_threshold_renewals: int = 5
     enable_adaptive: bool = True
+    silence_multiplier: float = 1.5
     priority_multipliers: dict[str, float] = field(
         default_factory=lambda: {
             "critical": 0.5,

--- a/src/core/assignment_lease.py
+++ b/src/core/assignment_lease.py
@@ -674,6 +674,9 @@ class AssignmentLeaseManager:
             assignment["renewal_count"] = lease.renewal_count
             assignment["progress_percentage"] = lease.progress_percentage
             assignment["last_progress_update"] = datetime.now(timezone.utc).isoformat()
+            assignment["update_timestamps"] = [
+                ts.isoformat() for ts in lease.update_timestamps
+            ]
             await self.assignment_persistence.save_assignment(
                 lease.agent_id,
                 lease.task_id,
@@ -705,6 +708,13 @@ class AssignmentLeaseManager:
                 )
             )
 
+            # Restore update timestamps for cadence-based recovery
+            raw_timestamps = assignment.get("update_timestamps", [])
+            update_timestamps = [
+                _ensure_timezone_aware(datetime.fromisoformat(ts))
+                for ts in raw_timestamps
+            ]
+
             lease = AssignmentLease(
                 task_id=task_id,
                 agent_id=agent_id,
@@ -713,6 +723,7 @@ class AssignmentLeaseManager:
                 last_renewed=last_renewed,
                 renewal_count=assignment.get("renewal_count", 0),
                 progress_percentage=assignment.get("progress_percentage", 0),
+                update_timestamps=update_timestamps,
             )
 
             self.active_leases[task_id] = lease

--- a/src/core/assignment_lease.py
+++ b/src/core/assignment_lease.py
@@ -14,8 +14,9 @@ Key features:
 
 import asyncio
 import logging
+import statistics
 from collections import deque
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
 from enum import Enum
 from typing import Any, Deque, Dict, List, Optional
@@ -51,6 +52,25 @@ class AssignmentLease:
     progress_percentage: int = 0
     last_progress_message: str = ""
     grace_period_seconds: Optional[float] = None  # Per-lease adaptive grace
+    update_timestamps: list[datetime] = field(default_factory=list)
+
+    @property
+    def median_update_interval(self) -> Optional[float]:
+        """Calculate median seconds between progress updates.
+
+        Returns
+        -------
+        Optional[float]
+            Median interval in seconds, or None if fewer than 2 timestamps.
+        """
+        if len(self.update_timestamps) < 2:
+            return None
+        sorted_ts = sorted(self.update_timestamps)
+        intervals = [
+            (sorted_ts[i] - sorted_ts[i - 1]).total_seconds()
+            for i in range(1, len(sorted_ts))
+        ]
+        return statistics.median(intervals)
 
     @property
     def time_remaining(self) -> timedelta:
@@ -170,6 +190,7 @@ class AssignmentLeaseManager:
         stuck_task_threshold_renewals: int = 5,
         enable_adaptive_leases: bool = True,
         task_list: Optional[List[Task]] = None,
+        silence_multiplier: float = 1.5,
     ):
         """
         Initialize the lease manager.
@@ -231,6 +252,7 @@ class AssignmentLeaseManager:
         self.max_lease_hours = max_lease_hours
         self.stuck_task_threshold_renewals = stuck_task_threshold_renewals
         self.enable_adaptive_leases = enable_adaptive_leases
+        self.silence_multiplier = silence_multiplier
 
         # Active leases tracked in memory
         self.active_leases: Dict[str, AssignmentLease] = {}
@@ -390,6 +412,9 @@ class AssignmentLeaseManager:
             # Update progress
             lease.progress_percentage = progress
             lease.last_progress_message = message
+
+            # Track update timestamp for cadence-based recovery
+            lease.update_timestamps.append(datetime.now(timezone.utc))
 
             # Use progressive timeout if in aggressive mode (< 1 hour default)
             if self.default_lease_hours < 1.0:
@@ -781,12 +806,12 @@ class AssignmentLeaseManager:
 
     async def should_recover_expired_lease(self, lease: AssignmentLease) -> bool:
         """
-        Determine if expired lease should be recovered (smart checks).
+        Determine if expired lease should be recovered using cadence detection.
 
-        Uses multiple signals to reduce false positive recovery:
-        1. Task progress percentage
-        2. Number of renewal cycles
-        3. Board activity timestamps
+        Compares time since last progress update against the agent's own
+        median update interval * silence_multiplier. If the agent has been
+        silent for longer than expected based on its established cadence,
+        it's considered dead and the task should be recovered.
 
         Parameters
         ----------
@@ -800,59 +825,48 @@ class AssignmentLeaseManager:
 
         Notes
         -----
-        This implements smart recovery without heartbeat by checking:
-        - Progress made (>0% gets grace extension)
-        - Renewal count (>2 renewals → recover)
-        - Board activity (recent updates → extend grace)
+        Real data from logs: median progress interval ~47s, mean ~60s.
+        Default silence_multiplier is 1.5x — configurable via constructor.
+
+        Fallback: if fewer than 2 progress updates exist (can't compute
+        median), always recover since the agent has no established cadence.
         """
-        # Check 1: Has progress but few renewals? Give grace
-        if lease.progress_percentage > 0 and lease.renewal_count < 3:
-            logger.info(
-                f"Task {lease.task_id} has {lease.progress_percentage}% "
-                f"progress with only {lease.renewal_count} renewal(s), "
-                f"extending grace"
-            )
-            return False
+        now = datetime.now(timezone.utc)
+        median_interval = lease.median_update_interval
 
-        # Check 1b: Low progress with many renewals - stuck
-        elif lease.progress_percentage > 0 and lease.renewal_count >= 3:
-            # Task is stuck with low progress - recover
+        # Not enough data to compute cadence — recover
+        if median_interval is None:
             logger.info(
-                f"Task {lease.task_id} has only {lease.progress_percentage}% "
-                f"progress after {lease.renewal_count} renewals, recovering"
+                f"Task {lease.task_id}: no established update cadence "
+                f"(updates={len(lease.update_timestamps)}), recovering"
             )
             return True
 
-        # Check 2: Too many renewals?
-        if lease.renewal_count >= 3:
-            # Task is stuck - recover
+        # Calculate silence duration from last update
+        if lease.update_timestamps:
+            last_update = max(lease.update_timestamps)
+            silence_seconds = (now - last_update).total_seconds()
+        else:
+            silence_seconds = (now - lease.assigned_at).total_seconds()
+
+        threshold = median_interval * self.silence_multiplier
+
+        if silence_seconds > threshold:
             logger.info(
-                f"Task {lease.task_id} has {lease.renewal_count} renewals, "
-                f"recovering"
+                f"Task {lease.task_id}: silence={silence_seconds:.0f}s > "
+                f"threshold={threshold:.0f}s "
+                f"(median={median_interval:.0f}s * "
+                f"{self.silence_multiplier}x), recovering"
             )
             return True
 
-        # Check 3: Check board for recent updates
-        try:
-            task = await self.kanban_client.get_task_by_id(lease.task_id)
-            if task and hasattr(task, "updated_at") and task.updated_at:
-                # Ensure timezone aware
-                task_updated = _ensure_timezone_aware(task.updated_at)
-                now = datetime.now(timezone.utc)
-                seconds_since_update = (now - task_updated).total_seconds()
-
-                # If board shows recent activity (< 2 minutes), don't recover
-                if seconds_since_update < 120:
-                    logger.info(
-                        f"Task {lease.task_id} updated on board "
-                        f"{seconds_since_update:.0f}s ago, extending grace"
-                    )
-                    return False
-        except Exception as e:
-            logger.warning(f"Could not check board activity: {e}")
-
-        # All checks passed - safe to recover
-        return True
+        logger.info(
+            f"Task {lease.task_id}: silence={silence_seconds:.0f}s <= "
+            f"threshold={threshold:.0f}s "
+            f"(median={median_interval:.0f}s * "
+            f"{self.silence_multiplier}x), extending grace"
+        )
+        return False
 
     async def _create_recovery_handoff_comment(
         self, lease: AssignmentLease, recovery_info: RecoveryInfo

--- a/src/marcus_mcp/server.py
+++ b/src/marcus_mcp/server.py
@@ -640,6 +640,7 @@ class MarcusServer:
                     stuck_task_threshold_renewals=lease_config.stuck_threshold_renewals,
                     enable_adaptive_leases=lease_config.enable_adaptive,
                     task_list=self.project_tasks,
+                    silence_multiplier=lease_config.silence_multiplier,
                 )
             else:
                 # It's a dict from project config
@@ -660,6 +661,7 @@ class MarcusServer:
                     ),
                     enable_adaptive_leases=lease_config.get("enable_adaptive", True),
                     task_list=self.project_tasks,
+                    silence_multiplier=lease_config.get("silence_multiplier", 1.5),
                 )
             self.lease_monitor = LeaseMonitor(self.lease_manager)
             await self.lease_monitor.start()

--- a/tests/unit/core/test_assignment_lease.py
+++ b/tests/unit/core/test_assignment_lease.py
@@ -550,6 +550,112 @@ class TestNaiveDatetimeBackwardsCompatibility:
         assert new_lease.time_remaining  # Computed successfully
 
 
+class TestUpdateTimestampPersistence:
+    """Test that update_timestamps survive persist/load cycle."""
+
+    @pytest.mark.asyncio
+    async def test_load_active_leases_restores_update_timestamps(self):
+        """Test that update_timestamps are restored from persistence."""
+        from src.core.assignment_persistence import AssignmentPersistence
+
+        now = datetime.now(timezone.utc)
+        timestamps = [
+            (now - timedelta(seconds=180)).isoformat(),
+            (now - timedelta(seconds=120)).isoformat(),
+            (now - timedelta(seconds=60)).isoformat(),
+        ]
+
+        mock_persistence = Mock(spec=AssignmentPersistence)
+        mock_persistence.load_assignments = AsyncMock(
+            return_value={
+                "agent-001": {
+                    "task_id": "task-123",
+                    "assigned_at": now.isoformat(),
+                    "lease_expires": (now + timedelta(minutes=2)).isoformat(),
+                    "lease_renewed_at": now.isoformat(),
+                    "renewal_count": 3,
+                    "progress_percentage": 50,
+                    "update_timestamps": timestamps,
+                }
+            }
+        )
+
+        lease_manager = AssignmentLeaseManager(
+            kanban_client=Mock(),
+            assignment_persistence=mock_persistence,
+        )
+        await lease_manager.load_active_leases()
+
+        lease = lease_manager.active_leases["task-123"]
+        assert len(lease.update_timestamps) == 3
+        assert all(ts.tzinfo is not None for ts in lease.update_timestamps)
+
+    @pytest.mark.asyncio
+    async def test_load_active_leases_handles_missing_timestamps(self):
+        """Test that missing update_timestamps defaults to empty list."""
+        from src.core.assignment_persistence import AssignmentPersistence
+
+        now = datetime.now(timezone.utc)
+        mock_persistence = Mock(spec=AssignmentPersistence)
+        mock_persistence.load_assignments = AsyncMock(
+            return_value={
+                "agent-001": {
+                    "task_id": "task-456",
+                    "assigned_at": now.isoformat(),
+                    "lease_expires": (now + timedelta(minutes=2)).isoformat(),
+                    "lease_renewed_at": now.isoformat(),
+                    "renewal_count": 0,
+                    "progress_percentage": 0,
+                }
+            }
+        )
+
+        lease_manager = AssignmentLeaseManager(
+            kanban_client=Mock(),
+            assignment_persistence=mock_persistence,
+        )
+        await lease_manager.load_active_leases()
+
+        lease = lease_manager.active_leases["task-456"]
+        assert lease.update_timestamps == []
+
+    @pytest.mark.asyncio
+    async def test_persist_lease_saves_update_timestamps(self):
+        """Test that _persist_lease includes update_timestamps."""
+        from src.core.assignment_persistence import AssignmentPersistence
+
+        now = datetime.now(timezone.utc)
+        mock_persistence = Mock(spec=AssignmentPersistence)
+        existing_assignment: dict[str, Any] = {
+            "task_id": "task-789",
+            "assigned_at": now.isoformat(),
+        }
+        mock_persistence.get_assignment = AsyncMock(return_value=existing_assignment)
+        mock_persistence.save_assignment = AsyncMock()
+
+        lease_manager = AssignmentLeaseManager(
+            kanban_client=Mock(),
+            assignment_persistence=mock_persistence,
+        )
+
+        lease = AssignmentLease(
+            task_id="task-789",
+            agent_id="agent-001",
+            assigned_at=now,
+            lease_expires=now + timedelta(minutes=2),
+            last_renewed=now,
+            update_timestamps=[
+                now - timedelta(seconds=60),
+                now,
+            ],
+        )
+
+        await lease_manager._persist_lease(lease)
+
+        assert "update_timestamps" in existing_assignment
+        assert len(existing_assignment["update_timestamps"]) == 2
+
+
 class TestRecoveryInfo:
     """Test suite for RecoveryInfo dataclass."""
 

--- a/tests/unit/core/test_progressive_timeout.py
+++ b/tests/unit/core/test_progressive_timeout.py
@@ -116,126 +116,215 @@ class TestProgressiveTimeoutCalculation:
             assert lease_seconds + grace_seconds == 75  # Total: 1.25 min
 
 
-class TestSmartRecoveryChecks:
-    """Test smart recovery checks without heartbeat."""
+class TestCadenceBasedRecovery:
+    """Test cadence-based recovery using median update interval.
+
+    Recovery compares time since last update against the agent's own
+    median update cadence * silence_multiplier. Default multiplier is
+    1.5x — if an agent that normally updates every ~60s hasn't updated
+    in 90s, it's dead.
+
+    Real data from logs: mean=60s, median=47s, P95=137s.
+    """
 
     @pytest.mark.asyncio
-    async def test_should_recover_no_progress(self, lease_manager_aggressive):
-        """Test recovery when task has 0% progress."""
+    async def test_should_recover_no_updates(self, lease_manager_aggressive):
+        """Test recovery when agent never sent a progress update."""
         lease = AssignmentLease(
             task_id="task-1",
             agent_id="agent-1",
             assigned_at=datetime.now(timezone.utc) - timedelta(minutes=5),
-            lease_expires=datetime.now(timezone.utc) - timedelta(seconds=10),
-            last_renewed=datetime.now(timezone.utc) - timedelta(minutes=5),
-            progress_percentage=0,  # No progress
-            renewal_count=0,
-        )
-
-        should_recover = await lease_manager_aggressive.should_recover_expired_lease(
-            lease
-        )
-
-        # Should recover - no progress made
-        assert should_recover is True
-
-    @pytest.mark.asyncio
-    async def test_should_not_recover_with_progress_first_time(
-        self, lease_manager_aggressive
-    ):
-        """Test that task with progress gets grace extension on first expiry."""
-        lease = AssignmentLease(
-            task_id="task-1",
-            agent_id="agent-1",
-            assigned_at=datetime.now(timezone.utc) - timedelta(minutes=5),
-            lease_expires=datetime.now(timezone.utc) - timedelta(seconds=10),
-            last_renewed=datetime.now(timezone.utc) - timedelta(minutes=2),
-            progress_percentage=40,  # Has progress
-            renewal_count=1,
-        )
-
-        should_recover = await lease_manager_aggressive.should_recover_expired_lease(
-            lease
-        )
-
-        # Should NOT recover - has progress, first expiry
-        assert should_recover is False
-
-    @pytest.mark.asyncio
-    async def test_should_recover_with_progress_after_max_renewals(
-        self, lease_manager_aggressive
-    ):
-        """Test recovery when renewal count exceeds threshold."""
-        lease = AssignmentLease(
-            task_id="task-1",
-            agent_id="agent-1",
-            assigned_at=datetime.now(timezone.utc) - timedelta(minutes=10),
-            lease_expires=datetime.now(timezone.utc) - timedelta(seconds=10),
-            last_renewed=datetime.now(timezone.utc) - timedelta(minutes=3),
-            progress_percentage=40,
-            renewal_count=3,  # Too many renewals
-        )
-
-        should_recover = await lease_manager_aggressive.should_recover_expired_lease(
-            lease
-        )
-
-        # Should recover - too many renewals, likely stuck
-        assert should_recover is True
-
-    @pytest.mark.asyncio
-    async def test_should_not_recover_recent_board_activity(
-        self, lease_manager_aggressive, mock_kanban_client
-    ):
-        """Test that recent board activity prevents recovery."""
-        lease = AssignmentLease(
-            task_id="task-1",
-            agent_id="agent-1",
-            assigned_at=datetime.now(timezone.utc) - timedelta(minutes=5),
-            lease_expires=datetime.now(timezone.utc) - timedelta(seconds=10),
-            last_renewed=datetime.now(timezone.utc) - timedelta(minutes=2),
-            progress_percentage=0,  # No progress reported
-            renewal_count=0,
-        )
-
-        # Mock task with recent board update
-        mock_task = Mock()
-        mock_task.updated_at = datetime.now(timezone.utc) - timedelta(seconds=30)
-        mock_kanban_client.get_task_by_id.return_value = mock_task
-
-        should_recover = await lease_manager_aggressive.should_recover_expired_lease(
-            lease
-        )
-
-        # Should NOT recover - board shows recent activity
-        assert should_recover is False
-
-    @pytest.mark.asyncio
-    async def test_should_recover_old_board_activity(
-        self, lease_manager_aggressive, mock_kanban_client
-    ):
-        """Test recovery when board activity is old."""
-        lease = AssignmentLease(
-            task_id="task-1",
-            agent_id="agent-1",
-            assigned_at=datetime.now(timezone.utc) - timedelta(minutes=10),
             lease_expires=datetime.now(timezone.utc) - timedelta(seconds=10),
             last_renewed=datetime.now(timezone.utc) - timedelta(minutes=5),
             progress_percentage=0,
             renewal_count=0,
+            update_timestamps=[],
         )
-
-        # Mock task with old board update
-        mock_task = Mock()
-        mock_task.updated_at = datetime.now(timezone.utc) - timedelta(minutes=10)
-        mock_kanban_client.get_task_by_id.return_value = mock_task
 
         should_recover = await lease_manager_aggressive.should_recover_expired_lease(
             lease
         )
 
-        # Should recover - board activity is stale
+        # No updates → recover immediately
         assert should_recover is True
+
+    @pytest.mark.asyncio
+    async def test_should_recover_silent_past_cadence(self, lease_manager_aggressive):
+        """Test recovery when silence exceeds 1.5x median interval."""
+        now = datetime.now(timezone.utc)
+        # Agent updated every ~60s, last update 100s ago (>1.5*60=90s)
+        lease = AssignmentLease(
+            task_id="task-1",
+            agent_id="agent-1",
+            assigned_at=now - timedelta(minutes=10),
+            lease_expires=now - timedelta(seconds=10),
+            last_renewed=now - timedelta(seconds=100),
+            progress_percentage=40,
+            renewal_count=3,
+            update_timestamps=[
+                now - timedelta(seconds=280),
+                now - timedelta(seconds=220),
+                now - timedelta(seconds=160),
+                now - timedelta(seconds=100),
+            ],
+        )
+
+        should_recover = await lease_manager_aggressive.should_recover_expired_lease(
+            lease
+        )
+
+        # Median interval=60s, silence=100s > 1.5*60=90s → recover
+        assert should_recover is True
+
+    @pytest.mark.asyncio
+    async def test_should_not_recover_within_cadence(self, lease_manager_aggressive):
+        """Test no recovery when silence is within expected cadence."""
+        now = datetime.now(timezone.utc)
+        # Agent updates every ~60s, last update was 80s ago (<1.5*60=90s)
+        lease = AssignmentLease(
+            task_id="task-1",
+            agent_id="agent-1",
+            assigned_at=now - timedelta(minutes=5),
+            lease_expires=now - timedelta(seconds=5),
+            last_renewed=now - timedelta(seconds=80),
+            progress_percentage=50,
+            renewal_count=2,
+            update_timestamps=[
+                now - timedelta(seconds=200),
+                now - timedelta(seconds=140),
+                now - timedelta(seconds=80),
+            ],
+        )
+
+        should_recover = await lease_manager_aggressive.should_recover_expired_lease(
+            lease
+        )
+
+        # Median interval=60s, silence=80s < 1.5*60=90s → don't recover
+        assert should_recover is False
+
+    @pytest.mark.asyncio
+    async def test_should_recover_single_update_then_silence(
+        self, lease_manager_aggressive
+    ):
+        """Test recovery when agent sent one update then went silent."""
+        now = datetime.now(timezone.utc)
+        lease = AssignmentLease(
+            task_id="task-1",
+            agent_id="agent-1",
+            assigned_at=now - timedelta(minutes=5),
+            lease_expires=now - timedelta(seconds=10),
+            last_renewed=now - timedelta(seconds=200),
+            progress_percentage=25,
+            renewal_count=1,
+            update_timestamps=[
+                now - timedelta(seconds=200),
+            ],
+        )
+
+        should_recover = await lease_manager_aggressive.should_recover_expired_lease(
+            lease
+        )
+
+        # Only 1 update → can't compute median, fall back to default → recover
+        assert should_recover is True
+
+    @pytest.mark.asyncio
+    async def test_should_recover_slow_agent_gone_silent(
+        self, lease_manager_aggressive
+    ):
+        """Test recovery for slow-cadence agent that stops entirely."""
+        now = datetime.now(timezone.utc)
+        # Agent was slow (~120s between updates), last update 200s ago
+        lease = AssignmentLease(
+            task_id="task-1",
+            agent_id="agent-1",
+            assigned_at=now - timedelta(minutes=15),
+            lease_expires=now - timedelta(seconds=10),
+            last_renewed=now - timedelta(seconds=200),
+            progress_percentage=50,
+            renewal_count=3,
+            update_timestamps=[
+                now - timedelta(seconds=560),
+                now - timedelta(seconds=440),
+                now - timedelta(seconds=320),
+                now - timedelta(seconds=200),
+            ],
+        )
+
+        should_recover = await lease_manager_aggressive.should_recover_expired_lease(
+            lease
+        )
+
+        # Median interval=120s, silence=200s > 1.5*120=180s → recover
+        assert should_recover is True
+
+    @pytest.mark.asyncio
+    async def test_should_not_recover_slow_agent_within_cadence(
+        self, lease_manager_aggressive
+    ):
+        """Test that slow but consistent agents aren't falsely recovered."""
+        now = datetime.now(timezone.utc)
+        # Agent was slow (~120s between updates), last update 150s ago
+        lease = AssignmentLease(
+            task_id="task-1",
+            agent_id="agent-1",
+            assigned_at=now - timedelta(minutes=15),
+            lease_expires=now - timedelta(seconds=5),
+            last_renewed=now - timedelta(seconds=150),
+            progress_percentage=50,
+            renewal_count=3,
+            update_timestamps=[
+                now - timedelta(seconds=510),
+                now - timedelta(seconds=390),
+                now - timedelta(seconds=270),
+                now - timedelta(seconds=150),
+            ],
+        )
+
+        should_recover = await lease_manager_aggressive.should_recover_expired_lease(
+            lease
+        )
+
+        # Median interval=120s, silence=150s < 1.5*120=180s → don't recover
+        assert should_recover is False
+
+    @pytest.mark.asyncio
+    async def test_custom_silence_multiplier(
+        self, mock_kanban_client, mock_assignment_persistence
+    ):
+        """Test that silence_multiplier is configurable."""
+        manager = AssignmentLeaseManager(
+            kanban_client=mock_kanban_client,
+            assignment_persistence=mock_assignment_persistence,
+            default_lease_hours=0.025,
+            grace_period_minutes=0.5,
+            min_lease_hours=0.0167,
+            max_lease_hours=0.0333,
+            silence_multiplier=2.0,  # More lenient than default 1.5
+        )
+
+        now = datetime.now(timezone.utc)
+        # Agent updates every ~60s, last update 100s ago
+        lease = AssignmentLease(
+            task_id="task-1",
+            agent_id="agent-1",
+            assigned_at=now - timedelta(minutes=5),
+            lease_expires=now - timedelta(seconds=5),
+            last_renewed=now - timedelta(seconds=100),
+            progress_percentage=50,
+            renewal_count=2,
+            update_timestamps=[
+                now - timedelta(seconds=220),
+                now - timedelta(seconds=160),
+                now - timedelta(seconds=100),
+            ],
+        )
+
+        should_recover = await manager.should_recover_expired_lease(lease)
+
+        # Median=60s, silence=100s < 2.0*60=120s → don't recover (lenient)
+        assert should_recover is False
 
 
 class TestAggressiveVsConservativeTimeouts:
@@ -307,75 +396,94 @@ class TestAggressiveVsConservativeTimeouts:
         assert p2_lease + p2_grace < p3_lease + p3_grace
 
 
-class TestFalsePositiveReduction:
-    """Test strategies to reduce false positive recovery."""
+class TestMedianUpdateInterval:
+    """Test the median_update_interval property on AssignmentLease."""
 
-    @pytest.mark.asyncio
-    async def test_grace_extension_for_progressed_task(self, lease_manager_aggressive):
-        """Test that tasks with progress get grace extension."""
+    def test_no_timestamps_returns_none(self):
+        """Test that no timestamps yields None interval."""
         lease = AssignmentLease(
             task_id="task-1",
             agent_id="agent-1",
-            assigned_at=datetime.now(timezone.utc) - timedelta(minutes=3),
-            lease_expires=datetime.now(timezone.utc) - timedelta(seconds=5),
-            last_renewed=datetime.now(timezone.utc) - timedelta(minutes=1),
-            progress_percentage=60,  # Significant progress
-            renewal_count=1,
+            assigned_at=datetime.now(timezone.utc),
+            lease_expires=datetime.now(timezone.utc) + timedelta(minutes=2),
+            last_renewed=datetime.now(timezone.utc),
+            update_timestamps=[],
         )
 
-        should_recover = await lease_manager_aggressive.should_recover_expired_lease(
-            lease
-        )
+        assert lease.median_update_interval is None
 
-        # Should NOT recover - task has significant progress
-        assert should_recover is False
-
-    @pytest.mark.asyncio
-    async def test_no_grace_for_zero_progress(self, lease_manager_aggressive):
-        """Test that tasks with 0% progress don't get grace extension."""
+    def test_single_timestamp_returns_none(self):
+        """Test that a single timestamp yields None (need >= 2 for interval)."""
+        now = datetime.now(timezone.utc)
         lease = AssignmentLease(
             task_id="task-1",
             agent_id="agent-1",
-            assigned_at=datetime.now(timezone.utc) - timedelta(minutes=3),
-            lease_expires=datetime.now(timezone.utc) - timedelta(seconds=5),
-            last_renewed=datetime.now(timezone.utc) - timedelta(minutes=1),
-            progress_percentage=0,  # No progress
-            renewal_count=0,
+            assigned_at=now,
+            lease_expires=now + timedelta(minutes=2),
+            last_renewed=now,
+            update_timestamps=[now],
         )
 
-        should_recover = await lease_manager_aggressive.should_recover_expired_lease(
-            lease
-        )
+        assert lease.median_update_interval is None
 
-        # Should recover - no progress made
-        assert should_recover is True
-
-    @pytest.mark.asyncio
-    async def test_board_activity_check_protects_working_agent(
-        self, lease_manager_aggressive, mock_kanban_client
-    ):
-        """Test that board activity check prevents false positive."""
+    def test_two_timestamps_calculates_interval(self):
+        """Test interval calculation with two timestamps."""
+        now = datetime.now(timezone.utc)
         lease = AssignmentLease(
             task_id="task-1",
             agent_id="agent-1",
-            assigned_at=datetime.now(timezone.utc) - timedelta(minutes=3),
-            lease_expires=datetime.now(timezone.utc) - timedelta(seconds=5),
-            last_renewed=datetime.now(timezone.utc) - timedelta(minutes=2),
-            progress_percentage=30,
-            renewal_count=0,
+            assigned_at=now - timedelta(minutes=5),
+            lease_expires=now + timedelta(minutes=2),
+            last_renewed=now,
+            update_timestamps=[
+                now - timedelta(seconds=120),
+                now - timedelta(seconds=60),
+            ],
         )
 
-        # Agent updated board 45 seconds ago (recent)
-        mock_task = Mock()
-        mock_task.updated_at = datetime.now(timezone.utc) - timedelta(seconds=45)
-        mock_kanban_client.get_task_by_id.return_value = mock_task
+        assert lease.median_update_interval == 60.0
 
-        should_recover = await lease_manager_aggressive.should_recover_expired_lease(
-            lease
+    def test_odd_number_of_intervals_picks_middle(self):
+        """Test median with odd count of intervals."""
+        now = datetime.now(timezone.utc)
+        lease = AssignmentLease(
+            task_id="task-1",
+            agent_id="agent-1",
+            assigned_at=now - timedelta(minutes=10),
+            lease_expires=now + timedelta(minutes=2),
+            last_renewed=now,
+            update_timestamps=[
+                now - timedelta(seconds=240),
+                now - timedelta(seconds=200),  # 40s gap
+                now - timedelta(seconds=120),  # 80s gap
+                now - timedelta(seconds=60),  # 60s gap
+            ],
         )
 
-        # Should NOT recover - board shows agent is working
-        assert should_recover is False
+        # Intervals: [40, 80, 60] → sorted: [40, 60, 80] → median = 60
+        assert lease.median_update_interval == 60.0
+
+    def test_even_number_of_intervals_picks_lower_middle(self):
+        """Test median with even count of intervals."""
+        now = datetime.now(timezone.utc)
+        lease = AssignmentLease(
+            task_id="task-1",
+            agent_id="agent-1",
+            assigned_at=now - timedelta(minutes=10),
+            lease_expires=now + timedelta(minutes=2),
+            last_renewed=now,
+            update_timestamps=[
+                now - timedelta(seconds=300),
+                now - timedelta(seconds=260),  # 40s gap
+                now - timedelta(seconds=140),  # 120s gap
+                now - timedelta(seconds=80),  # 60s gap
+                now - timedelta(seconds=20),  # 60s gap
+            ],
+        )
+
+        # Intervals: [40, 120, 60, 60] → sorted: [40, 60, 60, 120]
+        # Even count → average of middle two: (60+60)/2 = 60
+        assert lease.median_update_interval == 60.0
 
 
 class TestDataDrivenDecisions:


### PR DESCRIPTION
## Summary
- Replace arbitrary renewal-count and board-activity checks in `should_recover_expired_lease` with **cadence-based detection** using the agent's own median progress update interval
- Add `update_timestamps` field to `AssignmentLease` to track when each progress report arrives
- Add `median_update_interval` property that computes median seconds between updates
- Add configurable `silence_multiplier` (default 1.5x) — recover when silence exceeds `median * multiplier`
- Based on real log data: median progress interval ~47s, so recovery triggers after ~70s of silence

## Why
When an agent is killed, the old `should_recover_expired_lease` would skip recovery if the agent had reported any progress with <3 renewals, or if the board showed recent activity. This meant dead agents could hold tasks for minutes or hours. The new approach uses the agent's actual update cadence — if it normally reports every ~47s and goes silent for 70s+, it's dead.

## Test plan
- [x] `TestCadenceBasedRecovery` — 7 tests covering no updates, silence past cadence, within cadence, single update fallback, slow agents, custom multiplier
- [x] `TestMedianUpdateInterval` — 5 tests covering edge cases (0/1 timestamps, odd/even interval counts)
- [x] All 2293 unit tests pass
- [x] All pre-commit hooks pass (mypy, black, isort, flake8, bandit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)