### PR TITLE
perf: parallelize design autocomplete LLM calls (#304)

### DIFF
--- a/scripts/smoke_test_design_autocomplete.py
+++ b/scripts/smoke_test_design_autocomplete.py
@@ -1,0 +1,300 @@
+#!/usr/bin/env python3
+"""
+Smoke test for GH-304 design autocomplete parallelism.
+
+Runs ``_generate_design_content()`` end-to-end against the *real* LLM
+provider configured in ``config_marcus.json``, not a mock. Reports
+wall-clock time, artifact counts per task, and a pass/fail verdict so
+the author can paste the output into the PR description as evidence.
+
+This is NOT a pytest test. It costs real money (one full run is ~$0.50
+to ~$3.00 depending on model and project size) and should be run once
+before merging #304. Do not wire it into CI.
+
+Usage
+-----
+Run from the repo root::
+
+    python scripts/smoke_test_design_autocomplete.py
+
+    # Or with a different complexity:
+    python scripts/smoke_test_design_autocomplete.py --complexity prototype
+    python scripts/smoke_test_design_autocomplete.py --complexity enterprise
+
+Exit codes
+----------
+0
+    Smoke test passed (wall-clock under budget, all design tasks
+    produced artifacts).
+1
+    Smoke test failed — see stderr for details.
+
+Notes
+-----
+The script instantiates a temporary project workspace under
+``/tmp/marcus-smoke-304-<timestamp>/`` and leaves it in place on success
+for manual inspection of generated artifacts.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import logging
+import os
+import sys
+import tempfile
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, List
+
+# Ensure the repo root is on sys.path when running as a script
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_REPO_ROOT))
+
+from src.core.models import Priority, TaskStatus  # noqa: E402
+from src.integrations.nlp_tools import _generate_design_content  # noqa: E402
+
+# Budgets used for the pass/fail verdict. These reflect the GH-304 goal
+# of keeping project creation under the 10-minute timeout.
+_WALL_CLOCK_BUDGETS_SECONDS = {
+    "prototype": 180.0,  # 1-2 design tasks
+    "standard": 300.0,  # 3 design tasks
+    "enterprise": 540.0,  # up to 10 design tasks, buffer under 600s timeout
+}
+
+
+class _SmokeTask:
+    """Minimal Task-like object that passes ``_is_design_task``.
+
+    We don't use the full ``src.core.models.Task`` dataclass because it
+    has strict field validation; this smoke test only needs enough
+    surface area for ``_generate_design_content`` to mutate state on
+    success.
+    """
+
+    def __init__(self, name: str, description: str) -> None:
+        self.name = name
+        self.description = description
+        self.labels: List[str] = ["design"]
+        self.status: TaskStatus = TaskStatus.TODO
+        self.assigned_to: Any = None
+        self.priority: Priority = Priority.HIGH
+
+
+def _build_design_tasks(complexity: str) -> List[_SmokeTask]:
+    """Build a synthetic list of design tasks for the given complexity.
+
+    Parameters
+    ----------
+    complexity : str
+        One of ``"prototype"``, ``"standard"``, ``"enterprise"``.
+
+    Returns
+    -------
+    List[_SmokeTask]
+        A list of design tasks that mirrors what Marcus's PRD parser
+        would emit for a project of this complexity.
+    """
+    base = [
+        _SmokeTask(
+            "Design Authentication",
+            "User signup, login, and session management with JWTs.",
+        ),
+        _SmokeTask(
+            "Design Data Layer",
+            "PostgreSQL schemas for users, accounts, and audit logs.",
+        ),
+    ]
+    extras_standard = [
+        _SmokeTask(
+            "Design API Gateway",
+            "REST API with rate limiting and request validation.",
+        ),
+    ]
+    extras_enterprise = [
+        _SmokeTask(
+            "Design Notification System",
+            "Email + SMS delivery with retry queue and dead-letter handling.",
+        ),
+        _SmokeTask(
+            "Design Search",
+            "Full-text search over user documents via OpenSearch.",
+        ),
+        _SmokeTask(
+            "Design Analytics Pipeline",
+            "Event ingestion, aggregation, and dashboard backend.",
+        ),
+        _SmokeTask(
+            "Design Billing",
+            "Stripe integration, subscription management, invoice generation.",
+        ),
+        _SmokeTask(
+            "Design Admin Console",
+            "Internal tools for support, user management, and audit review.",
+        ),
+        _SmokeTask(
+            "Design DevOps",
+            "CI/CD pipeline, Terraform infrastructure, observability stack.",
+        ),
+        _SmokeTask(
+            "Design Security",
+            "RBAC, secrets management, vulnerability scanning.",
+        ),
+    ]
+
+    if complexity == "prototype":
+        return base[:1]
+    if complexity == "standard":
+        return base + extras_standard
+    if complexity == "enterprise":
+        return base + extras_standard + extras_enterprise
+    raise ValueError(f"Unknown complexity: {complexity}")
+
+
+async def _run_smoke(complexity: str, workdir: Path) -> int:
+    """Run the parallel design autocomplete and report the result.
+
+    Parameters
+    ----------
+    complexity : str
+        Project complexity name (``prototype``/``standard``/``enterprise``).
+    workdir : Path
+        Project workspace where artifact files will be written.
+
+    Returns
+    -------
+    int
+        Process exit code: 0 on success, 1 on failure.
+    """
+    tasks = _build_design_tasks(complexity)
+    budget = _WALL_CLOCK_BUDGETS_SECONDS[complexity]
+
+    print(f"GH-304 smoke test — complexity={complexity}")
+    print(f"  design tasks: {len(tasks)}")
+    print(f"  wall-clock budget: {budget:.0f}s")
+    print(f"  workdir: {workdir}")
+    print()
+
+    start = time.monotonic()
+    try:
+        design_content = await _generate_design_content(
+            tasks=tasks,
+            project_description=(
+                "A multi-tenant SaaS platform with real-time collaboration, "
+                "audit logging, and enterprise SSO."
+            ),
+            project_name="SmokeTest-304",
+            project_root=str(workdir),
+        )
+    except Exception as exc:
+        wall_clock = time.monotonic() - start
+        print(f"FAIL — _generate_design_content raised after {wall_clock:.1f}s")
+        print(f"  exception: {type(exc).__name__}: {exc}")
+        return 1
+
+    wall_clock = time.monotonic() - start
+    print(f"Completed in {wall_clock:.1f}s wall-clock " f"(budget {budget:.0f}s)")
+    print()
+
+    # Per-task artifact summary
+    print("Per-task summary:")
+    missing: List[str] = []
+    for task in tasks:
+        entry = design_content.get(task.name)
+        if entry is None:
+            missing.append(task.name)
+            print(f"  [MISS] {task.name}: no artifacts, status={task.status.value}")
+            continue
+        n_art = len(entry["artifacts"])
+        n_dec = len(entry["decisions"])
+        print(
+            f"  [ OK ] {task.name}: {n_art} artifact(s), "
+            f"{n_dec} decision(s), status={task.status.value}"
+        )
+    print()
+
+    # Verdict
+    verdict_ok = True
+    if wall_clock > budget:
+        print(f"FAIL — wall-clock {wall_clock:.1f}s exceeds budget {budget:.0f}s")
+        verdict_ok = False
+    if missing:
+        print(f"FAIL — {len(missing)} design task(s) produced no artifacts:")
+        for name in missing:
+            print(f"    - {name}")
+        verdict_ok = False
+
+    if verdict_ok:
+        print("PASS — all design tasks produced artifacts within budget")
+        print(f"  artifacts preserved under {workdir} for inspection")
+        return 0
+    return 1
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "GH-304 smoke test: run _generate_design_content() against "
+            "a real LLM and report wall-clock + artifact counts."
+        )
+    )
+    parser.add_argument(
+        "--complexity",
+        choices=["prototype", "standard", "enterprise"],
+        default="standard",
+        help="Which project complexity to simulate (default: standard).",
+    )
+    parser.add_argument(
+        "--verbose",
+        "-v",
+        action="store_true",
+        help="Enable INFO-level logging from marcus modules.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    """Parse CLI args, validate credentials, and run the smoke test.
+
+    Returns
+    -------
+    int
+        Process exit code: 0 on pass, 1 on fail, 130 on Ctrl-C.
+    """
+    args = _parse_args()
+
+    if args.verbose:
+        logging.basicConfig(
+            level=logging.INFO,
+            format="%(asctime)s %(name)s %(levelname)s %(message)s",
+        )
+    else:
+        logging.basicConfig(level=logging.WARNING)
+
+    if (
+        not os.environ.get("ANTHROPIC_API_KEY")
+        and not Path("config_marcus.json").exists()
+    ):
+        print(
+            "ERROR: no ANTHROPIC_API_KEY in environment and no "
+            "config_marcus.json found. Set one or the other before "
+            "running this smoke test.",
+            file=sys.stderr,
+        )
+        return 1
+
+    timestamp = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S")
+    workdir = Path(tempfile.gettempdir()) / f"marcus-smoke-304-{timestamp}"
+    workdir.mkdir(parents=True, exist_ok=True)
+
+    try:
+        return asyncio.run(_run_smoke(args.complexity, workdir))
+    except KeyboardInterrupt:
+        print("\naborted by user", file=sys.stderr)
+        return 130
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/integrations/nlp_tools.py
+++ b/src/integrations/nlp_tools.py
@@ -8,6 +8,7 @@ These tools expose Marcus's AI capabilities for:
 This refactored version eliminates code duplication by using base classes and utilities.
 """
 
+import asyncio
 import logging
 import os
 import sys
@@ -22,6 +23,7 @@ from src.ai.advanced.prd.advanced_parser import (  # noqa: E402
     ProjectConstraints,
 )
 from src.core.models import Priority, Task, TaskStatus  # noqa: E402
+from src.core.resilience import RetryConfig, with_retry  # noqa: E402
 from src.detection.board_analyzer import BoardAnalyzer  # noqa: E402
 from src.detection.context_detector import ContextDetector, MarcusMode  # noqa: E402
 
@@ -31,6 +33,69 @@ from src.integrations.nlp_task_utils import TaskType  # noqa: E402
 from src.modes.adaptive.basic_adaptive import BasicAdaptiveMode  # noqa: E402
 
 logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Design autocomplete parallelism helpers (GH-304)
+#
+# Concurrency cap: ``_DESIGN_LLM_CONCURRENCY`` limits in-flight ``llm.analyze``
+# calls across all design tasks in a single ``_generate_design_content()``
+# invocation. For a 10-task enterprise project with 5 LLM calls per task (4
+# artifacts + 1 decisions), uncapped parallelism would burst up to 50 calls
+# simultaneously and risk tripping Anthropic's per-minute rate limit. 10 is a
+# safe ceiling for Claude Sonnet at paid-tier rate limits while preserving
+# most of the wall-clock speedup.
+# ---------------------------------------------------------------------------
+_DESIGN_LLM_CONCURRENCY = 10
+
+
+@with_retry(RetryConfig(max_attempts=3, base_delay=2.0, jitter=True))
+async def _bounded_llm_analyze(
+    llm: Any,
+    prompt: str,
+    context: Any,
+    semaphore: asyncio.Semaphore,
+) -> str:
+    """Call ``llm.analyze`` under a concurrency cap with retry + backoff.
+
+    Wraps a single LLM call so that:
+
+    - at most ``semaphore._value`` calls run concurrently (rate-limit guard),
+    - transient failures retry up to 3 times with jittered exponential
+      backoff (``RetryConfig(max_attempts=3, base_delay=2.0, jitter=True)``).
+
+    If all retries fail the last exception propagates to the caller, which
+    aborts the surrounding ``asyncio.gather`` and fails the whole design
+    autocomplete phase (hard-fail semantics — see GH-304).
+
+    Parameters
+    ----------
+    llm : Any
+        An LLM client exposing an async ``analyze(prompt, context)`` method.
+    prompt : str
+        Prompt text passed through unchanged.
+    context : Any
+        Context object passed through unchanged (typically provides
+        ``max_tokens`` and similar knobs).
+    semaphore : asyncio.Semaphore
+        Concurrency guard. Must be created inside a running event loop so
+        it binds to the correct loop (created per-call in
+        :func:`_generate_design_content`).
+
+    Returns
+    -------
+    str
+        Raw LLM response text.
+
+    Raises
+    ------
+    Exception
+        Re-raises the last exception from ``llm.analyze`` after retries are
+        exhausted.
+    """
+    async with semaphore:
+        response: str = await llm.analyze(prompt=prompt, context=context)
+        return response
 
 
 class NaturalLanguageProjectCreator(NaturalLanguageTaskCreator):
@@ -1396,6 +1461,300 @@ def _domain_slug(task_name: str) -> str:
     return name.strip().replace(" ", "-")
 
 
+async def _generate_single_artifact(
+    llm: Any,
+    spec: Dict[str, Any],
+    task: Any,
+    project_name: str,
+    project_description: str,
+    project_root_path: Any,
+    context: Any,
+    semaphore: asyncio.Semaphore,
+) -> Optional[Dict[str, Any]]:
+    """Generate one design artifact document via a single bounded LLM call.
+
+    Builds the artifact prompt from the task description, calls the LLM
+    under the concurrency cap (see :func:`_bounded_llm_analyze`), writes
+    the response to disk under ``project_root_path``, and returns the
+    artifact metadata dict for later registration in Phase B.
+
+    Returns ``None`` (and logs a warning) when the LLM response is empty
+    or shorter than 20 characters — the caller treats that as "no
+    artifact produced for this spec" without aborting the task.
+
+    Parameters
+    ----------
+    llm : Any
+        LLM client instance.
+    spec : Dict[str, Any]
+        One entry from ``_DESIGN_ARTIFACT_SPECS`` describing the
+        filename template, artifact type, and prompt label.
+    task : Any
+        The design Task object (used for ``name``/``description``).
+    project_name : str
+        Project name for prompt templating.
+    project_description : str
+        Full project description for prompt templating.
+    project_root_path : pathlib.Path
+        Absolute path to the project implementation directory.
+    context : Any
+        Context object passed to ``llm.analyze``.
+    semaphore : asyncio.Semaphore
+        Concurrency guard shared across all design task coroutines in
+        the current invocation.
+
+    Returns
+    -------
+    Optional[Dict[str, Any]]
+        Artifact metadata dict with keys ``filename``, ``artifact_type``,
+        ``content``, ``description``, ``relative_path`` — or ``None`` if
+        the LLM returned an empty/short response.
+
+    Raises
+    ------
+    Exception
+        Propagates any unrecoverable LLM error after ``_bounded_llm_analyze``
+        exhausts its retries. Also propagates disk I/O failures.
+    """
+    from pathlib import Path
+
+    from src.marcus_mcp.tools.attachment import ARTIFACT_PATHS
+
+    domain = _domain_slug(task.name)
+    fname = spec["filename_template"].format(domain_slug=domain)
+    desc = spec["description_template"].format(domain=task.name.replace("Design ", ""))
+
+    if spec["label"] == "interface contracts":
+        prompt = _INTERFACE_CONTRACTS_PROMPT.format(
+            project_name=project_name,
+            project_description=project_description,
+            task_description=task.description,
+        )
+    else:
+        prompt = _ARTIFACT_PROMPT.format(
+            project_name=project_name,
+            project_description=project_description,
+            task_description=task.description,
+            artifact_label=spec["label"],
+        )
+
+    response = await _bounded_llm_analyze(llm, prompt, context, semaphore)
+
+    if not response or len(response.strip()) < 20:
+        logger.warning(
+            f"[design_autocomplete] Phase A: "
+            f"empty/short response for "
+            f"'{task.name}' {spec['label']}"
+        )
+        return None
+
+    # Write document to disk
+    atype = spec["artifact_type"]
+    base = ARTIFACT_PATHS.get(atype, "docs/artifacts")
+    rel_path = Path(base) / fname
+    full_path = project_root_path / rel_path
+    full_path.parent.mkdir(parents=True, exist_ok=True)
+    full_path.write_text(response.strip(), encoding="utf-8")
+
+    logger.info(f"[design_autocomplete] Phase A: wrote {rel_path}")
+
+    return {
+        "filename": fname,
+        "artifact_type": atype,
+        "content": response.strip(),
+        "description": desc,
+        "relative_path": str(rel_path),
+    }
+
+
+async def _generate_single_decisions(
+    llm: Any,
+    task: Any,
+    project_name: str,
+    project_description: str,
+    context: Any,
+    semaphore: asyncio.Semaphore,
+) -> List[Dict[str, Any]]:
+    """Generate the decisions list for one design task via one LLM call.
+
+    The decisions prompt is self-contained: it depends only on the task
+    description and project metadata, not on the artifact outputs, which
+    is why it can run in parallel with the artifact calls (see GH-304).
+
+    Parameters
+    ----------
+    llm : Any
+        LLM client instance.
+    task : Any
+        The design Task object.
+    project_name : str
+        Project name for prompt templating.
+    project_description : str
+        Full project description for prompt templating.
+    context : Any
+        Context object passed to ``llm.analyze``.
+    semaphore : asyncio.Semaphore
+        Shared concurrency guard for the current invocation.
+
+    Returns
+    -------
+    List[Dict[str, Any]]
+        List of decision dicts, each with at least ``what``, ``why``,
+        and ``impact`` keys. Empty list if the response could not be
+        parsed as JSON (a warning is logged in that case).
+
+    Raises
+    ------
+    Exception
+        Propagates any unrecoverable LLM error after retries exhaust.
+    """
+    import json
+
+    dec_prompt = _DECISIONS_PROMPT.format(
+        project_name=project_name,
+        project_description=project_description,
+        task_description=task.description,
+    )
+
+    dec_response = await _bounded_llm_analyze(llm, dec_prompt, context, semaphore)
+
+    if not dec_response:
+        return []
+
+    try:
+        from src.utils.json_parser import clean_json_response
+
+        cleaned = clean_json_response(dec_response)
+        parsed = json.loads(cleaned)
+        # Response could be a list or {"decisions": [...]}
+        if isinstance(parsed, list):
+            dec_list = parsed
+        elif isinstance(parsed, dict):
+            dec_list = parsed.get("decisions", [])
+        else:
+            dec_list = []
+
+        logged_decisions: List[Dict[str, Any]] = [
+            d for d in dec_list if all(k in d for k in ("what", "why", "impact"))
+        ]
+
+        logger.info(
+            f"[design_autocomplete] Phase A: "
+            f"{len(logged_decisions)} decision(s) "
+            f"for '{task.name}'"
+        )
+        return logged_decisions
+
+    except (json.JSONDecodeError, ValueError) as e:
+        logger.warning(
+            f"[design_autocomplete] Phase A: "
+            f"could not parse decisions for "
+            f"'{task.name}': {e}"
+        )
+        return []
+
+
+async def _process_design_task(
+    llm: Any,
+    task: Any,
+    project_name: str,
+    project_description: str,
+    project_root_path: Any,
+    context: Any,
+    semaphore: asyncio.Semaphore,
+) -> Optional[Dict[str, Any]]:
+    """Run all LLM calls for one design task concurrently (Level 2).
+
+    Kicks off 4 artifact coroutines plus 1 decisions coroutine under a
+    single ``asyncio.gather``, so all 5 LLM calls for a task run in
+    parallel, capped by the shared semaphore. Returns ``None`` when no
+    artifacts were produced (the task should stay TODO in that case).
+
+    Parameters
+    ----------
+    llm : Any
+        LLM client instance.
+    task : Any
+        The design Task object.
+    project_name : str
+        Project name for prompt templating.
+    project_description : str
+        Full project description for prompt templating.
+    project_root_path : pathlib.Path
+        Absolute path to the project implementation directory.
+    context : Any
+        Context object passed through to each LLM call.
+    semaphore : asyncio.Semaphore
+        Shared concurrency guard across all design tasks.
+
+    Returns
+    -------
+    Optional[Dict[str, Any]]
+        ``{"artifacts": [...], "decisions": [...]}`` on success, or
+        ``None`` if no artifacts survived the empty/short filter.
+
+    Raises
+    ------
+    Exception
+        Propagates the first unrecoverable LLM error (after retries)
+        from any of the 5 parallel calls. Fail-fast: the caller aborts
+        the whole design phase. See GH-304 decision rationale.
+    """
+    artifact_coros = [
+        _generate_single_artifact(
+            llm=llm,
+            spec=spec,
+            task=task,
+            project_name=project_name,
+            project_description=project_description,
+            project_root_path=project_root_path,
+            context=context,
+            semaphore=semaphore,
+        )
+        for spec in _DESIGN_ARTIFACT_SPECS
+    ]
+    decisions_coro = _generate_single_decisions(
+        llm=llm,
+        task=task,
+        project_name=project_name,
+        project_description=project_description,
+        context=context,
+        semaphore=semaphore,
+    )
+
+    # Level 2 parallelism: 4 artifact calls + 1 decisions call all in flight
+    # at once for this task. The nested ``asyncio.gather`` shape lets mypy
+    # infer the two result slots (list of artifacts, list of decisions)
+    # without a ``cast``. gather() propagates the first exception (after
+    # retries exhaust) and cancels the remaining coroutines.
+    artifact_results, decisions = await asyncio.gather(
+        asyncio.gather(*artifact_coros),
+        decisions_coro,
+    )
+
+    written_artifacts: List[Dict[str, Any]] = [
+        a for a in artifact_results if a is not None
+    ]
+
+    if not written_artifacts:
+        logger.warning(
+            f"[design_autocomplete] Phase A: no "
+            f"artifacts for '{task.name}' — "
+            f"stays TODO"
+        )
+        return None
+
+    n_a = len(written_artifacts)
+    n_d = len(decisions)
+    logger.info(
+        f"[design_autocomplete] Phase A: "
+        f"'{task.name}' → {n_a} artifact(s), "
+        f"{n_d} decision(s)"
+    )
+
+    return {"artifacts": written_artifacts, "decisions": decisions}
+
+
 async def _generate_design_content(
     tasks: List[Any],
     project_description: str,
@@ -1406,16 +1765,43 @@ async def _generate_design_content(
     Phase A: Generate design artifacts + decisions and set status to DONE.
 
     Makes separate LLM calls per artifact document, just like an agent
-    would make separate log_artifact calls. Writes files to disk and
-    marks design tasks as DONE. Runs BEFORE create_tasks_on_board so
+    would make separate ``log_artifact`` calls. Writes files to disk and
+    marks design tasks as DONE. Runs BEFORE ``create_tasks_on_board`` so
     design tasks are born DONE on the kanban board.
+
+    Parallelism (GH-304)
+    --------------------
+    Level 1 — across design tasks: all design tasks run concurrently via
+    ``asyncio.gather``.
+    Level 2 — within each task: the 4 artifact LLM calls and the 1
+    decisions LLM call run concurrently for that task.
+
+    Combined with the per-invocation ``asyncio.Semaphore`` cap of
+    ``_DESIGN_LLM_CONCURRENCY`` (10), this brings a 10-task enterprise
+    project from ~25–33 min (sequential) down to ~1–3 min wall-clock
+    without exceeding rate limits.
+
+    Failure semantics
+    -----------------
+    Fail-fast. Each LLM call is wrapped with
+    ``@with_retry(RetryConfig(max_attempts=3, base_delay=2.0, jitter=True))``
+    via :func:`_bounded_llm_analyze`. If retries exhaust for any single
+    call, the exception propagates out of the inner ``gather``, aborts
+    the outer ``gather``, and this function raises — no task state
+    mutations happen, and the caller must retry project creation.
+
+    This is a behavior change from pre-GH-304 code, which warned and
+    continued on a per-task basis. Rationale: partial design results
+    (some tasks designed, some not) silently corrupt downstream agent
+    work. Hard-fail surfaces the problem immediately.
 
     Parameters
     ----------
     tasks : List[Any]
-        All tasks (design + implementation). Design tasks are
-        modified in-place: status set to DONE, auto_completed
-        label added.
+        All tasks (design + implementation). Design tasks are modified
+        in-place on success: status set to DONE, ``assigned_to="Marcus"``,
+        and ``"auto_completed"`` label added. No mutations happen on
+        failure — state updates are atomic across all design tasks.
     project_description : str
         Full project description for LLM context.
     project_name : str
@@ -1426,26 +1812,36 @@ async def _generate_design_content(
     Returns
     -------
     Dict[str, Dict[str, Any]]
-        Mapping of task name -> {artifacts, decisions} for Phase B.
+        Mapping of task name -> ``{"artifacts": [...], "decisions": [...]}``
+        for Phase B.
 
-    See: https://github.com/lwgray/marcus/issues/297
+    Raises
+    ------
+    Exception
+        Any unrecoverable LLM or I/O error from the parallel design calls
+        (fail-fast). Disk side effects (partial artifact files under
+        ``project_root_path``) may still be present on failure — this
+        matches pre-GH-304 behavior.
+
+    See Also
+    --------
+    GH-297 : Phase A / Phase B design autocomplete design.
+    GH-304 : Parallelization decision and Kaia architectural review.
     """
-    import json
     from pathlib import Path
 
     from src.ai.providers.llm_abstraction import LLMAbstraction
-    from src.marcus_mcp.tools.attachment import ARTIFACT_PATHS
 
-    design_content: Dict[str, Dict[str, Any]] = {}
     project_root_path = Path(project_root)
 
     design_tasks = [t for t in tasks if _is_design_task(t)]
     if not design_tasks:
-        return design_content
+        return {}
 
     logger.info(
         f"[design_autocomplete] Phase A: generating content "
-        f"for {len(design_tasks)} design task(s)"
+        f"for {len(design_tasks)} design task(s) "
+        f"(concurrency cap={_DESIGN_LLM_CONCURRENCY})"
     )
 
     llm = LLMAbstraction()
@@ -1453,141 +1849,51 @@ async def _generate_design_content(
     class _Ctx:
         max_tokens = 4000
 
-    for task in design_tasks:
-        try:
-            domain = _domain_slug(task.name)
-            written_artifacts: List[Dict[str, Any]] = []
-            logged_decisions: List[Dict[str, Any]] = []
+    # Create the semaphore inside the function so it binds to the
+    # currently running event loop. A module-level semaphore leaks across
+    # pytest-asyncio function-scoped loops and causes confusing test
+    # failures; binding per-call is cheap and guarantees correctness.
+    semaphore = asyncio.Semaphore(_DESIGN_LLM_CONCURRENCY)
 
-            # Generate each artifact document separately
-            for spec in _DESIGN_ARTIFACT_SPECS:
-                fname = spec["filename_template"].format(domain_slug=domain)
-                desc = spec["description_template"].format(
-                    domain=task.name.replace("Design ", "")
-                )
+    task_coros = [
+        _process_design_task(
+            llm=llm,
+            task=task,
+            project_name=project_name,
+            project_description=project_description,
+            project_root_path=project_root_path,
+            context=_Ctx(),
+            semaphore=semaphore,
+        )
+        for task in design_tasks
+    ]
 
-                if spec["label"] == "interface contracts":
-                    prompt = _INTERFACE_CONTRACTS_PROMPT.format(
-                        project_name=project_name,
-                        project_description=project_description,
-                        task_description=task.description,
-                    )
-                else:
-                    prompt = _ARTIFACT_PROMPT.format(
-                        project_name=project_name,
-                        project_description=project_description,
-                        task_description=task.description,
-                        artifact_label=spec["label"],
-                    )
+    # Level 1 parallelism. return_exceptions=False so the first
+    # unrecoverable failure propagates immediately (fail-fast semantics
+    # per GH-304).
+    task_results = await asyncio.gather(*task_coros)
 
-                response = await llm.analyze(prompt=prompt, context=_Ctx())
-
-                if not response or len(response.strip()) < 20:
-                    logger.warning(
-                        f"[design_autocomplete] Phase A: "
-                        f"empty/short response for "
-                        f"'{task.name}' {spec['label']}"
-                    )
-                    continue
-
-                # Write document to disk
-                atype = spec["artifact_type"]
-                base = ARTIFACT_PATHS.get(atype, "docs/artifacts")
-                rel_path = Path(base) / fname
-                full_path = project_root_path / rel_path
-                full_path.parent.mkdir(parents=True, exist_ok=True)
-                full_path.write_text(response.strip(), encoding="utf-8")
-
-                written_artifacts.append(
-                    {
-                        "filename": fname,
-                        "artifact_type": atype,
-                        "content": response.strip(),
-                        "description": desc,
-                        "relative_path": str(rel_path),
-                    }
-                )
-
-                logger.info(f"[design_autocomplete] Phase A: " f"wrote {rel_path}")
-
-            # Generate decisions separately
-            dec_prompt = _DECISIONS_PROMPT.format(
-                project_name=project_name,
-                project_description=project_description,
-                task_description=task.description,
-            )
-
-            dec_response = await llm.analyze(prompt=dec_prompt, context=_Ctx())
-
-            if dec_response:
-                try:
-                    from src.utils.json_parser import (
-                        clean_json_response,
-                    )
-
-                    cleaned = clean_json_response(dec_response)
-                    parsed = json.loads(cleaned)
-                    # Response could be a list or {"decisions": [...]}
-                    if isinstance(parsed, list):
-                        dec_list = parsed
-                    elif isinstance(parsed, dict):
-                        dec_list = parsed.get("decisions", [])
-                    else:
-                        dec_list = []
-
-                    for d in dec_list:
-                        if all(k in d for k in ("what", "why", "impact")):
-                            logged_decisions.append(d)
-
-                    logger.info(
-                        f"[design_autocomplete] Phase A: "
-                        f"{len(logged_decisions)} decision(s) "
-                        f"for '{task.name}'"
-                    )
-                except (json.JSONDecodeError, ValueError) as e:
-                    logger.warning(
-                        f"[design_autocomplete] Phase A: "
-                        f"could not parse decisions for "
-                        f"'{task.name}': {e}"
-                    )
-
-            # Only mark DONE if we produced at least one artifact
-            if not written_artifacts:
-                logger.warning(
-                    f"[design_autocomplete] Phase A: no "
-                    f"artifacts for '{task.name}' — "
-                    f"stays TODO"
-                )
-                continue
-
-            # Store for Phase B
-            design_content[task.name] = {
-                "artifacts": written_artifacts,
-                "decisions": logged_decisions,
-            }
-
-            # Mark task as DONE before it hits the board
-            task.status = TaskStatus.DONE
-            task.assigned_to = "Marcus"
-            if not hasattr(task, "labels") or task.labels is None:
-                task.labels = []
-            if "auto_completed" not in task.labels:
-                task.labels.append("auto_completed")
-
-            n_a = len(written_artifacts)
-            n_d = len(logged_decisions)
-            logger.info(
-                f"[design_autocomplete] Phase A: "
-                f"'{task.name}' → {n_a} artifact(s), "
-                f"{n_d} decision(s), status=DONE"
-            )
-
-        except Exception as e:
-            logger.warning(
-                f"[design_autocomplete] Phase A: failed "
-                f"for '{task.name}': {e} — stays TODO"
-            )
+    # All tasks finished without raising. Atomically update task state
+    # on the board-bound Task objects and assemble the design_content
+    # mapping for Phase B.
+    design_content: Dict[str, Dict[str, Any]] = {}
+    for task, result in zip(design_tasks, task_results):
+        if result is None:
+            # No artifacts produced — task stays TODO, warning already logged
+            # inside _process_design_task. Skip state mutation.
             continue
+
+        design_content[task.name] = result
+
+        # Mark task as DONE before it hits the board
+        task.status = TaskStatus.DONE
+        task.assigned_to = "Marcus"
+        if not hasattr(task, "labels") or task.labels is None:
+            task.labels = []
+        if "auto_completed" not in task.labels:
+            task.labels.append("auto_completed")
+
+        logger.info(f"[design_autocomplete] Phase A: " f"'{task.name}' status=DONE")
 
     return design_content
 

--- a/src/integrations/nlp_tools.py
+++ b/src/integrations/nlp_tools.py
@@ -1634,8 +1634,16 @@ async def _generate_single_decisions(
         else:
             dec_list = []
 
+        # Guard against malformed list elements (mixed types from the LLM:
+        # strings, numbers, None) BEFORE checking for required keys.
+        # Without the isinstance check, ``"what" in d`` raises TypeError on
+        # non-iterables (or matches a substring on a string), which under
+        # the GH-304 fail-fast gather would abort the entire design phase
+        # for a recoverable formatting issue. See PR #319 Codex review.
         logged_decisions: List[Dict[str, Any]] = [
-            d for d in dec_list if all(k in d for k in ("what", "why", "impact"))
+            d
+            for d in dec_list
+            if isinstance(d, dict) and all(k in d for k in ("what", "why", "impact"))
         ]
 
         logger.info(
@@ -1870,8 +1878,21 @@ async def _generate_design_content(
 
     # Level 1 parallelism. return_exceptions=False so the first
     # unrecoverable failure propagates immediately (fail-fast semantics
-    # per GH-304).
-    task_results = await asyncio.gather(*task_coros)
+    # per GH-304). The thin try/except adds the batch size and task names
+    # to the error log so failures are diagnosable from logs alone — the
+    # @with_retry layer only knows about a single failing call, not the
+    # surrounding batch.
+    try:
+        task_results = await asyncio.gather(*task_coros)
+    except Exception as exc:
+        task_names = ", ".join(repr(t.name) for t in design_tasks)
+        logger.error(
+            f"[design_autocomplete] Phase A: aborted batch of "
+            f"{len(design_tasks)} design task(s) due to "
+            f"{type(exc).__name__}: {exc}. "
+            f"tasks in batch: {task_names}"
+        )
+        raise
 
     # All tasks finished without raising. Atomically update task state
     # on the board-bound Task objects and assemble the design_content

--- a/tests/unit/integrations/test_design_autocomplete_parallelism.py
+++ b/tests/unit/integrations/test_design_autocomplete_parallelism.py
@@ -220,6 +220,64 @@ class TestDesignAutocompleteParallelism:
         assert tasks[0].status == TaskStatus.DONE
 
     @pytest.mark.asyncio
+    async def test_malformed_decisions_list_does_not_abort_design_phase(
+        self, tmp_path: Any
+    ) -> None:
+        """Non-dict elements in the LLM decisions list must not crash.
+
+        Regression test for PR #319 Codex P1 review: an LLM that returns
+        a decisions JSON list with mixed types (e.g. a trailing string,
+        number, or null) used to raise ``TypeError`` from
+        ``"what" in d`` for non-iterable elements. Under the GH-304
+        fail-fast ``asyncio.gather`` flow, that exception would abort
+        the entire design phase for what is really a recoverable
+        formatting issue. The parser must filter to ``isinstance(dict)``
+        before checking for required keys.
+        """
+        # Decisions response: 1 valid dict, 1 string, 1 int, 1 dict
+        # missing required keys, 1 None. Only the first should survive.
+        malformed_decisions = (
+            "["
+            '{"what": "Use REST", "why": "Simpler", "impact": "OK"},'
+            '"a stray string",'
+            "42,"
+            '{"what": "Missing keys"},'
+            "null"
+            "]"
+        )
+
+        async def malformed_analyze(prompt: str, context: Any) -> str:
+            if "decision" in prompt.lower() and "json" in prompt.lower():
+                return malformed_decisions
+            return _VALID_ARTIFACT_RESPONSE
+
+        mock_llm = Mock()
+        mock_llm.analyze = AsyncMock(side_effect=malformed_analyze)
+
+        tasks = [_make_design_task("Design Mixed")]
+
+        with patch(
+            "src.ai.providers.llm_abstraction.LLMAbstraction",
+            return_value=mock_llm,
+        ):
+            # This used to raise TypeError before the isinstance guard.
+            result = await _generate_design_content(
+                tasks=tasks,
+                project_description="P",
+                project_name="P",
+                project_root=str(tmp_path),
+            )
+
+        # The design phase must complete normally
+        entry = result["Design Mixed"]
+        assert len(entry["artifacts"]) == 4
+        # Only the one well-formed dict should pass the filter
+        assert len(entry["decisions"]) == 1
+        assert entry["decisions"][0]["what"] == "Use REST"
+        # And the task should still be marked DONE
+        assert tasks[0].status == TaskStatus.DONE
+
+    @pytest.mark.asyncio
     async def test_llm_failure_exhausts_retries_then_propagates(
         self, tmp_path: Any
     ) -> None:

--- a/tests/unit/integrations/test_design_autocomplete_parallelism.py
+++ b/tests/unit/integrations/test_design_autocomplete_parallelism.py
@@ -1,0 +1,349 @@
+"""
+Unit tests for parallel design autocomplete (GH-304).
+
+Verifies that ``_generate_design_content()`` parallelizes LLM calls both
+across design tasks (Level 1) and within each task (Level 2), wraps each
+call with retry, caps concurrency via ``asyncio.Semaphore``, and
+fail-fasts when any call exhausts retries.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from typing import Any, Dict, List, Optional
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+
+from src.core.models import Priority, TaskStatus
+from src.integrations.nlp_tools import _generate_design_content
+
+
+def _make_design_task(name: str, description: str = "Do the design") -> Mock:
+    """Build a minimal design Task stand-in that passes ``_is_design_task``.
+
+    Parameters
+    ----------
+    name : str
+        Task name. Must start with ``"Design "`` for ``_is_design_task``
+        to return True.
+    description : str
+        Task description used in LLM prompt templating.
+
+    Returns
+    -------
+    Mock
+        A ``Mock`` object with ``name``, ``description``, ``labels``,
+        ``status``, and ``assigned_to`` attributes wired so that
+        ``_is_design_task(task)`` is True and the function-under-test
+        can mutate the status/labels on success.
+    """
+    task = Mock()
+    task.name = name
+    task.description = description
+    task.labels = ["design"]
+    task.status = TaskStatus.TODO
+    task.assigned_to = None
+    task.priority = Priority.HIGH
+    return task
+
+
+# Valid architecture/API/data-model response bodies (> 20 chars to pass the
+# empty/short filter in _generate_single_artifact).
+_VALID_ARTIFACT_RESPONSE = (
+    "## Architecture\n\nComponent A talks to Component B via REST.\n"
+)
+
+# Valid decisions response — JSON with the three required keys.
+_VALID_DECISIONS_RESPONSE = (
+    '[{"what": "Use REST", "why": "Simpler", "impact": "Lower latency"}]'
+)
+
+
+def _mock_llm_response(prompt: str, context: Any) -> str:
+    """Return a valid response string for artifact or decisions prompts.
+
+    Dispatches on prompt content so the same mock can serve both artifact
+    calls and the decisions call with semantically valid payloads.
+    """
+    if "decision" in prompt.lower() and "json" in prompt.lower():
+        return _VALID_DECISIONS_RESPONSE
+    return _VALID_ARTIFACT_RESPONSE
+
+
+@pytest.mark.unit
+class TestDesignAutocompleteParallelism:
+    """Test suite for ``_generate_design_content()`` GH-304 parallelism."""
+
+    @pytest.mark.asyncio
+    async def test_llm_calls_run_in_parallel_across_tasks_and_specs(
+        self, tmp_path: Any
+    ) -> None:
+        """Wall-clock time must be far below sequential baseline.
+
+        With 3 design tasks × 5 LLM calls each = 15 total calls, and each
+        mocked call taking 100ms, a sequential implementation would take
+        ~1500ms. A correctly parallelized implementation (Level 1 across
+        tasks + Level 2 within each task, with Semaphore(10)) should
+        complete in ~100–300ms wall-clock.
+        """
+        call_times: List[float] = []
+
+        async def slow_analyze(prompt: str, context: Any) -> str:
+            call_times.append(time.monotonic())
+            await asyncio.sleep(0.1)
+            return _mock_llm_response(prompt, context)
+
+        mock_llm = Mock()
+        mock_llm.analyze = AsyncMock(side_effect=slow_analyze)
+
+        tasks = [
+            _make_design_task("Design Authentication"),
+            _make_design_task("Design Payments"),
+            _make_design_task("Design Notifications"),
+        ]
+
+        with patch(
+            "src.ai.providers.llm_abstraction.LLMAbstraction",
+            return_value=mock_llm,
+        ):
+            start = time.monotonic()
+            result = await _generate_design_content(
+                tasks=tasks,
+                project_description="Build a widget.",
+                project_name="TestProject",
+                project_root=str(tmp_path),
+            )
+            wall_clock = time.monotonic() - start
+
+        # All 3 design tasks were processed with 5 calls each = 15 calls
+        assert mock_llm.analyze.call_count == 15
+
+        # Parallel: all 15 calls should have STARTED within a narrow
+        # window (well under the sequential baseline of 1.5s)
+        assert wall_clock < 0.5, (
+            f"Wall-clock {wall_clock:.3f}s suggests sequential execution — "
+            f"expected < 0.5s for parallel (baseline sequential = 1.5s)"
+        )
+
+        # All 3 tasks should appear in the returned design_content and
+        # have been mutated to DONE
+        assert set(result.keys()) == {
+            "Design Authentication",
+            "Design Payments",
+            "Design Notifications",
+        }
+        for task in tasks:
+            assert task.status == TaskStatus.DONE
+            assert task.assigned_to == "Marcus"
+            assert "auto_completed" in task.labels
+
+    @pytest.mark.asyncio
+    async def test_each_task_produces_four_artifacts_and_decisions(
+        self, tmp_path: Any
+    ) -> None:
+        """Each design task should produce 4 artifacts + the decisions list.
+
+        Verifies the inner Level-2 gather includes all 4 artifact specs
+        and the decisions call, and that the results are assembled
+        correctly.
+        """
+        mock_llm = Mock()
+        mock_llm.analyze = AsyncMock(side_effect=_mock_llm_response)
+
+        tasks = [_make_design_task("Design Auth")]
+
+        with patch(
+            "src.ai.providers.llm_abstraction.LLMAbstraction",
+            return_value=mock_llm,
+        ):
+            result = await _generate_design_content(
+                tasks=tasks,
+                project_description="A project.",
+                project_name="P",
+                project_root=str(tmp_path),
+            )
+
+        # 5 LLM calls per task (4 artifact specs + 1 decisions)
+        assert mock_llm.analyze.call_count == 5
+
+        entry = result["Design Auth"]
+        # 4 artifact specs defined in _DESIGN_ARTIFACT_SPECS
+        assert len(entry["artifacts"]) == 4
+        assert len(entry["decisions"]) == 1
+        # Each artifact file should be written under tmp_path
+        for artifact in entry["artifacts"]:
+            file_path = tmp_path / artifact["relative_path"]
+            assert file_path.exists(), f"Missing artifact file: {file_path}"
+
+    @pytest.mark.asyncio
+    async def test_empty_response_skips_artifact_without_aborting_task(
+        self, tmp_path: Any
+    ) -> None:
+        """Short LLM responses are skipped without failing the whole task.
+
+        If the LLM returns an empty or <20-char response for one artifact
+        spec, that spec is dropped, but the other 3 artifacts and the
+        decisions call should still succeed and the task should still
+        complete (since at least one artifact was produced).
+        """
+        call_count = {"n": 0}
+
+        async def mixed_analyze(prompt: str, context: Any) -> str:
+            call_count["n"] += 1
+            # First artifact call returns garbage, the rest return valid
+            if call_count["n"] == 1:
+                return "nope"
+            return _mock_llm_response(prompt, context)
+
+        mock_llm = Mock()
+        mock_llm.analyze = AsyncMock(side_effect=mixed_analyze)
+
+        tasks = [_make_design_task("Design X")]
+
+        with patch(
+            "src.ai.providers.llm_abstraction.LLMAbstraction",
+            return_value=mock_llm,
+        ):
+            result = await _generate_design_content(
+                tasks=tasks,
+                project_description="P",
+                project_name="P",
+                project_root=str(tmp_path),
+            )
+
+        entry = result["Design X"]
+        # 3 of 4 artifacts should have survived
+        assert len(entry["artifacts"]) == 3
+        # Task should still be marked DONE (at least one artifact produced)
+        assert tasks[0].status == TaskStatus.DONE
+
+    @pytest.mark.asyncio
+    async def test_llm_failure_exhausts_retries_then_propagates(
+        self, tmp_path: Any
+    ) -> None:
+        """If any LLM call fails after 3 retries, the whole function raises.
+
+        Verifies fail-fast semantics (GH-304 Option B): the Kaia-reviewed
+        retry config (``max_attempts=3``) means a persistently-failing
+        LLM call gets exactly 3 attempts before its exception propagates
+        out, aborts the surrounding ``gather``, and raises out of
+        ``_generate_design_content``. No task state mutations happen.
+        """
+        fail_count = {"n": 0}
+
+        async def always_fail(prompt: str, context: Any) -> str:
+            fail_count["n"] += 1
+            raise RuntimeError("LLM provider exploded")
+
+        mock_llm = Mock()
+        mock_llm.analyze = AsyncMock(side_effect=always_fail)
+
+        tasks = [_make_design_task("Design Broken")]
+
+        # Skip backoff sleeps so the test doesn't spend seconds sleeping.
+        # Patches asyncio.sleep *inside the resilience module only* so the
+        # @with_retry decorator's exponential-backoff waits are no-ops;
+        # the test's own asyncio.sleep calls (if any) are unaffected.
+        async def _no_sleep(_delay: float) -> None:
+            return None
+
+        with (
+            patch(
+                "src.ai.providers.llm_abstraction.LLMAbstraction",
+                return_value=mock_llm,
+            ),
+            patch("src.core.resilience.asyncio.sleep", new=_no_sleep),
+        ):
+            with pytest.raises(RuntimeError, match="LLM provider exploded"):
+                await _generate_design_content(
+                    tasks=tasks,
+                    project_description="P",
+                    project_name="P",
+                    project_root=str(tmp_path),
+                )
+
+        # At least 3 attempts must have fired for the failing call.
+        # (The other 4 parallel calls for this task may also have fired
+        # before gather cancelled them — we don't assert an exact count.)
+        assert fail_count["n"] >= 3
+
+        # Task must NOT have been marked DONE on failure
+        assert tasks[0].status == TaskStatus.TODO
+        assert tasks[0].assigned_to is None
+        assert "auto_completed" not in tasks[0].labels
+
+    @pytest.mark.asyncio
+    async def test_no_design_tasks_returns_empty_dict(self, tmp_path: Any) -> None:
+        """Early-return path when no design tasks exist in the input."""
+        # Implementation task, not a design task
+        task = Mock()
+        task.name = "Implement Feature"
+        task.description = "..."
+        task.labels = ["backend"]
+        task.status = TaskStatus.TODO
+
+        with patch("src.ai.providers.llm_abstraction.LLMAbstraction") as mock_llm_cls:
+            result = await _generate_design_content(
+                tasks=[task],
+                project_description="P",
+                project_name="P",
+                project_root=str(tmp_path),
+            )
+
+        assert result == {}
+        # Should not even instantiate the LLM client
+        mock_llm_cls.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_concurrency_cap_limits_in_flight_calls(self, tmp_path: Any) -> None:
+        """Semaphore(10) should cap the max observed in-flight LLM calls.
+
+        With 3 tasks × 5 calls = 15 potential parallel calls, the
+        Semaphore(10) guard should limit concurrent in-flight calls to
+        at most 10 at any instant. We observe this by tracking
+        enter/exit of the mocked ``analyze`` coroutine.
+        """
+        concurrency = {"current": 0, "max": 0}
+        lock = asyncio.Lock()
+
+        async def tracked_analyze(prompt: str, context: Any) -> str:
+            async with lock:
+                concurrency["current"] += 1
+                concurrency["max"] = max(concurrency["max"], concurrency["current"])
+            try:
+                await asyncio.sleep(0.05)
+                return _mock_llm_response(prompt, context)
+            finally:
+                async with lock:
+                    concurrency["current"] -= 1
+
+        mock_llm = Mock()
+        mock_llm.analyze = AsyncMock(side_effect=tracked_analyze)
+
+        tasks = [
+            _make_design_task("Design One"),
+            _make_design_task("Design Two"),
+            _make_design_task("Design Three"),
+        ]
+
+        with patch(
+            "src.ai.providers.llm_abstraction.LLMAbstraction",
+            return_value=mock_llm,
+        ):
+            await _generate_design_content(
+                tasks=tasks,
+                project_description="P",
+                project_name="P",
+                project_root=str(tmp_path),
+            )
+
+        # Semaphore is set to 10; 15 potential calls — max observed should
+        # be ≤ 10 (with some slack for scheduler timing, we assert ≤ 10)
+        assert concurrency["max"] <= 10, (
+            f"Observed {concurrency['max']} concurrent LLM calls — "
+            f"Semaphore(10) should cap this"
+        )
+        # All 15 calls should have completed
+        assert mock_llm.analyze.call_count == 15


### PR DESCRIPTION
Closes #304.

## Summary
Replaces the sequential for-loops in `_generate_design_content()` (at `src/integrations/nlp_tools.py`) with two levels of `asyncio.gather` parallelism, capped by an `asyncio.Semaphore(10)` and wrapped with `@with_retry` from `src/core/resilience.py`.

Per [Kaia architectural review](#) (logged via `/simon` decision `44a82c6e`).

## Wall-clock impact
| Complexity | Design tasks | Sequential | Parallel | Under 10-min timeout? |
|---|---|---|---|---|
| prototype  | 1  | ~2 min     | ~30 s    | ✅ (was ✅) |
| standard   | 3  | ~6 min     | ~1-2 min | ✅ (was ✅) |
| enterprise | 10 | ~25-33 min | ~1-3 min | ✅ (**was ❌ — this is the fix**) |

## Parallelism shape
- **Level 1 — across design tasks:** all design tasks run concurrently via `asyncio.gather`.
- **Level 2 — within each task:** the 4 artifact LLM calls and the 1 decisions LLM call run concurrently (verified self-contained: decisions prompt depends only on `task.description`, not on artifact outputs).
- **Concurrency cap:** `asyncio.Semaphore(10)`, created inside `_generate_design_content()` so it binds to the currently running event loop (avoids leaks across pytest-asyncio function-scoped loops).
- **Retries:** `@with_retry(RetryConfig(max_attempts=3, base_delay=2.0, jitter=True))` wraps every `llm.analyze()` call through the new `_bounded_llm_analyze()` helper.

## ⚠️ Behavior change — fail-fast semantics

**Previously:** the function warned-and-continued per task. If task B's loop raised mid-loop, tasks A and C still completed. This silently produced projects where some design artifacts existed and others were missing, corrupting downstream agent work.

**Now:** any unrecoverable failure (after 3 retries) aborts the entire function. Task state mutations (`status=DONE`, `assigned_to=\"Marcus\"`, `auto_completed` label) are deferred until after all tasks succeed, so they are atomic across design tasks. Disk side effects (partial artifact files) match pre-PR behavior — not made worse by this change.

## Files changed
- `src/integrations/nlp_tools.py` — new helpers (`_bounded_llm_analyze`, `_generate_single_artifact`, `_generate_single_decisions`, `_process_design_task`) + rewritten `_generate_design_content()`. Numpy-style docstrings throughout.
- `tests/unit/integrations/test_design_autocomplete_parallelism.py` — new, 6 tests, all `@pytest.mark.unit`.
- `scripts/smoke_test_design_autocomplete.py` — new, manual smoke-test script (not wired into CI).

## Tests (6 new)
1. **Wall-clock assertion** — 3 tasks × 5 calls × 100ms mock latency must finish in <500ms. Sequential baseline is 1.5s. Catches future regressions that reintroduce sequential behavior.
2. **Artifact shape** — each task produces exactly 4 artifacts + decisions via 5 LLM calls, with files written to disk.
3. **Empty response** — short/empty LLM response for one artifact spec is skipped without aborting the whole task.
4. **Retry exhaustion** — mock fails every call; `@with_retry` fires ≥3 times; exception propagates out; no task state mutated on failure. `asyncio.sleep` inside `src.core.resilience` patched to a no-op so the test doesn't wait on backoff.
5. **Empty input** — no design tasks in input returns \`{}\` without instantiating the LLM client.
6. **Concurrency cap** — `Semaphore(10)` with 15 potential parallel calls, max observed in-flight ≤10.

## Smoke test
\`scripts/smoke_test_design_autocomplete.py\` runs the function against a real LLM and reports wall-clock + per-task artifact counts. Not wired into CI (costs real money). I should run this once before merging:

\`\`\`bash
python scripts/smoke_test_design_autocomplete.py --complexity enterprise
\`\`\`

Paste the output below when run:
\`\`\`
(smoke test output goes here)
\`\`\`

## Quality gates
- [x] \`pytest -m unit\` → **385 passed**, 0 failed (was 379 on develop, +6 new tests)
- [x] \`pytest tests/integration -m \"integration and internal\"\` → **7 passed**, 0 failed
- [x] \`mypy --strict src/integrations/nlp_tools.py\` → clean
- [x] Pre-commit: black, isort, flake8, bandit, pydocstyle, secrets scan, naive-datetime guard — all green
- [ ] Smoke test with real LLM (manual, before merge)

## Follow-up captured
- Simon concern \`c4be0e0f\`: Marcus has two \`with_retry\` implementations (\`src/core/resilience.py\` and \`src/core/error_strategies.py\`). Should consolidate in a follow-up cleanup issue. Not blocking this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)