### PR TITLE
fix: add TERM normalization and pane readiness polling to tmux spawner

### DIFF
--- a/dev-tools/experiments/runners/spawn_agents.py
+++ b/dev-tools/experiments/runners/spawn_agents.py
@@ -16,6 +16,70 @@ from typing import Any, Dict, List
 import yaml
 
 
+def wait_for_pane_ready(
+    pane_target: str,
+    timeout: float = 10.0,
+    poll_interval: float = 0.3,
+) -> bool:
+    """Wait for a tmux pane's shell to be ready before sending commands.
+
+    Polls the pane content until a shell prompt indicator appears or the
+    content stabilizes (stops changing for 2+ consecutive polls). This
+    prevents send-keys from firing before the shell is initialized.
+
+    Parameters
+    ----------
+    pane_target : str
+        Tmux pane target (e.g. ``session:window.pane`` or a pane ID).
+    timeout : float
+        Maximum seconds to wait before giving up.
+    poll_interval : float
+        Seconds between polls.
+
+    Returns
+    -------
+    bool
+        True if the pane is ready, False if timed out.
+    """
+    prompt_indicators = {"$", "%", "#", "❯", ">", "›"}
+    deadline = time.monotonic() + timeout
+    prev_content = ""
+    stable_count = 0
+
+    while time.monotonic() < deadline:
+        result = subprocess.run(
+            ["tmux", "capture-pane", "-p", "-t", pane_target],
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode != 0:
+            time.sleep(poll_interval)
+            continue
+
+        content = result.stdout.rstrip()
+
+        # Check for shell prompt indicators on the last non-empty line
+        lines = [ln for ln in content.split("\n") if ln.strip()]
+        if lines:
+            last_line = lines[-1].strip()
+            if any(last_line.endswith(ind) for ind in prompt_indicators):
+                return True
+
+        # Content stabilization: if content hasn't changed for 2 polls
+        # and there IS content, the shell is ready
+        if content and content == prev_content:
+            stable_count += 1
+            if stable_count >= 2:
+                return True
+        else:
+            stable_count = 0
+
+        prev_content = content
+        time.sleep(poll_interval)
+
+    return False
+
+
 def confirm_trust_if_prompted(
     pane_target: str,
     timeout: float = 5.0,
@@ -655,15 +719,19 @@ CRITICAL INSTRUCTIONS:
             target = result.stdout.strip()
             time.sleep(0.2)  # Give tmux time to stabilize
 
-        # Send commands to the pane using its actual ID
-        subprocess.run(
-            ["tmux", "send-keys", "-t", target, f"bash {script_file}", "Enter"],
-            check=True,
-        )
-
         # Set pane title
         subprocess.run(
             ["tmux", "select-pane", "-t", target, "-T", title],
+            check=True,
+        )
+
+        # Wait for the pane shell to be ready before sending commands
+        if not wait_for_pane_ready(target):
+            print(f"  ⚠ Pane {target} did not stabilize, sending anyway")
+
+        # Send commands to the pane using its actual ID
+        subprocess.run(
+            ["tmux", "send-keys", "-t", target, f"bash {script_file}", "Enter"],
             check=True,
         )
 
@@ -713,6 +781,11 @@ CRITICAL INSTRUCTIONS:
 
 # Prevent Claude from detecting nesting and refusing to start
 unset CLAUDECODE CLAUDE_CODE_ENTRYPOINT CLAUDE_CODE_SESSION
+
+# Normalize TERM for non-interactive shells (IDE terminals, CI, cron)
+if [ "$TERM" = "dumb" ] || [ -z "$TERM" ]; then
+    export TERM=xterm-256color
+fi
 
 cd {self.config.implementation_dir} || exit 1
 echo "=========================================="
@@ -777,6 +850,11 @@ echo "=========================================="
 # Prevent Claude from detecting nesting and refusing to start
 unset CLAUDECODE CLAUDE_CODE_ENTRYPOINT CLAUDE_CODE_SESSION
 
+# Normalize TERM for non-interactive shells (IDE terminals, CI, cron)
+if [ "$TERM" = "dumb" ] || [ -z "$TERM" ]; then
+    export TERM=xterm-256color
+fi
+
 cd {self.config.implementation_dir} || exit 1
 echo "=========================================="
 echo "{agent_name.upper()}"
@@ -832,6 +910,11 @@ echo "=========================================="
 
 # Prevent Claude from detecting nesting and refusing to start
 unset CLAUDECODE CLAUDE_CODE_ENTRYPOINT CLAUDE_CODE_SESSION
+
+# Normalize TERM for non-interactive shells (IDE terminals, CI, cron)
+if [ "$TERM" = "dumb" ] || [ -z "$TERM" ]; then
+    export TERM=xterm-256color
+fi
 
 cd {self.config.implementation_dir} || exit 1
 echo "=========================================="

--- a/experiments/dashboard-time-weather/implementation/docs/api/weather-api-contract.yaml
+++ b/experiments/dashboard-time-weather/implementation/docs/api/weather-api-contract.yaml
@@ -1,0 +1,284 @@
+openapi: "3.0.3"
+info:
+  title: Weather Information Service API
+  version: "1.0.0"
+  description: |
+    Backend API for the Weather Widget. Proxies requests to OpenWeatherMap
+    and provides cached weather data for configured cities.
+
+servers:
+  - url: http://localhost:8000
+    description: Local development
+
+paths:
+  /api/weather:
+    get:
+      summary: Get current weather for a city
+      description: |
+        Returns current weather conditions. Results are cached for 5 minutes
+        to reduce external API calls. If the external API is down, stale
+        cached data may be returned with a `stale` flag.
+      parameters:
+        - name: city
+          in: query
+          required: true
+          description: City name (e.g., "New York", "London", "Tokyo")
+          schema:
+            type: string
+            minLength: 1
+            maxLength: 100
+            example: "New York"
+        - name: units
+          in: query
+          required: false
+          description: Temperature units
+          schema:
+            type: string
+            enum: [metric, imperial]
+            default: imperial
+      responses:
+        "200":
+          description: Current weather data
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WeatherResponse"
+              example:
+                success: true
+                data:
+                  city: "New York"
+                  country: "US"
+                  temperature: 72.5
+                  feels_like: 70.1
+                  temp_min: 68.0
+                  temp_max: 75.0
+                  humidity: 55
+                  pressure: 1013
+                  wind_speed: 8.5
+                  wind_direction: 220
+                  condition: "clear sky"
+                  condition_code: 800
+                  icon: "01d"
+                  icon_url: "https://openweathermap.org/img/wn/01d@2x.png"
+                  visibility: 10000
+                  timestamp: "2026-03-31T20:30:00Z"
+                  sunrise: "2026-03-31T10:45:00Z"
+                  sunset: "2026-03-31T23:15:00Z"
+                stale: false
+                cached_at: "2026-03-31T20:30:00Z"
+        "400":
+          description: Invalid request (missing or invalid city)
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+              example:
+                success: false
+                error:
+                  code: "INVALID_CITY"
+                  message: "City parameter is required and must be a non-empty string"
+        "404":
+          description: City not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+              example:
+                success: false
+                error:
+                  code: "CITY_NOT_FOUND"
+                  message: "Could not find weather data for 'Faketown'"
+        "429":
+          description: Rate limited
+          headers:
+            Retry-After:
+              schema:
+                type: integer
+              description: Seconds to wait before retrying
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+              example:
+                success: false
+                error:
+                  code: "RATE_LIMITED"
+                  message: "Too many requests. Please try again later."
+        "503":
+          description: External weather service unavailable
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+              example:
+                success: false
+                error:
+                  code: "SERVICE_UNAVAILABLE"
+                  message: "Weather service is temporarily unavailable"
+
+  /api/weather/cities:
+    get:
+      summary: Search for cities
+      description: Returns a list of matching cities for autocomplete/search
+      parameters:
+        - name: q
+          in: query
+          required: true
+          description: Search query (partial city name)
+          schema:
+            type: string
+            minLength: 2
+            maxLength: 100
+            example: "New"
+      responses:
+        "200":
+          description: List of matching cities
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CitySearchResponse"
+              example:
+                success: true
+                cities:
+                  - name: "New York"
+                    country: "US"
+                    state: "New York"
+                  - name: "New Orleans"
+                    country: "US"
+                    state: "Louisiana"
+                  - name: "New Delhi"
+                    country: "IN"
+                    state: "Delhi"
+
+components:
+  schemas:
+    WeatherData:
+      type: object
+      required:
+        - city
+        - country
+        - temperature
+        - humidity
+        - condition
+        - condition_code
+        - icon
+        - icon_url
+        - timestamp
+      properties:
+        city:
+          type: string
+          description: City name
+        country:
+          type: string
+          description: ISO 3166 country code
+        temperature:
+          type: number
+          format: float
+          description: Current temperature in requested units
+        feels_like:
+          type: number
+          format: float
+          description: Perceived temperature (feels like)
+        temp_min:
+          type: number
+          format: float
+          description: Minimum temperature currently observed
+        temp_max:
+          type: number
+          format: float
+          description: Maximum temperature currently observed
+        humidity:
+          type: integer
+          description: Humidity percentage (0-100)
+        pressure:
+          type: integer
+          description: Atmospheric pressure in hPa
+        wind_speed:
+          type: number
+          format: float
+          description: Wind speed in mph (imperial) or m/s (metric)
+        wind_direction:
+          type: integer
+          description: Wind direction in degrees (0-360)
+        condition:
+          type: string
+          description: Human-readable weather condition
+        condition_code:
+          type: integer
+          description: OpenWeatherMap condition code for icon mapping
+        icon:
+          type: string
+          description: Icon code (e.g., "01d", "10n")
+        icon_url:
+          type: string
+          format: uri
+          description: Full URL to weather icon image
+        visibility:
+          type: integer
+          description: Visibility in meters
+        timestamp:
+          type: string
+          format: date-time
+          description: When the weather data was observed
+        sunrise:
+          type: string
+          format: date-time
+          description: Sunrise time
+        sunset:
+          type: string
+          format: date-time
+          description: Sunset time
+
+    WeatherResponse:
+      type: object
+      required: [success, data, stale, cached_at]
+      properties:
+        success:
+          type: boolean
+          enum: [true]
+        data:
+          $ref: "#/components/schemas/WeatherData"
+        stale:
+          type: boolean
+          description: True if data is from an expired cache (API was unavailable)
+        cached_at:
+          type: string
+          format: date-time
+          description: When this data was cached
+
+    CitySearchResponse:
+      type: object
+      required: [success, cities]
+      properties:
+        success:
+          type: boolean
+          enum: [true]
+        cities:
+          type: array
+          items:
+            type: object
+            properties:
+              name:
+                type: string
+              country:
+                type: string
+              state:
+                type: string
+
+    ErrorResponse:
+      type: object
+      required: [success, error]
+      properties:
+        success:
+          type: boolean
+          enum: [false]
+        error:
+          type: object
+          required: [code, message]
+          properties:
+            code:
+              type: string
+              description: Machine-readable error code
+            message:
+              type: string
+              description: Human-readable error message

--- a/experiments/dashboard-time-weather/implementation/docs/architecture/weather-service-architecture.md
+++ b/experiments/dashboard-time-weather/implementation/docs/architecture/weather-service-architecture.md
@@ -1,0 +1,98 @@
+# Weather Information Service - Architecture Design
+
+## Component Architecture
+
+```
+┌─────────────────────────────────────────────────────────┐
+│                    FRONTEND (React)                      │
+│                                                          │
+│  ┌──────────────────────────────────────────────────┐   │
+│  │            WeatherWidget Component                │   │
+│  │  ┌────────────┐ ┌──────────┐ ┌────────────────┐ │   │
+│  │  │ CitySelect │ │ TempDisp │ │ WeatherIcon    │ │   │
+│  │  │ (dropdown) │ │ (°F/°C)  │ │ (condition)    │ │   │
+│  │  └────────────┘ └──────────┘ └────────────────┘ │   │
+│  │  ┌────────────────────┐ ┌──────────────────────┐ │   │
+│  │  │ ConditionDesc      │ │ MetadataBar          │ │   │
+│  │  │ (sunny, rainy...)  │ │ (humidity, wind,     │ │   │
+│  │  │                    │ │  last updated)       │ │   │
+│  │  └────────────────────┘ └──────────────────────┘ │   │
+│  └──────────────────────────────────────────────────┘   │
+│                         │                                │
+│              useWeather() hook                           │
+│              (polling every 5 min)                       │
+└─────────────┬───────────────────────────────────────────┘
+              │ HTTP GET /api/weather?city={city}
+              ▼
+┌─────────────────────────────────────────────────────────┐
+│                  BACKEND (FastAPI)                        │
+│                                                          │
+│  ┌──────────────────┐   ┌─────────────────────────────┐ │
+│  │  Weather Router   │──▶│  WeatherService             │ │
+│  │  /api/weather     │   │  - get_current_weather()    │ │
+│  │  /api/weather/    │   │  - search_cities()          │ │
+│  │    cities         │   │  - validate_city()          │ │
+│  └──────────────────┘   └────────────┬────────────────┘ │
+│                                      │                   │
+│                          ┌───────────▼──────────┐       │
+│                          │  WeatherCache        │       │
+│                          │  (in-memory, 5m TTL) │       │
+│                          └───────────┬──────────┘       │
+│                                      │ cache miss       │
+│                          ┌───────────▼──────────┐       │
+│                          │  WeatherAPIClient    │       │
+│                          │  (OpenWeatherMap)    │       │
+│                          └──────────────────────┘       │
+└─────────────────────────────────────────────────────────┘
+              │
+              │ HTTPS GET api.openweathermap.org
+              ▼
+┌─────────────────────────────────────────────────────────┐
+│           OpenWeatherMap API (External)                   │
+│           - Current Weather Data endpoint                 │
+│           - Free tier: 60 calls/min                      │
+└─────────────────────────────────────────────────────────┘
+```
+
+## Component Responsibilities
+
+### Frontend Components
+
+| Component | Responsibility |
+|-----------|---------------|
+| `WeatherWidget` | Container component; manages city state, renders sub-components |
+| `CitySelector` | Dropdown for selecting city; calls /api/weather/cities for suggestions |
+| `TemperatureDisplay` | Shows temperature with unit toggle (°F/°C) |
+| `WeatherIcon` | Maps weather condition codes to visual icons |
+| `ConditionDescription` | Displays human-readable weather description |
+| `MetadataBar` | Shows humidity, wind speed, and last-updated timestamp |
+| `useWeather` hook | Fetches weather data, manages polling interval, handles errors |
+
+### Backend Components
+
+| Component | Responsibility |
+|-----------|---------------|
+| `weather_router` | FastAPI router; defines HTTP endpoints, validates query params |
+| `WeatherService` | Business logic; orchestrates cache checks and API calls |
+| `WeatherCache` | In-memory cache with TTL; reduces external API calls |
+| `WeatherAPIClient` | HTTP client for OpenWeatherMap; handles auth, transforms responses |
+
+## Data Flow
+
+1. User selects a city in `CitySelector`
+2. `useWeather` hook triggers GET `/api/weather?city={city}`
+3. `weather_router` receives request, validates city parameter
+4. `WeatherService.get_current_weather(city)` checks `WeatherCache`
+5. **Cache HIT**: Return cached data immediately
+6. **Cache MISS**: `WeatherAPIClient` calls OpenWeatherMap API
+7. Response transformed into `WeatherData` model
+8. Result cached with 5-minute TTL
+9. JSON response sent to frontend
+10. `WeatherWidget` renders updated weather data
+
+## Error Handling Flow
+
+- **External API down**: Return cached data (even if stale) with `stale: true` flag
+- **Invalid city**: Return 404 with helpful message
+- **Rate limited**: Return 429 with retry-after header
+- **Network error**: Frontend shows last known data with "offline" indicator

--- a/experiments/dashboard-time-weather/implementation/docs/design/weather-integration-spec.md
+++ b/experiments/dashboard-time-weather/implementation/docs/design/weather-integration-spec.md
@@ -1,0 +1,313 @@
+# Weather Information Service - Integration Specification
+
+## Overview
+
+This document defines how components communicate, how external APIs are integrated,
+and the data transformation pipeline from OpenWeatherMap to the frontend widget.
+
+## 1. Frontend ↔ Backend Communication
+
+### Polling Strategy
+
+The frontend `useWeather` hook polls the backend at a fixed interval:
+
+```
+Interval: 300,000 ms (5 minutes)
+Method:   HTTP GET
+Endpoint: /api/weather?city={city}&units={units}
+Trigger:  On mount + every 5 minutes + on city change
+```
+
+**Why polling over WebSockets?**
+- Weather data changes slowly (every few minutes at most)
+- Polling is simpler to implement, debug, and scale
+- No persistent connection overhead
+- 5-minute interval matches our cache TTL
+
+### Request Flow
+
+```
+1. useWeather hook fires (on mount, interval tick, or city change)
+2. GET /api/weather?city=New+York&units=imperial
+3. Headers: { Content-Type: application/json }
+4. On success: update state with WeatherData
+5. On error:
+   - 404: show "City not found" message
+   - 429: back off, retry after Retry-After header
+   - 503: show last known data with "offline" indicator
+   - Network error: show last known data with "offline" indicator
+```
+
+### Frontend Error Recovery
+
+```typescript
+// Pseudocode for useWeather hook
+const useWeather = (city: string, units: string = "imperial") => {
+  const [data, setData] = useState<WeatherData | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [stale, setStale] = useState(false);
+
+  const fetchWeather = async () => {
+    setLoading(true);
+    try {
+      const res = await fetch(`/api/weather?city=${encodeURIComponent(city)}&units=${units}`);
+      const json = await res.json();
+      if (json.success) {
+        setData(json.data);
+        setStale(json.stale);
+        setError(null);
+      } else {
+        setError(json.error.message);
+        // Keep previous data visible
+      }
+    } catch {
+      setError("Unable to connect to weather service");
+      // Keep previous data visible with stale indicator
+      setStale(true);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchWeather();
+    const interval = setInterval(fetchWeather, 300_000);
+    return () => clearInterval(interval);
+  }, [city, units]);
+
+  return { data, error, loading, stale };
+};
+```
+
+## 2. Backend ↔ OpenWeatherMap Integration
+
+### External API Configuration
+
+```python
+# Environment variables required
+OPENWEATHERMAP_API_KEY: str  # Required, no default
+WEATHER_CACHE_TTL: int = 300  # Optional, default 5 minutes
+DEFAULT_CITY: str = "New York"  # Optional, default city
+```
+
+### API Endpoints Used
+
+#### Current Weather Data
+```
+GET https://api.openweathermap.org/data/2.5/weather
+  ?q={city}
+  &units={imperial|metric}
+  &appid={API_KEY}
+```
+
+#### Geocoding (for city search)
+```
+GET http://api.openweathermap.org/geo/1.0/direct
+  ?q={query}
+  &limit=5
+  &appid={API_KEY}
+```
+
+### Data Transformation Pipeline
+
+```python
+async def transform_owm_response(raw: dict, units: str) -> WeatherData:
+    """Transform OpenWeatherMap API response to our WeatherData model.
+
+    Parameters
+    ----------
+    raw : dict
+        Raw JSON response from OpenWeatherMap current weather API.
+    units : str
+        Temperature units ("imperial" or "metric").
+
+    Returns
+    -------
+    WeatherData
+        Transformed weather data model.
+    """
+    weather = raw["weather"][0]
+    icon_code = weather["icon"]
+
+    return WeatherData(
+        city=raw["name"],
+        country=raw["sys"]["country"],
+        temperature=raw["main"]["temp"],
+        feels_like=raw["main"]["feels_like"],
+        temp_min=raw["main"]["temp_min"],
+        temp_max=raw["main"]["temp_max"],
+        humidity=raw["main"]["humidity"],
+        pressure=raw["main"]["pressure"],
+        wind_speed=raw["wind"]["speed"],
+        wind_direction=raw["wind"].get("deg", 0),
+        condition=weather["description"],
+        condition_code=weather["id"],
+        icon=icon_code,
+        icon_url=f"https://openweathermap.org/img/wn/{icon_code}@2x.png",
+        visibility=raw.get("visibility", 0),
+        timestamp=datetime.utcfromtimestamp(raw["dt"]),
+        sunrise=datetime.utcfromtimestamp(raw["sys"]["sunrise"]),
+        sunset=datetime.utcfromtimestamp(raw["sys"]["sunset"]),
+    )
+```
+
+### Error Handling for External API
+
+```python
+# HTTP status code mapping
+OWM_STATUS_MAPPING = {
+    401: ("INVALID_API_KEY", "Weather API key is invalid or expired"),
+    404: ("CITY_NOT_FOUND", "Could not find weather data for the specified city"),
+    429: ("RATE_LIMITED", "Weather API rate limit exceeded"),
+    500: ("SERVICE_ERROR", "Weather API internal error"),
+    502: ("SERVICE_UNAVAILABLE", "Weather API is temporarily unavailable"),
+    503: ("SERVICE_UNAVAILABLE", "Weather API is temporarily unavailable"),
+}
+```
+
+### Rate Limiting Strategy
+
+OpenWeatherMap free tier allows 60 calls/minute:
+
+- Backend cache (5-min TTL) dramatically reduces API calls
+- With 2 widgets polling every 5 min, worst case: ~24 calls/hour per city
+- Well within free tier limits even with multiple cities
+- If rate limited, serve stale cache and set Retry-After header
+
+## 3. Backend Caching Layer
+
+### Cache Implementation
+
+```python
+from datetime import datetime, timedelta
+
+
+class WeatherCache:
+    """In-memory weather data cache with TTL.
+
+    Parameters
+    ----------
+    ttl_seconds : int
+        Cache entry time-to-live in seconds.
+    """
+
+    def __init__(self, ttl_seconds: int = 300) -> None:
+        self._cache: dict[str, CacheEntry] = {}
+        self._ttl = timedelta(seconds=ttl_seconds)
+
+    def _make_key(self, city: str, units: str) -> str:
+        return f"weather:{city.lower().strip()}:{units}"
+
+    def get(self, city: str, units: str) -> CacheEntry | None:
+        key = self._make_key(city, units)
+        entry = self._cache.get(key)
+        if entry is None:
+            return None
+        return entry  # Caller checks is_expired
+
+    def set(self, city: str, units: str, data: WeatherData) -> None:
+        key = self._make_key(city, units)
+        now = datetime.utcnow()
+        self._cache[key] = CacheEntry(
+            data=data,
+            cached_at=now,
+            expires_at=now + self._ttl,
+        )
+```
+
+### Cache Flow Decision Tree
+
+```
+Request arrives for city={city}, units={units}
+  │
+  ├─ Cache entry exists?
+  │   ├─ YES, not expired → Return cached data (stale=false)
+  │   ├─ YES, expired → Try external API
+  │   │   ├─ API success → Update cache, return fresh data
+  │   │   └─ API failure → Return expired cache (stale=true)
+  │   └─ NO → Try external API
+  │       ├─ API success → Cache and return fresh data
+  │       └─ API failure → Return 503 error
+```
+
+## 4. File Structure
+
+```
+implementation/
+├── backend/
+│   ├── app/
+│   │   ├── __init__.py
+│   │   ├── main.py              # FastAPI app setup, CORS config
+│   │   ├── config.py            # Environment variable loading
+│   │   ├── models/
+│   │   │   ├── __init__.py
+│   │   │   └── weather.py       # Pydantic models (WeatherData, etc.)
+│   │   ├── routers/
+│   │   │   ├── __init__.py
+│   │   │   └── weather.py       # /api/weather endpoints
+│   │   ├── services/
+│   │   │   ├── __init__.py
+│   │   │   ├── weather_service.py   # Business logic orchestration
+│   │   │   ├── weather_cache.py     # In-memory caching
+│   │   │   └── weather_client.py    # OpenWeatherMap HTTP client
+│   │   └── exceptions.py       # Custom exception classes
+│   ├── tests/
+│   │   ├── unit/
+│   │   │   ├── test_weather_models.py
+│   │   │   ├── test_weather_cache.py
+│   │   │   └── test_weather_service.py
+│   │   └── integration/
+│   │       └── test_weather_api.py
+│   ├── requirements.txt
+│   └── .env.example
+├── frontend/
+│   ├── src/
+│   │   ├── components/
+│   │   │   └── weather/
+│   │   │       ├── WeatherWidget.tsx
+│   │   │       ├── CitySelector.tsx
+│   │   │       ├── TemperatureDisplay.tsx
+│   │   │       ├── WeatherIcon.tsx
+│   │   │       ├── ConditionDescription.tsx
+│   │   │       └── MetadataBar.tsx
+│   │   ├── hooks/
+│   │   │   └── useWeather.ts
+│   │   ├── types/
+│   │   │   └── weather.ts       # TypeScript interfaces
+│   │   └── api/
+│   │       └── weatherApi.ts    # API client functions
+│   ├── package.json
+│   └── tsconfig.json
+└── docs/
+    ├── architecture/
+    │   └── weather-service-architecture.md
+    ├── api/
+    │   └── weather-api-contract.yaml
+    ├── specifications/
+    │   └── weather-data-models.md
+    └── design/
+        └── weather-integration-spec.md
+```
+
+## 5. Configuration & Environment
+
+### Required Environment Variables
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `OPENWEATHERMAP_API_KEY` | Yes | — | API key from openweathermap.org |
+| `WEATHER_CACHE_TTL` | No | `300` | Cache TTL in seconds |
+| `DEFAULT_CITY` | No | `"New York"` | Default city on first load |
+| `CORS_ORIGINS` | No | `["http://localhost:3000"]` | Allowed CORS origins |
+| `API_HOST` | No | `"0.0.0.0"` | Backend host |
+| `API_PORT` | No | `8000` | Backend port |
+
+### .env.example
+
+```env
+OPENWEATHERMAP_API_KEY=your_api_key_here
+WEATHER_CACHE_TTL=300
+DEFAULT_CITY=New York
+CORS_ORIGINS=["http://localhost:3000"]
+```

--- a/experiments/dashboard-time-weather/implementation/docs/specifications/weather-data-models.md
+++ b/experiments/dashboard-time-weather/implementation/docs/specifications/weather-data-models.md
@@ -1,0 +1,281 @@
+# Weather Information Service - Data Models
+
+## Backend Models (Python/Pydantic)
+
+### WeatherData - Core weather response model
+
+```python
+from datetime import datetime
+from pydantic import BaseModel, Field
+
+
+class WeatherData(BaseModel):
+    """Core weather data model returned by the API.
+
+    Attributes
+    ----------
+    city : str
+        City name.
+    country : str
+        ISO 3166 country code.
+    temperature : float
+        Current temperature in requested units.
+    feels_like : float
+        Perceived temperature.
+    temp_min : float
+        Minimum temperature currently observed in the area.
+    temp_max : float
+        Maximum temperature currently observed in the area.
+    humidity : int
+        Humidity percentage (0-100).
+    pressure : int
+        Atmospheric pressure in hPa.
+    wind_speed : float
+        Wind speed (mph for imperial, m/s for metric).
+    wind_direction : int
+        Wind direction in degrees (0-360).
+    condition : str
+        Human-readable weather description (e.g., "clear sky").
+    condition_code : int
+        OpenWeatherMap condition code for icon mapping.
+    icon : str
+        Icon code (e.g., "01d", "10n").
+    icon_url : str
+        Full URL to the weather icon image.
+    visibility : int
+        Visibility in meters.
+    timestamp : datetime
+        When the weather data was observed (UTC).
+    sunrise : datetime
+        Sunrise time (UTC).
+    sunset : datetime
+        Sunset time (UTC).
+    """
+
+    city: str
+    country: str
+    temperature: float
+    feels_like: float
+    temp_min: float
+    temp_max: float
+    humidity: int = Field(ge=0, le=100)
+    pressure: int
+    wind_speed: float = Field(ge=0)
+    wind_direction: int = Field(ge=0, le=360)
+    condition: str
+    condition_code: int
+    icon: str
+    icon_url: str
+    visibility: int = Field(ge=0)
+    timestamp: datetime
+    sunrise: datetime
+    sunset: datetime
+```
+
+### WeatherResponse - API response wrapper
+
+```python
+class WeatherResponse(BaseModel):
+    """Wrapper for successful weather API responses.
+
+    Attributes
+    ----------
+    success : bool
+        Always True for successful responses.
+    data : WeatherData
+        The weather data payload.
+    stale : bool
+        True if data is from an expired cache entry.
+    cached_at : datetime
+        When this data was cached.
+    """
+
+    success: bool = True
+    data: WeatherData
+    stale: bool = False
+    cached_at: datetime
+```
+
+### ErrorResponse - API error wrapper
+
+```python
+class ErrorDetail(BaseModel):
+    """Error detail within an error response.
+
+    Attributes
+    ----------
+    code : str
+        Machine-readable error code (e.g., "CITY_NOT_FOUND").
+    message : str
+        Human-readable error description.
+    """
+
+    code: str
+    message: str
+
+
+class ErrorResponse(BaseModel):
+    """Wrapper for error API responses.
+
+    Attributes
+    ----------
+    success : bool
+        Always False for error responses.
+    error : ErrorDetail
+        Error details.
+    """
+
+    success: bool = False
+    error: ErrorDetail
+```
+
+### CityResult - City search result
+
+```python
+class CityResult(BaseModel):
+    """A single city search result.
+
+    Attributes
+    ----------
+    name : str
+        City name.
+    country : str
+        ISO 3166 country code.
+    state : str | None
+        State/province name if available.
+    """
+
+    name: str
+    country: str
+    state: str | None = None
+
+
+class CitySearchResponse(BaseModel):
+    """Response for city search endpoint.
+
+    Attributes
+    ----------
+    success : bool
+        Always True for successful responses.
+    cities : list[CityResult]
+        List of matching cities.
+    """
+
+    success: bool = True
+    cities: list[CityResult]
+```
+
+### CacheEntry - Internal cache model
+
+```python
+class CacheEntry(BaseModel):
+    """Internal model for cached weather data.
+
+    Attributes
+    ----------
+    data : WeatherData
+        The cached weather data.
+    cached_at : datetime
+        When the data was cached.
+    expires_at : datetime
+        When the cache entry expires.
+    """
+
+    data: WeatherData
+    cached_at: datetime
+    expires_at: datetime
+
+    @property
+    def is_expired(self) -> bool:
+        """Check if this cache entry has expired."""
+        return datetime.utcnow() > self.expires_at
+```
+
+## Frontend Models (TypeScript)
+
+### WeatherData interface
+
+```typescript
+interface WeatherData {
+  city: string;
+  country: string;
+  temperature: number;
+  feels_like: number;
+  temp_min: number;
+  temp_max: number;
+  humidity: number;
+  pressure: number;
+  wind_speed: number;
+  wind_direction: number;
+  condition: string;
+  condition_code: number;
+  icon: string;
+  icon_url: string;
+  visibility: number;
+  timestamp: string; // ISO 8601
+  sunrise: string;   // ISO 8601
+  sunset: string;    // ISO 8601
+}
+
+interface WeatherResponse {
+  success: true;
+  data: WeatherData;
+  stale: boolean;
+  cached_at: string; // ISO 8601
+}
+
+interface ErrorResponse {
+  success: false;
+  error: {
+    code: string;
+    message: string;
+  };
+}
+
+interface CityResult {
+  name: string;
+  country: string;
+  state?: string;
+}
+
+interface CitySearchResponse {
+  success: true;
+  cities: CityResult[];
+}
+
+// Union type for API responses
+type ApiResponse<T> = T | ErrorResponse;
+```
+
+## OpenWeatherMap API Response Mapping
+
+The backend transforms OpenWeatherMap's response into our `WeatherData` model:
+
+| OpenWeatherMap Field | Our Field | Transformation |
+|---------------------|-----------|----------------|
+| `name` | `city` | Direct copy |
+| `sys.country` | `country` | Direct copy |
+| `main.temp` | `temperature` | Direct copy (units handled by API param) |
+| `main.feels_like` | `feels_like` | Direct copy |
+| `main.temp_min` | `temp_min` | Direct copy |
+| `main.temp_max` | `temp_max` | Direct copy |
+| `main.humidity` | `humidity` | Direct copy |
+| `main.pressure` | `pressure` | Direct copy |
+| `wind.speed` | `wind_speed` | Direct copy |
+| `wind.deg` | `wind_direction` | Direct copy |
+| `weather[0].description` | `condition` | Direct copy |
+| `weather[0].id` | `condition_code` | Direct copy |
+| `weather[0].icon` | `icon` | Direct copy |
+| `weather[0].icon` | `icon_url` | Prefix with `https://openweathermap.org/img/wn/{icon}@2x.png` |
+| `visibility` | `visibility` | Direct copy |
+| `dt` | `timestamp` | Unix → ISO 8601 datetime |
+| `sys.sunrise` | `sunrise` | Unix → ISO 8601 datetime |
+| `sys.sunset` | `sunset` | Unix → ISO 8601 datetime |
+
+## Caching Strategy
+
+- **Cache key**: `weather:{city_lowercase}:{units}` (e.g., `weather:new york:imperial`)
+- **TTL**: 300 seconds (5 minutes)
+- **Storage**: In-memory dict (sufficient for single-server deployment)
+- **Stale serving**: If external API fails, serve expired cache with `stale: true`
+- **Cache invalidation**: Automatic via TTL; no manual invalidation needed

--- a/tests/unit/experiments/test_spawn_agents.py
+++ b/tests/unit/experiments/test_spawn_agents.py
@@ -10,6 +10,7 @@ import json
 import sys
 import time
 from pathlib import Path
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -100,6 +101,125 @@ class TestProjectInfoWaitCountdown:
         result = wait_for_project_info(mock_config)
 
         assert result is True
+
+
+class TestWaitForPaneReady:
+    """Test suite for tmux pane readiness polling."""
+
+    def test_returns_true_when_shell_prompt_detected(self) -> None:
+        """Test pane is ready when shell prompt indicator appears."""
+        wait_for_pane_ready = spawn_agents.wait_for_pane_ready
+
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="user@host ~ $")
+            result = wait_for_pane_ready("test:0.0", timeout=2.0)
+
+        assert result is True
+
+    def test_returns_true_when_zsh_prompt_detected(self) -> None:
+        """Test pane is ready when zsh prompt indicator appears."""
+        wait_for_pane_ready = spawn_agents.wait_for_pane_ready
+
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="lwgray@mac ~ %")
+            result = wait_for_pane_ready("test:0.0", timeout=2.0)
+
+        assert result is True
+
+    def test_returns_true_on_content_stabilization(self) -> None:
+        """Test pane is ready when content stops changing."""
+        wait_for_pane_ready = spawn_agents.wait_for_pane_ready
+
+        call_count = 0
+
+        def mock_capture(*args: Any, **kwargs: Any) -> MagicMock:
+            nonlocal call_count
+            call_count += 1
+            # First call: empty, then stable content without prompt
+            if call_count <= 1:
+                return MagicMock(returncode=0, stdout="")
+            return MagicMock(returncode=0, stdout="Loading shell...")
+
+        with patch("subprocess.run", side_effect=mock_capture):
+            with patch("time.sleep"):
+                result = wait_for_pane_ready(
+                    "test:0.0", timeout=5.0, poll_interval=0.01
+                )
+
+        assert result is True
+
+    def test_returns_false_on_timeout(self) -> None:
+        """Test pane readiness returns False when timeout expires."""
+        wait_for_pane_ready = spawn_agents.wait_for_pane_ready
+
+        call_count = 0
+
+        def mock_capture(*args: Any, **kwargs: Any) -> MagicMock:
+            nonlocal call_count
+            call_count += 1
+            # Content keeps changing — never stabilizes
+            return MagicMock(returncode=0, stdout=f"changing content {call_count}")
+
+        with patch("subprocess.run", side_effect=mock_capture):
+            with patch("time.sleep"):
+                result = wait_for_pane_ready(
+                    "test:0.0", timeout=0.01, poll_interval=0.001
+                )
+
+        assert result is False
+
+    def test_handles_tmux_capture_failure(self) -> None:
+        """Test graceful handling when tmux capture-pane fails."""
+        wait_for_pane_ready = spawn_agents.wait_for_pane_ready
+
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=1, stdout="")
+            with patch("time.sleep"):
+                result = wait_for_pane_ready(
+                    "test:0.0", timeout=0.01, poll_interval=0.001
+                )
+
+        assert result is False
+
+
+class TestTermNormalization:
+    """Test suite for TERM environment variable normalization in scripts."""
+
+    def test_term_normalization_in_project_creator_script(self, tmp_path: Path) -> None:
+        """Test project creator bash script includes TERM normalization."""
+        config = MagicMock()
+        config.experiment_dir = tmp_path
+        config.implementation_dir = tmp_path / "implementation"
+        config.implementation_dir.mkdir()
+        config.prompts_dir = tmp_path / "prompts"
+        config.prompts_dir.mkdir()
+        config.project_info_file = tmp_path / "project_info.json"
+        config.project_name = "test"
+        config.project_options = {
+            "complexity": "standard",
+            "provider": "sqlite",
+            "mode": "new_project",
+        }
+        config.agents = []
+        config.get_timeout.return_value = 300
+
+        spawner = spawn_agents.AgentSpawner.__new__(spawn_agents.AgentSpawner)
+        spawner.config = config
+        spawner.tmux_session = "test_session"
+        spawner.current_pane = 0
+        spawner.current_window = 0
+        spawner.panes_per_window = 4
+
+        # Mock tmux calls and generate the script
+        with patch("subprocess.run"):
+            with patch.object(spawner, "copy_agent_workflow_to_implementation"):
+                with patch.object(spawner, "run_in_tmux_pane"):
+                    spawner.spawn_project_creator()
+
+        script_file = config.prompts_dir / "project_creator.sh"
+        script_content = script_file.read_text()
+        assert "TERM=xterm-256color" in script_content
+        assert 'if [ "$TERM" = "dumb" ]' in script_content
 
 
 class TestKanbanConnectionResilience:


### PR DESCRIPTION
## Summary
- Add `wait_for_pane_ready()` that polls tmux pane content for shell prompt indicators or content stabilization before sending commands via `send-keys`
- Add TERM normalization (`TERM=dumb` → `xterm-256color`) to all agent bash scripts to handle non-interactive shell inheritance
- Fixes agents not starting in detached tmux panes until manual attach

## Context
Discovered by comparing Marcus spawn code with ClawTeam's `tmux_backend.py`. Marcus already had 2 of 4 techniques (env var unset, trust prompt auto-dismiss). This adds the remaining two.

## Test plan
- [x] `TestWaitForPaneReady` — 5 tests covering prompt detection, stabilization, timeout, and tmux failure
- [x] `TestTermNormalization` — verifies TERM normalization appears in generated bash scripts
- [x] All 20 tests pass, all pre-commit hooks pass

Closes #290

🤖 Generated with [Claude Code](https://claude.com/claude-code)