### PR TITLE
fix(#320): reconnect Phase A→B design artifact registration

### DIFF
--- a/docs/source/systems/coordination/52-design-autocomplete.md
+++ b/docs/source/systems/coordination/52-design-autocomplete.md
@@ -5,8 +5,8 @@
 | Field | Value |
 |-------|-------|
 | Status | Implemented |
-| Version | 1.0 |
-| Date | 2026-03-31 |
+| Version | 2.0 |
+| Date | 2026-04-11 |
 
 ## Problem
 
@@ -18,29 +18,53 @@ The root cause is that the agent has the full system design in its context when 
 
 ## Solution
 
-Marcus auto-completes design tasks during `create_project`, before any agent is spawned. Design artifacts are produced by Marcus itself using targeted LLM calls, and design tasks arrive on the board already marked DONE. No agent ever touches a design task.
+Marcus auto-completes design tasks during `create_project` without letting any agent touch them. Design artifacts are produced by Marcus itself using targeted LLM calls. The implementation runs in two phases that together live inside a single background task, `_run_design_phase`:
 
-This is a two-phase process because it spans two different stages of project creation.
+- **Phase A** generates design artifacts to disk via parallel LLM calls.
+- **Phase B** registers those artifacts into the MCP `state.task_artifacts` so downstream implementation tasks discover them via `get_task_context`.
 
-## Phase A: Generate Content (Before Board Creation)
+Both phases must run in lockstep. They used to be wired independently and that split broke silently when one was refactored — see [Regression History](#regression-history) below.
 
-Runs inside `create_project`, before `create_tasks_on_board()` is called.
+## Race Mitigation: `assigned_to="Marcus"`
+
+Design tasks are born with `assigned_to="Marcus"` rather than born DONE. Marcus's task assignment filter treats any task whose `assigned_to` is `"Marcus"` as off-limits to agents regardless of status. This prevents agents from grabbing design tasks during the window between `create_tasks_on_board()` and the kanban DONE update that marks Phase A complete.
+
+This is the mechanism that replaced the original "born DONE" invariant when Phase A moved to a background task in GH-314. The race still exists at the board level (tasks are TODO for a few seconds), but the assignment filter closes it at the allocation layer.
+
+## Background Execution Model
+
+`_run_design_phase` runs as an `asyncio.ensure_future` background task, scheduled after `create_tasks_on_board()` returns and BEFORE `create_project_from_description()` returns to its caller. The MCP tool response is not blocked on Phase A's LLM calls (1–3 min wall-clock after the GH-304 parallelization). Implementation tasks remain blocked on hard dependencies until the kanban DONE update inside the closure fires.
+
+```
+create_project_from_description():
+  ├── parse_prd_to_tasks() [synchronous]
+  ├── create_tasks_on_board() [synchronous]
+  │     design tasks born with assigned_to="Marcus", status=TODO
+  ├── asyncio.ensure_future(_run_design_phase(...))  [fire-and-forget]
+  └── return result  [MCP tool responds immediately]
+
+_run_design_phase() [background]:
+  ├── Phase A: _generate_design_content()
+  │     └── parallel LLM calls, write files to disk
+  ├── Phase B: _register_design_via_mcp()         ← MUST be before kanban DONE
+  │     └── log_artifact() populates state.task_artifacts[design_task_id]
+  ├── Kanban DONE update                           ← unblocks impl tasks
+  │     └── kanban_client.update_task(id, "done")
+  └── _generate_project_scaffold()
+        └── writes initial project scaffolding
+```
+
+## Phase A: Generate Content
 
 For each design task, Marcus makes **separate LLM calls** for each artifact document:
 
 1. Architecture document
 2. API contracts
 3. Data models
-4. One call for decisions
+4. Interface contracts
+5. One call for decisions
 
 Each call writes its artifact file to disk at the standard `ARTIFACT_PATHS` location.
-
-Then Marcus sets on the task object:
-- `status = DONE`
-- `assigned_to = "Marcus"`
-- Label: `"auto_completed"`
-
-When `create_tasks_on_board()` runs, design tasks hit the board already DONE. No agent can grab them.
 
 ### Why separate LLM calls per artifact
 
@@ -48,51 +72,52 @@ A single LLM call producing all artifacts as one JSON response truncated at 7,71
 
 Separate calls per document mirror how agents actually work. Each document is a focused, bounded response that fits comfortably within output limits.
 
-## Phase B: Register Metadata (After State Refresh)
+### Parallelism (GH-304)
 
-Runs inside `src.marcus_mcp.tools.nlp.create_project()`, after `state.refresh_project_state()` has populated the MCP state object.
+The five LLM calls per task run concurrently (Level 2), and all design tasks run concurrently with each other (Level 1). A per-invocation `asyncio.Semaphore(10)` caps total in-flight LLM calls to respect provider rate limits. Wall-clock: 25–33 min sequential → 1–3 min parallel on a typical 10-task enterprise project.
 
-Phase B registers the artifacts and decisions through MCP tools:
+### Fail-fast semantics
 
-- `log_artifact()` for each file produced in Phase A — populates `state.task_artifacts`
+Each LLM call is wrapped with `@with_retry(max_attempts=3, base_delay=2.0, jitter=True)`. If retries exhaust on any single call, the exception propagates through the inner `gather`, aborts the outer `gather`, and `_generate_design_content` raises. `_run_design_phase` catches this, logs it, and short-circuits: no Phase B, no kanban updates, no scaffold, no partial state. Fail-fast was chosen over warn-and-continue because partial design outputs silently corrupt downstream agent work.
+
+## Phase B: Register Metadata
+
+Phase B registers artifacts and decisions through MCP tools:
+
+- `log_artifact()` for each file produced in Phase A — populates `state.task_artifacts[design_task_id]`
 - `log_decision()` for each architectural decision — populates `state.context.decisions`
 
-Phase B does **NOT** call `report_task_progress`. The task is already DONE from Phase A.
+Phase B does **NOT** call `report_task_progress`. The task's kanban DONE update happens in the next step.
 
-Workers discover design artifacts and decisions through `get_task_context` when they start dependent tasks.
+Workers discover design artifacts and decisions through `get_task_context` when they start dependent tasks. The retrieval path is `_collect_task_artifacts` (context.py) which walks `task.dependencies`, pulls `state.task_artifacts[dep_id]` for each, and returns the merged list to the agent.
 
-## Why Two Phases
+## Ordering Invariant
 
-```
-create_project flow:
+**Phase B registration MUST run before the kanban DONE update.** This is a load-bearing ordering constraint pinned by `_run_design_phase` and tested by `TestRunDesignPhaseHandoff`.
 
-  ┌──────────────────────────┐
-  │  Phase A                 │
-  │  - LLM calls             │   Needs to run BEFORE create_tasks_on_board()
-  │  - Write files to disk   │   so tasks are born DONE (prevents race
-  │  - Set status = DONE     │   condition where agents grab design tasks)
-  │  - Set auto_completed    │
-  └──────────┬───────────────┘
-             │
-             v
-  ┌──────────────────────────┐
-  │  create_tasks_on_board() │   Design tasks arrive DONE
-  └──────────┬───────────────┘
-             │
-             v
-  ┌──────────────────────────┐
-  │  refresh_project_state() │   Populates MCP state object
-  └──────────┬───────────────┘
-             │
-             v
-  ┌──────────────────────────┐
-  │  Phase B                 │   Needs MCP state object, which is only
-  │  - log_artifact()        │   available after refresh_project_state()
-  │  - log_decision()        │
-  └──────────────────────────┘
-```
+The kanban DONE update is what unblocks implementation tasks from hard dependencies. If Phase B runs after, there is a window where:
 
-The two phases serve different purposes and cannot be combined. Phase A needs to complete before board creation to prevent the race condition. Phase B needs the MCP `state` object which only exists after `refresh_project_state()`.
+1. Design task marked DONE on kanban
+2. Implementation task unblocked
+3. Agent requests implementation task
+4. `_collect_task_artifacts` walks dependencies, finds empty `state.task_artifacts[design_task_id]`
+5. Agent receives no contracts, proceeds without them
+
+The window is sub-second but races don't care about narrow windows. Phase B before kanban update closes it entirely.
+
+## Regression History
+
+This section exists because the Phase A → Phase B handoff was broken for 5 days (2026-04-06 to 2026-04-11) and the regression hid behind stale documentation.
+
+**2026-04-02 (GH-297, commit 4daccb7):** Two-phase design autocomplete landed. Phase A ran synchronously inside `create_project_from_description` and stored output in `result["design_content"]`. Phase B ran in `src/marcus_mcp/tools/nlp.py` after `state.refresh_project_state()`, reading the key from the result dict.
+
+**2026-04-06 (GH-314, commit 1c5c7f7):** Phase A moved to a background closure via `asyncio.ensure_future` to prevent Claude Code from timing out on long LLM calls. The line `result["design_content"] = design_content` was deleted as part of the refactor. Phase B in nlp.py continued to read `result.get("design_content", {})` but the key was never populated again. Phase B became dead code. No test caught it — the `TestRegisterDesignViaMcp` unit tests mocked `design_content` directly, bypassing the handoff.
+
+**2026-04-06 to 2026-04-11:** Marcus generated design artifacts to disk on every project creation but never registered them in `state.task_artifacts`. Agents calling `get_task_context` on implementation tasks walked the dependency graph and found empty artifact lists for every design task dependency. Contract-first decomposition was silently non-functional.
+
+**2026-04-11 (GH-320):** Regression discovered while planning the contract-first decomposer. Phase A and Phase B consolidated into a single `_run_design_phase` function that cannot break again without touching both phases. The dead Phase B block in nlp.py was removed. The ordering invariant (Phase B before kanban DONE) was pinned by `TestRunDesignPhaseHandoff`. This document was rewritten to match current code.
+
+**Lesson:** Cross-cutting handoffs between code owned by the same closure are fragile when the closure is refactored. If you ever split Phase A and Phase B again — or move Phase A to a different lifecycle hook — preserve the ordering invariant and add a chain-level test that exercises the full handoff with both phases mocked.
 
 ## Why MCP Tools for Registration
 
@@ -151,22 +176,31 @@ This keeps the board focused on work that agents are actually doing, while prese
 
 ## Implementation Files
 
-- `src/integrations/nlp_tools.py` — `_generate_design_content()` (Phase A), `_register_design_via_mcp()` (Phase B), `_ARTIFACT_PROMPT`, `_DECISIONS_PROMPT`
-- `src/integrations/nlp_tools.py` — Phase A wiring inside `NaturalLanguageProjectCreator.create_project_from_description()`
-- `src/marcus_mcp/tools/nlp.py` — Phase B wiring inside `create_project()` (the MCP tool entry point)
+- `src/integrations/nlp_tools.py`
+  - `_generate_design_content()` — Phase A: parallel LLM calls, writes files to disk
+  - `_register_design_via_mcp()` — Phase B: calls `log_artifact` / `log_decision` to populate MCP state
+  - `_run_design_phase()` — Background orchestrator: Phase A + Phase B + kanban DONE + scaffold, with load-bearing ordering
+  - `_ARTIFACT_PROMPT`, `_DECISIONS_PROMPT`, `_INTERFACE_CONTRACTS_PROMPT` — LLM prompt templates
+- `src/integrations/nlp_tools.py::NaturalLanguageProjectCreator.create_project_from_description()` — schedules `_run_design_phase` as a background task via `asyncio.ensure_future`
+- `tests/unit/integrations/test_design_autocomplete.py::TestRunDesignPhaseHandoff` — regression guard for the Phase A → Phase B handoff and ordering invariant
 - `cato_src/core/aggregator.py` — `_filter_tasks_by_view()` filters `auto_completed` label
 
 ## Pipeline Context
 
-Design autocomplete is Phase A of the project creation pipeline:
+Design autocomplete runs as a single background task within the project creation pipeline:
 
 ```
-Phase A:     Design artifacts + decisions (this system)
-Phase A.5:   Project scaffold (infrastructure/16-project-scaffolding.md)
-Board:       Tasks created on kanban
-Phase B:     Register artifacts + decisions via MCP tools (nlp.py)
-Worktrees:   Branch from main HEAD (inherits design + scaffold)
-Workers:     Start with design context + working project structure
+create_project (MCP tool)
+  ├── parse PRD synchronously
+  ├── create tasks on kanban board (design tasks born with assigned_to="Marcus")
+  ├── schedule _run_design_phase via ensure_future [fire-and-forget]
+  └── return to caller immediately
+
+_run_design_phase [background]:
+  ├── Phase A: LLM artifact generation + disk writes
+  ├── Phase B: log_artifact + log_decision via MCP tools
+  ├── Kanban DONE update (unblocks implementation tasks)
+  └── Phase A.5: Project scaffold generation
 ```
 
 Phase A.5 (project scaffolding) reads the architecture document produced

--- a/src/integrations/nlp_tools.py
+++ b/src/integrations/nlp_tools.py
@@ -2430,8 +2430,8 @@ async def _register_design_via_mcp(
 async def _run_design_phase(
     state: Any,
     kanban_client: Any,
-    safe_tasks: List[Any],
-    created_tasks: List[Any],
+    safe_tasks: List[Task],
+    created_tasks: List[Task],
     description: str,
     project_name: str,
     project_root: str,
@@ -2588,24 +2588,27 @@ async def _run_design_phase(
     # Kanban DONE update — unblocks implementation tasks. Runs
     # AFTER Phase B so that state.task_artifacts is already
     # populated when dependents walk the dependency graph.
-    for ct in created_tasks:
-        orig_idx = created_tasks.index(ct)
-        if orig_idx < len(safe_tasks):
-            orig = safe_tasks[orig_idx]
-            if _is_design_task(orig) and orig.name in design_content:
-                try:
-                    await kanban_client.update_task(
-                        ct.id,
-                        {"status": "done"},
-                    )
-                    logger.info(
-                        f"[design_autocomplete] Marked '{orig.name}' " f"DONE on board"
-                    )
-                except Exception as e:
-                    logger.warning(
-                        f"[design_autocomplete] Failed to update board "
-                        f"for '{orig.name}': {e}"
-                    )
+    #
+    # ``created_tasks`` and ``safe_tasks`` are index-aligned by
+    # construction in ``create_project_from_description``: each
+    # ``created_tasks[i]`` is the kanban-created counterpart of
+    # ``safe_tasks[i]``. ``zip`` is O(n) and handles the shorter-list
+    # case gracefully if the two arrays ever get out of sync.
+    for ct, orig in zip(created_tasks, safe_tasks):
+        if _is_design_task(orig) and orig.name in design_content:
+            try:
+                await kanban_client.update_task(
+                    ct.id,
+                    {"status": "done"},
+                )
+                logger.info(
+                    f"[design_autocomplete] Marked '{orig.name}' " f"DONE on board"
+                )
+            except Exception as e:
+                logger.warning(
+                    f"[design_autocomplete] Failed to update board "
+                    f"for '{orig.name}': {e}"
+                )
 
     # Scaffold generation — best effort, non-fatal on failure
     try:

--- a/src/integrations/nlp_tools.py
+++ b/src/integrations/nlp_tools.py
@@ -2561,16 +2561,39 @@ async def _run_design_phase(
 
     # Phase B — MUST run before kanban DONE update. See docstring
     # "Ordering is load-bearing" section for why.
+    #
+    # Race avoidance: Phase B matches ``state.project_tasks`` to
+    # ``design_content`` by task name. Because this closure runs as a
+    # background task, ``state.project_tasks`` may still be stale at
+    # the moment Phase B fires — the MCP tool caller's
+    # ``refresh_project_state()`` might not have completed yet. To
+    # close that race, refresh state ourselves before Phase B so the
+    # name match sees current kanban UUIDs. Codex review on PR #326
+    # caught the original hole: without this refresh, Phase B could
+    # silently register zero artifacts against an empty task list
+    # and the closure would still mark design tasks DONE, leaving
+    # impl tasks to unblock without contracts — the exact silent
+    # failure mode this function is supposed to eliminate.
+    phase_b_registered = 0
     if state is not None:
+        if hasattr(state, "refresh_project_state"):
+            try:
+                await state.refresh_project_state()
+            except Exception as e:
+                logger.warning(
+                    f"[design_autocomplete] Pre-Phase-B state refresh "
+                    f"failed: {e}. Phase B may see stale project_tasks."
+                )
         try:
             phase_b_result = await _register_design_via_mcp(
                 state=state,
                 design_content=design_content,
                 project_root=project_root,
             )
+            phase_b_registered = int(phase_b_result.get("artifacts_registered", 0))
             logger.info(
                 f"[design_autocomplete] Phase B: registered "
-                f"{phase_b_result.get('artifacts_registered', 0)} "
+                f"{phase_b_registered} "
                 f"artifact(s), "
                 f"{phase_b_result.get('decisions_logged', 0)} "
                 f"decision(s) via MCP tools"
@@ -2584,6 +2607,40 @@ async def _run_design_phase(
             "state.task_artifacts; downstream tasks will not discover "
             "them via get_task_context)"
         )
+
+    # Zero-registration guard (Codex review on PR #326).
+    #
+    # When ``state`` is provided and Phase A produced design content,
+    # Phase B MUST have registered at least one artifact for the
+    # kanban DONE update to be safe. If it registered zero, something
+    # is badly wrong — most likely ``state.project_tasks`` was still
+    # empty or none of the names matched. Marking design tasks DONE
+    # now would unblock impl tasks and they would walk dependencies
+    # into empty ``state.task_artifacts`` entries, reintroducing the
+    # silent-failure mode PR #326 was designed to eliminate.
+    #
+    # Skipping the DONE updates means impl tasks stay blocked on
+    # their design deps. That's the correct degenerate state: the
+    # user sees "design tasks never completed" in the kanban and can
+    # investigate, rather than seeing "implementation agents
+    # produced code that doesn't integrate and nobody knows why."
+    # Loud failure > silent corruption.
+    #
+    # The ``state is None`` path is exempt from this guard because
+    # legacy callers explicitly opt out of Phase B entirely — for
+    # them, the DONE updates are the only thing moving design tasks
+    # to the next state and skipping them would hang the project.
+    if state is not None and design_content and phase_b_registered == 0:
+        logger.error(
+            "[design_autocomplete] Phase B registered 0 artifacts "
+            "despite Phase A producing design_content. Refusing to "
+            "mark design tasks DONE — impl tasks would unblock "
+            "without contracts (exact silent failure mode from "
+            "#314). Design tasks will stay TODO; investigate why "
+            "state.project_tasks did not match design_content names. "
+            f"design_content keys: {list(design_content.keys())}"
+        )
+        return
 
     # Kanban DONE update — unblocks implementation tasks. Runs
     # AFTER Phase B so that state.task_artifacts is already

--- a/src/integrations/nlp_tools.py
+++ b/src/integrations/nlp_tools.py
@@ -111,11 +111,36 @@ class NaturalLanguageProjectCreator(NaturalLanguageTaskCreator):
         ai_engine: Any,
         subtask_manager: Any = None,
         complexity: str = "standard",
+        state: Any = None,
     ) -> None:
+        """Initialize the natural language project creator.
+
+        Parameters
+        ----------
+        kanban_client : Any
+            Kanban board client for task creation.
+        ai_engine : Any
+            AI engine for PRD parsing and task generation.
+        subtask_manager : Any, optional
+            Subtask manager for decomposed task tracking.
+        complexity : str, default="standard"
+            Project complexity mode: prototype / standard / enterprise.
+        state : Any, optional
+            Marcus MCP server state. Required for the Phase A → Phase B
+            design artifact registration chain (GH-320): when present,
+            the background design phase closure calls
+            ``_register_design_via_mcp`` with this state so design
+            contract artifacts reach ``state.task_artifacts`` and
+            become discoverable to downstream implementation tasks via
+            ``get_task_context``. When ``None``, design artifacts are
+            still written to disk but are not registered in MCP state
+            (legacy behavior).
+        """
         super().__init__(kanban_client, ai_engine, subtask_manager, complexity)
         self.prd_parser = AdvancedPRDParser()
         self.board_analyzer = BoardAnalyzer()
         self.context_detector = ContextDetector(self.board_analyzer)
+        self.state = state
 
     async def process_natural_language(
         self,
@@ -597,78 +622,27 @@ class NaturalLanguageProjectCreator(NaturalLanguageTaskCreator):
 
             logger.info(f"Successfully created project with {len(created_tasks)} tasks")
 
-            # Phase A (background): Generate design artifacts + scaffold
-            # Runs AFTER response is returned so Claude doesn't timeout.
-            # _generate_design_content marks design tasks DONE and writes
-            # artifacts to disk. Workers are blocked by hard dependencies
-            # until design tasks reach DONE status on the kanban board.
+            # Phase A+B (background): Generate design artifacts,
+            # register via MCP, mark design tasks DONE, generate
+            # scaffold. Runs AFTER response is returned so Claude
+            # doesn't timeout on long LLM calls. Workers are blocked
+            # by hard dependencies until design tasks reach DONE
+            # status on the kanban board.
             has_design_tasks = any(_is_design_task(t) for t in safe_tasks)
             if project_root and has_design_tasks:
                 import asyncio as _aio
 
-                kanban = self.kanban_client
-
-                async def _run_design_phase() -> None:
-                    design_content: Dict[str, Any] = {}
-                    try:
-                        design_content = await _generate_design_content(
-                            tasks=safe_tasks,
-                            project_description=description,
-                            project_name=project_name,
-                            project_root=project_root,
-                        )
-                        logger.info(
-                            "[design_autocomplete] Background Phase A " "complete"
-                        )
-                    except Exception as e:
-                        logger.warning(
-                            f"[design_autocomplete] Background Phase A "
-                            f"failed (non-fatal): {e}"
-                        )
-
-                    # Only mark design tasks DONE if they produced
-                    # artifacts. Tasks that failed stay TODO so workers
-                    # remain blocked (correct behavior — no design
-                    # outputs means implementation can't proceed).
-                    for ct in created_tasks:
-                        orig_idx = created_tasks.index(ct)
-                        if orig_idx < len(safe_tasks):
-                            orig = safe_tasks[orig_idx]
-                            if _is_design_task(orig) and orig.name in design_content:
-                                try:
-                                    await kanban.update_task(
-                                        ct.id,
-                                        {"status": "done"},
-                                    )
-                                    logger.info(
-                                        f"[design_autocomplete] "
-                                        f"Marked '{orig.name}' DONE "
-                                        f"on board"
-                                    )
-                                except Exception as e:
-                                    logger.warning(
-                                        f"[design_autocomplete] "
-                                        f"Failed to update board "
-                                        f"for '{orig.name}': {e}"
-                                    )
-
-                    if design_content:
-                        try:
-                            await _generate_project_scaffold(
-                                tasks=safe_tasks,
-                                project_description=description,
-                                project_name=project_name,
-                                project_root=project_root,
-                                design_content=design_content,
-                            )
-                            logger.info("[scaffold] Background generation complete")
-                        except Exception as e:
-                            logger.warning(
-                                f"[scaffold] Background generation "
-                                f"failed (non-fatal): {e}"
-                            )
-
-                _aio.ensure_future(_run_design_phase())
+                _aio.ensure_future(
+                    _run_design_phase(
+                        state=self.state,
+                        kanban_client=self.kanban_client,
+                        safe_tasks=safe_tasks,
+                        created_tasks=created_tasks,
+                        description=description,
+                        project_name=project_name,
+                        project_root=project_root,
+                    )
+                )
                 logger.info(
                     "[design_autocomplete] Phase A scheduled as " "background task"
                 )
@@ -2451,6 +2425,200 @@ async def _register_design_via_mcp(
         result["tasks_completed"] += 1
 
     return result
+
+
+async def _run_design_phase(
+    state: Any,
+    kanban_client: Any,
+    safe_tasks: List[Any],
+    created_tasks: List[Any],
+    description: str,
+    project_name: str,
+    project_root: str,
+) -> None:
+    """
+    Run the full background design phase: Phase A + Phase B + kanban + scaffold.
+
+    This orchestrates four steps in a fixed order:
+
+    1. **Phase A** — :func:`_generate_design_content` produces design
+       artifacts and decisions for each design task via parallel LLM
+       calls (GH-297, GH-304). Fail-fast: any unrecoverable LLM error
+       aborts the entire phase and no downstream steps run.
+    2. **Phase B** — :func:`_register_design_via_mcp` registers the
+       generated artifacts into ``state.task_artifacts`` keyed by the
+       real kanban UUIDs, so downstream implementation tasks discover
+       them via the dependency walk in
+       :func:`_collect_task_artifacts` (GH-320).
+    3. **Kanban DONE update** — mark design task cards as done,
+       which unblocks implementation tasks from hard dependencies.
+    4. **Scaffold generation** — :func:`_generate_project_scaffold`
+       writes initial project scaffolding files.
+
+    Ordering is load-bearing
+    ------------------------
+    Phase B (step 2) MUST run before the kanban DONE update (step 3).
+    The DONE update is what unblocks implementation tasks from hard
+    dependencies — if Phase B runs after, there is a window where:
+
+    1. Design task marked DONE on kanban
+    2. Implementation task unblocked
+    3. Agent requests implementation task
+    4. :func:`_collect_task_artifacts` walks dependencies, finds
+       empty ``state.task_artifacts[design_task_id]``
+    5. Agent receives no contracts
+
+    The window is sub-second but races don't care about narrow
+    windows. The ordering pinned here and tested by
+    ``TestRunDesignPhaseHandoff`` prevents it entirely.
+
+    Regression history
+    ------------------
+    Before GH-314 (commit 1c5c7f7, April 6, 2026), Phase A was
+    synchronous inside ``create_project_from_description`` and its
+    output was stored in ``result["design_content"]``. Phase B ran
+    separately inside ``src/marcus_mcp/tools/nlp.py`` after
+    ``refresh_project_state``, reading ``design_content`` out of the
+    result dict.
+
+    GH-314 moved Phase A to a background closure and deleted the
+    line ``result["design_content"] = design_content``. This
+    orphaned the Phase B call in nlp.py, which continued to read
+    ``result.get("design_content", {})`` — an empty dict forever.
+    The Phase B handoff was dead for 5 days until GH-320 caught it.
+
+    This function is the fix: Phase A and Phase B run together in
+    the same closure, so the handoff cannot be broken by refactoring
+    one without touching the other. The dead Phase B block in
+    nlp.py was removed as part of the same fix.
+
+    Parameters
+    ----------
+    state : Any
+        Marcus MCP server state. Required for Phase B — used to
+        populate ``state.task_artifacts`` via ``log_artifact``. If
+        ``None``, Phase B is skipped with a warning (legacy behavior
+        preserved for callers that don't pass state).
+    kanban_client : Any
+        Kanban client for marking design tasks DONE.
+    safe_tasks : List[Any]
+        Pre-board-creation task objects used to derive design task
+        names and descriptions.
+    created_tasks : List[Any]
+        Post-board-creation task objects with real kanban UUIDs. The
+        index must align with ``safe_tasks``.
+    description : str
+        Original project description (passed to Phase A LLM calls).
+    project_name : str
+        Project name (passed to Phase A and scaffold).
+    project_root : str
+        Absolute path where artifacts will be written.
+
+    Returns
+    -------
+    None
+        This is a background task — callers fire-and-forget via
+        :func:`asyncio.ensure_future`. All failures are logged and
+        non-fatal by design.
+
+    See Also
+    --------
+    _generate_design_content : Phase A implementation.
+    _register_design_via_mcp : Phase B implementation.
+    tests.unit.integrations.test_design_autocomplete.TestRunDesignPhaseHandoff :
+        Regression guard for the ordering invariant.
+
+    Notes
+    -----
+    GH-297 : Original two-phase design autocomplete.
+    GH-304 : Parallelization (Phase A 25-33min → 1-3min).
+    GH-314 : Moved Phase A to background (accidentally orphaned Phase B).
+    GH-320 : Reconnected Phase A → Phase B handoff (this function).
+    """
+    design_content: Dict[str, Any] = {}
+    try:
+        design_content = await _generate_design_content(
+            tasks=safe_tasks,
+            project_description=description,
+            project_name=project_name,
+            project_root=project_root,
+        )
+        logger.info("[design_autocomplete] Background Phase A complete")
+    except Exception as e:
+        logger.warning(
+            f"[design_autocomplete] Background Phase A failed (non-fatal): {e}"
+        )
+        # Fail-fast semantics: partial design outputs silently
+        # corrupt downstream agent work (#304). Return early so no
+        # Phase B, no kanban DONE updates, no scaffold.
+        return
+
+    if not design_content:
+        logger.info(
+            "[design_autocomplete] Phase A produced no content, skipping Phase B"
+        )
+        return
+
+    # Phase B — MUST run before kanban DONE update. See docstring
+    # "Ordering is load-bearing" section for why.
+    if state is not None:
+        try:
+            phase_b_result = await _register_design_via_mcp(
+                state=state,
+                design_content=design_content,
+                project_root=project_root,
+            )
+            logger.info(
+                f"[design_autocomplete] Phase B: registered "
+                f"{phase_b_result.get('artifacts_registered', 0)} "
+                f"artifact(s), "
+                f"{phase_b_result.get('decisions_logged', 0)} "
+                f"decision(s) via MCP tools"
+            )
+        except Exception as e:
+            logger.warning(f"[design_autocomplete] Phase B failed (non-fatal): {e}")
+    else:
+        logger.warning(
+            "[design_autocomplete] Phase B skipped: state is None "
+            "(design artifacts written to disk but not registered in "
+            "state.task_artifacts; downstream tasks will not discover "
+            "them via get_task_context)"
+        )
+
+    # Kanban DONE update — unblocks implementation tasks. Runs
+    # AFTER Phase B so that state.task_artifacts is already
+    # populated when dependents walk the dependency graph.
+    for ct in created_tasks:
+        orig_idx = created_tasks.index(ct)
+        if orig_idx < len(safe_tasks):
+            orig = safe_tasks[orig_idx]
+            if _is_design_task(orig) and orig.name in design_content:
+                try:
+                    await kanban_client.update_task(
+                        ct.id,
+                        {"status": "done"},
+                    )
+                    logger.info(
+                        f"[design_autocomplete] Marked '{orig.name}' " f"DONE on board"
+                    )
+                except Exception as e:
+                    logger.warning(
+                        f"[design_autocomplete] Failed to update board "
+                        f"for '{orig.name}': {e}"
+                    )
+
+    # Scaffold generation — best effort, non-fatal on failure
+    try:
+        await _generate_project_scaffold(
+            tasks=safe_tasks,
+            project_description=description,
+            project_name=project_name,
+            project_root=project_root,
+            design_content=design_content,
+        )
+        logger.info("[scaffold] Background generation complete")
+    except Exception as e:
+        logger.warning(f"[scaffold] Background generation failed (non-fatal): {e}")
 
 
 async def add_feature_natural_language(

--- a/src/marcus_mcp/tools/nlp.py
+++ b/src/marcus_mcp/tools/nlp.py
@@ -434,6 +434,7 @@ async def create_project(
             ai_engine=state.ai_engine,
             subtask_manager=subtask_manager,
             complexity=complexity,
+            state=state,
         )
 
         # Ensure we await the result properly
@@ -743,37 +744,16 @@ async def create_project(
                 },
             )
 
-        # Phase B (GH-297): Register design artifacts + decisions
-        # via MCP tools so state.task_artifacts and
-        # state.context.decisions are populated for get_task_context.
-        # Phase A ran inside create_project_from_description() and
-        # stored design_content in the result dict.
-        design_content = result.get("design_content", {})
-        if design_content and result.get("success"):
-            try:
-                from src.integrations.nlp_tools import (
-                    _register_design_via_mcp,
-                )
-
-                project_root = options.get("project_root") if options else None
-                phase_b = await _register_design_via_mcp(
-                    state=state,
-                    design_content=design_content,
-                    project_root=project_root,
-                )
-                if phase_b.get("tasks_completed", 0) > 0:
-                    logger.info(
-                        f"[design_autocomplete] Phase B: "
-                        f"registered "
-                        f"{phase_b['artifacts_registered']}"
-                        f" artifact(s), "
-                        f"{phase_b['decisions_logged']}"
-                        f" decision(s) via MCP tools"
-                    )
-            except Exception as e:
-                logger.warning(
-                    f"[design_autocomplete] Phase B " f"failed (non-fatal): {e}"
-                )
+        # Phase B registration is no longer wired here — it runs
+        # inside the background design closure in
+        # ``src/integrations/nlp_tools.py::_run_design_phase`` so it
+        # stays in lockstep with Phase A. Between GH-297 (April 2,
+        # 2026) and GH-314 (April 6, 2026), Phase B ran here reading
+        # ``result["design_content"]`` that Phase A had populated
+        # synchronously. GH-314 moved Phase A to a background closure
+        # and deleted the line that populated that key, orphaning
+        # Phase B silently. GH-320 consolidated both phases into
+        # ``_run_design_phase`` so the handoff cannot break again.
 
         # Record dedup timestamp AFTER successful creation so failed
         # attempts don't poison the cache and block legitimate retries.
@@ -1001,6 +981,7 @@ async def create_tasks(
             kanban_client=kanban_client,
             ai_engine=state.ai_engine,
             subtask_manager=subtask_manager,
+            state=state,
         )
 
         # Use the creator to parse tasks from description

--- a/tests/unit/integrations/test_design_autocomplete.py
+++ b/tests/unit/integrations/test_design_autocomplete.py
@@ -852,6 +852,128 @@ class TestRunDesignPhaseHandoff:
         mock_scaffold.assert_called_once()
 
     @pytest.mark.asyncio
+    async def test_run_design_phase_skips_done_when_phase_b_registered_zero(
+        self, mock_design_content, tasks
+    ):
+        """
+        Zero-registration guard (PR #326 Codex review).
+
+        When Phase A produces design_content but Phase B registers
+        zero artifacts, _run_design_phase MUST refuse to mark design
+        tasks DONE. The race condition: state.project_tasks can be
+        stale/empty if the background task fires before the MCP tool
+        caller's refresh_project_state() completes. Without this
+        guard, design tasks would unblock impl tasks even though
+        state.task_artifacts stayed empty — the exact silent failure
+        mode from #314 that this whole function was built to fix.
+        """
+        # State with EMPTY project_tasks — simulates the race where
+        # background Phase B fires before state refresh completes.
+        state = MagicMock()
+        state.task_artifacts = {}
+        state.project_tasks = []  # empty!
+        state.kanban_client = AsyncMock()
+        # No refresh_project_state method so we can observe the
+        # zero-registration case cleanly. The guard fires because
+        # Phase B cannot match any tasks by name.
+        del state.refresh_project_state
+        state.context = MagicMock()
+        state.current_project_name = "Test Project"
+
+        kanban = state.kanban_client
+
+        with (
+            patch(
+                "src.integrations.nlp_tools._generate_design_content",
+                new_callable=AsyncMock,
+            ) as mock_gen,
+            patch(
+                "src.marcus_mcp.tools.attachment.log_artifact",
+                new_callable=AsyncMock,
+            ) as mock_log_artifact,
+            patch(
+                "src.integrations.nlp_tools._generate_project_scaffold",
+                new_callable=AsyncMock,
+            ) as mock_scaffold,
+        ):
+            mock_gen.return_value = mock_design_content
+
+            # log_artifact should NOT be called because
+            # _register_design_via_mcp iterates empty state.project_tasks
+            # and matches zero tasks. We let the real
+            # _register_design_via_mcp run (not mocked) so the
+            # zero-count path is exercised end-to-end.
+            await _run_design_phase(
+                state=state,
+                kanban_client=kanban,
+                safe_tasks=tasks["safe"],
+                created_tasks=tasks["created"],
+                description="Test",
+                project_name="Test",
+                project_root="/var/folders/test",  # nosec B108
+            )
+
+        # Phase B registered zero (empty project_tasks → no matches)
+        mock_log_artifact.assert_not_called()
+        # Guard fires: kanban DONE update must be skipped
+        kanban.update_task.assert_not_called()
+        # Scaffold also skipped — the guard exits the function
+        mock_scaffold.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_run_design_phase_refreshes_state_before_phase_b(
+        self, state, mock_design_content, tasks
+    ):
+        """
+        Pre-Phase-B state refresh (PR #326 Codex review).
+
+        Before Phase B fires, _run_design_phase calls
+        state.refresh_project_state() so Phase B sees current kanban
+        UUIDs rather than the stale snapshot from when the background
+        task was scheduled. This closes the race window between
+        ensure_future() and the MCP tool caller's own refresh.
+        """
+        state.project_tasks = tasks["created"]
+        state.refresh_project_state = AsyncMock()
+        kanban = state.kanban_client
+
+        with (
+            patch(
+                "src.integrations.nlp_tools._generate_design_content",
+                new_callable=AsyncMock,
+            ) as mock_gen,
+            patch(
+                "src.marcus_mcp.tools.attachment.log_artifact",
+                new_callable=AsyncMock,
+            ) as mock_log_artifact,
+            patch(
+                "src.marcus_mcp.tools.context.log_decision",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "src.integrations.nlp_tools._generate_project_scaffold",
+                new_callable=AsyncMock,
+            ),
+        ):
+            mock_gen.return_value = mock_design_content
+            mock_log_artifact.return_value = {
+                "success": True,
+                "data": {"location": "docs/x.md"},
+            }
+
+            await _run_design_phase(
+                state=state,
+                kanban_client=kanban,
+                safe_tasks=tasks["safe"],
+                created_tasks=tasks["created"],
+                description="Test",
+                project_name="Test",
+                project_root="/var/folders/test",  # nosec B108
+            )
+
+        state.refresh_project_state.assert_called_once()
+
+    @pytest.mark.asyncio
     async def test_run_design_phase_handles_mismatched_task_arrays(
         self, state, mock_design_content
     ):
@@ -865,7 +987,6 @@ class TestRunDesignPhaseHandoff:
         desynchronizes them we want a clean short-circuit rather than
         an IndexError or silent off-by-one.
         """
-        state.project_tasks = []
         kanban = state.kanban_client
 
         # created_tasks shorter than safe_tasks (pathological case)
@@ -876,6 +997,11 @@ class TestRunDesignPhaseHandoff:
             _make_task("Design Authentication", labels=["design"]),
             _make_task("Design Extra", labels=["design"]),
         ]
+        # Populate state.project_tasks so Phase B can match at least
+        # one design task by name — otherwise the zero-registration
+        # guard fires and the kanban update loop is skipped.
+        state.project_tasks = short_created
+        state.refresh_project_state = AsyncMock()
 
         with (
             patch(

--- a/tests/unit/integrations/test_design_autocomplete.py
+++ b/tests/unit/integrations/test_design_autocomplete.py
@@ -20,6 +20,7 @@ from src.core.models import Priority, Task, TaskStatus
 from src.integrations.nlp_tools import (
     _generate_design_content,
     _register_design_via_mcp,
+    _run_design_phase,
 )
 
 
@@ -457,3 +458,342 @@ class TestRegisterDesignViaMcp:
                 project_root="/var/folders/test",  # nosec B108
             )
             mock_prog.assert_not_called()
+
+
+# ---- Phase A → Phase B Handoff Tests (GH-320 regression) ----
+
+
+class TestRunDesignPhaseHandoff:
+    """
+    Regression tests for GH-320: Phase A → Phase B handoff.
+
+    Guards against the regression introduced in #314 (commit 1c5c7f7,
+    April 6, 2026) where Phase A was moved to a background closure via
+    ``ensure_future`` and the line ``result["design_content"] =
+    design_content`` was deleted. That change orphaned the Phase B
+    caller in ``src/marcus_mcp/tools/nlp.py``, which still reads
+    ``result.get("design_content", {})`` — a key no longer populated.
+    The result: design artifacts were generated to disk but never
+    registered in ``state.task_artifacts``, so impl tasks walking
+    dependencies saw no contracts even though the retrieval path was
+    intact.
+
+    The unit tests in :class:`TestRegisterDesignViaMcp` mock
+    ``design_content`` directly and cannot catch a broken handoff.
+    These tests exercise the full chain inside ``_run_design_phase``:
+    ``_generate_design_content`` → ``_register_design_via_mcp`` →
+    ``state.task_artifacts`` populated → kanban DONE update.
+    """
+
+    @pytest.fixture
+    def state(self):
+        """Mock MCP state with empty task_artifacts."""
+        state = MagicMock()
+        state.task_artifacts = {}
+        state.kanban_client = AsyncMock()
+        state.context = MagicMock()
+        state.current_project_name = "Test Project"
+        return state
+
+    @pytest.fixture
+    def mock_design_content(self):
+        """Phase A output for a single design task."""
+        return {
+            "Design Authentication": {
+                "artifacts": [
+                    {
+                        "filename": "auth-arch.md",
+                        "artifact_type": "architecture",
+                        "content": "# Auth Architecture\n",
+                        "description": "Auth components",
+                        "relative_path": "docs/architecture/auth-arch.md",
+                    },
+                ],
+                "decisions": [],
+            }
+        }
+
+    @pytest.fixture
+    def tasks(self):
+        """One design task, one impl task. Impl depends on design."""
+        safe_design = _make_task(
+            "Design Authentication",
+            labels=["design", "architecture"],
+            task_id="safe_design_1",
+        )
+        safe_impl = _make_task(
+            "Implement Auth",
+            labels=["backend"],
+            task_id="safe_impl_1",
+        )
+        created_design = _make_task(
+            "Design Authentication",
+            labels=["design", "architecture"],
+            task_id="real_design_uuid",
+        )
+        created_impl = _make_task(
+            "Implement Auth",
+            labels=["backend"],
+            task_id="real_impl_uuid",
+        )
+        return {
+            "safe": [safe_design, safe_impl],
+            "created": [created_design, created_impl],
+        }
+
+    @pytest.mark.asyncio
+    async def test_run_design_phase_populates_state_task_artifacts(
+        self, state, mock_design_content, tasks
+    ):
+        """
+        Full chain: Phase A → Phase B → state.task_artifacts populated.
+
+        After ``_run_design_phase`` returns, ``state.task_artifacts``
+        must contain an entry keyed by the real design task UUID.
+        This is the assertion that would have caught #314's regression
+        on day one if it had existed.
+        """
+        # Arrange: state.project_tasks must contain the created design
+        # task so _register_design_via_mcp can match by name.
+        state.project_tasks = tasks["created"]
+        kanban = state.kanban_client
+
+        with (
+            patch(
+                "src.integrations.nlp_tools._generate_design_content",
+                new_callable=AsyncMock,
+            ) as mock_gen,
+            patch(
+                "src.marcus_mcp.tools.attachment.log_artifact",
+                new_callable=AsyncMock,
+            ) as mock_log_artifact,
+            patch(
+                "src.marcus_mcp.tools.context.log_decision",
+                new_callable=AsyncMock,
+            ) as mock_log_decision,
+            patch(
+                "src.integrations.nlp_tools._generate_project_scaffold",
+                new_callable=AsyncMock,
+            ),
+        ):
+            mock_gen.return_value = mock_design_content
+
+            # log_artifact must populate state.task_artifacts like the
+            # real function does (attachment.py:150-165).
+            async def populate_artifacts(**kwargs):
+                state.task_artifacts.setdefault(kwargs["task_id"], []).append(
+                    {
+                        "filename": kwargs["filename"],
+                        "location": "docs/architecture/auth-arch.md",
+                        "artifact_type": kwargs["artifact_type"],
+                    }
+                )
+                return {
+                    "success": True,
+                    "data": {"location": "docs/architecture/auth-arch.md"},
+                }
+
+            mock_log_artifact.side_effect = populate_artifacts
+            mock_log_decision.return_value = {"success": True}
+
+            # Act
+            await _run_design_phase(
+                state=state,
+                kanban_client=kanban,
+                safe_tasks=tasks["safe"],
+                created_tasks=tasks["created"],
+                description="Test",
+                project_name="Test",
+                project_root="/var/folders/test",  # nosec B108
+            )
+
+        # Assert: state.task_artifacts populated keyed by design task UUID
+        assert "real_design_uuid" in state.task_artifacts, (
+            "Phase B must populate state.task_artifacts with design "
+            "task UUID. This assertion guards against the #314 "
+            "regression where Phase B received empty design_content."
+        )
+        assert len(state.task_artifacts["real_design_uuid"]) == 1
+        assert state.task_artifacts["real_design_uuid"][0]["filename"] == "auth-arch.md"
+
+    @pytest.mark.asyncio
+    async def test_phase_b_registration_runs_before_kanban_done_update(
+        self, state, mock_design_content, tasks
+    ):
+        """
+        Ordering invariant: Phase B registration MUST run before the
+        kanban DONE update.
+
+        The kanban DONE update is what unblocks impl tasks from hard
+        dependencies. If Phase B runs after, there is a window where:
+
+        1. Design task marked DONE on kanban
+        2. Impl task unblocked
+        3. Agent requests impl task
+        4. ``_collect_task_artifacts`` walks deps, finds empty
+           ``state.task_artifacts[design_task_id]``
+        5. Agent gets no contracts
+
+        The window is sub-second but races don't care about narrow
+        windows. This test pins the ordering.
+        """
+        state.project_tasks = tasks["created"]
+        kanban = state.kanban_client
+
+        # Shared call-order tracker. Each side effect appends its name.
+        call_order: list[str] = []
+
+        with (
+            patch(
+                "src.integrations.nlp_tools._generate_design_content",
+                new_callable=AsyncMock,
+            ) as mock_gen,
+            patch(
+                "src.marcus_mcp.tools.attachment.log_artifact",
+                new_callable=AsyncMock,
+            ) as mock_log_artifact,
+            patch(
+                "src.marcus_mcp.tools.context.log_decision",
+                new_callable=AsyncMock,
+            ) as mock_log_decision,
+            patch(
+                "src.integrations.nlp_tools._generate_project_scaffold",
+                new_callable=AsyncMock,
+            ),
+        ):
+            mock_gen.return_value = mock_design_content
+
+            async def track_log_artifact(**kwargs):
+                call_order.append("phase_b_log_artifact")
+                return {
+                    "success": True,
+                    "data": {"location": "docs/x.md"},
+                }
+
+            async def track_kanban_update(*args, **kwargs):
+                call_order.append("kanban_done_update")
+                return {"success": True}
+
+            mock_log_artifact.side_effect = track_log_artifact
+            mock_log_decision.return_value = {"success": True}
+            kanban.update_task.side_effect = track_kanban_update
+
+            await _run_design_phase(
+                state=state,
+                kanban_client=kanban,
+                safe_tasks=tasks["safe"],
+                created_tasks=tasks["created"],
+                description="Test",
+                project_name="Test",
+                project_root="/var/folders/test",  # nosec B108
+            )
+
+        # Assert: Phase B (log_artifact) fires BEFORE any kanban DONE
+        # update. We only care about first occurrence of each.
+        phase_b_idx = next(
+            (
+                i
+                for i, event in enumerate(call_order)
+                if event == "phase_b_log_artifact"
+            ),
+            None,
+        )
+        kanban_idx = next(
+            (i for i, event in enumerate(call_order) if event == "kanban_done_update"),
+            None,
+        )
+
+        assert phase_b_idx is not None, (
+            "Phase B log_artifact was never called — registration hook "
+            "is not wired into _run_design_phase"
+        )
+        assert kanban_idx is not None, (
+            "Kanban DONE update was never called — design phase did " "not complete"
+        )
+        assert phase_b_idx < kanban_idx, (
+            f"Ordering violation: Phase B registration must run BEFORE "
+            f"kanban DONE update. Observed order: {call_order}. "
+            f"If registration runs after the unblock, impl tasks can "
+            f"start before contracts reach state.task_artifacts."
+        )
+
+    @pytest.mark.asyncio
+    async def test_run_design_phase_handles_phase_a_failure(self, state, tasks):
+        """
+        Phase A failure short-circuits — no Phase B, no kanban updates.
+
+        If ``_generate_design_content`` raises, ``state.task_artifacts``
+        stays empty, no kanban updates fire, no partial state. Matches
+        the atomic semantics #304 established (fail-fast, no partial
+        design outputs).
+        """
+        state.project_tasks = tasks["created"]
+        kanban = state.kanban_client
+
+        with (
+            patch(
+                "src.integrations.nlp_tools._generate_design_content",
+                new_callable=AsyncMock,
+            ) as mock_gen,
+            patch(
+                "src.marcus_mcp.tools.attachment.log_artifact",
+                new_callable=AsyncMock,
+            ) as mock_log_artifact,
+            patch(
+                "src.integrations.nlp_tools._generate_project_scaffold",
+                new_callable=AsyncMock,
+            ),
+        ):
+            mock_gen.side_effect = RuntimeError("LLM timeout")
+
+            await _run_design_phase(
+                state=state,
+                kanban_client=kanban,
+                safe_tasks=tasks["safe"],
+                created_tasks=tasks["created"],
+                description="Test",
+                project_name="Test",
+                project_root="/var/folders/test",  # nosec B108
+            )
+
+        # Assert: no Phase B side effects, no kanban updates
+        assert (
+            state.task_artifacts == {}
+        ), "Phase A failure must not leave partial state.task_artifacts"
+        mock_log_artifact.assert_not_called()
+        kanban.update_task.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_run_design_phase_noop_when_no_design_tasks(self, state, tasks):
+        """Empty design_content → no Phase B, no kanban updates."""
+        state.project_tasks = tasks["created"]
+        kanban = state.kanban_client
+
+        with (
+            patch(
+                "src.integrations.nlp_tools._generate_design_content",
+                new_callable=AsyncMock,
+            ) as mock_gen,
+            patch(
+                "src.marcus_mcp.tools.attachment.log_artifact",
+                new_callable=AsyncMock,
+            ) as mock_log_artifact,
+            patch(
+                "src.integrations.nlp_tools._generate_project_scaffold",
+                new_callable=AsyncMock,
+            ),
+        ):
+            mock_gen.return_value = {}
+
+            await _run_design_phase(
+                state=state,
+                kanban_client=kanban,
+                safe_tasks=tasks["safe"],
+                created_tasks=tasks["created"],
+                description="Test",
+                project_name="Test",
+                project_root="/var/folders/test",  # nosec B108
+            )
+
+        mock_log_artifact.assert_not_called()
+        kanban.update_task.assert_not_called()

--- a/tests/unit/integrations/test_design_autocomplete.py
+++ b/tests/unit/integrations/test_design_autocomplete.py
@@ -797,3 +797,117 @@ class TestRunDesignPhaseHandoff:
 
         mock_log_artifact.assert_not_called()
         kanban.update_task.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_run_design_phase_with_state_none_skips_phase_b(
+        self, mock_design_content, tasks
+    ):
+        """
+        Legacy backward-compat path: state=None skips Phase B cleanly.
+
+        Callers that don't pass state (e.g. add_task's add_feature path
+        that doesn't have a state reference in scope) must still get
+        Phase A, kanban DONE updates, and scaffold. Only Phase B
+        registration is skipped, and a warning is logged.
+
+        This pins the backward-compat guarantee made in
+        NaturalLanguageProjectCreator.__init__'s state parameter
+        docstring.
+        """
+        kanban = AsyncMock()
+
+        with (
+            patch(
+                "src.integrations.nlp_tools._generate_design_content",
+                new_callable=AsyncMock,
+            ) as mock_gen,
+            patch(
+                "src.marcus_mcp.tools.attachment.log_artifact",
+                new_callable=AsyncMock,
+            ) as mock_log_artifact,
+            patch(
+                "src.integrations.nlp_tools._generate_project_scaffold",
+                new_callable=AsyncMock,
+            ) as mock_scaffold,
+        ):
+            mock_gen.return_value = mock_design_content
+
+            await _run_design_phase(
+                state=None,  # legacy caller with no state reference
+                kanban_client=kanban,
+                safe_tasks=tasks["safe"],
+                created_tasks=tasks["created"],
+                description="Test",
+                project_name="Test",
+                project_root="/var/folders/test",  # nosec B108
+            )
+
+        # Phase B skipped — no log_artifact calls
+        mock_log_artifact.assert_not_called()
+
+        # But kanban DONE update and scaffold still fire (Phase A
+        # succeeded, so design tasks should still land as DONE on the
+        # board even though registration is skipped)
+        kanban.update_task.assert_called()
+        mock_scaffold.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_run_design_phase_handles_mismatched_task_arrays(
+        self, state, mock_design_content
+    ):
+        """
+        Defensive: if safe_tasks and created_tasks get out of sync,
+        the kanban update loop still terminates cleanly (zip handles
+        unequal lengths by stopping at the shorter array).
+
+        This is a defense-in-depth test — the two arrays are
+        index-aligned by construction, but if a future refactor ever
+        desynchronizes them we want a clean short-circuit rather than
+        an IndexError or silent off-by-one.
+        """
+        state.project_tasks = []
+        kanban = state.kanban_client
+
+        # created_tasks shorter than safe_tasks (pathological case)
+        short_created = [
+            _make_task("Design Authentication", labels=["design"], task_id="real_1"),
+        ]
+        long_safe = [
+            _make_task("Design Authentication", labels=["design"]),
+            _make_task("Design Extra", labels=["design"]),
+        ]
+
+        with (
+            patch(
+                "src.integrations.nlp_tools._generate_design_content",
+                new_callable=AsyncMock,
+            ) as mock_gen,
+            patch(
+                "src.marcus_mcp.tools.attachment.log_artifact",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "src.marcus_mcp.tools.context.log_decision",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "src.integrations.nlp_tools._generate_project_scaffold",
+                new_callable=AsyncMock,
+            ),
+        ):
+            mock_gen.return_value = mock_design_content
+
+            # Must not raise IndexError or any exception
+            await _run_design_phase(
+                state=state,
+                kanban_client=kanban,
+                safe_tasks=long_safe,
+                created_tasks=short_created,
+                description="Test",
+                project_name="Test",
+                project_root="/var/folders/test",  # nosec B108
+            )
+
+        # Only the one created task got a kanban update (zip stopped
+        # at the shorter list)
+        assert kanban.update_task.call_count == 1


### PR DESCRIPTION
## Summary

Phase B (design artifact registration via MCP tools) has been dead code for 5 days. Design artifacts generated by Phase A never reached \`state.task_artifacts\`, so implementation tasks walking dependencies via \`_collect_task_artifacts\` found empty dicts for every design task dependency. Contract-first decomposition was silently non-functional.

**This PR is a side-quest bug fix.** It does NOT close #320. #320 PR 2 proper (\`decompose_by_contract\` + \`Task.responsibility\` + \`MARCUS_DECOMPOSER\` feature flag) is still ahead as a separate PR.

## Root Cause

Timeline:

- **2026-04-02** (#297, commit \`4daccb7\`): Two-phase design autocomplete landed. Phase A synchronous inside \`create_project_from_description\`, stored output in \`result[\"design_content\"]\`. Phase B in \`src/marcus_mcp/tools/nlp.py\` read the key after \`state.refresh_project_state()\`. Handoff worked.
- **2026-04-06** (#314, commit \`1c5c7f7\`): Phase A moved to background closure via \`asyncio.ensure_future\` to prevent Claude Code timeouts on long LLM calls. The line \`result[\"design_content\"] = design_content\` was deleted as part of the refactor. Phase B in nlp.py continued to read \`result.get(\"design_content\", {})\` — always \`{}\`. Dead code.
- **2026-04-06 → 2026-04-11**: Marcus generated design artifacts to disk on every project creation but never registered them in \`state.task_artifacts\`. Agents saw no contracts from design deps.
- **2026-04-11** (this PR): Regression discovered while planning #320 PR 2.

No existing test caught the regression. The \`TestRegisterDesignViaMcp\` unit tests mock \`design_content\` directly, bypassing the handoff.

## Fix

Consolidate Phase A and Phase B into a single module-level \`_run_design_phase\` function that runs both in lockstep inside the background task. Cannot break again without touching both phases together.

### Ordering Invariant

**Phase B registration MUST run before the kanban DONE update.** The DONE update unblocks implementation tasks from hard dependencies — if Phase B runs after, there's a sub-second window where an impl task unblocks before \`state.task_artifacts\` is populated, and the agent's dependency walk returns empty.

Ordering is pinned in \`_run_design_phase\` and tested by \`test_phase_b_registration_runs_before_kanban_done_update\`.

## Changes

### \`src/integrations/nlp_tools.py\` (+247 / -73)

- New module-level async \`_run_design_phase(state, kanban_client, safe_tasks, created_tasks, description, project_name, project_root)\` — orchestrates Phase A → Phase B → kanban DONE → scaffold in a fixed order with load-bearing ordering
- \`NaturalLanguageProjectCreator.__init__\` takes optional \`state\` param (None default for backward compat)
- Closure inside \`create_project_from_description\` replaced with direct call to \`_run_design_phase\` via \`ensure_future\`
- Fail-fast semantics: Phase A exception short-circuits the entire phase (no partial state.task_artifacts, no kanban updates, no scaffold)

### \`src/marcus_mcp/tools/nlp.py\` (-30 / +13)

- Dropped the dead Phase B block that read \`result[\"design_content\"]\`
- Both call sites now pass \`state=state\` to \`NaturalLanguageProjectCreator\`

### \`tests/unit/integrations/test_design_autocomplete.py\` (+340)

New \`TestRunDesignPhaseHandoff\` class with 4 chain-level regression tests:

1. \`test_run_design_phase_populates_state_task_artifacts\` — full chain: Phase A → Phase B → \`state.task_artifacts[design_task_id]\` populated. This is the assertion that would have caught #314's regression on day one.
2. \`test_phase_b_registration_runs_before_kanban_done_update\` — ordering invariant: Phase B \`log_artifact\` fires before \`kanban.update_task\` DONE
3. \`test_run_design_phase_handles_phase_a_failure\` — Phase A exception short-circuits, no Phase B, no kanban updates, no partial state
4. \`test_run_design_phase_noop_when_no_design_tasks\` — empty \`design_content\` is a clean no-op

### \`docs/source/systems/coordination/52-design-autocomplete.md\` (rewritten)

The old version still described the pre-#314 design (Phase A synchronous, tasks born DONE). Updated to match current code:

- Background execution model via \`ensure_future\`
- \`assigned_to=\"Marcus\"\` race mitigation (replaces \"born DONE\" invariant)
- Ordering invariant (Phase B before kanban DONE)
- **Regression History** section documenting the 5-day outage so future refactors know why the two phases were consolidated

## Test Results

- \`tests/unit/integrations/test_design_autocomplete.py\`: 15/15 passed
- \`pytest -m unit\`: 391/391 passed
- \`mypy src/integrations/nlp_tools.py src/marcus_mcp/tools/nlp.py\`: clean

## Test plan

- [x] Chain-level regression test: create_project → background Phase A → Phase B → \`state.task_artifacts\` populated
- [x] Ordering invariant test: Phase B log_artifact before kanban update_task DONE
- [x] Phase A failure: no partial state, no kanban updates, no scaffold
- [x] Empty design_content: clean no-op
- [x] Backward compat: optional \`state\` param defaults to None, legacy behavior preserved
- [x] \`pytest -m unit\` green
- [x] mypy clean on touched files
- [ ] Post-merge: run snake game with Phase B alive, verify integration_verification.py receives richer evidence

## Related

- Supersedes nothing (new PR)
- Related to #320 PR 2 (does NOT close — PR 2 proper is decomposer work still ahead)
- Regression from #314
- Built on #297's infrastructure

🤖 Generated with [Claude Code](https://claude.com/claude-code)