### PR TITLE
feat: instrument get_task_context with agent event logging (#285)

### DIFF
--- a/src/marcus_mcp/tools/context.py
+++ b/src/marcus_mcp/tools/context.py
@@ -12,6 +12,7 @@ from src.core.project_history import Decision as HistoryDecision
 from src.core.project_history import (
     ProjectHistoryPersistence,
 )
+from src.logging.agent_events import log_agent_event
 
 logger = logging.getLogger(__name__)
 
@@ -136,6 +137,18 @@ async def get_task_context(task_id: str, state: Any) -> Dict[str, Any]:
         decisions. For subtasks, includes parent_task, shared_conventions,
         and dependency_artifacts.
     """
+    # Log to agent events — proof the agent called get_task_context
+    agent_id = getattr(state, "_current_client_id", None) or "unknown"
+    project_name = getattr(state, "current_project_name", None) or "unknown"
+    log_agent_event(
+        "context_requested",
+        {
+            "agent_id": agent_id,
+            "task_id": task_id,
+            "project": project_name,
+        },
+    )
+
     try:
         # Check if this is a subtask
         if hasattr(state, "subtask_manager") and state.subtask_manager:

--- a/src/marcus_mcp/tools/context.py
+++ b/src/marcus_mcp/tools/context.py
@@ -138,7 +138,14 @@ async def get_task_context(task_id: str, state: Any) -> Dict[str, Any]:
         and dependency_artifacts.
     """
     # Log to agent events — proof the agent called get_task_context
-    agent_id = getattr(state, "_current_client_id", None) or "unknown"
+    # Resolve agent_id: try authenticated client first, then task assignment
+    agent_id = getattr(state, "_current_client_id", None)
+    if not agent_id and hasattr(state, "project_tasks"):
+        for t in state.project_tasks:
+            if t.id == task_id and t.assigned_to:
+                agent_id = t.assigned_to
+                break
+    agent_id = agent_id or "unknown"
     project_name = getattr(state, "current_project_name", None) or "unknown"
     log_agent_event(
         "context_requested",

--- a/tests/unit/mcp/test_context_tools.py
+++ b/tests/unit/mcp/test_context_tools.py
@@ -6,7 +6,7 @@ Tests the get_task_context and log_decision functions in the context module.
 
 from datetime import datetime, timezone
 from typing import Any, Dict, List
-from unittest.mock import AsyncMock, Mock
+from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 
@@ -431,6 +431,24 @@ class TestGetTaskContext:
         assert context["parent_task"]["id"] == "parent-task-1"
         assert "shared_conventions" in context
         assert "sibling_subtasks" in context
+
+    @pytest.mark.asyncio
+    async def test_get_task_context_logs_agent_event(self, mock_state, sample_task):
+        """Test that get_task_context writes a context_requested agent event."""
+        # Arrange
+        mock_state.project_tasks = [sample_task]
+        mock_state._current_client_id = "agent-2"
+
+        with patch("src.marcus_mcp.tools.context.log_agent_event") as mock_log:
+            # Act
+            result = await get_task_context("test-task-1", mock_state)
+
+        # Assert
+        assert result["success"] is True
+        mock_log.assert_called_once_with(
+            "context_requested",
+            {"agent_id": "agent-2", "task_id": "test-task-1", "project": "unknown"},
+        )
 
 
 class TestLogDecision:


### PR DESCRIPTION
## Summary
- Adds `log_agent_event("context_requested", ...)` to `get_task_context` so we have proof agents called the tool
- Resolves agent_id from task assignment when `_current_client_id` is not set (which is the case in real experiments)
- Events written to `logs/agent_events/` alongside existing task_request, task_assignment, progress_update events

## Usage
```bash
# Check if any agent called get_task_context in an experiment
grep 'context_requested' logs/agent_events/agent_events_*.jsonl

# Filter by experiment
grep 'dashboard-v12' logs/agent_events/agent_events_*.jsonl | grep 'context_requested'
```

## Commits
- `feat: instrument get_task_context with agent event logging (#285)`
- `fix: resolve agent_id from task assignment when client_id unavailable`

## Related
- Closes Step 1 of #285
- Supersedes #196

## Test plan
- [ ] Unit tests pass: `pytest tests/unit/mcp/test_context_tools.py`
- [ ] Run experiment and verify `context_requested` events appear in agent event logs
- [ ] Confirmed working in dashboard-v12 experiment (8 events captured)

🤖 Generated with [Claude Code](https://claude.com/claude-code)