### PR TITLE
feat: add integration verification phase (#271)

### DIFF
--- a/src/core/phase_dependency_enforcer.py
+++ b/src/core/phase_dependency_enforcer.py
@@ -26,8 +26,9 @@ class TaskPhase(Enum):
     INFRASTRUCTURE = 2
     IMPLEMENTATION = 3
     TESTING = 4
-    DOCUMENTATION = 5
-    DEPLOYMENT = 6
+    INTEGRATION = 5
+    DOCUMENTATION = 6
+    DEPLOYMENT = 7
 
     @classmethod
     def get_dependencies(cls, phase: "TaskPhase") -> List["TaskPhase"]:
@@ -83,6 +84,7 @@ class PhaseDependencyEnforcer:
         TaskPhase.INFRASTRUCTURE,
         TaskPhase.IMPLEMENTATION,
         TaskPhase.TESTING,
+        TaskPhase.INTEGRATION,
         TaskPhase.DOCUMENTATION,
         TaskPhase.DEPLOYMENT,
     ]
@@ -93,6 +95,7 @@ class PhaseDependencyEnforcer:
         TaskType.INFRASTRUCTURE: TaskPhase.INFRASTRUCTURE,
         TaskType.IMPLEMENTATION: TaskPhase.IMPLEMENTATION,
         TaskType.TESTING: TaskPhase.TESTING,
+        TaskType.INTEGRATION: TaskPhase.INTEGRATION,
         TaskType.DOCUMENTATION: TaskPhase.DOCUMENTATION,
         TaskType.DEPLOYMENT: TaskPhase.DEPLOYMENT,
         TaskType.OTHER: TaskPhase.IMPLEMENTATION,  # Default to implementation

--- a/src/integrations/adaptive_documentation.py
+++ b/src/integrations/adaptive_documentation.py
@@ -275,7 +275,8 @@ class AdaptiveDocumentationGenerator:
         """Find appropriate dependencies for documentation task."""
         dependencies = []
 
-        # For README documentation, depend on all major implementation and test tasks
+        # For README documentation, depend on all major implementation,
+        # test, and integration verification tasks
         if doc_type == DocumentationType.README_DOCUMENTATION:
             for task in context.existing_tasks:
                 if any(
@@ -284,11 +285,15 @@ class AdaptiveDocumentationGenerator:
                         "type:feature",
                         "type:testing",
                         "type:deployment",
+                        "type:integration",
                         "component:backend",
                         "component:frontend",
                         "component:api",
                     ]
-                ) and task.priority in [Priority.HIGH, Priority.URGENT]:
+                ) and task.priority in [
+                    Priority.HIGH,
+                    Priority.URGENT,
+                ]:
                     dependencies.append(task.id)
 
         # For bug fixes, depend on fix implementation and testing

--- a/src/integrations/documentation_tasks.py
+++ b/src/integrations/documentation_tasks.py
@@ -85,15 +85,9 @@ class DocumentationTaskGenerator:
 
         # README documentation depends on ALL non-documentation tasks
         # This ensures it's only available when the entire project is
-        # complete
-        dependencies = [
-            t.id
-            for t in existing_tasks
-            if not any(
-                label in t.labels
-                for label in ["documentation", "final", "verification"]
-            )
-        ]
+        # complete. Integration verification tasks ARE dependencies —
+        # docs should wait for integration to finish.
+        dependencies = [t.id for t in existing_tasks if "documentation" not in t.labels]
 
         # CRITICAL VALIDATION: README documentation must depend on implementation tasks
         # If dependencies is empty but implementation tasks exist, this is a BUG

--- a/src/integrations/enhanced_task_classifier.py
+++ b/src/integrations/enhanced_task_classifier.py
@@ -261,6 +261,28 @@ class EnhancedTaskClassifier:
                 "migrate",
             ],
         },
+        TaskType.INTEGRATION: {
+            "primary": [
+                "integration verification",
+                "build verification",
+                "smoke test",
+                "startup verification",
+                "system verification",
+            ],
+            "secondary": [
+                "health check",
+                "port check",
+                "endpoint verification",
+                "runtime verification",
+                "startup check",
+            ],
+            "verbs": [
+                "verify integration",
+                "verify build",
+                "verify startup",
+                "smoke test",
+            ],
+        },
         TaskType.INFRASTRUCTURE: {
             "primary": [
                 "infrastructure",
@@ -351,6 +373,13 @@ class EnhancedTaskClassifier:
             r"(?:rollout|launch)\s+(?:the\s+)?(?:feature|update|version)",
             r"(?:migrate|upgrade)\s+(?:the\s+)?(?:production|live)\s+"
             r"(?:environment|system)",
+        ],
+        TaskType.INTEGRATION: [
+            r"(?:integration|build|startup)\s+verification",
+            r"(?:verify|check)\s+(?:the\s+)?(?:build|startup|integration)",
+            r"smoke\s+test\s+(?:the\s+)?(?:application|app|project)",
+            r"(?:verify|check)\s+(?:the\s+)?(?:app|application)\s+"
+            r"(?:works|runs|starts|responds)",
         ],
         TaskType.INFRASTRUCTURE: [
             r"(?:setup|configure)\s+(?:the\s+)?(?:ci/cd|pipeline|automation)",
@@ -593,6 +622,12 @@ class EnhancedTaskClassifier:
             elif (
                 label_lower in ["infrastructure", "devops", "setup"]
                 and task_type == TaskType.INFRASTRUCTURE
+            ):
+                label_boost += 8.0
+                matched_keywords.append(label_lower)
+            elif (
+                label_lower in ["integration", "integration verification"]
+                and task_type == TaskType.INTEGRATION
             ):
                 label_boost += 8.0
                 matched_keywords.append(label_lower)

--- a/src/integrations/integration_verification.py
+++ b/src/integrations/integration_verification.py
@@ -104,7 +104,7 @@ class IntegrationTaskGenerator:
             "Project builds without errors",
             "Application actually starts (startup output captured)",
             "Key endpoints hit with curl, full response captured",
-            "No missing components (APIs, modules, __init__.py)",
+            "No missing components detected",
             "All results include raw command output as evidence",
             "integration_verification.json artifact logged",
         ]
@@ -207,7 +207,6 @@ Fabricating output is worse than reporting a failure.
    - Find configuration files (package.json, pyproject.toml,
      Makefile, Dockerfile, Cargo.toml, go.mod, index.html, etc.)
    - Determine the appropriate build, install, and start commands
-   - Check that all __init__.py files exist for Python packages
    - Verify the project's module/package structure is complete
 
 3. **Run Tests**:
@@ -246,7 +245,6 @@ Fabricating output is worse than reporting a failure.
 8. **Check for Missing Components**:
    - Are there API calls to endpoints that don't exist?
    - Are there imports of modules that were never created?
-   - Are there missing __init__.py files in Python packages?
    - Are there references to services that weren't built?
    - Does the design spec describe components that have no code?
 

--- a/src/integrations/integration_verification.py
+++ b/src/integrations/integration_verification.py
@@ -1,0 +1,326 @@
+"""
+Integration Verification Task Generation for Marcus.
+
+Adds a verification task to projects that runs after implementation
+completes. The integration agent inspects the project, figures out
+how to build and start it, and reports whether the product actually
+works end-to-end.
+
+Phase 1: Visibility only — the task always completes (DONE) and
+reports pass/fail as an artifact. It does not block the experiment.
+"""
+
+import logging
+import uuid
+from datetime import datetime, timezone
+from typing import List, Optional
+
+from src.core.models import Priority, Task, TaskStatus
+
+logger = logging.getLogger(__name__)
+
+
+class IntegrationTaskGenerator:
+    """Generate integration verification tasks for projects.
+
+    Creates a task that runs after all implementation and testing tasks
+    complete. The assigned agent inspects the project structure, figures
+    out how to build/start it (regardless of language or framework),
+    and reports whether the product actually works.
+
+    Parameters
+    ----------
+    None
+
+    Examples
+    --------
+    >>> generator = IntegrationTaskGenerator()
+    >>> task = generator.create_integration_task(existing_tasks, "Dashboard")
+    >>> if task:
+    ...     tasks.append(task)
+    """
+
+    @staticmethod
+    def create_integration_task(
+        existing_tasks: List[Task],
+        project_name: str = "Project",
+    ) -> Optional[Task]:
+        """
+        Create an integration verification task.
+
+        Depends on all non-documentation, non-integration tasks.
+        Returns None if no implementation tasks exist.
+
+        Parameters
+        ----------
+        existing_tasks : List[Task]
+            List of all project tasks created so far.
+        project_name : str
+            Name of the project.
+
+        Returns
+        -------
+        Optional[Task]
+            Integration verification task, or None if no
+            implementation tasks exist.
+        """
+        # Check for implementation tasks
+        implementation_tasks = [
+            t
+            for t in existing_tasks
+            if any(
+                label in t.labels
+                for label in [
+                    "type:feature",
+                    "component:backend",
+                    "component:frontend",
+                    "component:api",
+                    "component:database",
+                    "component:authentication",
+                    "component:ecommerce",
+                ]
+            )
+        ]
+
+        if not implementation_tasks:
+            logger.info(
+                "No implementation tasks found, " "skipping integration verification"
+            )
+            return None
+
+        # Depend on ALL non-documentation, non-integration tasks
+        dependencies = [
+            t.id
+            for t in existing_tasks
+            if "documentation" not in t.labels and "type:integration" not in t.labels
+        ]
+
+        logger.info(
+            f"Integration verification task will depend on "
+            f"{len(dependencies)} tasks"
+        )
+
+        description = IntegrationTaskGenerator._generate_integration_description(
+            project_name
+        )
+
+        acceptance_criteria = [
+            "Project dependencies installed successfully",
+            "Project builds without errors",
+            "Application starts and responds to requests",
+            "Key endpoints/pages return expected content " "(not error HTML or 404)",
+            "No missing components detected " "(all referenced APIs/modules exist)",
+            "Results logged as integration_verification.json artifact",
+        ]
+
+        task = Task(
+            id=f"integration_verify_{uuid.uuid4().hex[:8]}",
+            name=(f"Integration verification for {project_name}"),
+            description=description,
+            status=TaskStatus.TODO,
+            priority=Priority.URGENT,
+            labels=["integration", "verification", "type:integration"],
+            dependencies=dependencies,
+            estimated_hours=1.0,
+            created_at=datetime.now(timezone.utc),
+            updated_at=datetime.now(timezone.utc),
+            assigned_to=None,
+            due_date=None,
+            acceptance_criteria=acceptance_criteria,
+        )
+
+        return task
+
+    @staticmethod
+    def should_add_integration_task(
+        project_description: str,
+    ) -> bool:
+        """
+        Determine if an integration task should be added.
+
+        Skips for prototypes, demos, experiments, and POCs.
+
+        Parameters
+        ----------
+        project_description : str
+            Natural language project description.
+
+        Returns
+        -------
+        bool
+            True if integration verification should be added.
+        """
+        skip_keywords = [
+            "poc",
+            "proof of concept",
+            "demo",
+            "experiment",
+            "test",
+        ]
+        description_lower = project_description.lower()
+
+        if any(keyword in description_lower for keyword in skip_keywords):
+            return False
+
+        return True
+
+    @staticmethod
+    def _generate_integration_description(
+        project_name: str,
+    ) -> str:
+        """
+        Generate the integration task description.
+
+        The description instructs the agent to inspect the project
+        and figure out how to verify it works, regardless of the
+        language, framework, or project type.
+
+        Parameters
+        ----------
+        project_name : str
+            Name of the project.
+
+        Returns
+        -------
+        str
+            Detailed task description with verification steps.
+        """
+        return f"""Verify that {project_name} actually builds, starts, \
+and works end-to-end.
+
+**IMPORTANT**: This is a verification task, not an implementation task. \
+Your job is to check whether the product works as built. Always mark \
+this task as DONE when finished — report failures in the artifact, \
+do NOT block the experiment.
+
+1. **Read Context**:
+   - Review design documents and architecture decisions
+   - Check README.md for documented build/start commands
+   - Use `get_task_context` for completed implementation tasks
+   - Understand what the project is supposed to do
+
+2. **Inspect the Project**:
+   - Look at the project structure and files
+   - Identify the language(s), framework(s), and build system
+   - Find configuration files (package.json, pyproject.toml,
+     Makefile, Dockerfile, Cargo.toml, go.mod, index.html, etc.)
+   - Determine the appropriate build, install, and start commands
+
+3. **Install Dependencies**:
+   - Run the appropriate install command for the project
+   - Log the exit code and any errors
+
+4. **Build the Project**:
+   - Run the appropriate build command
+   - If no build step is needed (e.g., static HTML), skip this
+   - Log the exit code and any errors
+
+5. **Start the Application**:
+   - Run the appropriate start command
+   - Wait for the application to be ready
+   - If the app is a static site, serve it with a simple server
+
+6. **Verify the Application Works**:
+   - Hit the main page/endpoint and check for a real response
+   - Check that key features described in the design actually work
+   - Look for error states (API calls returning HTML instead of
+     JSON, missing backends, broken imports)
+   - Verify that components built by different agents connect
+     properly
+
+7. **Check for Missing Components**:
+   - Are there API calls to endpoints that don't exist?
+   - Are there imports of modules that were never created?
+   - Are there references to services that weren't built?
+   - Does the design spec describe components that have no code?
+
+8. **Log Results**:
+   CRITICAL: Log verification results as an artifact:
+   ```
+   log_artifact(
+       task_id="<current_task_id>",
+       filename="integration_verification.json",
+       content="<json results>",
+       artifact_type="integration-verification",
+       project_root="<project_root>",
+       description="Integration verification results"
+   )
+   ```
+
+   JSON format:
+   ```json
+   {{
+     "project_name": "{project_name}",
+     "install": {{
+       "command": "...",
+       "exit_code": 0,
+       "success": true,
+       "output": "..."
+     }},
+     "build": {{
+       "command": "...",
+       "exit_code": 0,
+       "success": true,
+       "output": "..."
+     }},
+     "start": {{
+       "command": "...",
+       "success": true,
+       "output": "..."
+     }},
+     "health_check": {{
+       "url": "...",
+       "status_code": 200,
+       "success": true,
+       "response_type": "html/json/etc"
+     }},
+     "missing_components": [],
+     "overall_pass": true,
+     "remediation_notes": null
+   }}
+   ```
+
+9. **Always Complete the Task**:
+   - Mark this task as DONE regardless of pass/fail
+   - Set `overall_pass` to false if verification failed
+   - Include detailed `remediation_notes` describing what
+     failed and why
+"""
+
+
+def enhance_project_with_integration(
+    tasks: List[Task],
+    project_description: str,
+    project_name: str = "Project",
+) -> List[Task]:
+    """
+    Add integration verification task to project if appropriate.
+
+    Should be called BEFORE enhance_project_with_documentation()
+    so that the documentation task depends on the integration task.
+
+    Parameters
+    ----------
+    tasks : List[Task]
+        Original project tasks.
+    project_description : str
+        Project description.
+    project_name : str
+        Name of the project.
+
+    Returns
+    -------
+    List[Task]
+        Task list with integration task added if appropriate.
+    """
+    if not IntegrationTaskGenerator.should_add_integration_task(project_description):
+        logger.info("Skipping integration verification for this project")
+        return tasks
+
+    task = IntegrationTaskGenerator.create_integration_task(tasks, project_name)
+
+    if task:
+        logger.info(f"Added integration verification task: {task.name}")
+        return tasks + [task]
+
+    return tasks

--- a/src/integrations/integration_verification.py
+++ b/src/integrations/integration_verification.py
@@ -16,6 +16,7 @@ from datetime import datetime, timezone
 from typing import List, Optional
 
 from src.core.models import Priority, Task, TaskStatus
+from src.integrations.nlp_task_utils import TaskType
 
 logger = logging.getLogger(__name__)
 
@@ -64,23 +65,16 @@ class IntegrationTaskGenerator:
             Integration verification task, or None if no
             implementation tasks exist.
         """
-        # Check for implementation tasks
-        implementation_tasks = [
-            t
-            for t in existing_tasks
-            if any(
-                label in t.labels
-                for label in [
-                    "type:feature",
-                    "component:backend",
-                    "component:frontend",
-                    "component:api",
-                    "component:database",
-                    "component:authentication",
-                    "component:ecommerce",
-                ]
-            )
-        ]
+        # Check for implementation tasks using the classifier
+        # (not hardcoded labels, which AI-generated tasks may not have)
+        from src.integrations.enhanced_task_classifier import (
+            EnhancedTaskClassifier,
+        )
+
+        classifier = EnhancedTaskClassifier()
+        implementation_tasks = classifier.filter_by_type(
+            existing_tasks, TaskType.IMPLEMENTATION
+        )
 
         if not implementation_tasks:
             logger.info(

--- a/src/integrations/integration_verification.py
+++ b/src/integrations/integration_verification.py
@@ -99,12 +99,14 @@ class IntegrationTaskGenerator:
         )
 
         acceptance_criteria = [
+            "Tests run with full terminal output captured",
             "Project dependencies installed successfully",
             "Project builds without errors",
-            "Application starts and responds to requests",
-            "Key endpoints/pages return expected content " "(not error HTML or 404)",
-            "No missing components detected " "(all referenced APIs/modules exist)",
-            "Results logged as integration_verification.json artifact",
+            "Application actually starts (startup output captured)",
+            "Key endpoints hit with curl, full response captured",
+            "No missing components (APIs, modules, __init__.py)",
+            "All results include raw command output as evidence",
+            "integration_verification.json artifact logged",
         ]
 
         task = Task(
@@ -187,6 +189,12 @@ Your job is to check whether the product works as built. Always mark \
 this task as DONE when finished — report failures in the artifact, \
 do NOT block the experiment.
 
+**CRITICAL RULE — EVIDENCE REQUIRED**: Every step below MUST include \
+the actual command you ran AND its real stdout/stderr output. Do NOT \
+summarize, paraphrase, or claim a command succeeded without showing \
+the output. If you cannot run a command, say so explicitly. \
+Fabricating output is worse than reporting a failure.
+
 1. **Read Context**:
    - Review design documents and architecture decisions
    - Check README.md for documented build/start commands
@@ -199,37 +207,53 @@ do NOT block the experiment.
    - Find configuration files (package.json, pyproject.toml,
      Makefile, Dockerfile, Cargo.toml, go.mod, index.html, etc.)
    - Determine the appropriate build, install, and start commands
+   - Check that all __init__.py files exist for Python packages
+   - Verify the project's module/package structure is complete
 
-3. **Install Dependencies**:
+3. **Run Tests**:
+   - Run the project's test suite (pytest, npm test, etc.)
+   - Capture the FULL terminal output (not a summary)
+   - Record: command, exit code, pass/fail counts, raw output
+   - If tests fail, record the actual error messages
+
+4. **Install Dependencies**:
    - Run the appropriate install command for the project
-   - Log the exit code and any errors
+   - Capture the FULL terminal output
+   - Record: command, exit code, raw output
 
-4. **Build the Project**:
+5. **Build the Project**:
    - Run the appropriate build command
    - If no build step is needed (e.g., static HTML), skip this
-   - Log the exit code and any errors
+   - Capture the FULL terminal output
+   - Record: command, exit code, raw output
 
-5. **Start the Application**:
+6. **Start the Application**:
    - Run the appropriate start command
-   - Wait for the application to be ready
+   - Wait for the application to be ready (5-10 seconds)
+   - Capture any startup output or errors
+   - If the app fails to start, record the exact error
    - If the app is a static site, serve it with a simple server
 
-6. **Verify the Application Works**:
-   - Hit the main page/endpoint and check for a real response
-   - Check that key features described in the design actually work
+7. **Verify the Application Responds**:
+   - Run `curl` against the main page/endpoint
+   - Capture the FULL curl output including HTTP status
+   - Check that key features described in the design work
    - Look for error states (API calls returning HTML instead of
      JSON, missing backends, broken imports)
    - Verify that components built by different agents connect
-     properly
+   - Record each curl command and its full response
 
-7. **Check for Missing Components**:
+8. **Check for Missing Components**:
    - Are there API calls to endpoints that don't exist?
    - Are there imports of modules that were never created?
+   - Are there missing __init__.py files in Python packages?
    - Are there references to services that weren't built?
    - Does the design spec describe components that have no code?
 
-8. **Log Results**:
-   CRITICAL: Log verification results as an artifact:
+9. **Log Results**:
+   CRITICAL: Log verification results as an artifact. Every field \
+in the JSON below MUST contain real command output, not summaries.
+
    ```
    log_artifact(
        task_id="<current_task_id>",
@@ -245,40 +269,54 @@ do NOT block the experiment.
    ```json
    {{
      "project_name": "{project_name}",
+     "tests": {{
+       "command": "pytest tests/ -v",
+       "exit_code": 0,
+       "passed": 45,
+       "failed": 0,
+       "success": true,
+       "raw_output": "<PASTE FULL TERMINAL OUTPUT HERE>"
+     }},
      "install": {{
-       "command": "...",
+       "command": "pip install -r requirements.txt",
        "exit_code": 0,
        "success": true,
-       "output": "..."
+       "raw_output": "<PASTE FULL TERMINAL OUTPUT HERE>"
      }},
      "build": {{
-       "command": "...",
+       "command": "npm run build",
        "exit_code": 0,
        "success": true,
-       "output": "..."
+       "raw_output": "<PASTE FULL TERMINAL OUTPUT HERE>"
      }},
      "start": {{
-       "command": "...",
+       "command": "uvicorn src.backend.main:app",
        "success": true,
-       "output": "..."
+       "raw_output": "<PASTE STARTUP OUTPUT HERE>"
      }},
-     "health_check": {{
-       "url": "...",
-       "status_code": 200,
-       "success": true,
-       "response_type": "html/json/etc"
-     }},
+     "health_checks": [
+       {{
+         "url": "http://localhost:8000/api/health",
+         "curl_command": "curl -s http://localhost:8000/api/health",
+         "status_code": 200,
+         "success": true,
+         "raw_response": "<PASTE FULL CURL RESPONSE HERE>"
+       }}
+     ],
      "missing_components": [],
      "overall_pass": true,
      "remediation_notes": null
    }}
    ```
 
-9. **Always Complete the Task**:
-   - Mark this task as DONE regardless of pass/fail
-   - Set `overall_pass` to false if verification failed
-   - Include detailed `remediation_notes` describing what
-     failed and why
+   If a command fails, set success=false and paste the error output.
+   Do NOT set success=true unless you have real output proving it.
+
+10. **Always Complete the Task**:
+    - Mark this task as DONE regardless of pass/fail
+    - Set `overall_pass` to false if verification failed
+    - Include detailed `remediation_notes` describing what
+      failed and why
 """
 
 

--- a/src/integrations/nlp_task_utils.py
+++ b/src/integrations/nlp_task_utils.py
@@ -20,6 +20,7 @@ class TaskType(Enum):
     DEPLOYMENT = "deployment"
     IMPLEMENTATION = "implementation"
     TESTING = "testing"
+    INTEGRATION = "integration"
     DOCUMENTATION = "documentation"
     INFRASTRUCTURE = "infrastructure"
     OTHER = "other"
@@ -83,9 +84,17 @@ class TaskClassifier:
             "check",
             "assert",
             "unittest",
-            "integration",
             "e2e",
             "coverage",
+        ],
+        TaskType.INTEGRATION: [
+            "integration verification",
+            "build verification",
+            "smoke test",
+            "startup verification",
+            "system verification",
+            "health check",
+            "endpoint verification",
         ],
         TaskType.DOCUMENTATION: [
             "document",
@@ -134,6 +143,7 @@ class TaskClassifier:
         # Testing should be checked before Implementation to catch "Write tests" tasks
         priority_order = [
             TaskType.DEPLOYMENT,  # Most specific - deployment keywords are unique
+            TaskType.INTEGRATION,  # Check before testing (multi-word keywords)
             TaskType.TESTING,  # Check before implementation to catch "write tests"
             TaskType.DOCUMENTATION,  # Check before implementation to catch "write docs"
             TaskType.DESIGN,  # Check before implementation to catch "design API"

--- a/src/integrations/nlp_tools.py
+++ b/src/integrations/nlp_tools.py
@@ -287,6 +287,20 @@ class NaturalLanguageProjectCreator(NaturalLanguageTaskCreator):
                 safe_tasks = await self.apply_safety_checks(tasks)
                 logger.info(f"Safety checks passed, {len(safe_tasks)} tasks ready")
 
+                # Add integration verification task if appropriate
+                # Must be added BEFORE documentation so doc task
+                # depends on integration task
+                from src.integrations.integration_verification import (
+                    enhance_project_with_integration,
+                )
+
+                safe_tasks = enhance_project_with_integration(
+                    safe_tasks, description, project_name
+                )
+                logger.info(
+                    "After integration enhancement: " f"{len(safe_tasks)} tasks"
+                )
+
                 # Add documentation task if appropriate
                 from src.integrations.documentation_tasks import (
                     enhance_project_with_documentation,
@@ -295,7 +309,9 @@ class NaturalLanguageProjectCreator(NaturalLanguageTaskCreator):
                 safe_tasks = enhance_project_with_documentation(
                     safe_tasks, description, project_name
                 )
-                logger.info(f"After documentation enhancement: {len(safe_tasks)} tasks")
+                logger.info(
+                    "After documentation enhancement: " f"{len(safe_tasks)} tasks"
+                )
 
                 # Log safety check impact
                 added_tasks = len(safe_tasks) - len(tasks)

--- a/src/marcus_mcp/coordinator/dependency_wiring.py
+++ b/src/marcus_mcp/coordinator/dependency_wiring.py
@@ -347,7 +347,13 @@ def extract_phase(task_name: str) -> Optional[str]:
         or None if no phase could be determined
     """
     name_lower = task_name.lower()
-    phase_order = {"design": 0, "implement": 1, "test": 2, "integration": 3}
+    phase_order = {
+        "design": 0,
+        "implement": 1,
+        "test": 2,
+        "integration": 3,
+        "documentation": 4,
+    }
 
     # First check: Is this a test task? (most specific)
     if detect_test_task(task_name):
@@ -391,7 +397,13 @@ def validate_phase_order(subtask: Task, dependency_task: Task) -> bool:
     bool
         True if phase ordering is valid
     """
-    phase_order = {"design": 0, "implement": 1, "test": 2, "integration": 3}
+    phase_order = {
+        "design": 0,
+        "implement": 1,
+        "test": 2,
+        "integration": 3,
+        "documentation": 4,
+    }
 
     subtask_phase = extract_phase(subtask.name)
     dep_phase = extract_phase(dependency_task.name)

--- a/tests/unit/integrations/test_integration_verification.py
+++ b/tests/unit/integrations/test_integration_verification.py
@@ -1,0 +1,486 @@
+"""
+Unit tests for Integration Verification Task Generator.
+
+Tests the integration verification phase that runs after implementation
+completes to verify the project actually builds, starts, and works.
+"""
+
+import uuid
+from datetime import datetime, timezone
+from unittest.mock import patch
+
+import pytest
+
+from src.core.models import Priority, Task, TaskStatus
+from src.integrations.nlp_task_utils import TaskType
+
+
+def create_test_task(
+    task_id: str,
+    name: str,
+    labels: list[str] | None = None,
+    priority: Priority = Priority.HIGH,
+    status: TaskStatus = TaskStatus.TODO,
+    dependencies: list[str] | None = None,
+) -> Task:
+    """Create a test task with sensible defaults."""
+    return Task(
+        id=task_id,
+        name=name,
+        description=f"Description for {name}",
+        status=status,
+        priority=priority,
+        assigned_to=None,
+        created_at=datetime.now(timezone.utc),
+        updated_at=datetime.now(timezone.utc),
+        due_date=None,
+        estimated_hours=4.0,
+        labels=labels or [],
+        dependencies=dependencies or [],
+    )
+
+
+@pytest.fixture
+def sample_implementation_tasks() -> list[Task]:
+    """Create sample implementation tasks for testing."""
+    return [
+        create_test_task(
+            "impl-001",
+            "Build weather widget",
+            labels=["type:feature", "component:frontend"],
+        ),
+        create_test_task(
+            "impl-002",
+            "Build clock widget",
+            labels=["type:feature", "component:frontend"],
+        ),
+    ]
+
+
+@pytest.fixture
+def sample_testing_tasks() -> list[Task]:
+    """Create sample testing tasks for testing."""
+    return [
+        create_test_task(
+            "test-001",
+            "Write widget tests",
+            labels=["type:testing"],
+        ),
+    ]
+
+
+@pytest.fixture
+def sample_design_tasks() -> list[Task]:
+    """Create sample design tasks for testing."""
+    return [
+        create_test_task(
+            "design-001",
+            "Design dashboard architecture",
+            labels=["type:design"],
+        ),
+    ]
+
+
+@pytest.fixture
+def all_sample_tasks(
+    sample_design_tasks: list[Task],
+    sample_implementation_tasks: list[Task],
+    sample_testing_tasks: list[Task],
+) -> list[Task]:
+    """Combine all sample tasks."""
+    return sample_design_tasks + sample_implementation_tasks + sample_testing_tasks
+
+
+class TestIntegrationTaskGenerator:
+    """Test suite for IntegrationTaskGenerator."""
+
+    def test_creates_task_with_correct_dependencies(
+        self, all_sample_tasks: list[Task]
+    ) -> None:
+        """Test integration task depends on all impl and test tasks."""
+        from src.integrations.integration_verification import (
+            IntegrationTaskGenerator,
+        )
+
+        task = IntegrationTaskGenerator.create_integration_task(
+            all_sample_tasks, "Dashboard"
+        )
+
+        assert task is not None
+        # Should depend on design, impl, and test tasks
+        assert "design-001" in task.dependencies
+        assert "impl-001" in task.dependencies
+        assert "impl-002" in task.dependencies
+        assert "test-001" in task.dependencies
+
+    def test_no_task_when_no_implementation_tasks(self) -> None:
+        """Test returns None when no implementation tasks exist."""
+        from src.integrations.integration_verification import (
+            IntegrationTaskGenerator,
+        )
+
+        design_only = [
+            create_test_task(
+                "design-001",
+                "Design system",
+                labels=["type:design"],
+            ),
+        ]
+        task = IntegrationTaskGenerator.create_integration_task(design_only, "Project")
+
+        assert task is None
+
+    def test_task_labels_correct(self, all_sample_tasks: list[Task]) -> None:
+        """Test integration task has correct labels."""
+        from src.integrations.integration_verification import (
+            IntegrationTaskGenerator,
+        )
+
+        task = IntegrationTaskGenerator.create_integration_task(
+            all_sample_tasks, "Dashboard"
+        )
+
+        assert task is not None
+        assert "integration" in task.labels
+        assert "verification" in task.labels
+        assert "type:integration" in task.labels
+
+    def test_task_priority_urgent(self, all_sample_tasks: list[Task]) -> None:
+        """Test integration task has URGENT priority."""
+        from src.integrations.integration_verification import (
+            IntegrationTaskGenerator,
+        )
+
+        task = IntegrationTaskGenerator.create_integration_task(
+            all_sample_tasks, "Dashboard"
+        )
+
+        assert task is not None
+        assert task.priority == Priority.URGENT
+
+    def test_task_description_includes_verification_steps(
+        self, all_sample_tasks: list[Task]
+    ) -> None:
+        """Test task description includes key verification instructions."""
+        from src.integrations.integration_verification import (
+            IntegrationTaskGenerator,
+        )
+
+        task = IntegrationTaskGenerator.create_integration_task(
+            all_sample_tasks, "Dashboard"
+        )
+
+        assert task is not None
+        desc = task.description
+        # Should mention key verification steps
+        assert "build" in desc.lower()
+        assert "start" in desc.lower()
+        assert "verify" in desc.lower()
+        assert "integration_verification.json" in desc
+        assert "log_artifact" in desc
+
+    def test_task_id_format(self, all_sample_tasks: list[Task]) -> None:
+        """Test integration task ID starts with correct prefix."""
+        from src.integrations.integration_verification import (
+            IntegrationTaskGenerator,
+        )
+
+        task = IntegrationTaskGenerator.create_integration_task(
+            all_sample_tasks, "Dashboard"
+        )
+
+        assert task is not None
+        assert task.id.startswith("integration_verify_")
+
+    def test_acceptance_criteria_set(self, all_sample_tasks: list[Task]) -> None:
+        """Test integration task has meaningful acceptance criteria."""
+        from src.integrations.integration_verification import (
+            IntegrationTaskGenerator,
+        )
+
+        task = IntegrationTaskGenerator.create_integration_task(
+            all_sample_tasks, "Dashboard"
+        )
+
+        assert task is not None
+        assert task.acceptance_criteria is not None
+        assert len(task.acceptance_criteria) > 0
+
+    def test_task_status_is_todo(self, all_sample_tasks: list[Task]) -> None:
+        """Test integration task starts in TODO status."""
+        from src.integrations.integration_verification import (
+            IntegrationTaskGenerator,
+        )
+
+        task = IntegrationTaskGenerator.create_integration_task(
+            all_sample_tasks, "Dashboard"
+        )
+
+        assert task is not None
+        assert task.status == TaskStatus.TODO
+
+    def test_task_name_includes_project_name(
+        self, all_sample_tasks: list[Task]
+    ) -> None:
+        """Test integration task name includes the project name."""
+        from src.integrations.integration_verification import (
+            IntegrationTaskGenerator,
+        )
+
+        task = IntegrationTaskGenerator.create_integration_task(
+            all_sample_tasks, "My Dashboard"
+        )
+
+        assert task is not None
+        assert "My Dashboard" in task.name
+
+
+class TestEnhanceProjectWithIntegration:
+    """Test suite for enhance_project_with_integration function."""
+
+    def test_adds_integration_task_to_task_list(
+        self, all_sample_tasks: list[Task]
+    ) -> None:
+        """Test that integration task is added to task list."""
+        from src.integrations.integration_verification import (
+            enhance_project_with_integration,
+        )
+
+        result = enhance_project_with_integration(
+            all_sample_tasks, "Build a dashboard app", "Dashboard"
+        )
+
+        assert len(result) == len(all_sample_tasks) + 1
+        integration_tasks = [t for t in result if "integration" in t.labels]
+        assert len(integration_tasks) == 1
+
+    def test_skips_poc_projects(self, all_sample_tasks: list[Task]) -> None:
+        """Test that POC projects don't get integration tasks."""
+        from src.integrations.integration_verification import (
+            enhance_project_with_integration,
+        )
+
+        result = enhance_project_with_integration(
+            all_sample_tasks, "Build a poc dashboard", "Dashboard"
+        )
+
+        assert len(result) == len(all_sample_tasks)
+
+    def test_skips_demo_projects(self, all_sample_tasks: list[Task]) -> None:
+        """Test that demo projects don't get integration tasks."""
+        from src.integrations.integration_verification import (
+            enhance_project_with_integration,
+        )
+
+        result = enhance_project_with_integration(
+            all_sample_tasks, "Build a demo app", "Dashboard"
+        )
+
+        assert len(result) == len(all_sample_tasks)
+
+    def test_documentation_depends_on_integration(
+        self, all_sample_tasks: list[Task]
+    ) -> None:
+        """Test doc task includes integration task in dependencies."""
+        from src.integrations.documentation_tasks import (
+            DocumentationTaskGenerator,
+        )
+        from src.integrations.integration_verification import (
+            enhance_project_with_integration,
+        )
+
+        # First add integration task
+        tasks_with_integration = enhance_project_with_integration(
+            all_sample_tasks,
+            "Build a dashboard app",
+            "Dashboard",
+        )
+
+        # Find the integration task
+        integration_task = next(
+            t for t in tasks_with_integration if "integration" in t.labels
+        )
+
+        # Now create documentation task from the updated list
+        doc_task = DocumentationTaskGenerator.create_documentation_task(
+            tasks_with_integration, "Dashboard"
+        )
+
+        assert doc_task is not None
+        assert integration_task.id in doc_task.dependencies
+
+    def test_returns_unchanged_when_no_impl_tasks(self) -> None:
+        """Test returns original tasks when no impl tasks exist."""
+        from src.integrations.integration_verification import (
+            enhance_project_with_integration,
+        )
+
+        design_only = [
+            create_test_task(
+                "design-001",
+                "Design system",
+                labels=["type:design"],
+            ),
+        ]
+        result = enhance_project_with_integration(
+            design_only, "Build a system", "System"
+        )
+
+        assert len(result) == len(design_only)
+
+
+class TestPhaseEnumUpdates:
+    """Test that INTEGRATION is properly added to phase enums."""
+
+    def test_integration_phase_exists(self) -> None:
+        """Test TaskPhase.INTEGRATION exists."""
+        from src.core.phase_dependency_enforcer import TaskPhase
+
+        assert hasattr(TaskPhase, "INTEGRATION")
+
+    def test_integration_phase_between_testing_and_documentation(
+        self,
+    ) -> None:
+        """Test INTEGRATION phase is ordered between TESTING and DOCS."""
+        from src.core.phase_dependency_enforcer import TaskPhase
+
+        assert TaskPhase.TESTING.value < TaskPhase.INTEGRATION.value
+        assert TaskPhase.INTEGRATION.value < TaskPhase.DOCUMENTATION.value
+
+    def test_integration_type_exists(self) -> None:
+        """Test TaskType.INTEGRATION exists."""
+        assert hasattr(TaskType, "INTEGRATION")
+        assert TaskType.INTEGRATION.value == "integration"
+
+    def test_type_to_phase_mapping(self) -> None:
+        """Test TaskType.INTEGRATION maps to TaskPhase.INTEGRATION."""
+        from src.core.phase_dependency_enforcer import (
+            PhaseDependencyEnforcer,
+            TaskPhase,
+        )
+
+        mapping = PhaseDependencyEnforcer.TYPE_TO_PHASE_MAP
+        assert TaskType.INTEGRATION in mapping
+        assert mapping[TaskType.INTEGRATION] == TaskPhase.INTEGRATION
+
+    def test_integration_in_phase_order(self) -> None:
+        """Test INTEGRATION is in PHASE_ORDER list."""
+        from src.core.phase_dependency_enforcer import (
+            PhaseDependencyEnforcer,
+            TaskPhase,
+        )
+
+        assert TaskPhase.INTEGRATION in PhaseDependencyEnforcer.PHASE_ORDER
+        # Should be after TESTING and before DOCUMENTATION
+        order = PhaseDependencyEnforcer.PHASE_ORDER
+        testing_idx = order.index(TaskPhase.TESTING)
+        integration_idx = order.index(TaskPhase.INTEGRATION)
+        doc_idx = order.index(TaskPhase.DOCUMENTATION)
+        assert testing_idx < integration_idx < doc_idx
+
+
+class TestIntegrationTaskClassification:
+    """Test that integration tasks are classified correctly."""
+
+    def test_classify_integration_verification_task(self) -> None:
+        """Test task with 'integration verification' is classified."""
+        from src.integrations.enhanced_task_classifier import (
+            EnhancedTaskClassifier,
+        )
+
+        classifier = EnhancedTaskClassifier()
+        task = create_test_task(
+            "int-001",
+            "Integration verification for Dashboard",
+            labels=["integration", "verification"],
+        )
+
+        result = classifier.classify(task)
+        assert result == TaskType.INTEGRATION
+
+    def test_classify_build_verification_task(self) -> None:
+        """Test task with 'build verification' is classified."""
+        from src.integrations.enhanced_task_classifier import (
+            EnhancedTaskClassifier,
+        )
+
+        classifier = EnhancedTaskClassifier()
+        task = create_test_task(
+            "int-002",
+            "Build verification and smoke test",
+            labels=["integration"],
+        )
+
+        result = classifier.classify(task)
+        assert result == TaskType.INTEGRATION
+
+    def test_integration_not_confused_with_testing(self) -> None:
+        """Test 'Write integration tests' classifies as TESTING."""
+        from src.integrations.enhanced_task_classifier import (
+            EnhancedTaskClassifier,
+        )
+
+        classifier = EnhancedTaskClassifier()
+        task = create_test_task(
+            "test-002",
+            "Write integration tests for API",
+            labels=["type:testing"],
+        )
+
+        result = classifier.classify(task)
+        # Should be TESTING, not INTEGRATION
+        assert result == TaskType.TESTING
+
+
+class TestShouldAddIntegrationTask:
+    """Test the should_add_integration_task decision logic."""
+
+    def test_normal_project_gets_integration(self) -> None:
+        """Test normal projects get integration verification."""
+        from src.integrations.integration_verification import (
+            IntegrationTaskGenerator,
+        )
+
+        assert IntegrationTaskGenerator.should_add_integration_task(
+            "Build an e-commerce platform"
+        )
+
+    def test_poc_skips_integration(self) -> None:
+        """Test POC projects skip integration verification."""
+        from src.integrations.integration_verification import (
+            IntegrationTaskGenerator,
+        )
+
+        assert not IntegrationTaskGenerator.should_add_integration_task(
+            "Build a poc to test the idea"
+        )
+
+    def test_proof_of_concept_skips_integration(self) -> None:
+        """Test proof of concept projects skip integration."""
+        from src.integrations.integration_verification import (
+            IntegrationTaskGenerator,
+        )
+
+        assert not IntegrationTaskGenerator.should_add_integration_task(
+            "Proof of concept for new API"
+        )
+
+    def test_demo_skips_integration(self) -> None:
+        """Test demo projects skip integration verification."""
+        from src.integrations.integration_verification import (
+            IntegrationTaskGenerator,
+        )
+
+        assert not IntegrationTaskGenerator.should_add_integration_task(
+            "Create a demo for the team"
+        )
+
+    def test_experiment_skips_integration(self) -> None:
+        """Test experiment projects skip integration verification."""
+        from src.integrations.integration_verification import (
+            IntegrationTaskGenerator,
+        )
+
+        assert not IntegrationTaskGenerator.should_add_integration_task(
+            "Experiment with new rendering"
+        )

--- a/tests/unit/integrations/test_integration_verification.py
+++ b/tests/unit/integrations/test_integration_verification.py
@@ -42,17 +42,21 @@ def create_test_task(
 
 @pytest.fixture
 def sample_implementation_tasks() -> list[Task]:
-    """Create sample implementation tasks for testing."""
+    """Create sample implementation tasks for testing.
+
+    Uses realistic AI-generated labels (not hardcoded type:feature).
+    The classifier detects implementation from the task name.
+    """
     return [
         create_test_task(
             "impl-001",
             "Build weather widget",
-            labels=["type:feature", "component:frontend"],
+            labels=["implement", "frontend"],
         ),
         create_test_task(
             "impl-002",
             "Build clock widget",
-            labels=["type:feature", "component:frontend"],
+            labels=["implement", "frontend"],
         ),
     ]
 
@@ -64,7 +68,7 @@ def sample_testing_tasks() -> list[Task]:
         create_test_task(
             "test-001",
             "Write widget tests",
-            labels=["type:testing"],
+            labels=["testing"],
         ),
     ]
 
@@ -76,7 +80,7 @@ def sample_design_tasks() -> list[Task]:
         create_test_task(
             "design-001",
             "Design dashboard architecture",
-            labels=["type:design"],
+            labels=["design"],
         ),
     ]
 
@@ -234,6 +238,42 @@ class TestIntegrationTaskGenerator:
         assert task is not None
         assert "My Dashboard" in task.name
 
+    def test_works_with_generic_ai_labels(self) -> None:
+        """Test integration task created with generic labels.
+
+        AI-generated tasks often have simple labels like 'implement'
+        instead of 'type:feature'. The classifier should still detect
+        them as implementation tasks.
+        """
+        from src.integrations.integration_verification import (
+            IntegrationTaskGenerator,
+        )
+
+        tasks = [
+            create_test_task(
+                "t1",
+                "Design the system",
+                labels=["design"],
+            ),
+            create_test_task(
+                "t2",
+                "Build the backend API",
+                labels=["implement", "backend"],
+            ),
+            create_test_task(
+                "t3",
+                "Build the frontend UI",
+                labels=["frontend"],
+            ),
+        ]
+
+        task = IntegrationTaskGenerator.create_integration_task(tasks, "Dashboard")
+
+        assert task is not None, (
+            "Integration task should be created even with generic "
+            "AI-generated labels (not type:feature)"
+        )
+
 
 class TestEnhanceProjectWithIntegration:
     """Test suite for enhance_project_with_integration function."""
@@ -278,9 +318,7 @@ class TestEnhanceProjectWithIntegration:
 
         assert len(result) == len(all_sample_tasks)
 
-    def test_documentation_depends_on_integration(
-        self, all_sample_tasks: list[Task]
-    ) -> None:
+    def test_documentation_depends_on_integration(self) -> None:
         """Test doc task includes integration task in dependencies."""
         from src.integrations.documentation_tasks import (
             DocumentationTaskGenerator,
@@ -289,9 +327,29 @@ class TestEnhanceProjectWithIntegration:
             enhance_project_with_integration,
         )
 
+        # Use type:feature labels so DocumentationTaskGenerator
+        # also recognizes them (it still uses hardcoded labels)
+        tasks_with_typed_labels = [
+            create_test_task(
+                "design-001",
+                "Design dashboard architecture",
+                labels=["type:design"],
+            ),
+            create_test_task(
+                "impl-001",
+                "Build weather widget",
+                labels=["type:feature", "component:frontend"],
+            ),
+            create_test_task(
+                "test-001",
+                "Write widget tests",
+                labels=["type:testing"],
+            ),
+        ]
+
         # First add integration task
         tasks_with_integration = enhance_project_with_integration(
-            all_sample_tasks,
+            tasks_with_typed_labels,
             "Build a dashboard app",
             "Dashboard",
         )


### PR DESCRIPTION
## Summary
- Adds an integration verification phase that runs after implementation tasks complete
- Uses AI classifier instead of hardcoded labels to detect implementation tasks
- Requires raw command output as evidence (not agent summaries)
- Removes language-specific checks for broader applicability

## Commits
- `feat: add Integration Verification phase after implementation tasks (#271)`
- `fix: use classifier instead of hardcoded labels for impl task detection`
- `fix: require raw command output evidence in integration verification`
- `fix: remove language-specific checks from integration verification`

## Test plan
- [ ] Unit tests pass: `pytest tests/unit/integrations/test_integration_verification.py`
- [ ] Verify classifier correctly identifies implementation vs design tasks
- [ ] Run an experiment and confirm verification triggers after impl tasks

🤖 Generated with [Claude Code](https://claude.com/claude-code)