### PR TITLE
feat: add phase-level timing to request_next_task

### DIFF
--- a/src/marcus_mcp/audit.py
+++ b/src/marcus_mcp/audit.py
@@ -140,14 +140,18 @@ class AuditLogger:
         client_type: Optional[str],
         tool_name: str,
         reason: str,
+        duration_ms: Optional[float] = None,
     ) -> None:
         """Log an access denied event."""
+        details: Dict[str, Any] = {"reason": reason}
+        if duration_ms is not None:
+            details["duration_ms"] = duration_ms
         await self.log_event(
             event_type="access_denied",
             client_id=client_id,
             client_type=client_type,
             tool_name=tool_name,
-            details={"reason": reason},
+            details=details,
             success=False,
         )
 

--- a/src/marcus_mcp/handlers.py
+++ b/src/marcus_mcp/handlers.py
@@ -969,6 +969,7 @@ async def handle_tool_call(
     allowed_tools = get_client_tools(client_id, state)
     if name not in allowed_tools and "*" not in allowed_tools:
         # Audit access denied
+        duration_ms = (time.time() - start_time) * 1000
         await audit_logger.log_access_denied(
             client_id=client_id,
             client_type=client_type,
@@ -977,6 +978,7 @@ async def handle_tool_call(
                 f"Tool '{name}' not allowed for client type "
                 f"'{client_type or 'unregistered'}'"
             ),
+            duration_ms=duration_ms,
         )
 
         return [

--- a/src/marcus_mcp/tools/task.py
+++ b/src/marcus_mcp/tools/task.py
@@ -12,6 +12,7 @@ import json
 import logging
 import os
 import threading
+import time
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
 
@@ -614,6 +615,13 @@ async def request_next_task(agent_id: str, state: Any) -> Any:
     )
 
     try:
+        # Phase timing for performance monitoring (GH-228)
+        _perf_start = time.perf_counter()
+        _perf_marks: Dict[str, float] = {}
+
+        def _mark(name: str) -> None:
+            _perf_marks[name] = (time.perf_counter() - _perf_start) * 1000
+
         # Log the task request immediately
         state.log_event(
             "task_request",
@@ -631,6 +639,7 @@ async def request_next_task(agent_id: str, state: Any) -> Any:
 
         # Get current project state
         await state.refresh_project_state()
+        _mark("state_refresh")
 
         # Log thinking about finding task
         agent = state.agent_status.get(agent_id)
@@ -678,6 +687,7 @@ async def request_next_task(agent_id: str, state: Any) -> Any:
 
         # Find optimal task for this agent
         optimal_task = await find_optimal_task_for_agent(agent_id, state)
+        _mark("task_selection")
 
         if optimal_task:
             try:
@@ -776,6 +786,8 @@ async def request_next_task(agent_id: str, state: Any) -> Any:
                             f"{dep_count} future tasks depend on your work:\n{dep_list}"
                         )
 
+                _mark("context_building")
+
                 # Get predictions if Memory system is available
                 predictions = None
                 if hasattr(state, "memory") and state.memory:
@@ -822,6 +834,8 @@ async def request_next_task(agent_id: str, state: Any) -> Any:
                     # Record task start in memory
                     await state.memory.record_task_start(agent_id, optimal_task)
 
+                _mark("memory_predictions")
+
                 # Generate detailed instructions with AI
                 try:
                     base_instructions = (
@@ -849,6 +863,8 @@ async def request_next_task(agent_id: str, state: Any) -> Any:
                 except Exception as e:
                     logger.error(f"Error generating task instructions: {e}")
                     raise
+
+                _mark("instruction_generation")
 
                 # Log decision process
                 conversation_logger.log_pm_decision(
@@ -885,6 +901,8 @@ async def request_next_task(agent_id: str, state: Any) -> Any:
                     optimal_task.id,
                     {"status": TaskStatus.IN_PROGRESS, "assigned_to": agent_id},
                 )
+
+                _mark("kanban_update")
 
                 # If kanban update succeeded, track assignment
                 state.agent_tasks[agent_id] = assignment
@@ -1026,6 +1044,24 @@ async def request_next_task(agent_id: str, state: Any) -> Any:
                             "has_dependencies": dependency_awareness is not None,
                         },
                     )
+
+                # Log phase timings (GH-228)
+                _mark("total")
+                task_count = len(state.project_tasks) if state.project_tasks else 0
+                # Convert cumulative marks to per-phase durations
+                _phases = list(_perf_marks.items())
+                _phase_durations: Dict[str, float] = {}
+                for i, (name, cumulative_ms) in enumerate(_phases):
+                    prev_ms = _phases[i - 1][1] if i > 0 else 0.0
+                    _phase_durations[name] = round(cumulative_ms - prev_ms, 2)
+                logger.info(
+                    "request_next_task timing: "
+                    f"agent={agent_id} "
+                    f"task={optimal_task.name!r} "
+                    f"task_count={task_count} "
+                    f"total_ms={_phase_durations.get('total', 0)} "
+                    f"phases={_phase_durations}"
+                )
 
                 return serialize_for_mcp(response)
 

--- a/src/marcus_mcp/tools/task.py
+++ b/src/marcus_mcp/tools/task.py
@@ -1048,7 +1048,9 @@ async def request_next_task(agent_id: str, state: Any) -> Any:
                 # Log phase timings (GH-228)
                 _mark("total")
                 task_count = len(state.project_tasks) if state.project_tasks else 0
-                # Convert cumulative marks to per-phase durations
+                # total_ms is the cumulative wall-clock time
+                total_ms = round(_perf_marks["total"], 2)
+                # Convert cumulative marks to per-phase deltas
                 _phases = list(_perf_marks.items())
                 _phase_durations: Dict[str, float] = {}
                 for i, (name, cumulative_ms) in enumerate(_phases):
@@ -1059,7 +1061,7 @@ async def request_next_task(agent_id: str, state: Any) -> Any:
                     f"agent={agent_id} "
                     f"task={optimal_task.name!r} "
                     f"task_count={task_count} "
-                    f"total_ms={_phase_durations.get('total', 0)} "
+                    f"total_ms={total_ms} "
                     f"phases={_phase_durations}"
                 )
 


### PR DESCRIPTION
## Summary
- Adds per-phase duration logging to `request_next_task` so we can measure and compare assignment latency across experiments
- Fixes `audit.log_access_denied()` to include `duration_ms` so denied calls also get timing data
- Closes #228

## Changes (3 files, +43 lines)
- **`task.py`**: `_mark()` helper records cumulative timestamps at 7 phase boundaries (state_refresh, task_selection, context_building, memory_predictions, instruction_generation, kanban_update, total). Converts to per-phase durations and emits a single `logger.info` line per successful assignment.
- **`audit.py`**: Added optional `duration_ms` param to `log_access_denied()`
- **`handlers.py`**: Passes `duration_ms` to the access_denied audit call

## Example output
```
request_next_task timing: agent=agent-1 task='Implement Login' task_count=42 total_ms=1523.4 phases={state_refresh: 203.1, task_selection: 412.7, context_building: 89.3, memory_predictions: 201.5, instruction_generation: 504.2, kanban_update: 98.1, total: 14.5}
```

## Test plan
- [x] All 708 unit tests pass
- [x] All pre-commit hooks pass (mypy, black, isort, flake8, bandit)
- [ ] Run a Marcus experiment and verify timing line appears in logs
- [ ] Compare timing across multiple experiments to establish baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)