### PR TITLE
fix: improve agent startup reliability in detached tmux sessions

### DIFF
--- a/dev-tools/experiments/runners/spawn_agents.py
+++ b/dev-tools/experiments/runners/spawn_agents.py
@@ -247,6 +247,51 @@ class AgentSpawner:
         self.current_window = 0
         self.current_pane = 0
 
+    @staticmethod
+    def _pretrust_directory(directory: Path) -> None:
+        """Pre-trust a directory in ~/.claude.json.
+
+        Marks the directory as trusted so Claude skips the
+        'Do you trust this folder?' prompt.
+
+        Parameters
+        ----------
+        directory : Path
+            Directory to mark as trusted.
+        """
+        claude_json = Path.home() / ".claude.json"
+        try:
+            if claude_json.exists():
+                with open(claude_json, "r") as f:
+                    config = json.load(f)
+            else:
+                config = {}
+
+            projects = config.setdefault("projects", {})
+            dir_key = str(directory)
+
+            if dir_key not in projects:
+                projects[dir_key] = {
+                    "allowedTools": [],
+                    "mcpContextUris": [],
+                    "mcpServers": {},
+                    "enabledMcpjsonServers": [],
+                    "disabledMcpjsonServers": [],
+                    "hasTrustDialogAccepted": True,
+                }
+                print(f"  ✓ Pre-trusted directory: {directory}")
+            elif not projects[dir_key].get("hasTrustDialogAccepted"):
+                projects[dir_key]["hasTrustDialogAccepted"] = True
+                print(f"  ✓ Re-trusted directory: {directory}")
+            else:
+                print(f"  ✓ Directory already trusted: {directory}")
+                return
+
+            with open(claude_json, "w") as f:
+                json.dump(config, f, indent=2)
+        except (json.JSONDecodeError, OSError) as e:
+            print(f"  ⚠️  Could not pre-trust directory: {e}")
+
     def create_project_creator_prompt(self) -> str:
         """
         Create the prompt for the project creator agent.
@@ -467,9 +512,22 @@ CRITICAL INSTRUCTIONS:
             capture_output=True,
         )
 
-        # Create new session (detached)
+        # Create new session (detached) with explicit dimensions so panes
+        # are large enough for Claude's TUI even before a client attaches.
         subprocess.run(
-            ["tmux", "new-session", "-d", "-s", self.tmux_session, "-n", "agents-0"],
+            [
+                "tmux",
+                "new-session",
+                "-d",
+                "-s",
+                self.tmux_session,
+                "-n",
+                "agents-0",
+                "-x",
+                "200",
+                "-y",
+                "50",
+            ],
             check=True,
         )
 
@@ -653,6 +711,9 @@ CRITICAL INSTRUCTIONS:
 [ -f ~/.zshrc ] && source ~/.zshrc
 [ -f ~/.bashrc ] && source ~/.bashrc
 
+# Prevent Claude from detecting nesting and refusing to start
+unset CLAUDECODE CLAUDE_CODE_ENTRYPOINT CLAUDE_CODE_SESSION
+
 cd {self.config.implementation_dir} || exit 1
 echo "=========================================="
 echo "PROJECT CREATOR AGENT"
@@ -713,6 +774,9 @@ echo "=========================================="
 [ -f ~/.zshrc ] && source ~/.zshrc
 [ -f ~/.bashrc ] && source ~/.bashrc
 
+# Prevent Claude from detecting nesting and refusing to start
+unset CLAUDECODE CLAUDE_CODE_ENTRYPOINT CLAUDE_CODE_SESSION
+
 cd {self.config.implementation_dir} || exit 1
 echo "=========================================="
 echo "{agent_name.upper()}"
@@ -765,6 +829,9 @@ echo "=========================================="
 # Source shell profile to get nvm/claude in PATH
 [ -f ~/.zshrc ] && source ~/.zshrc
 [ -f ~/.bashrc ] && source ~/.bashrc
+
+# Prevent Claude from detecting nesting and refusing to start
+unset CLAUDECODE CLAUDE_CODE_ENTRYPOINT CLAUDE_CODE_SESSION
 
 cd {self.config.implementation_dir} || exit 1
 echo "=========================================="
@@ -838,6 +905,10 @@ echo "=========================================="
         if self.config.project_info_file.exists():
             self.config.project_info_file.unlink()
             print("  ✓ Removed old project_info.json")
+
+        # Pre-trust the implementation directory so Claude doesn't
+        # show the "Do you trust this folder?" prompt.
+        self._pretrust_directory(self.config.implementation_dir)
 
         # Create tmux session
         print("\n[Setup] Creating tmux session")

--- a/tests/unit/experiments/test_spawn_agents.py
+++ b/tests/unit/experiments/test_spawn_agents.py
@@ -168,3 +168,106 @@ class TestMCPHealthCheck:
             result = check_mcp_health("http://localhost:4298")
 
         assert result is False
+
+
+class TestPretrustDirectory:
+    """Test suite for pre-trusting directories in ~/.claude.json."""
+
+    def test_creates_new_config_when_missing(self, tmp_path: Path) -> None:
+        """Test pre-trust creates ~/.claude.json if it doesn't exist."""
+        claude_json = tmp_path / ".claude.json"
+        impl_dir = tmp_path / "implementation"
+        impl_dir.mkdir()
+
+        with patch.object(Path, "home", return_value=tmp_path):
+            spawn_agents.AgentSpawner._pretrust_directory(impl_dir)
+
+        assert claude_json.exists()
+        config = json.loads(claude_json.read_text())
+        dir_key = str(impl_dir)
+        assert dir_key in config["projects"]
+        assert config["projects"][dir_key]["hasTrustDialogAccepted"] is True
+
+    def test_updates_existing_config(self, tmp_path: Path) -> None:
+        """Test pre-trust adds to existing ~/.claude.json without clobbering."""
+        claude_json = tmp_path / ".claude.json"
+        existing = {
+            "numStartups": 42,
+            "projects": {
+                "/some/other/project": {
+                    "hasTrustDialogAccepted": True,
+                }
+            },
+        }
+        claude_json.write_text(json.dumps(existing))
+
+        impl_dir = tmp_path / "implementation"
+        impl_dir.mkdir()
+
+        with patch.object(Path, "home", return_value=tmp_path):
+            spawn_agents.AgentSpawner._pretrust_directory(impl_dir)
+
+        config = json.loads(claude_json.read_text())
+        # Existing data preserved
+        assert config["numStartups"] == 42
+        assert "/some/other/project" in config["projects"]
+        # New directory added
+        assert config["projects"][str(impl_dir)]["hasTrustDialogAccepted"] is True
+
+    def test_retrusts_directory_with_false_flag(self, tmp_path: Path) -> None:
+        """Test pre-trust flips hasTrustDialogAccepted from False to True."""
+        claude_json = tmp_path / ".claude.json"
+        impl_dir = tmp_path / "implementation"
+        impl_dir.mkdir()
+        dir_key = str(impl_dir)
+
+        existing = {
+            "projects": {
+                dir_key: {
+                    "hasTrustDialogAccepted": False,
+                    "allowedTools": ["Bash"],
+                }
+            }
+        }
+        claude_json.write_text(json.dumps(existing))
+
+        with patch.object(Path, "home", return_value=tmp_path):
+            spawn_agents.AgentSpawner._pretrust_directory(impl_dir)
+
+        config = json.loads(claude_json.read_text())
+        assert config["projects"][dir_key]["hasTrustDialogAccepted"] is True
+        # Existing fields preserved
+        assert config["projects"][dir_key]["allowedTools"] == ["Bash"]
+
+    def test_skips_already_trusted_directory(self, tmp_path: Path) -> None:
+        """Test pre-trust is a no-op when directory is already trusted."""
+        claude_json = tmp_path / ".claude.json"
+        impl_dir = tmp_path / "implementation"
+        impl_dir.mkdir()
+        dir_key = str(impl_dir)
+
+        existing = {"projects": {dir_key: {"hasTrustDialogAccepted": True}}}
+        claude_json.write_text(json.dumps(existing))
+        original_mtime = claude_json.stat().st_mtime
+
+        with patch.object(Path, "home", return_value=tmp_path):
+            spawn_agents.AgentSpawner._pretrust_directory(impl_dir)
+
+        # File should not be rewritten
+        assert claude_json.stat().st_mtime == original_mtime
+
+    def test_handles_malformed_json(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """Test graceful handling of corrupted ~/.claude.json."""
+        claude_json = tmp_path / ".claude.json"
+        claude_json.write_text("{bad json")
+
+        impl_dir = tmp_path / "implementation"
+        impl_dir.mkdir()
+
+        with patch.object(Path, "home", return_value=tmp_path):
+            spawn_agents.AgentSpawner._pretrust_directory(impl_dir)
+
+        output = capsys.readouterr().out
+        assert "Could not pre-trust" in output


### PR DESCRIPTION
## Summary
- Pre-trust implementation directory in `~/.claude.json` before spawning agents, eliminating the "Do you trust this folder?" prompt entirely
- Set explicit tmux session dimensions (`-x 200 -y 50`) so panes have enough rows for Claude's TUI when detached
- Unset `CLAUDECODE`, `CLAUDE_CODE_ENTRYPOINT`, and `CLAUDE_CODE_SESSION` env vars in agent bash scripts to prevent nesting detection

## Context
Intermittent agent startup failures in detached tmux sessions:
- ~2% of the time: trust prompt blocks agents
- ~8% of the time: agents don't start until tmux is manually attached (likely due to tiny pane dimensions in detached sessions)

## Test plan
- [x] Verified agents start reliably without attaching to tmux
- [ ] Confirm trust prompt no longer appears for new experiment directories
- [ ] Verify agents work across multiple sequential runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)