### PR TITLE
feat: show AI model info in marcus status

### DIFF
--- a/marcus
+++ b/marcus
@@ -365,9 +365,13 @@ class MarcusCLI:
         """Check Marcus status"""
         if self._is_running():
             pid = self._get_pid()
+            config = get_config()
             print("✅ Marcus is running")
             print(f"   PID: {pid}")
             print(f"   Provider: {get_kanban_provider()}")
+            print(f"   AI Model: {config.get('ai.model', 'unknown')}")
+            print(f"   AI Provider: {config.get('ai.provider', 'unknown')}")
+            print(f"   Temperature: {config.get('ai.temperature', 'unknown')}")
 
             # Get process info
             try:
@@ -383,7 +387,6 @@ class MarcusCLI:
                 pass
 
             # Show transport info
-            config = get_config()
             transport = config.get("transport", {}).get("type", "stdio")
 
             # Check if running in multi mode by looking for config

--- a/src/ai/advanced/prd/advanced_parser.py
+++ b/src/ai/advanced/prd/advanced_parser.py
@@ -776,10 +776,10 @@ Provide ONLY valid JSON, no preamble."""
             result = await self.llm_client.analyze(prompt, context)
             response_text = str(result) if result else "{}"
 
-            # Parse JSON response
-            import json
+            # Parse JSON response (handle markdown fences, preamble, etc.)
+            from src.utils.json_parser import parse_ai_json_response
 
-            domain_data = json.loads(response_text)
+            domain_data = parse_ai_json_response(response_text)
             domains_list = domain_data.get("domains", [])
 
             # Convert to simple dict mapping


### PR DESCRIPTION
## Summary

Two fixes for model-related visibility and behavior:

### 1. Show AI model info in `./marcus status`
Adds AI model, provider, and temperature to CLI status output so you can verify what model the running server loaded.

```
✅ Marcus is running
   PID: 12345
   Provider: sqlite
   AI Model: claude-haiku-4-5-20251001
   AI Provider: anthropic
   Temperature: 0.1
```

### 2. Fix domain discovery JSON parsing for Haiku 4.5
Haiku 4.5 wraps JSON responses in markdown fences, causing `json.loads()` to fail and falling back to generic "Project Domain" name. Replaced with `parse_ai_json_response()` which already handles fences/preamble (used everywhere else in the PRD parser).

## Context
- Debugging deprecated model (404 errors) was hard — no way to see what model was loaded
- "Design Project Domain" instead of "Design Snake Game Engine" was caused by domain discovery silently failing on every run with Haiku 4.5

## Related
- #261 (same AI info for MCP ping tool)

## Test plan
- [x] Pre-commit hooks pass
- [ ] `./marcus status` shows AI info
- [ ] Run experiment — domain names should be project-specific, not "Project Domain"

🤖 Generated with [Claude Code](https://claude.com/claude-code)