### PR TITLE
feat(#320): contract-aware decomposer + Task.responsibility (PR 2)

### DIFF
--- a/docs/experiments/gh320-experiment-3-runbook.md
+++ b/docs/experiments/gh320-experiment-3-runbook.md
@@ -1,0 +1,145 @@
+# GH-320 Experiment 3 — 3-agent contract-based decomposition
+
+| Field | Value |
+|-------|-------|
+| Status | Not yet run |
+| Blocked by | Nothing (can run any time after PR #327 merges) |
+| Motivation | Test whether contract-based decomposition maintains boundary discipline and clean merges when three agents work in parallel on a tightly-coupled problem, not just two |
+| Success criterion | Contribution distribution avoids Single-Author Product verdict; clean merge across 3 worktrees; zero contract modifications |
+| Related | GH-320 PR 2, Experiment 1 (2026-04-10, snake game, 2 agents, hand-crafted contract) |
+
+## Why this experiment exists
+
+Experiment 1 validated 2-agent contract-based decomposition on a tightly-coupled problem. Two agents produced a ~30/70 contribution split, clean merge, zero contract modifications — the first Marcus experiment on tight coupling that did not produce a Single-Author Product verdict.
+
+**Unknowns at 3+ agents:**
+- Does boundary discipline hold when the contract has three interface boundaries instead of two?
+- Do transitive dependencies between contract interfaces cause cascading coordination failures?
+- Does the "file ownership emerges from contract ownership" invariant still hold when three agents touch three distinct files?
+- Does the contribution distribution stay balanced (33/33/34) or collapse into a Single-Author pattern?
+
+Experiment 1 alone is not sufficient evidence to generalize contract-first decomposition to N-agent runs. This experiment is the second data point.
+
+## Setup
+
+Same Vite + React + TypeScript scaffold as Experiment 1. Three-way split along three natural contract boundaries:
+
+- **Agent A — GameEngine**: implements `GameEngine` class (core game loop, state transitions, collision detection)
+- **Agent B — Renderer**: implements `Renderer` class (pure rendering of GameState to DOM, no input handling)
+- **Agent C — Controller**: implements `Controller` class (input handling, binds keyboard to engine, manages timing/game loop)
+
+Contract file `src/types.ts` (hand-crafted, committed on main before any agent starts):
+
+```typescript
+export type Direction = 'up' | 'down' | 'left' | 'right';
+export type Coord = { x: number; y: number };
+
+export interface GameState {
+  snake: Coord[];
+  food: Coord;
+  score: number;
+  gameOver: boolean;
+}
+
+export interface GameEngine {
+  tick(): GameState;
+  setDirection(dir: Direction): void;
+  reset(): void;
+  getState(): GameState;
+}
+
+export interface Renderer {
+  /** Render the game state to a container element. Pure: no mutation of state. */
+  render(state: GameState, container: HTMLElement): void;
+  /** Show game-over overlay. */
+  showGameOver(score: number, container: HTMLElement): void;
+}
+
+export interface Controller {
+  /** Bind keyboard events and start the game loop. Returns a cleanup function. */
+  start(engine: GameEngine, renderer: Renderer, container: HTMLElement): () => void;
+}
+```
+
+Note: three interfaces with explicit dependency ordering. `Controller` composes both `GameEngine` and `Renderer`, so it has the most coordination surface. This is the failure mode to watch — does Agent C stay within its contract or drift into rewriting the engine or renderer?
+
+## Execution
+
+```bash
+# Prereqs: git, node 20+, Claude Code CLI
+mkdir -p ~/experiments/snake-contract-3agent
+cd ~/experiments/snake-contract-3agent
+
+# Baseline
+npm create vite@latest baseline -- --template react-ts
+cd baseline
+# Copy types.ts above to src/types.ts
+git init && git add -A && git commit -m "baseline + contract"
+cd ..
+
+# Three worktrees off main
+git -C baseline worktree add ../agent-a-engine main
+git -C baseline worktree add ../agent-b-renderer main
+git -C baseline worktree add ../agent-c-controller main
+```
+
+Run three Claude Code sessions in parallel:
+
+**Agent A prompt:**
+> Implement the `GameEngine` interface from `src/types.ts` in a new file `src/gameEngine.ts`. Do not touch any other file. Do not modify `src/types.ts`. The contract is read-only and authoritative.
+
+**Agent B prompt:**
+> Implement the `Renderer` interface from `src/types.ts` in a new file `src/renderer.ts`. Render the snake game state to a container element using simple DOM manipulation (divs with inline styles) or canvas. Do not touch any other file. Do not modify `src/types.ts`.
+
+**Agent C prompt:**
+> Implement the `Controller` interface from `src/types.ts` in a new file `src/controller.ts`. Bind arrow key events on the container, call `engine.setDirection()` on input, drive the game loop with `setInterval`, and call `renderer.render()` on each tick. Also wire up `src/App.tsx` and `src/main.tsx` to instantiate `GameEngine`, `Renderer`, and `Controller` and mount them to a container. Do not touch `gameEngine.ts`, `renderer.ts`, or `types.ts`.
+
+## Measurements to capture
+
+After all three agents complete, merge the worktrees and verify:
+
+1. **Contribution distribution**: use Epictetus audit to check for Single-Author Product verdict. Target: ~33/33/34 split by lines of product code. Hard failure if any agent produced <10% of total.
+2. **Contract adherence**: `git diff main..HEAD -- src/types.ts` should be empty. Any diff = contract modification = failed experiment.
+3. **File boundary discipline**: each agent's worktree should only modify its owned file plus the shared scaffolding files in Agent C's case (App.tsx, main.tsx). Cross-boundary edits = boundary discipline failure.
+4. **Clean merge**: three-way merge via octopus merge or sequential merges should produce zero conflicts. Contract-based boundaries should prevent conflicts by construction.
+5. **Build status**: `tsc --noEmit` exit 0 after merge.
+6. **Runtime check**: `npm run dev`, hit arrow keys, verify snake moves, food spawns, game-over fires.
+
+## Expected outcomes and interpretation
+
+### Hypothesis A (contract discipline holds at N=3)
+
+Contribution distribution is roughly balanced. All three agents produce substantive code in their owned files. No contract modifications. Clean three-way merge. Snake game runs.
+
+**Implication**: contract-based decomposition generalizes beyond 2 agents. Marcus can safely recommend contract-first for projects with 3+ agents on tightly-coupled problems.
+
+### Hypothesis B (Single-Author Product re-emerges)
+
+One agent (likely Agent C, the one with the most coordination surface) absorbs all the work. Agent A and/or B produce empty or trivial files. Or one agent silently edits another's contract.
+
+**Implication**: contract-based decomposition has an N-agent scaling ceiling. Need to investigate whether the failure is:
+- Contract design (3 interfaces not enough isolation; need 4+ or different shape)
+- Prompt design (agents don't understand ownership)
+- Fundamental (contracts can't carry enough information to isolate 3+ agents)
+
+### Hypothesis C (partial success)
+
+Two agents produce substantive code, one produces empty or trivial. Contract is not modified. Merge is clean.
+
+**Implication**: closer to #267's original Single-Author observation than to experiment 1's result. Contract-based decomposition helps but doesn't fully solve N-agent coordination at N=3. Need to understand which contract interface failed to carry enough signal.
+
+## What to do with the result
+
+Whichever hypothesis fires, write the outcome to `docs/audit-reports/snake-contract-3agent-YYYY-MM-DD.json` in the Epictetus format used by prior audits. Update GH-320 with the finding. If hypothesis B or C fires, file a follow-up issue on what's next — likely "experiment 3b with 4 contract interfaces" or "contract amendment flow" (the open question from the #320 issue body).
+
+## What this experiment does NOT test
+
+- **LLM-generated contracts** — this uses a hand-crafted contract. Experiment 4 covers LLM-generated contracts.
+- **The Marcus contract-first decomposer** — this runs Claude Code agents directly, not via Marcus. Experiment 4 covers the full Marcus pipeline.
+- **Contract amendment mid-implementation** — if an agent discovers the contract is missing something, what happens? Out of scope. Separate experiment.
+
+## Related
+
+- GH-320 issue body, "Experiment 3" section
+- `~/experiments/snake-contract-test/RESULT.md` — Experiment 1 result template
+- Experiment 4 (`gh320-experiment-4-runbook.md`) — LLM-generated contract validation via Marcus pipeline

--- a/docs/experiments/gh320-experiment-4-runbook.md
+++ b/docs/experiments/gh320-experiment-4-runbook.md
@@ -1,0 +1,144 @@
+# GH-320 Experiment 4 — LLM-generated contract snake game (validation gate)
+
+| Field | Value |
+|-------|-------|
+| Status | Not yet run |
+| Blocked by | PR #327 must merge (contract-aware decomposer implementation) |
+| Motivation | Validate that contract-first decomposition works end-to-end through Marcus's actual pipeline with an LLM-generated contract, not a hand-crafted one |
+| Success criterion | Reproduce Experiment 1's ~30/70 contribution split and clean merge on snake game **without** a human writing the contract |
+| Related | GH-320, PR #327, Experiment 1 (2026-04-10, hand-crafted contract) |
+
+## Why this experiment exists
+
+This is **the real productionization validation gate for PR 2b**.
+
+Experiment 1 proved the mechanism: if you give two agents a good contract and task descriptions that tie each agent to one side of the contract, they produce integrated code. But the contract was **hand-crafted by a human**. Production Marcus will use **LLM-generated contracts** via `_generate_contracts_by_domain`.
+
+The weak link in contract-first decomposition is the contract itself. An LLM-generated contract can be:
+- Ambiguous (interface methods without semantics)
+- Incomplete (missing a method one agent needs)
+- Misaligned (types that don't actually compose)
+
+If the LLM-generated contract is bad, downstream decomposition produces tasks with vague responsibilities, agents produce code that doesn't integrate, and we're back to the Single-Author Product verdict. **Until Experiment 4 passes, PR #327 is unproven in production.**
+
+GH-320 issue body, verbatim: *"LLM-generated contracts are the weak link. Everything above assumes contract generation produces output good enough to decompose from. The experiment-1 contract was hand-crafted by a human. Production Marcus will use LLM-generated contracts. Failure mode: the contract is ambiguous, has type mismatches, or omits a method one agent needs."*
+
+## Prerequisites
+
+1. **PR #327 merged to develop**. Contract-aware decomposer, Task.responsibility field, feature flag, and agent prompt surfacing must all be live.
+2. **PR #326 merged to develop**. Phase A→B handoff must work so design artifacts flow to `state.task_artifacts` and downstream agents can discover them via `get_task_context`. (Merged 2026-04-11.)
+3. **Marcus configured with Anthropic API key**. Contract generation needs real LLM calls.
+4. **Clean baseline directory** for the experiment (no prior project state).
+
+## Setup
+
+```bash
+# Ensure develop is up to date
+cd /Users/lwgray/dev/marcus
+git checkout develop
+git pull origin develop
+
+# Verify both prereqs landed
+git log --oneline | head -5
+# Expect: feat(#320): contract-aware decomposer + Task.responsibility (PR 2)
+#         fix(#320): reconnect Phase A→B design artifact registration (#326)
+
+# Start Marcus with contract-first flag on
+export MARCUS_DECOMPOSER=contract_first
+# Start Marcus per your normal startup procedure
+```
+
+## Execution
+
+Create a new snake game project via Marcus with contract-first enabled:
+
+```python
+# Via Claude Code or direct MCP call:
+create_project(
+    description=(
+        "Build a classic snake game in TypeScript with React. "
+        "The snake moves on a grid, eats food, grows, and ends "
+        "the game on wall or self collision. Arrow keys control "
+        "direction. Display current score and a restart button "
+        "on game over."
+    ),
+    project_name="snake-game-exp4",
+    options={
+        "decomposer": "contract_first",  # Explicit override, belt-and-suspenders
+        "agent_count": 2,
+        "project_root": "/Users/lwgray/dev/snake-game-exp4",
+        "complexity": "standard",
+    }
+)
+```
+
+Then spawn 2 agents as usual. Observe:
+
+1. **Contract generation**: Marcus's design phase should produce contract artifacts under `snake-game-exp4/docs/` — at minimum an API contract describing `GameState`, `GameEngine`, and UI consumer interface. **Capture a copy of the generated contract file.** This is the experiment's input for analysis.
+2. **Task list**: the kanban board should have tasks with `responsibility` field set, naming specific interfaces from the generated contract. Tasks with `responsibility == None` are a failure — the contract-first decomposer didn't fire or fell back to feature-based.
+3. **Agent work**: two agents pick up contract-first tasks. Each agent's instruction should include the `CONTRACT RESPONSIBILITY` layer (visible in agent logs or `get_task_context` output). Each agent reads the contract file before writing code.
+4. **Integration verification**: after both agents complete, the integration verification task runs with the contract-first preamble, treating the contract file as authoritative.
+
+## Measurements to capture
+
+Same structure as Experiment 1, plus contract-quality metrics:
+
+### Primary — did contract-first work?
+
+1. **Contribution distribution via Epictetus audit**: target ~30/70 or better balance. Hard failure if Single-Author Product verdict fires.
+2. **Contract adherence**: neither agent modified the contract file. Diff against the pre-agent-work snapshot.
+3. **Clean integration**: `tsc --noEmit` exit 0 post-merge, game actually runs, arrow keys work.
+4. **Integration verification**: passes without needing to rewrite the contract. If integration agent flags a mismatch and fixes the implementation (not the contract), that's a successful run.
+
+### Secondary — how good was the LLM contract?
+
+5. **Contract completeness**: did the generated contract define all the interfaces needed? If Agent A asked for a method that wasn't in the contract, that's a completeness gap.
+6. **Contract ambiguity**: did either agent have to guess at semantics? Look for agent logs or decision artifacts mentioning "unclear from contract" or equivalent.
+7. **Contract type soundness**: did the interfaces compose without the agents needing to add glue types?
+8. **Decomposer task count**: did `decompose_by_contract` produce 2-3 tasks as instructed? More means the decomposer failed to isolate boundaries; fewer means the contract was too thin.
+
+## Three possible outcomes
+
+### Outcome A — contract-first works as advertised
+
+Contribution ~30/70, clean merge, contract unmodified, integration verification passes. LLM-generated contract was as good as hand-crafted.
+
+**Implication**: GH-320 is effectively closed. PR #327 productionization is validated. Experiment 3 can proceed using LLM-generated contracts as well. Consider defaulting `MARCUS_DECOMPOSER=contract_first` for tightly-coupled project classes.
+
+### Outcome B — contract quality is the bottleneck
+
+Contribution is better than feature-based (some improvement over 100/0 baseline) but not as balanced as Experiment 1. Or the integration agent had to make significant fixes. Or the contract had clear completeness/ambiguity gaps.
+
+**Implication**: PR #327 plumbing is correct but the contract-generation prompts (`_ARTIFACT_PROMPT`, `_INTERFACE_CONTRACTS_PROMPT`) need iteration. File a follow-up issue on prompt tuning. Keep contract-first behind the flag until prompts are good enough.
+
+### Outcome C — contract-first re-collapses to Single-Author
+
+One agent absorbs all the work. Either the contract was too thin to isolate work, the decomposer's tasks were vague, or the agents ignored the contract layer in their prompts.
+
+**Implication**: something structural in PR #327 is broken or insufficient. Investigate whether:
+- Agent prompt layer isn't actually reaching the agent (prompts truncated, layer skipped)
+- `Task.responsibility` isn't making it to the agent via `get_task_context`
+- The LLM-generated contract is fundamentally thinner than a hand-crafted one, and the delta matters
+- Marcus's decompose_by_contract is producing tasks with weak `responsibility` values that don't give agents enough to lock onto
+
+Likely requires one or more of: contract amendment flow, stricter decomposer prompt, agent prompt emphasis, or a hybrid strategy that falls back to feature_based inside specific sub-domains.
+
+## What to do with the result
+
+Write the outcome to `docs/audit-reports/snake-contract-llm-YYYY-MM-DD.json`. Update GH-320 with the finding. Specifically:
+
+- **If Outcome A fires**: close GH-320 PR 2 as validated. Mention the experiment in the CHANGELOG. Consider running Experiment 3 with LLM-generated 3-way contract.
+- **If Outcome B fires**: file a new issue "improve contract generation prompts for contract-first decomposition" with specific failure modes observed.
+- **If Outcome C fires**: file a new issue "contract-first decomposition fails with LLM-generated contracts — investigate" with the observed failure mode and a hypothesis. Keep the flag off by default until resolved.
+
+## Baseline for comparison
+
+The v0.3.0 CHANGELOG documents the feature-based baseline on snake game: contribution split 100/0, 98.5/1.5, 96.9/3.1 across three runs. Experiment 1 (hand-crafted contract) improved this to ~30/70. Experiment 4 should match or exceed that result. Anything worse than 70/30 on an LLM-generated contract is a warning sign.
+
+## Related
+
+- GH-320 issue body, "Experiment 4" section
+- PR #327 (contract-aware decomposer + Task.responsibility)
+- PR #326 (Phase A→B handoff reconnect, prerequisite)
+- Experiment 1 (`~/experiments/snake-contract-test/RESULT.md`)
+- Experiment 3 (`gh320-experiment-3-runbook.md`, 3-agent contract-based)

--- a/src/ai/advanced/prd/advanced_parser.py
+++ b/src/ai/advanced/prd/advanced_parser.py
@@ -504,25 +504,69 @@ class AdvancedPRDParser:
         now = datetime.now(timezone.utc)
 
         for idx, raw in enumerate(raw_tasks, start=1):
-            estimated_minutes = float(raw.get("estimated_minutes", 8.0))
+            # Defensive coercion for every field we read from the LLM.
+            # ``generate_structured_response`` parses JSON but does NOT
+            # enforce the schema, so malformed-but-parseable responses
+            # can leak through with wrong types: ``estimated_minutes:
+            # null``, non-string ``description``, missing keys, etc.
+            # Convert everything to the expected type or a safe
+            # default, and raise RuntimeError on unrecoverable shape
+            # drift so the caller's fallback path triggers cleanly.
+            # Codex caught this on PR #327 review.
+            if not isinstance(raw, dict):
+                raise RuntimeError(
+                    f"Contract decomposition task {idx} is not a "
+                    f"dict: {type(raw).__name__}"
+                )
+
+            raw_minutes = raw.get("estimated_minutes")
+            try:
+                estimated_minutes = (
+                    float(raw_minutes) if raw_minutes is not None else 8.0
+                )
+            except (TypeError, ValueError):
+                estimated_minutes = 8.0
             estimated_hours = estimated_minutes / 60.0
 
-            contract_file = raw.get("contract_file", "")
-            responsibility = raw.get("responsibility", "")
+            contract_file = str(raw.get("contract_file") or "")
+            responsibility = str(raw.get("responsibility") or "")
 
-            # Task description embeds the contract reference so even
-            # callers that don't consult Task.responsibility see it.
-            description = raw.get("description", "").strip()
-            if contract_file and contract_file not in description:
+            raw_description = raw.get("description")
+            description = (
+                str(raw_description).strip() if raw_description is not None else ""
+            )
+            # Embed a structured marker in the description so the
+            # contract-first metadata survives round-tripping through
+            # kanban providers that don't persist Task.responsibility
+            # or Task.source_context as top-level fields (e.g. Planka).
+            # Agent prompt surfacing (build_tiered_instructions) parses
+            # these markers as a fallback when task.responsibility is
+            # absent after reload. Codex caught this on PR #327 review.
+            # See ``_parse_contract_metadata`` in marcus_mcp/tools/task.py.
+            if responsibility or contract_file:
                 description = (
                     f"{description}\n\n"
-                    f"Contract: {contract_file}\n"
-                    f"Responsibility: {responsibility}"
+                    f"<!-- MARCUS_CONTRACT_FIRST\n"
+                    f"responsibility: {responsibility}\n"
+                    f"contract_file: {contract_file}\n"
+                    f"-->"
                 )
+
+            raw_provides = raw.get("provides")
+            provides = str(raw_provides) if raw_provides is not None else None
+
+            raw_requires = raw.get("requires")
+            if raw_requires is None or raw_requires == "None":
+                requires: Optional[str] = None
+            else:
+                requires = str(raw_requires)
+
+            raw_name = raw.get("name")
+            name = str(raw_name) if raw_name is not None else f"Contract Task {idx}"
 
             task = Task(
                 id=f"contract_task_{idx}",
-                name=raw.get("name", f"Contract Task {idx}"),
+                name=name,
                 description=description,
                 status=TaskStatus.TODO,
                 priority=Priority.HIGH,
@@ -536,9 +580,15 @@ class AdvancedPRDParser:
                 source_context={
                     "contract_file": contract_file,
                     "complexity_mode": complexity_mode,
+                    # Also persist responsibility here so it round-trips
+                    # through kanban providers that don't yet serialize
+                    # ``Task.responsibility`` as a top-level field.
+                    # ``build_tiered_instructions`` reads both sources
+                    # when surfacing the CONTRACT RESPONSIBILITY layer.
+                    "responsibility": responsibility,
                 },
-                provides=raw.get("provides"),
-                requires=raw.get("requires") if raw.get("requires") != "None" else None,
+                provides=provides,
+                requires=requires,
                 responsibility=responsibility,
             )
             tasks.append(task)

--- a/src/ai/advanced/prd/advanced_parser.py
+++ b/src/ai/advanced/prd/advanced_parser.py
@@ -261,6 +261,406 @@ class AdvancedPRDParser:
             ),
         )
 
+    async def decompose_by_contract(
+        self,
+        prd_analysis: PRDAnalysis,
+        contract_artifacts: Dict[str, Optional[Dict[str, Any]]],
+        agent_count: int,
+        constraints: Optional[ProjectConstraints] = None,
+    ) -> List[Task]:
+        """
+        Contract-first task decomposition (GH-320 PR 2).
+
+        Given a PRD analysis and pre-generated contract artifacts (one per
+        domain), produce a list of Task objects where each task owns exactly
+        one side of a contract interface. This is the productionized
+        mechanism that experiment 1 (2026-04-10, hand-crafted TypeScript
+        contract) validated for tightly-coupled problems.
+
+        The key difference from ``parse_prd_to_tasks``:
+
+        - Feature-based (``parse_prd_to_tasks``): tasks are shaped by
+          functional requirements. Multiple tasks can end up editing the
+          same file when features are tightly coupled — one agent absorbs
+          the work and produces a Single-Author Product.
+        - Contract-first (``decompose_by_contract``): tasks are shaped by
+          contract interfaces. Each task carries a ``responsibility`` field
+          naming the interface it owns from the shared contract artifact.
+          The agent prompt frames the task as ownership of that interface,
+          and the agent reads the contract before writing code. File
+          ownership emerges naturally from contract ownership — two agents
+          implementing two sides of a contract land in different files
+          because the contract interface was already the boundary.
+
+        The caller is responsible for running contract generation
+        (``_generate_contracts_by_domain``) before calling this method.
+        This method trusts the contracts as input and builds tasks around
+        them — it does not regenerate contracts.
+
+        Parameters
+        ----------
+        prd_analysis : PRDAnalysis
+            Deep PRD analysis produced by ``_analyze_prd_deeply``. Used
+            for project description, complexity assessment, and NFR
+            awareness.
+        contract_artifacts : Dict[str, Dict[str, Any]]
+            Output of ``_generate_contracts_by_domain``: a mapping of
+            ``domain_name -> {"artifacts": [...], "decisions": [...]}``.
+            Each artifact has ``filename``, ``content``, ``artifact_type``,
+            ``relative_path``. Domains where contract generation produced
+            no output map to ``None``.
+        agent_count : int
+            Number of agents available to work on this project. Influences
+            the target task count — the decomposer aims to produce tasks
+            where each agent owns at least one contract interface, with
+            some parallelizable room.
+        constraints : Optional[ProjectConstraints]
+            Project constraints (complexity mode, deployment target, etc.).
+            If omitted, defaults are used.
+
+        Returns
+        -------
+        List[Task]
+            Task objects with ``responsibility`` field set. Tasks are
+            returned in the order produced by the LLM. Dependencies
+            between tasks use the ``provides``/``requires`` cross-parent
+            wiring mechanism. The caller is responsible for assigning
+            kanban-backed IDs and creating cards.
+
+        Raises
+        ------
+        ValueError
+            If ``contract_artifacts`` is empty, or if every domain produced
+            None. This indicates contract generation was a complete
+            failure and the caller should fall back to feature-based
+            decomposition with a visible warning.
+        RuntimeError
+            If the LLM call fails after retries or returns a response
+            that cannot be parsed as a valid task list.
+
+        Notes
+        -----
+        The LLM call uses structured output with a JSON schema. See
+        ``_build_contract_decomposition_prompt`` for the prompt template.
+
+        This method does not handle the fallback itself — the caller (in
+        ``NaturalLanguageProjectCreator``) decides whether to fall back to
+        feature-based decomposition based on whether this method raises
+        and whether the contract quality threshold is met.
+
+        See Also
+        --------
+        _generate_contracts_by_domain : Upstream contract generation.
+        parse_prd_to_tasks : Feature-based decomposition (default path).
+        _build_contract_decomposition_prompt : LLM prompt template.
+
+        References
+        ----------
+        GH-320 : Contract-first task decomposition.
+        Experiment 1 (2026-04-10) : Validated mechanism on hand-crafted
+            TypeScript contract with snake game (30/70 split, clean merge).
+        """
+        # Drop empty domain results so the LLM sees only real contracts.
+        usable_contracts = {
+            domain: payload
+            for domain, payload in contract_artifacts.items()
+            if payload is not None and payload.get("artifacts")
+        }
+
+        if not usable_contracts:
+            raise ValueError(
+                "contract_artifacts has no usable domains — contract "
+                "generation produced no artifacts for any domain. "
+                "Caller should fall back to feature-based decomposition."
+            )
+
+        logger.info(
+            f"[decompose_by_contract] Decomposing with "
+            f"{len(usable_contracts)} contract domain(s) for "
+            f"{agent_count} agent(s)"
+        )
+
+        prompt = self._build_contract_decomposition_prompt(
+            prd_analysis=prd_analysis,
+            contract_artifacts=usable_contracts,
+            agent_count=agent_count,
+        )
+
+        response_format = {
+            "type": "object",
+            "properties": {
+                "tasks": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "name": {
+                                "type": "string",
+                                "description": (
+                                    "Short imperative task name, e.g. "
+                                    "'Implement GameEngine'"
+                                ),
+                            },
+                            "description": {
+                                "type": "string",
+                                "description": (
+                                    "Full task description explaining "
+                                    "what to build, reading from the "
+                                    "contract."
+                                ),
+                            },
+                            "responsibility": {
+                                "type": "string",
+                                "description": (
+                                    "Contract interface or module this "
+                                    "task owns, e.g. 'implements "
+                                    "GameEngine interface from "
+                                    "src/types.ts'. Must reference an "
+                                    "actual interface from the provided "
+                                    "contract artifacts."
+                                ),
+                            },
+                            "contract_file": {
+                                "type": "string",
+                                "description": (
+                                    "Relative path to the contract "
+                                    "artifact this task reads from."
+                                ),
+                            },
+                            "provides": {
+                                "type": "string",
+                                "description": (
+                                    "Semantic description of what this "
+                                    "task delivers to downstream tasks."
+                                ),
+                            },
+                            "requires": {
+                                "type": "string",
+                                "description": (
+                                    "Semantic description of what this "
+                                    "task needs from upstream tasks. "
+                                    "'None' if no prerequisites."
+                                ),
+                            },
+                            "estimated_minutes": {
+                                "type": "number",
+                                "description": (
+                                    "Reality-based estimate in minutes "
+                                    "(typically 4-15 for contract-first "
+                                    "tasks)."
+                                ),
+                            },
+                        },
+                        "required": [
+                            "name",
+                            "description",
+                            "responsibility",
+                            "contract_file",
+                            "provides",
+                            "requires",
+                            "estimated_minutes",
+                        ],
+                    },
+                },
+            },
+            "required": ["tasks"],
+        }
+
+        system_prompt = (
+            "You are a software architect decomposing a project into "
+            "agent-owned tasks based on shared interface contracts. "
+            "Each task you produce MUST own exactly one contract "
+            "interface. You are NOT telling agents which files to edit — "
+            "you are telling them which interface they own. File "
+            "ownership emerges naturally from contract ownership. "
+            "Respond with structured JSON matching the provided schema."
+        )
+
+        # Use AIAnalysisEngine for structured output. LLMAbstraction
+        # only exposes ``analyze`` which returns unstructured text.
+        ai_engine = AIAnalysisEngine()
+        try:
+            response = await ai_engine.generate_structured_response(
+                prompt=prompt,
+                system_prompt=system_prompt,
+                response_format=response_format,
+            )
+        except Exception as e:
+            raise RuntimeError(f"Contract decomposition LLM call failed: {e}") from e
+
+        # generate_structured_response returns a Dict per its type
+        # signature.
+        response_data: Dict[str, Any] = response
+
+        raw_tasks = response_data.get("tasks", [])
+        if not raw_tasks:
+            raise RuntimeError("Contract decomposition LLM response contained no tasks")
+
+        # Build Task objects. IDs are synthetic — caller replaces with
+        # kanban UUIDs when creating cards.
+        constraints = constraints or ProjectConstraints()
+        complexity_mode = constraints.complexity_mode
+        tasks: List[Task] = []
+        now = datetime.now(timezone.utc)
+
+        for idx, raw in enumerate(raw_tasks, start=1):
+            estimated_minutes = float(raw.get("estimated_minutes", 8.0))
+            estimated_hours = estimated_minutes / 60.0
+
+            contract_file = raw.get("contract_file", "")
+            responsibility = raw.get("responsibility", "")
+
+            # Task description embeds the contract reference so even
+            # callers that don't consult Task.responsibility see it.
+            description = raw.get("description", "").strip()
+            if contract_file and contract_file not in description:
+                description = (
+                    f"{description}\n\n"
+                    f"Contract: {contract_file}\n"
+                    f"Responsibility: {responsibility}"
+                )
+
+            task = Task(
+                id=f"contract_task_{idx}",
+                name=raw.get("name", f"Contract Task {idx}"),
+                description=description,
+                status=TaskStatus.TODO,
+                priority=Priority.HIGH,
+                assigned_to=None,
+                created_at=now,
+                updated_at=now,
+                due_date=None,
+                estimated_hours=estimated_hours,
+                labels=["contract_first", "implementation"],
+                source_type="contract_first",
+                source_context={
+                    "contract_file": contract_file,
+                    "complexity_mode": complexity_mode,
+                },
+                provides=raw.get("provides"),
+                requires=raw.get("requires") if raw.get("requires") != "None" else None,
+                responsibility=responsibility,
+            )
+            tasks.append(task)
+
+        logger.info(
+            f"[decompose_by_contract] Produced {len(tasks)} "
+            f"contract-owned tasks from {len(usable_contracts)} domains"
+        )
+        return tasks
+
+    def _build_contract_decomposition_prompt(
+        self,
+        prd_analysis: PRDAnalysis,
+        contract_artifacts: Dict[str, Dict[str, Any]],
+        agent_count: int,
+    ) -> str:
+        """
+        Build the LLM prompt for contract-first decomposition.
+
+        Embeds the project description, the full content of each contract
+        artifact, and the agent count. Instructs the LLM to produce tasks
+        where each task owns one contract interface.
+
+        Parameters
+        ----------
+        prd_analysis : PRDAnalysis
+            PRD analysis with original description and complexity.
+        contract_artifacts : Dict[str, Dict[str, Any]]
+            Domain-keyed contract artifacts (only usable ones, per
+            ``decompose_by_contract`` filtering).
+        agent_count : int
+            Number of agents to target.
+
+        Returns
+        -------
+        str
+            Fully rendered prompt text.
+
+        Notes
+        -----
+        The prompt includes ALL contract content inline rather than
+        summaries because downstream decomposition quality depends on the
+        LLM seeing the actual interface signatures, types, and
+        documentation. Truncation risk is managed by the contract
+        generation prompt (``_ARTIFACT_PROMPT``) which already targets
+        bounded artifacts.
+        """
+        contract_sections = []
+        for domain_name, payload in contract_artifacts.items():
+            artifacts = payload.get("artifacts", [])
+            artifact_blocks = []
+            for art in artifacts:
+                filename = art.get("filename", "unknown")
+                relative_path = art.get("relative_path", filename)
+                artifact_type = art.get("artifact_type", "artifact")
+                content = art.get("content", "")
+                artifact_blocks.append(
+                    f"### {filename} ({artifact_type})\n"
+                    f"Path: {relative_path}\n\n"
+                    f"```\n{content}\n```"
+                )
+            contract_sections.append(
+                f"## Domain: {domain_name}\n\n" + "\n\n".join(artifact_blocks)
+            )
+
+        contracts_text = "\n\n---\n\n".join(contract_sections)
+
+        # Target task count: aim for at least agent_count tasks, up to
+        # a reasonable ceiling. Each task should own a distinct contract
+        # interface.
+        min_tasks = max(agent_count, 2)
+        max_tasks = max(agent_count * 2, 4)
+
+        return f"""You are decomposing a software project into tasks based \
+on shared interface contracts.
+
+## Project
+{prd_analysis.original_description or "Project description unavailable"}
+
+## Contracts
+The following contracts have been generated for this project. Each \
+contract defines interfaces, data models, or APIs that implementation \
+tasks must adhere to. Your job is to produce tasks where each task \
+owns exactly one interface from these contracts.
+
+{contracts_text}
+
+## Decomposition Requirements
+
+- Target {min_tasks}-{max_tasks} tasks total (agent count: {agent_count}).
+- Each task MUST own exactly one interface, module, or contract
+  boundary identified in the contracts above.
+- Each task MUST reference the contract file it reads from (use the
+  relative path from the contract sections).
+- Task responsibility field must name the specific interface/module
+  owned, e.g. "implements GameEngine interface from src/types.ts".
+- DO NOT tell agents which files to write. Tell them which interface
+  they own. File structure emerges from contract ownership.
+- Prefer splitting tasks along natural contract boundaries (e.g.
+  producer vs consumer, frontend vs backend, data model vs business
+  logic).
+- Set provides/requires fields to describe dependency relationships
+  between tasks at the semantic layer.
+- Tasks that don't depend on other tasks should have requires="None".
+- Estimated minutes should be reality-based (4-15 minutes is typical
+  for focused contract-first tasks).
+
+## Output Format
+
+Return a JSON object with a "tasks" array. Each task has:
+- name: Short imperative name
+- description: Full description explaining what to build
+- responsibility: Contract interface owned (must reference an actual
+  interface from above)
+- contract_file: Relative path to the contract artifact
+- provides: Semantic description of what this task delivers
+- requires: Semantic description of what this task needs (or "None")
+- estimated_minutes: Reality-based estimate
+
+Return ONLY the JSON object. Do not include commentary.
+"""
+
     async def _analyze_prd_deeply(
         self, prd_content: str, constraints: ProjectConstraints
     ) -> PRDAnalysis:

--- a/src/config/decomposer_config.py
+++ b/src/config/decomposer_config.py
@@ -1,0 +1,129 @@
+"""
+Decomposer strategy selection (GH-320 PR 2).
+
+Resolves which task decomposition strategy to use at project creation
+time. Two strategies are supported:
+
+- **feature_based** (default): the legacy path. Tasks are shaped by
+  functional requirements from the PRD.
+  :func:`src.ai.advanced.prd.advanced_parser.AdvancedPRDParser.parse_prd_to_tasks`.
+- **contract_first**: tasks are shaped by contract interfaces generated
+  before decomposition. Each task owns one side of a contract.
+  :func:`src.ai.advanced.prd.advanced_parser.AdvancedPRDParser.decompose_by_contract`.
+
+Selection precedence (highest to lowest):
+
+1. Explicit ``options["decomposer"]`` passed to ``create_project``
+2. ``MARCUS_DECOMPOSER`` environment variable
+3. Default: ``feature_based``
+
+Rationale
+---------
+Options-dict precedence lets callers (experiment runners, tests, CI)
+override the environment at call time without touching process state.
+Environment variable precedence lets operators flip the strategy for a
+running Marcus server without restarting. The default preserves
+backward compatibility — projects created without an explicit strategy
+continue to use the path that's been in production since v0.3.0.
+
+See Also
+--------
+src.ai.advanced.prd.advanced_parser.AdvancedPRDParser.decompose_by_contract :
+    The contract-first decomposer implementation.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any, Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+DECOMPOSER_FEATURE_BASED = "feature_based"
+DECOMPOSER_CONTRACT_FIRST = "contract_first"
+
+VALID_DECOMPOSERS = {DECOMPOSER_FEATURE_BASED, DECOMPOSER_CONTRACT_FIRST}
+
+ENV_VAR = "MARCUS_DECOMPOSER"
+
+
+def resolve_decomposer(options: Optional[Dict[str, Any]] = None) -> str:
+    """
+    Resolve the active decomposer strategy from options and environment.
+
+    Parameters
+    ----------
+    options : Optional[Dict[str, Any]]
+        Options dict passed to ``create_project``. If it contains a
+        ``"decomposer"`` key with a valid strategy name, that wins.
+
+    Returns
+    -------
+    str
+        Either ``"feature_based"`` or ``"contract_first"``.
+
+    Notes
+    -----
+    Unknown strategy values (from either source) trigger a loud
+    warning and fall back to ``"feature_based"``. Silent fallbacks
+    would hide configuration errors — the user asked for
+    ``contract_first`` and got feature_based without knowing. Loud
+    warning surfaces the problem at project creation time.
+
+    Examples
+    --------
+    >>> resolve_decomposer({"decomposer": "contract_first"})
+    'contract_first'
+    >>> resolve_decomposer(None)  # MARCUS_DECOMPOSER unset
+    'feature_based'
+    >>> # With MARCUS_DECOMPOSER=contract_first in env
+    >>> resolve_decomposer(None)
+    'contract_first'
+    """
+    if options is not None:
+        explicit = options.get("decomposer")
+        if explicit is not None:
+            if explicit in VALID_DECOMPOSERS:
+                logger.info(f"[decomposer] Using '{explicit}' from options dict")
+                return str(explicit)
+            logger.warning(
+                f"[decomposer] Unknown strategy '{explicit}' in options; "
+                f"falling back to '{DECOMPOSER_FEATURE_BASED}'. "
+                f"Valid strategies: {sorted(VALID_DECOMPOSERS)}"
+            )
+            return DECOMPOSER_FEATURE_BASED
+
+    env_value = os.environ.get(ENV_VAR)
+    if env_value is not None:
+        if env_value in VALID_DECOMPOSERS:
+            logger.info(f"[decomposer] Using '{env_value}' from {ENV_VAR}")
+            return env_value
+        logger.warning(
+            f"[decomposer] Unknown strategy '{env_value}' in {ENV_VAR}; "
+            f"falling back to '{DECOMPOSER_FEATURE_BASED}'. "
+            f"Valid strategies: {sorted(VALID_DECOMPOSERS)}"
+        )
+        return DECOMPOSER_FEATURE_BASED
+
+    return DECOMPOSER_FEATURE_BASED
+
+
+def is_contract_first(options: Optional[Dict[str, Any]] = None) -> bool:
+    """
+    Return True if the contract-first decomposer is active.
+
+    Convenience wrapper around :func:`resolve_decomposer`.
+
+    Parameters
+    ----------
+    options : Optional[Dict[str, Any]]
+        Options dict passed to ``create_project``.
+
+    Returns
+    -------
+    bool
+        ``True`` if ``contract_first`` is selected; ``False`` for
+        ``feature_based`` (the default).
+    """
+    return resolve_decomposer(options) == DECOMPOSER_CONTRACT_FIRST

--- a/src/config/decomposer_config.py
+++ b/src/config/decomposer_config.py
@@ -36,19 +36,30 @@ from __future__ import annotations
 
 import logging
 import os
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Literal, Optional
 
 logger = logging.getLogger(__name__)
 
-DECOMPOSER_FEATURE_BASED = "feature_based"
-DECOMPOSER_CONTRACT_FIRST = "contract_first"
+# Literal type for the decomposer strategy. Downstream callers that
+# need exhaustiveness checking (match statements, type guards) can
+# import this and get compile-time verification that they're handling
+# every valid strategy.
+DecomposerStrategy = Literal["feature_based", "contract_first"]
 
-VALID_DECOMPOSERS = {DECOMPOSER_FEATURE_BASED, DECOMPOSER_CONTRACT_FIRST}
+DECOMPOSER_FEATURE_BASED: DecomposerStrategy = "feature_based"
+DECOMPOSER_CONTRACT_FIRST: DecomposerStrategy = "contract_first"
+
+VALID_DECOMPOSERS: set[DecomposerStrategy] = {
+    DECOMPOSER_FEATURE_BASED,
+    DECOMPOSER_CONTRACT_FIRST,
+}
 
 ENV_VAR = "MARCUS_DECOMPOSER"
 
 
-def resolve_decomposer(options: Optional[Dict[str, Any]] = None) -> str:
+def resolve_decomposer(
+    options: Optional[Dict[str, Any]] = None,
+) -> DecomposerStrategy:
     """
     Resolve the active decomposer strategy from options and environment.
 
@@ -60,8 +71,10 @@ def resolve_decomposer(options: Optional[Dict[str, Any]] = None) -> str:
 
     Returns
     -------
-    str
-        Either ``"feature_based"`` or ``"contract_first"``.
+    DecomposerStrategy
+        Either ``"feature_based"`` or ``"contract_first"``. The
+        ``DecomposerStrategy`` literal type lets callers use
+        exhaustive match/if-else without defensive fallthroughs.
 
     Notes
     -----
@@ -86,7 +99,9 @@ def resolve_decomposer(options: Optional[Dict[str, Any]] = None) -> str:
         if explicit is not None:
             if explicit in VALID_DECOMPOSERS:
                 logger.info(f"[decomposer] Using '{explicit}' from options dict")
-                return str(explicit)
+                # cast via local variable so mypy narrows the type
+                validated: DecomposerStrategy = explicit
+                return validated
             logger.warning(
                 f"[decomposer] Unknown strategy '{explicit}' in options; "
                 f"falling back to '{DECOMPOSER_FEATURE_BASED}'. "
@@ -98,7 +113,8 @@ def resolve_decomposer(options: Optional[Dict[str, Any]] = None) -> str:
     if env_value is not None:
         if env_value in VALID_DECOMPOSERS:
             logger.info(f"[decomposer] Using '{env_value}' from {ENV_VAR}")
-            return env_value
+            validated_env: DecomposerStrategy = env_value  # type: ignore[assignment]
+            return validated_env
         logger.warning(
             f"[decomposer] Unknown strategy '{env_value}' in {ENV_VAR}; "
             f"falling back to '{DECOMPOSER_FEATURE_BASED}'. "

--- a/src/core/models.py
+++ b/src/core/models.py
@@ -225,6 +225,15 @@ class Task:
         What interface/functionality this task provides for dependent tasks
     requires : Optional[str]
         What this task needs from its dependencies
+    responsibility : Optional[str]
+        Contract interface or module this task is responsible for implementing
+        when the project is decomposed by contract-first decomposition
+        (GH-320 PR 2). Names a specific interface from the shared contract
+        artifact — e.g. ``"implements GameEngine interface from src/types.ts"``.
+        When set, the agent prompt frames the task as ownership of this
+        contract interface rather than a generic implementation task, and
+        the agent is directed to read the contract artifact before writing
+        code. None for tasks produced by the legacy feature-based decomposer.
 
     Notes
     -----
@@ -235,6 +244,10 @@ class Task:
     preserving organizational hierarchy.
     The provides/requires fields enable automatic cross-parent dependency wiring
     by matching semantic contracts between subtasks.
+    The responsibility field is orthogonal to provides/requires: provides/requires
+    describe the contract this task SATISFIES at the dependency-wiring layer;
+    responsibility names the contract interface this task OWNS from an
+    authoritative shared contract file the agent must read.
     """
 
     id: str
@@ -269,6 +282,11 @@ class Task:
     # Fields for cross-parent dependency wiring
     provides: Optional[str] = None  # What interface/functionality this task provides
     requires: Optional[str] = None  # What this task needs from dependencies
+
+    # Field for contract-first decomposition (GH-320 PR 2)
+    # Names the contract interface this task owns from a shared contract
+    # artifact. Set by decompose_by_contract, surfaced in agent prompts.
+    responsibility: Optional[str] = None
 
     # Recovery information (if task was recovered from another agent)
     recovery_info: Optional["RecoveryInfo"] = None

--- a/src/integrations/ai_analysis_engine.py
+++ b/src/integrations/ai_analysis_engine.py
@@ -483,7 +483,7 @@ Identify risks and provide JSON:
             elif "test" in task.name.lower() or "type:testing" in task_labels:
                 task_type = "testing"
 
-        task_data = {
+        task_data: Dict[str, Any] = {
             "name": task.name,
             "description": task.description,
             "priority": task.priority.value,
@@ -492,6 +492,19 @@ Identify risks and provide JSON:
             "labels": getattr(task, "labels", []) or [],
             "type": task_type,
         }
+
+        # Contract-first ownership (GH-320 PR 2). When Task.responsibility
+        # is set, surface it into the LLM prompt so the generated
+        # instructions emphasize contract ownership and read-the-contract-
+        # first behavior.
+        responsibility = getattr(task, "responsibility", None)
+        if responsibility:
+            task_data["responsibility"] = responsibility
+            source_context = getattr(task, "source_context", None) or {}
+            contract_file = source_context.get("contract_file")
+            if contract_file:
+                task_data["contract_file"] = contract_file
+            task_data["contract_first"] = True
 
         agent_data = {
             "name": agent.name if agent else "Unknown",

--- a/src/integrations/ai_analysis_engine.py
+++ b/src/integrations/ai_analysis_engine.py
@@ -493,17 +493,26 @@ Identify risks and provide JSON:
             "type": task_type,
         }
 
-        # Contract-first ownership (GH-320 PR 2). When Task.responsibility
-        # is set, surface it into the LLM prompt so the generated
-        # instructions emphasize contract ownership and read-the-contract-
-        # first behavior.
-        responsibility = getattr(task, "responsibility", None)
-        if responsibility:
-            task_data["responsibility"] = responsibility
-            source_context = getattr(task, "source_context", None) or {}
-            contract_file = source_context.get("contract_file")
-            if contract_file:
-                task_data["contract_file"] = contract_file
+        # Contract-first ownership (GH-320 PR 2). When the task is a
+        # contract-first task, surface the responsibility and contract
+        # file into the LLM prompt so the generated instructions
+        # emphasize contract ownership and read-the-contract-first
+        # behavior.
+        #
+        # Uses ``_parse_contract_metadata`` so the detection works
+        # regardless of whether the task was freshly constructed from
+        # the decomposer (``Task.responsibility`` set) or reloaded from
+        # a kanban provider that stripped the field during persistence
+        # (falls back to source_context and then to the
+        # MARCUS_CONTRACT_FIRST description marker). Codex P1 from
+        # PR #327 review.
+        from src.marcus_mcp.tools.task import _parse_contract_metadata
+
+        contract_meta = _parse_contract_metadata(task)
+        if contract_meta["responsibility"]:
+            task_data["responsibility"] = contract_meta["responsibility"]
+            if contract_meta["contract_file"]:
+                task_data["contract_file"] = contract_meta["contract_file"]
             task_data["contract_first"] = True
 
         agent_data = {

--- a/src/integrations/integration_verification.py
+++ b/src/integrations/integration_verification.py
@@ -49,6 +49,7 @@ class IntegrationTaskGenerator:
     def create_integration_task(
         existing_tasks: List[Task],
         project_name: str = "Project",
+        contract_file: Optional[str] = None,
     ) -> Optional[Task]:
         """
         Create an integration verification task.
@@ -62,6 +63,16 @@ class IntegrationTaskGenerator:
             List of all project tasks created so far.
         project_name : str
             Name of the project.
+        contract_file : Optional[str]
+            Path to the shared contract artifact when contract-first
+            decomposition is active (GH-320 PR 2). When set, the
+            integration task description explicitly names this file
+            and instructs the integration agent to treat it as
+            authoritative — fix implementations that diverge, do NOT
+            modify the contract. Without this instruction, an
+            integration agent could silently "fix" a mismatch by
+            editing the contract, breaking the invariant that made
+            contract-first decomposition work in the first place.
 
         Returns
         -------
@@ -99,7 +110,7 @@ class IntegrationTaskGenerator:
         )
 
         description = IntegrationTaskGenerator._generate_integration_description(
-            project_name
+            project_name, contract_file=contract_file
         )
 
         acceptance_criteria = [
@@ -176,6 +187,7 @@ class IntegrationTaskGenerator:
     @staticmethod
     def _generate_integration_description(
         project_name: str,
+        contract_file: Optional[str] = None,
     ) -> str:
         """
         Generate the integration task description.
@@ -188,13 +200,39 @@ class IntegrationTaskGenerator:
         ----------
         project_name : str
             Name of the project.
+        contract_file : Optional[str]
+            Path to the shared contract artifact when contract-first
+            decomposition is active. When set, a contract-authority
+            preamble is prepended to the description so the integration
+            agent treats the contract as read-only.
 
         Returns
         -------
         str
             Detailed task description with verification steps.
         """
-        return f"""Verify that {project_name} actually builds, starts, \
+        preamble = ""
+        if contract_file:
+            preamble = (
+                "**CONTRACT-FIRST PROJECT**: This project was decomposed "
+                "using contract-first decomposition (GH-320). The shared "
+                f"contract lives at:\n\n"
+                f"    {contract_file}\n\n"
+                "**The contract is AUTHORITATIVE**. Agents built their "
+                "implementations against it. If any implementation "
+                "diverges from the contract during your verification, "
+                "FIX THE IMPLEMENTATION — do NOT modify the contract "
+                "file. The contract was the agreed-upon interface "
+                "boundary; silently editing it to match a broken "
+                "implementation defeats the purpose of contract-first "
+                "decomposition and will cause future regressions.\n\n"
+                "Before starting Phase 1, `Read` the contract file so "
+                "you know the authoritative interface shapes, "
+                "identifiers, and configuration values. Use the "
+                "contract as your reference when verifying cross-agent "
+                "boundaries in step 9.\n\n---\n\n"
+            )
+        return preamble + f"""Verify that {project_name} actually builds, starts, \
 and works end-to-end — and FIX any issues you find.
 
 **IMPORTANT**: This is an integration AND remediation task. You verify \
@@ -488,6 +526,7 @@ def enhance_project_with_integration(
     tasks: List[Task],
     project_description: str,
     project_name: str = "Project",
+    contract_file: Optional[str] = None,
 ) -> List[Task]:
     """
     Add integration verification task to project if appropriate.
@@ -503,6 +542,11 @@ def enhance_project_with_integration(
         Project description.
     project_name : str
         Name of the project.
+    contract_file : Optional[str]
+        Path to the shared contract artifact when contract-first
+        decomposition is active (GH-320 PR 2). Forwarded to the
+        integration task generator so the verification agent treats
+        the contract as read-only authoritative.
 
     Returns
     -------
@@ -513,7 +557,9 @@ def enhance_project_with_integration(
         logger.info("Skipping integration verification for this project")
         return tasks
 
-    task = IntegrationTaskGenerator.create_integration_task(tasks, project_name)
+    task = IntegrationTaskGenerator.create_integration_task(
+        tasks, project_name, contract_file=contract_file
+    )
 
     if task:
         logger.info(f"Added integration verification task: {task.name}")

--- a/src/integrations/nlp_tools.py
+++ b/src/integrations/nlp_tools.py
@@ -426,10 +426,24 @@ class NaturalLanguageProjectCreator(NaturalLanguageTaskCreator):
                 agent_count=agent_count,
                 constraints=constraints,
             )
-        except (ValueError, RuntimeError) as e:
+        except Exception as e:
+            # Catch broadly so the fallback path is bulletproof. The
+            # advertised behavior of this helper is "return None on any
+            # decomposition failure so the caller falls back to
+            # feature_based". Narrowing to ValueError/RuntimeError
+            # leaked TypeError/AttributeError from malformed-but-
+            # parseable LLM JSON (e.g. ``estimated_minutes: null``
+            # causing ``float(None)`` → TypeError, or non-string
+            # description breaking ``.strip()``) — those should
+            # trigger fallback, not crash project creation. Codex
+            # caught this on PR #327 review. ``decompose_by_contract``
+            # also now coerces its inputs defensively so most of these
+            # never fire, but the broad catch is the last line of
+            # defense for unknown shape drift in LLM output.
             logger.warning(
-                f"[decomposer] contract_first decomposer failed: {e}; "
-                f"falling back to feature_based"
+                f"[decomposer] contract_first decomposer failed "
+                f"({type(e).__name__}): {e}; falling back to "
+                f"feature_based"
             )
             return None
 

--- a/src/integrations/nlp_tools.py
+++ b/src/integrations/nlp_tools.py
@@ -22,6 +22,7 @@ from src.ai.advanced.prd.advanced_parser import (  # noqa: E402
     AdvancedPRDParser,
     ProjectConstraints,
 )
+from src.config.decomposer_config import is_contract_first  # noqa: E402
 from src.core.models import Priority, Task, TaskStatus  # noqa: E402
 from src.core.resilience import RetryConfig, with_retry  # noqa: E402
 from src.detection.board_analyzer import BoardAnalyzer  # noqa: E402
@@ -151,10 +152,32 @@ class NaturalLanguageProjectCreator(NaturalLanguageTaskCreator):
         Process project description into tasks.
 
         Implementation of abstract method from base class.
+
+        Decomposer strategy
+        -------------------
+        The active decomposer strategy is resolved from
+        ``options["decomposer"]`` or the ``MARCUS_DECOMPOSER``
+        environment variable via
+        :func:`src.config.decomposer_config.resolve_decomposer`:
+
+        - ``feature_based`` (default): calls
+          :meth:`AdvancedPRDParser.parse_prd_to_tasks`. Tasks shaped by
+          functional requirements.
+        - ``contract_first``: discovers domains from the PRD analysis,
+          generates contract artifacts via
+          :func:`_generate_contracts_by_domain`, and calls
+          :meth:`AdvancedPRDParser.decompose_by_contract` to produce
+          tasks where each task owns a contract interface (GH-320 PR 2).
+
+        If contract-first is selected but contract generation or
+        decomposition fails (weak contracts, LLM failure, empty
+        domains), the caller falls back to feature-based with a loud
+        warning — never a silent fallback.
         """
         # Extract arguments from kwargs
-        project_name = kwargs.get("project_name")  # noqa: F841
+        project_name = kwargs.get("project_name") or "Unnamed Project"
         options = kwargs.get("options")
+        project_root = options.get("project_root") if options else None
 
         # Detect context (Phase 1)
         await self.board_analyzer.analyze_board("default", [])
@@ -169,6 +192,34 @@ class NaturalLanguageProjectCreator(NaturalLanguageTaskCreator):
         constraints = self._build_constraints(options)
         logger.info(f"Parsing PRD with constraints: {constraints}")
 
+        # Contract-first decomposition path (GH-320 PR 2)
+        if is_contract_first(options):
+            logger.info(
+                "[decomposer] contract_first strategy selected — "
+                "attempting contract-first decomposition"
+            )
+            contract_tasks = await self._try_contract_first_decomposition(
+                description=description,
+                project_name=project_name,
+                project_root=project_root,
+                constraints=constraints,
+                options=options,
+            )
+            if contract_tasks is not None:
+                logger.info(
+                    f"[decomposer] contract_first produced "
+                    f"{len(contract_tasks)} task(s)"
+                )
+                return contract_tasks
+            # Fell through to feature-based fallback
+            logger.warning(
+                "[decomposer] contract_first decomposition failed or "
+                "produced weak contracts; falling back to feature_based "
+                "(this is a visible fallback — the user asked for "
+                "contract_first and is not getting it)"
+            )
+
+        # Feature-based decomposition path (default + fallback target)  # noqa: E501
         prd_result = await self.prd_parser.parse_prd_to_tasks(description, constraints)
 
         task_count = len(prd_result.tasks) if prd_result.tasks else 0
@@ -212,6 +263,184 @@ class NaturalLanguageProjectCreator(NaturalLanguageTaskCreator):
             logger.info("No dependencies returned from PRD parser")
 
         return prd_result.tasks
+
+    async def _try_contract_first_decomposition(
+        self,
+        description: str,
+        project_name: str,
+        project_root: Optional[str],
+        constraints: ProjectConstraints,
+        options: Optional[Dict[str, Any]],
+    ) -> Optional[List[Task]]:
+        """
+        Attempt contract-first decomposition (GH-320 PR 2).
+
+        Runs the full contract-first pipeline:
+
+        1. Deep PRD analysis to get functional requirements.
+        2. Discover natural domain groupings from the requirements.
+        3. Generate contract artifacts per domain via
+           :func:`_generate_contracts_by_domain`.
+        4. Call :meth:`AdvancedPRDParser.decompose_by_contract` with
+           the generated contracts to produce contract-owned tasks.
+
+        The method returns ``None`` on any failure so the caller can
+        fall back to feature-based decomposition with a visible
+        warning. No silent fallbacks.
+
+        Parameters
+        ----------
+        description : str
+            Project description (from the user).
+        project_name : str
+            Project name (used in contract artifact metadata).
+        project_root : Optional[str]
+            Where contract artifacts are written. If ``None``,
+            contract-first cannot proceed (artifacts have nowhere to
+            land) and the method returns None.
+        constraints : ProjectConstraints
+            Project constraints from the caller. Forwarded to the
+            PRD parser and the decomposer.
+        options : Optional[Dict[str, Any]]
+            Project options dict. Used for the agent count hint.
+
+        Returns
+        -------
+        Optional[List[Task]]
+            A list of contract-owned tasks on success, or ``None``
+            on any failure. Caller falls back to feature_based when
+            None is returned.
+
+        Notes
+        -----
+        Domain discovery and contract generation are the two
+        pre-existing weak points — they rely on LLM quality. If the
+        LLM produces a single undifferentiated "General" domain or
+        empty contract artifacts for every domain, contract-first
+        decomposition cannot proceed and we fall back.
+
+        GH-320 : Contract-first task decomposition.
+        Experiment 4 (pending) : LLM-generated contract validation gate.
+        """
+        if project_root is None:
+            logger.warning(
+                "[decomposer] contract_first requires project_root in "
+                "options; falling back to feature_based"
+            )
+            return None
+
+        agent_count = 2
+        if options is not None:
+            agent_count = int(options.get("agent_count", 2))
+
+        try:
+            prd_analysis = await self.prd_parser._analyze_prd_deeply(
+                description, constraints
+            )
+        except Exception as e:
+            logger.warning(
+                f"[decomposer] contract_first PRD analysis failed: {e}; "
+                f"falling back to feature_based"
+            )
+            return None
+
+        functional_reqs = prd_analysis.functional_requirements or []
+        if not functional_reqs:
+            logger.warning(
+                "[decomposer] contract_first: PRD produced no functional "
+                "requirements; falling back to feature_based"
+            )
+            return None
+
+        try:
+            domain_groups = await self.prd_parser._discover_domains(functional_reqs)
+        except Exception as e:
+            logger.warning(
+                f"[decomposer] contract_first domain discovery failed: {e}; "
+                f"falling back to feature_based"
+            )
+            return None
+
+        if not domain_groups:
+            logger.warning(
+                "[decomposer] contract_first: no domains discovered; "
+                "falling back to feature_based"
+            )
+            return None
+
+        # Build ``{domain_name: description}`` mapping that
+        # ``_generate_contracts_by_domain`` expects. Each domain
+        # description is a bulleted list of its features — enough
+        # context for the LLM to generate a meaningful contract.
+        domains_for_contracts: Dict[str, str] = {}
+        feature_map = {
+            req.get("id", f"feature_{idx}"): req
+            for idx, req in enumerate(functional_reqs, start=1)
+        }
+        for domain_name, feature_ids in domain_groups.items():
+            bullets = []
+            for feature_id in feature_ids:
+                feature = feature_map.get(feature_id)
+                if feature is None:
+                    continue
+                name = feature.get("name", feature_id)
+                feature_desc = feature.get("description", "")
+                bullets.append(f"- {name}: {feature_desc}")
+            domains_for_contracts[domain_name] = (
+                f"Domain: {domain_name}\n\nFeatures:\n" + "\n".join(bullets)
+            )
+
+        try:
+            contract_artifacts = await _generate_contracts_by_domain(
+                domains=domains_for_contracts,
+                project_description=description,
+                project_name=project_name,
+                project_root=project_root,
+            )
+        except Exception as e:
+            logger.warning(
+                f"[decomposer] contract_first contract generation failed: "
+                f"{e}; falling back to feature_based"
+            )
+            return None
+
+        # Check contract completeness threshold: at least one domain
+        # must produce usable artifacts.
+        usable_contracts = {
+            domain: payload
+            for domain, payload in contract_artifacts.items()
+            if payload is not None and payload.get("artifacts")
+        }
+        if not usable_contracts:
+            logger.warning(
+                "[decomposer] contract_first: contract generation "
+                "produced no usable artifacts for any domain; falling "
+                "back to feature_based"
+            )
+            return None
+
+        try:
+            tasks = await self.prd_parser.decompose_by_contract(
+                prd_analysis=prd_analysis,
+                contract_artifacts=contract_artifacts,
+                agent_count=agent_count,
+                constraints=constraints,
+            )
+        except (ValueError, RuntimeError) as e:
+            logger.warning(
+                f"[decomposer] contract_first decomposer failed: {e}; "
+                f"falling back to feature_based"
+            )
+            return None
+
+        if not tasks:
+            logger.warning(
+                "[decomposer] contract_first decomposer returned no "
+                "tasks; falling back to feature_based"
+            )
+            return None
+
+        return tasks
 
     async def create_project_from_description(
         self,
@@ -378,13 +607,30 @@ class NaturalLanguageProjectCreator(NaturalLanguageTaskCreator):
 
                 # Add integration verification task if appropriate
                 # Must be added BEFORE documentation so doc task
-                # depends on integration task
+                # depends on integration task.
+                #
+                # For contract-first decomposition (GH-320 PR 2),
+                # pass the shared contract file path so the
+                # integration task description instructs the
+                # verification agent to treat it as authoritative
+                # (fix implementations, not the contract).
                 from src.integrations.integration_verification import (
                     enhance_project_with_integration,
                 )
 
+                contract_file_for_integration: Optional[str] = None
+                for task in safe_tasks:
+                    ctx = getattr(task, "source_context", None) or {}
+                    candidate = ctx.get("contract_file")
+                    if candidate:
+                        contract_file_for_integration = candidate
+                        break
+
                 safe_tasks = enhance_project_with_integration(
-                    safe_tasks, description, project_name
+                    safe_tasks,
+                    description,
+                    project_name,
+                    contract_file=contract_file_for_integration,
                 )
                 logger.info(
                     "After integration enhancement: " f"{len(safe_tasks)} tasks"

--- a/src/marcus_mcp/tools/task.py
+++ b/src/marcus_mcp/tools/task.py
@@ -249,6 +249,41 @@ def build_tiered_instructions(
                 f"- Recovery reason: {recovery.recovery_reason}"
             )
 
+    # Layer 1.3: Contract Responsibility (GH-320 PR 2)
+    # When a task owns a contract interface (contract-first
+    # decomposition), surface that ownership with high signal. This
+    # layer fires BEFORE subtask context because contract ownership
+    # is structural — the agent must understand the contract before
+    # considering the task's subtask-vs-standalone status.
+    responsibility = getattr(task, "responsibility", None)
+    if responsibility:
+        source_context = getattr(task, "source_context", None) or {}
+        contract_file = source_context.get("contract_file", "")
+        contract_notice = (
+            f"\n\n📜 CONTRACT RESPONSIBILITY (contract-first decomposition):\n"
+            f"You OWN: {responsibility}\n"
+        )
+        if contract_file:
+            contract_notice += (
+                f"Contract file: {contract_file}\n\n"
+                f"BEFORE writing any code, Read() the contract file at "
+                f"{contract_file}. The contract defines the interface "
+                f"boundary your implementation must satisfy. Other agents "
+                f"are implementing other sides of this same contract in "
+                f"parallel — if you diverge from it, the integration "
+                f"fails.\n\n"
+                f"Your implementation MUST conform to the contract. If "
+                f"the contract is missing something you need, report a "
+                f"blocker — do NOT silently modify the contract file."
+            )
+        else:
+            contract_notice += (
+                "\nRead the shared contract artifacts in docs/ before "
+                "writing code. Your implementation must conform to the "
+                "contract boundary."
+            )
+        instructions_parts.append(contract_notice)
+
     # Layer 1.5: Subtask Context (if this is a subtask)
     if hasattr(task, "_is_subtask") and task._is_subtask:
         parent_name = getattr(task, "_parent_task_name", "parent task")

--- a/src/marcus_mcp/tools/task.py
+++ b/src/marcus_mcp/tools/task.py
@@ -178,6 +178,97 @@ incomplete implementations."""
     return workflow_prompt
 
 
+def _parse_contract_metadata(task: Task) -> Dict[str, str]:
+    """
+    Resolve contract-first metadata from a task across storage layers.
+
+    GH-320 PR 2 introduces the ``Task.responsibility`` field and
+    stores ``contract_file`` in ``Task.source_context``. Some kanban
+    providers don't persist these fields through their round-trip:
+
+    - SQLite (``src/integrations/providers/sqlite_kanban.py``) persists
+      ``source_context`` but not ``responsibility`` as a top-level
+      column.
+    - Planka (``src/integrations/kanban_client.py``) persists neither
+      — the provider's ``_card_to_task`` mapping constructs ``Task``
+      with a minimal field set.
+
+    To make the CONTRACT RESPONSIBILITY layer work for tasks reloaded
+    from any kanban provider, ``decompose_by_contract`` also embeds
+    the metadata as a structured HTML comment marker in the task
+    description (which every provider round-trips as the core field).
+
+    This helper looks in three places, in priority order:
+
+    1. ``task.responsibility`` + ``task.source_context["contract_file"]``
+       (set by fresh decomposer output, best signal)
+    2. ``task.source_context["responsibility"]`` + ``["contract_file"]``
+       (set by decomposer as belt-and-suspenders, survives providers
+       that persist source_context like SQLite)
+    3. Parsed from the ``MARCUS_CONTRACT_FIRST`` marker in
+       ``task.description`` (last-resort fallback for providers that
+       only persist description, like Planka)
+
+    Parameters
+    ----------
+    task : Task
+        The task to inspect.
+
+    Returns
+    -------
+    Dict[str, str]
+        Dict with keys ``"responsibility"`` and ``"contract_file"``.
+        Values are empty strings when not found. Callers can treat
+        an empty ``responsibility`` as "this task is not contract-
+        first" without needing a separate boolean flag.
+
+    Notes
+    -----
+    Codex caught the persistence gap on PR #327 review. Without this
+    helper, the CONTRACT RESPONSIBILITY layer would silently never
+    fire for tasks reloaded from the board even though the task was
+    born contract-first, defeating the whole point of PR 2.
+    """
+    # Priority 1: direct Task.responsibility field
+    responsibility = getattr(task, "responsibility", None)
+    source_context = getattr(task, "source_context", None) or {}
+
+    if responsibility:
+        return {
+            "responsibility": str(responsibility),
+            "contract_file": str(source_context.get("contract_file", "") or ""),
+        }
+
+    # Priority 2: responsibility stored in source_context
+    sc_responsibility = source_context.get("responsibility")
+    if sc_responsibility:
+        return {
+            "responsibility": str(sc_responsibility),
+            "contract_file": str(source_context.get("contract_file", "") or ""),
+        }
+
+    # Priority 3: parse HTML comment marker from description
+    description = getattr(task, "description", "") or ""
+    marker_start = description.find("<!-- MARCUS_CONTRACT_FIRST")
+    if marker_start == -1:
+        return {"responsibility": "", "contract_file": ""}
+    marker_end = description.find("-->", marker_start)
+    if marker_end == -1:
+        return {"responsibility": "", "contract_file": ""}
+
+    marker_body = description[marker_start:marker_end]
+    parsed_resp = ""
+    parsed_file = ""
+    for line in marker_body.splitlines():
+        line = line.strip()
+        if line.startswith("responsibility:"):
+            parsed_resp = line[len("responsibility:") :].strip()
+        elif line.startswith("contract_file:"):
+            parsed_file = line[len("contract_file:") :].strip()
+
+    return {"responsibility": parsed_resp, "contract_file": parsed_file}
+
+
 def build_tiered_instructions(
     base_instructions: str,
     task: Task,
@@ -255,10 +346,17 @@ def build_tiered_instructions(
     # layer fires BEFORE subtask context because contract ownership
     # is structural — the agent must understand the contract before
     # considering the task's subtask-vs-standalone status.
-    responsibility = getattr(task, "responsibility", None)
+    #
+    # Metadata is resolved via ``_parse_contract_metadata`` which
+    # checks Task.responsibility, Task.source_context, and the
+    # MARCUS_CONTRACT_FIRST description marker in priority order.
+    # This makes the layer robust to kanban providers that don't
+    # round-trip Task.responsibility or source_context — Codex P1
+    # from PR #327 review.
+    contract_meta = _parse_contract_metadata(task)
+    responsibility = contract_meta["responsibility"]
     if responsibility:
-        source_context = getattr(task, "source_context", None) or {}
-        contract_file = source_context.get("contract_file", "")
+        contract_file = contract_meta["contract_file"]
         contract_notice = (
             f"\n\n📜 CONTRACT RESPONSIBILITY (contract-first decomposition):\n"
             f"You OWN: {responsibility}\n"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,90 +10,15 @@ This configuration file is automatically loaded by pytest and provides shared
 resources for all tests in the suite.
 """
 
-import json
 import os
 import sys
-import tempfile
 from datetime import datetime, timezone
-from pathlib import Path
 from typing import Any, AsyncGenerator, Dict
 
 import pytest
 
-# Add src to path for imports (must happen before Marcus imports below)
+# Add src to path for imports
 sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(__file__)), "src"))
-
-
-# GH-320 PR 2: provide a minimal valid Marcus config for the whole
-# test suite by writing one to /tmp and pointing MARCUS_CONFIG at it.
-#
-# Why this is necessary
-# ---------------------
-# ``AdvancedPRDParser.__init__`` (and anything that constructs
-# ``NaturalLanguageProjectCreator``) instantiates ``LLMAbstraction``
-# which calls ``get_config()`` → ``MarcusConfig.from_file()`` →
-# ``validate()``. In CI there is no ``config_marcus.json`` in the
-# working directory, so ``from_file`` returns defaults with
-# ``anthropic_api_key=None``, and ``validate()`` raises because the
-# default provider is ``anthropic``.
-#
-# Why the env var alone doesn't work
-# ----------------------------------
-# Setting ``ANTHROPIC_API_KEY`` does NOT fix this. The default config
-# does not consult environment variables directly — only ``${VAR}``
-# substitutions inside a config file do, and without a config file
-# there is nothing to substitute into.
-#
-# Why seeding ``_config`` alone doesn't work
-# ------------------------------------------
-# Pre-populating ``marcus_config._config`` in conftest.py survives
-# the initial import, but ~20 tests in ``tests/unit/ai/test_openai_provider.py``
-# reset ``marcus_config._config = None`` in their fixture setup to
-# patch ``get_config``. When any test runs after one of those, the
-# next call to ``get_config()`` hits ``from_file`` again and fails
-# with the same error because there is still no config file on disk.
-#
-# The fix
-# -------
-# Write a minimal valid config file to a stable temp path and point
-# ``MARCUS_CONFIG`` at it. Now any code path — including the
-# openai_provider fixtures that reset the cache — will re-load the
-# valid config from disk instead of crashing on defaults.
-#
-# This must happen at conftest.py module-level so it runs before
-# pytest collects any test file that imports
-# ``src.ai.advanced.prd.advanced_parser`` or
-# ``src.integrations.nlp_tools``. Pytest processes conftest.py before
-# collecting test modules.
-def _install_test_config() -> None:
-    """Install a minimal valid Marcus config for the test session."""
-    # Stable path so reruns within a session find the same file.
-    # ``gettempdir`` respects TMPDIR on macOS and /tmp on Linux.
-    test_config_path = Path(tempfile.gettempdir()) / "marcus_test_config.json"
-
-    # Write every time so test runs are deterministic regardless of
-    # leftover state in /tmp.
-    test_config_path.write_text(
-        json.dumps(
-            {
-                "ai": {
-                    "provider": "anthropic",
-                    "anthropic_api_key": "test-key-not-real",
-                    "model": "claude-3-5-sonnet-latest",
-                    "max_tokens": 4096,
-                    "temperature": 0.7,
-                }
-            }
-        )
-    )
-
-    # Point MARCUS_CONFIG at the test file so every code path that
-    # calls ``os.getenv("MARCUS_CONFIG", "config_marcus.json")`` picks
-    # it up instead of the missing default path.
-    os.environ["MARCUS_CONFIG"] = str(test_config_path)
-
-
-_install_test_config()
 
 from mcp import ClientSession, StdioServerParameters
 from mcp.client.stdio import stdio_client

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,34 +10,90 @@ This configuration file is automatically loaded by pytest and provides shared
 resources for all tests in the suite.
 """
 
+import json
 import os
 import sys
+import tempfile
 from datetime import datetime, timezone
+from pathlib import Path
 from typing import Any, AsyncGenerator, Dict
 
 import pytest
 
-# GH-320 PR 2: ensure a dummy ANTHROPIC_API_KEY is set before any
-# test imports happen. ``AdvancedPRDParser.__init__`` (and anything
-# that constructs ``NaturalLanguageProjectCreator``) instantiates
-# ``LLMAbstraction`` which validates Marcus config on first call.
-# In CI, no config file exists and no env var is set, so validation
-# fails with "anthropic_api_key is not set" and any test that touches
-# the decomposer crashes at construction time. Unit tests never make
-# real LLM calls, so a placeholder is safe.
-#
-# This must run BEFORE any test module imports src.ai.advanced.prd
-# or src.integrations.nlp_tools, which is why it lives at conftest.py
-# module level (pytest processes conftest.py before collecting test
-# files). Per-file ``os.environ.setdefault`` calls in individual test
-# modules aren't guaranteed to run early enough because pytest import
-# order depends on collection order, and earlier test files that
-# accidentally import Marcus config modules can poison the cache.
-if not os.environ.get("ANTHROPIC_API_KEY"):
-    os.environ["ANTHROPIC_API_KEY"] = "test-key-not-real"
-
-# Add src to path for imports
+# Add src to path for imports (must happen before Marcus imports below)
 sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(__file__)), "src"))
+
+
+# GH-320 PR 2: provide a minimal valid Marcus config for the whole
+# test suite by writing one to /tmp and pointing MARCUS_CONFIG at it.
+#
+# Why this is necessary
+# ---------------------
+# ``AdvancedPRDParser.__init__`` (and anything that constructs
+# ``NaturalLanguageProjectCreator``) instantiates ``LLMAbstraction``
+# which calls ``get_config()`` → ``MarcusConfig.from_file()`` →
+# ``validate()``. In CI there is no ``config_marcus.json`` in the
+# working directory, so ``from_file`` returns defaults with
+# ``anthropic_api_key=None``, and ``validate()`` raises because the
+# default provider is ``anthropic``.
+#
+# Why the env var alone doesn't work
+# ----------------------------------
+# Setting ``ANTHROPIC_API_KEY`` does NOT fix this. The default config
+# does not consult environment variables directly — only ``${VAR}``
+# substitutions inside a config file do, and without a config file
+# there is nothing to substitute into.
+#
+# Why seeding ``_config`` alone doesn't work
+# ------------------------------------------
+# Pre-populating ``marcus_config._config`` in conftest.py survives
+# the initial import, but ~20 tests in ``tests/unit/ai/test_openai_provider.py``
+# reset ``marcus_config._config = None`` in their fixture setup to
+# patch ``get_config``. When any test runs after one of those, the
+# next call to ``get_config()`` hits ``from_file`` again and fails
+# with the same error because there is still no config file on disk.
+#
+# The fix
+# -------
+# Write a minimal valid config file to a stable temp path and point
+# ``MARCUS_CONFIG`` at it. Now any code path — including the
+# openai_provider fixtures that reset the cache — will re-load the
+# valid config from disk instead of crashing on defaults.
+#
+# This must happen at conftest.py module-level so it runs before
+# pytest collects any test file that imports
+# ``src.ai.advanced.prd.advanced_parser`` or
+# ``src.integrations.nlp_tools``. Pytest processes conftest.py before
+# collecting test modules.
+def _install_test_config() -> None:
+    """Install a minimal valid Marcus config for the test session."""
+    # Stable path so reruns within a session find the same file.
+    # ``gettempdir`` respects TMPDIR on macOS and /tmp on Linux.
+    test_config_path = Path(tempfile.gettempdir()) / "marcus_test_config.json"
+
+    # Write every time so test runs are deterministic regardless of
+    # leftover state in /tmp.
+    test_config_path.write_text(
+        json.dumps(
+            {
+                "ai": {
+                    "provider": "anthropic",
+                    "anthropic_api_key": "test-key-not-real",
+                    "model": "claude-3-5-sonnet-latest",
+                    "max_tokens": 4096,
+                    "temperature": 0.7,
+                }
+            }
+        )
+    )
+
+    # Point MARCUS_CONFIG at the test file so every code path that
+    # calls ``os.getenv("MARCUS_CONFIG", "config_marcus.json")`` picks
+    # it up instead of the missing default path.
+    os.environ["MARCUS_CONFIG"] = str(test_config_path)
+
+
+_install_test_config()
 
 from mcp import ClientSession, StdioServerParameters
 from mcp.client.stdio import stdio_client

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,6 +17,25 @@ from typing import Any, AsyncGenerator, Dict
 
 import pytest
 
+# GH-320 PR 2: ensure a dummy ANTHROPIC_API_KEY is set before any
+# test imports happen. ``AdvancedPRDParser.__init__`` (and anything
+# that constructs ``NaturalLanguageProjectCreator``) instantiates
+# ``LLMAbstraction`` which validates Marcus config on first call.
+# In CI, no config file exists and no env var is set, so validation
+# fails with "anthropic_api_key is not set" and any test that touches
+# the decomposer crashes at construction time. Unit tests never make
+# real LLM calls, so a placeholder is safe.
+#
+# This must run BEFORE any test module imports src.ai.advanced.prd
+# or src.integrations.nlp_tools, which is why it lives at conftest.py
+# module level (pytest processes conftest.py before collecting test
+# files). Per-file ``os.environ.setdefault`` calls in individual test
+# modules aren't guaranteed to run early enough because pytest import
+# order depends on collection order, and earlier test files that
+# accidentally import Marcus config modules can poison the cache.
+if not os.environ.get("ANTHROPIC_API_KEY"):
+    os.environ["ANTHROPIC_API_KEY"] = "test-key-not-real"
+
 # Add src to path for imports
 sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(__file__)), "src"))
 

--- a/tests/unit/ai/test_decompose_by_contract.py
+++ b/tests/unit/ai/test_decompose_by_contract.py
@@ -1,0 +1,397 @@
+"""
+Unit tests for ``AdvancedPRDParser.decompose_by_contract`` (GH-320 PR 2).
+
+Tests the contract-first decomposition path that produces tasks where
+each task owns one side of a contract interface. Experiment 1
+(2026-04-10) validated the mechanism on a hand-crafted TypeScript
+contract; these tests pin the productionized path.
+
+Test strategy
+-------------
+- Mock ``AIAnalysisEngine.generate_structured_response`` to return
+  controlled task lists. Never call real LLMs from unit tests.
+- Exercise the happy path, the empty-contracts fallback, the
+  LLM-failure path, and the Task.responsibility plumbing.
+"""
+
+import os
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+# AdvancedPRDParser.__init__ instantiates LLMAbstraction which validates
+# Marcus config on first construction. Provide a dummy API key so the
+# validation passes — we never actually make LLM calls in unit tests.
+os.environ.setdefault("ANTHROPIC_API_KEY", "test-key-not-real")
+
+from src.ai.advanced.prd.advanced_parser import (  # noqa: E402
+    AdvancedPRDParser,
+    PRDAnalysis,
+    ProjectConstraints,
+)
+from src.core.models import TaskStatus  # noqa: E402
+
+pytestmark = pytest.mark.unit
+
+
+def _make_prd_analysis() -> PRDAnalysis:
+    """Build a minimal PRDAnalysis for tests."""
+    return PRDAnalysis(
+        functional_requirements=[
+            {
+                "id": "game_engine",
+                "name": "Game Engine",
+                "description": "Core game loop and state management",
+                "complexity": "coordinated",
+            },
+            {
+                "id": "game_ui",
+                "name": "Game UI",
+                "description": "Render and handle user input",
+                "complexity": "simple",
+            },
+        ],
+        non_functional_requirements=[],
+        technical_constraints=[],
+        business_objectives=[],
+        user_personas=[],
+        success_metrics=[],
+        implementation_approach="iterative",
+        complexity_assessment={"level": "medium"},
+        risk_factors=[],
+        confidence=0.85,
+        original_description="Build a snake game with React and TypeScript",
+    )
+
+
+def _make_contract_artifacts():
+    """Build contract artifacts matching _generate_contracts_by_domain output."""
+    return {
+        "Game Engine": {
+            "artifacts": [
+                {
+                    "filename": "types.ts",
+                    "artifact_type": "api",
+                    "content": (
+                        "export interface GameEngine {\n"
+                        "  tick(): GameState;\n"
+                        "  reset(): void;\n"
+                        "}\n"
+                        "export interface GameState {\n"
+                        "  snake: Coord[];\n"
+                        "  food: Coord;\n"
+                        "  score: number;\n"
+                        "}\n"
+                    ),
+                    "description": "Shared interface contract",
+                    "relative_path": "docs/api/types.ts",
+                },
+            ],
+            "decisions": [],
+        },
+        "Game UI": {
+            "artifacts": [
+                {
+                    "filename": "ui-contract.md",
+                    "artifact_type": "specification",
+                    "content": "# UI contract\n\nConsumes GameState from types.ts\n",
+                    "description": "UI consumer contract",
+                    "relative_path": "docs/specifications/ui-contract.md",
+                },
+            ],
+            "decisions": [],
+        },
+    }
+
+
+class TestDecomposeByContract:
+    """Test suite for AdvancedPRDParser.decompose_by_contract."""
+
+    @pytest.mark.asyncio
+    async def test_happy_path_produces_tasks_with_responsibility(self):
+        """
+        LLM returns structured tasks → Task objects with responsibility.
+
+        The decomposer builds Task objects whose ``responsibility``
+        field names the contract interface each task owns. This is the
+        core productionization of experiment 1.
+        """
+        parser = AdvancedPRDParser()
+        prd_analysis = _make_prd_analysis()
+        contracts = _make_contract_artifacts()
+
+        llm_response = {
+            "tasks": [
+                {
+                    "name": "Implement GameEngine",
+                    "description": "Build the game loop and state transitions",
+                    "responsibility": "implements GameEngine interface from types.ts",
+                    "contract_file": "docs/api/types.ts",
+                    "provides": "GameState transitions, tick() implementation",
+                    "requires": "None",
+                    "estimated_minutes": 10,
+                },
+                {
+                    "name": "Implement Game UI",
+                    "description": "Render the board and handle keyboard input",
+                    "responsibility": "consumes GameState, implements UI layer",
+                    "contract_file": "docs/specifications/ui-contract.md",
+                    "provides": "Rendered board, input dispatch",
+                    "requires": "GameEngine tick() output",
+                    "estimated_minutes": 8,
+                },
+            ]
+        }
+
+        with patch(
+            "src.integrations.ai_analysis_engine.AIAnalysisEngine."
+            "generate_structured_response",
+            new_callable=AsyncMock,
+            return_value=llm_response,
+        ):
+            tasks = await parser.decompose_by_contract(
+                prd_analysis=prd_analysis,
+                contract_artifacts=contracts,
+                agent_count=2,
+                constraints=ProjectConstraints(complexity_mode="standard"),
+            )
+
+        assert len(tasks) == 2
+
+        engine_task = tasks[0]
+        assert engine_task.name == "Implement GameEngine"
+        assert engine_task.responsibility == (
+            "implements GameEngine interface from types.ts"
+        )
+        assert engine_task.status == TaskStatus.TODO
+        assert engine_task.source_type == "contract_first"
+        assert engine_task.source_context is not None
+        assert engine_task.source_context.get("contract_file") == "docs/api/types.ts"
+        assert engine_task.provides == "GameState transitions, tick() implementation"
+        # "None" maps to Python None for requires
+        assert engine_task.requires is None
+        # 10 minutes -> hours
+        assert abs(engine_task.estimated_hours - (10 / 60)) < 1e-6
+        # Description embeds the contract reference
+        assert "docs/api/types.ts" in engine_task.description
+
+        ui_task = tasks[1]
+        assert ui_task.responsibility == "consumes GameState, implements UI layer"
+        assert ui_task.requires == "GameEngine tick() output"
+
+    @pytest.mark.asyncio
+    async def test_empty_contracts_raises_value_error(self):
+        """
+        All-None contracts → ValueError so caller can fall back.
+
+        When every domain's contract generation produced no artifacts
+        (payload=None), the decomposer cannot proceed. The caller in
+        NaturalLanguageProjectCreator catches ValueError and falls back
+        to feature_based with a visible warning.
+        """
+        parser = AdvancedPRDParser()
+        prd_analysis = _make_prd_analysis()
+
+        empty_contracts = {"Game Engine": None, "Game UI": None}
+
+        with pytest.raises(ValueError, match="no usable domains"):
+            await parser.decompose_by_contract(
+                prd_analysis=prd_analysis,
+                contract_artifacts=empty_contracts,
+                agent_count=2,
+            )
+
+    @pytest.mark.asyncio
+    async def test_contracts_with_empty_artifacts_raises_value_error(self):
+        """
+        Domains with empty artifact lists are treated as unusable.
+
+        A payload with ``{"artifacts": []}`` is as useless as None —
+        the LLM would see no contract content to decompose against.
+        """
+        parser = AdvancedPRDParser()
+        prd_analysis = _make_prd_analysis()
+
+        empty_contracts = {
+            "Game Engine": {"artifacts": [], "decisions": []},
+        }
+
+        with pytest.raises(ValueError, match="no usable domains"):
+            await parser.decompose_by_contract(
+                prd_analysis=prd_analysis,
+                contract_artifacts=empty_contracts,
+                agent_count=2,
+            )
+
+    @pytest.mark.asyncio
+    async def test_llm_failure_raises_runtime_error(self):
+        """LLM exception → RuntimeError so caller can fall back."""
+        parser = AdvancedPRDParser()
+        prd_analysis = _make_prd_analysis()
+        contracts = _make_contract_artifacts()
+
+        with patch(
+            "src.integrations.ai_analysis_engine.AIAnalysisEngine."
+            "generate_structured_response",
+            new_callable=AsyncMock,
+            side_effect=TimeoutError("LLM call timed out"),
+        ):
+            with pytest.raises(RuntimeError, match="Contract decomposition LLM"):
+                await parser.decompose_by_contract(
+                    prd_analysis=prd_analysis,
+                    contract_artifacts=contracts,
+                    agent_count=2,
+                )
+
+    @pytest.mark.asyncio
+    async def test_empty_task_list_in_response_raises(self):
+        """LLM returns ``{"tasks": []}`` → RuntimeError (unusable)."""
+        parser = AdvancedPRDParser()
+        prd_analysis = _make_prd_analysis()
+        contracts = _make_contract_artifacts()
+
+        with patch(
+            "src.integrations.ai_analysis_engine.AIAnalysisEngine."
+            "generate_structured_response",
+            new_callable=AsyncMock,
+            return_value={"tasks": []},
+        ):
+            with pytest.raises(RuntimeError, match="contained no tasks"):
+                await parser.decompose_by_contract(
+                    prd_analysis=prd_analysis,
+                    contract_artifacts=contracts,
+                    agent_count=2,
+                )
+
+    @pytest.mark.asyncio
+    async def test_labels_include_contract_first(self):
+        """Contract-first tasks carry a 'contract_first' label for filtering."""
+        parser = AdvancedPRDParser()
+        prd_analysis = _make_prd_analysis()
+        contracts = _make_contract_artifacts()
+
+        llm_response = {
+            "tasks": [
+                {
+                    "name": "Implement thing",
+                    "description": "Do the thing",
+                    "responsibility": "implements Thing from contract",
+                    "contract_file": "docs/api/types.ts",
+                    "provides": "thing",
+                    "requires": "None",
+                    "estimated_minutes": 5,
+                },
+            ]
+        }
+
+        with patch(
+            "src.integrations.ai_analysis_engine.AIAnalysisEngine."
+            "generate_structured_response",
+            new_callable=AsyncMock,
+            return_value=llm_response,
+        ):
+            tasks = await parser.decompose_by_contract(
+                prd_analysis=prd_analysis,
+                contract_artifacts=contracts,
+                agent_count=1,
+            )
+
+        assert "contract_first" in tasks[0].labels
+        assert "implementation" in tasks[0].labels
+
+    @pytest.mark.asyncio
+    async def test_contract_file_embedded_in_description(self):
+        """Task description includes the contract file path for agent discovery."""
+        parser = AdvancedPRDParser()
+        prd_analysis = _make_prd_analysis()
+        contracts = _make_contract_artifacts()
+
+        llm_response = {
+            "tasks": [
+                {
+                    "name": "Implement thing",
+                    "description": "Build the thing (no contract ref in LLM output)",
+                    "responsibility": "implements Thing interface",
+                    "contract_file": "docs/api/types.ts",
+                    "provides": "thing",
+                    "requires": "None",
+                    "estimated_minutes": 5,
+                },
+            ]
+        }
+
+        with patch(
+            "src.integrations.ai_analysis_engine.AIAnalysisEngine."
+            "generate_structured_response",
+            new_callable=AsyncMock,
+            return_value=llm_response,
+        ):
+            tasks = await parser.decompose_by_contract(
+                prd_analysis=prd_analysis,
+                contract_artifacts=contracts,
+                agent_count=1,
+            )
+
+        # Even if the LLM didn't embed the contract_file in its own
+        # description text, the decomposer augments it so agents can
+        # read the contract without hunting through source_context.
+        assert "docs/api/types.ts" in tasks[0].description
+        assert "implements Thing interface" in tasks[0].description
+
+    @pytest.mark.asyncio
+    async def test_mixed_none_and_usable_contracts(self):
+        """Partial contract generation → decomposer uses only usable ones."""
+        parser = AdvancedPRDParser()
+        prd_analysis = _make_prd_analysis()
+        # One domain succeeded, one failed (None)
+        contracts = {
+            "Game Engine": {
+                "artifacts": [
+                    {
+                        "filename": "types.ts",
+                        "artifact_type": "api",
+                        "content": "export interface GameEngine {}",
+                        "description": "contract",
+                        "relative_path": "docs/api/types.ts",
+                    }
+                ],
+                "decisions": [],
+            },
+            "Game UI": None,  # contract generation failed for this domain
+        }
+
+        llm_response = {
+            "tasks": [
+                {
+                    "name": "Implement GameEngine",
+                    "description": "Build the engine",
+                    "responsibility": "implements GameEngine",
+                    "contract_file": "docs/api/types.ts",
+                    "provides": "engine",
+                    "requires": "None",
+                    "estimated_minutes": 8,
+                }
+            ]
+        }
+
+        with patch(
+            "src.integrations.ai_analysis_engine.AIAnalysisEngine."
+            "generate_structured_response",
+            new_callable=AsyncMock,
+            return_value=llm_response,
+        ) as mock_llm:
+            tasks = await parser.decompose_by_contract(
+                prd_analysis=prd_analysis,
+                contract_artifacts=contracts,
+                agent_count=1,
+            )
+
+        # Decomposition proceeded with 1 usable contract
+        assert len(tasks) == 1
+        # Verify the prompt sent to the LLM only included the Game Engine
+        # section (the None domain was filtered out).
+        call_args = mock_llm.call_args
+        prompt = call_args.kwargs["prompt"]
+        assert "Game Engine" in prompt
+        assert "Game UI" not in prompt

--- a/tests/unit/ai/test_decompose_by_contract.py
+++ b/tests/unit/ai/test_decompose_by_contract.py
@@ -340,6 +340,208 @@ class TestDecomposeByContract:
         assert "implements Thing interface" in tasks[0].description
 
     @pytest.mark.asyncio
+    async def test_malformed_estimated_minutes_coerced_to_default(self):
+        """
+        LLM returns ``estimated_minutes: null`` → coerced to 8.0 default.
+
+        ``generate_structured_response`` parses JSON but does NOT
+        enforce the schema, so nulls can leak through. Must not
+        raise TypeError from ``float(None)``. Codex P1 on PR #327.
+        """
+        parser = AdvancedPRDParser()
+        prd_analysis = _make_prd_analysis()
+        contracts = _make_contract_artifacts()
+
+        llm_response = {
+            "tasks": [
+                {
+                    "name": "Implement thing",
+                    "description": "Do the thing",
+                    "responsibility": "implements Thing",
+                    "contract_file": "docs/api/types.ts",
+                    "provides": "thing",
+                    "requires": "None",
+                    "estimated_minutes": None,  # malformed
+                },
+            ]
+        }
+
+        with patch(
+            "src.integrations.ai_analysis_engine.AIAnalysisEngine."
+            "generate_structured_response",
+            new_callable=AsyncMock,
+            return_value=llm_response,
+        ):
+            tasks = await parser.decompose_by_contract(
+                prd_analysis=prd_analysis,
+                contract_artifacts=contracts,
+                agent_count=1,
+            )
+
+        assert len(tasks) == 1
+        # Default 8.0 minutes → 8/60 hours
+        assert abs(tasks[0].estimated_hours - (8.0 / 60)) < 1e-6
+
+    @pytest.mark.asyncio
+    async def test_malformed_description_coerced_to_string(self):
+        """
+        LLM returns non-string description → coerced to string.
+
+        Must not raise AttributeError from ``.strip()`` on a non-str.
+        """
+        parser = AdvancedPRDParser()
+        prd_analysis = _make_prd_analysis()
+        contracts = _make_contract_artifacts()
+
+        llm_response = {
+            "tasks": [
+                {
+                    "name": "Implement thing",
+                    # LLM returned null for description
+                    "description": None,
+                    "responsibility": "implements Thing",
+                    "contract_file": "docs/api/types.ts",
+                    "provides": "thing",
+                    "requires": "None",
+                    "estimated_minutes": 5,
+                },
+            ]
+        }
+
+        with patch(
+            "src.integrations.ai_analysis_engine.AIAnalysisEngine."
+            "generate_structured_response",
+            new_callable=AsyncMock,
+            return_value=llm_response,
+        ):
+            tasks = await parser.decompose_by_contract(
+                prd_analysis=prd_analysis,
+                contract_artifacts=contracts,
+                agent_count=1,
+            )
+
+        assert len(tasks) == 1
+        # Empty description + contract metadata marker appended
+        assert "MARCUS_CONTRACT_FIRST" in tasks[0].description
+
+    @pytest.mark.asyncio
+    async def test_non_dict_task_raises_runtime_error(self):
+        """
+        LLM returns a task that's not a dict (e.g. a string) → clean
+        RuntimeError so the caller's fallback fires.
+        """
+        parser = AdvancedPRDParser()
+        prd_analysis = _make_prd_analysis()
+        contracts = _make_contract_artifacts()
+
+        llm_response = {
+            "tasks": [
+                "this is not a dict",  # malformed
+            ]
+        }
+
+        with patch(
+            "src.integrations.ai_analysis_engine.AIAnalysisEngine."
+            "generate_structured_response",
+            new_callable=AsyncMock,
+            return_value=llm_response,
+        ):
+            with pytest.raises(RuntimeError, match="not a dict"):
+                await parser.decompose_by_contract(
+                    prd_analysis=prd_analysis,
+                    contract_artifacts=contracts,
+                    agent_count=1,
+                )
+
+    @pytest.mark.asyncio
+    async def test_responsibility_persisted_in_source_context(self):
+        """
+        decompose_by_contract stores responsibility in source_context
+        so providers that persist source_context (e.g. SQLite) can
+        round-trip contract metadata even though Task.responsibility
+        isn't a top-level kanban column. Codex P1 on PR #327.
+        """
+        parser = AdvancedPRDParser()
+        prd_analysis = _make_prd_analysis()
+        contracts = _make_contract_artifacts()
+
+        llm_response = {
+            "tasks": [
+                {
+                    "name": "Implement thing",
+                    "description": "Do the thing",
+                    "responsibility": "implements Thing interface",
+                    "contract_file": "docs/api/types.ts",
+                    "provides": "thing",
+                    "requires": "None",
+                    "estimated_minutes": 5,
+                },
+            ]
+        }
+
+        with patch(
+            "src.integrations.ai_analysis_engine.AIAnalysisEngine."
+            "generate_structured_response",
+            new_callable=AsyncMock,
+            return_value=llm_response,
+        ):
+            tasks = await parser.decompose_by_contract(
+                prd_analysis=prd_analysis,
+                contract_artifacts=contracts,
+                agent_count=1,
+            )
+
+        task = tasks[0]
+        assert task.responsibility == "implements Thing interface"
+        assert task.source_context is not None
+        # Responsibility also stored in source_context as belt-and-suspenders
+        assert task.source_context["responsibility"] == "implements Thing interface"
+        assert task.source_context["contract_file"] == "docs/api/types.ts"
+
+    @pytest.mark.asyncio
+    async def test_description_embeds_marker_for_persistence_fallback(self):
+        """
+        decompose_by_contract embeds MARCUS_CONTRACT_FIRST marker in
+        description so the metadata survives providers that only
+        persist description (e.g. Planka).
+        """
+        parser = AdvancedPRDParser()
+        prd_analysis = _make_prd_analysis()
+        contracts = _make_contract_artifacts()
+
+        llm_response = {
+            "tasks": [
+                {
+                    "name": "Implement thing",
+                    "description": "Build the thing",
+                    "responsibility": "implements Thing from types.ts",
+                    "contract_file": "docs/api/types.ts",
+                    "provides": "thing",
+                    "requires": "None",
+                    "estimated_minutes": 5,
+                },
+            ]
+        }
+
+        with patch(
+            "src.integrations.ai_analysis_engine.AIAnalysisEngine."
+            "generate_structured_response",
+            new_callable=AsyncMock,
+            return_value=llm_response,
+        ):
+            tasks = await parser.decompose_by_contract(
+                prd_analysis=prd_analysis,
+                contract_artifacts=contracts,
+                agent_count=1,
+            )
+
+        desc = tasks[0].description
+        assert "<!-- MARCUS_CONTRACT_FIRST" in desc
+        assert "responsibility: implements Thing from types.ts" in desc
+        assert "contract_file: docs/api/types.ts" in desc
+        assert "-->" in desc
+
+    @pytest.mark.asyncio
     async def test_mixed_none_and_usable_contracts(self):
         """Partial contract generation → decomposer uses only usable ones."""
         parser = AdvancedPRDParser()

--- a/tests/unit/ai/test_decompose_by_contract.py
+++ b/tests/unit/ai/test_decompose_by_contract.py
@@ -8,31 +8,45 @@ contract; these tests pin the productionized path.
 
 Test strategy
 -------------
+- Stub ``LLMAbstraction`` at ``AdvancedPRDParser`` construction time
+  so Marcus config validation is bypassed. This is the project-wide
+  convention for unit tests that instantiate the parser — see
+  ``tests/unit/ai/test_advanced_prd_parser.py`` and every other
+  existing parser test.
 - Mock ``AIAnalysisEngine.generate_structured_response`` to return
   controlled task lists. Never call real LLMs from unit tests.
 - Exercise the happy path, the empty-contracts fallback, the
   LLM-failure path, and the Task.responsibility plumbing.
 """
 
-import os
 from datetime import datetime, timezone
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-# AdvancedPRDParser.__init__ instantiates LLMAbstraction which validates
-# Marcus config on first construction. Provide a dummy API key so the
-# validation passes — we never actually make LLM calls in unit tests.
-os.environ.setdefault("ANTHROPIC_API_KEY", "test-key-not-real")
-
-from src.ai.advanced.prd.advanced_parser import (  # noqa: E402
+from src.ai.advanced.prd.advanced_parser import (
     AdvancedPRDParser,
     PRDAnalysis,
     ProjectConstraints,
 )
-from src.core.models import TaskStatus  # noqa: E402
+from src.core.models import TaskStatus
 
 pytestmark = pytest.mark.unit
+
+
+def _make_parser() -> AdvancedPRDParser:
+    """
+    Instantiate ``AdvancedPRDParser`` with ``LLMAbstraction`` stubbed.
+
+    Matches the project convention for parser unit tests (see
+    ``test_advanced_prd_parser.py``). Without the stub, parser
+    construction would call ``get_config()`` and fail in environments
+    that have no ``config_marcus.json`` or ``ANTHROPIC_API_KEY``
+    (e.g. CI).
+    """
+    with patch("src.ai.advanced.prd.advanced_parser.LLMAbstraction") as mock_llm_class:
+        mock_llm_class.return_value = MagicMock()
+        return AdvancedPRDParser()
 
 
 def _make_prd_analysis() -> PRDAnalysis:
@@ -117,7 +131,7 @@ class TestDecomposeByContract:
         field names the contract interface each task owns. This is the
         core productionization of experiment 1.
         """
-        parser = AdvancedPRDParser()
+        parser = _make_parser()
         prd_analysis = _make_prd_analysis()
         contracts = _make_contract_artifacts()
 
@@ -190,7 +204,7 @@ class TestDecomposeByContract:
         NaturalLanguageProjectCreator catches ValueError and falls back
         to feature_based with a visible warning.
         """
-        parser = AdvancedPRDParser()
+        parser = _make_parser()
         prd_analysis = _make_prd_analysis()
 
         empty_contracts = {"Game Engine": None, "Game UI": None}
@@ -210,7 +224,7 @@ class TestDecomposeByContract:
         A payload with ``{"artifacts": []}`` is as useless as None —
         the LLM would see no contract content to decompose against.
         """
-        parser = AdvancedPRDParser()
+        parser = _make_parser()
         prd_analysis = _make_prd_analysis()
 
         empty_contracts = {
@@ -227,7 +241,7 @@ class TestDecomposeByContract:
     @pytest.mark.asyncio
     async def test_llm_failure_raises_runtime_error(self):
         """LLM exception → RuntimeError so caller can fall back."""
-        parser = AdvancedPRDParser()
+        parser = _make_parser()
         prd_analysis = _make_prd_analysis()
         contracts = _make_contract_artifacts()
 
@@ -247,7 +261,7 @@ class TestDecomposeByContract:
     @pytest.mark.asyncio
     async def test_empty_task_list_in_response_raises(self):
         """LLM returns ``{"tasks": []}`` → RuntimeError (unusable)."""
-        parser = AdvancedPRDParser()
+        parser = _make_parser()
         prd_analysis = _make_prd_analysis()
         contracts = _make_contract_artifacts()
 
@@ -267,7 +281,7 @@ class TestDecomposeByContract:
     @pytest.mark.asyncio
     async def test_labels_include_contract_first(self):
         """Contract-first tasks carry a 'contract_first' label for filtering."""
-        parser = AdvancedPRDParser()
+        parser = _make_parser()
         prd_analysis = _make_prd_analysis()
         contracts = _make_contract_artifacts()
 
@@ -303,7 +317,7 @@ class TestDecomposeByContract:
     @pytest.mark.asyncio
     async def test_contract_file_embedded_in_description(self):
         """Task description includes the contract file path for agent discovery."""
-        parser = AdvancedPRDParser()
+        parser = _make_parser()
         prd_analysis = _make_prd_analysis()
         contracts = _make_contract_artifacts()
 
@@ -348,7 +362,7 @@ class TestDecomposeByContract:
         enforce the schema, so nulls can leak through. Must not
         raise TypeError from ``float(None)``. Codex P1 on PR #327.
         """
-        parser = AdvancedPRDParser()
+        parser = _make_parser()
         prd_analysis = _make_prd_analysis()
         contracts = _make_contract_artifacts()
 
@@ -389,7 +403,7 @@ class TestDecomposeByContract:
 
         Must not raise AttributeError from ``.strip()`` on a non-str.
         """
-        parser = AdvancedPRDParser()
+        parser = _make_parser()
         prd_analysis = _make_prd_analysis()
         contracts = _make_contract_artifacts()
 
@@ -430,7 +444,7 @@ class TestDecomposeByContract:
         LLM returns a task that's not a dict (e.g. a string) → clean
         RuntimeError so the caller's fallback fires.
         """
-        parser = AdvancedPRDParser()
+        parser = _make_parser()
         prd_analysis = _make_prd_analysis()
         contracts = _make_contract_artifacts()
 
@@ -461,7 +475,7 @@ class TestDecomposeByContract:
         round-trip contract metadata even though Task.responsibility
         isn't a top-level kanban column. Codex P1 on PR #327.
         """
-        parser = AdvancedPRDParser()
+        parser = _make_parser()
         prd_analysis = _make_prd_analysis()
         contracts = _make_contract_artifacts()
 
@@ -505,7 +519,7 @@ class TestDecomposeByContract:
         description so the metadata survives providers that only
         persist description (e.g. Planka).
         """
-        parser = AdvancedPRDParser()
+        parser = _make_parser()
         prd_analysis = _make_prd_analysis()
         contracts = _make_contract_artifacts()
 
@@ -544,7 +558,7 @@ class TestDecomposeByContract:
     @pytest.mark.asyncio
     async def test_mixed_none_and_usable_contracts(self):
         """Partial contract generation → decomposer uses only usable ones."""
-        parser = AdvancedPRDParser()
+        parser = _make_parser()
         prd_analysis = _make_prd_analysis()
         # One domain succeeded, one failed (None)
         contracts = {

--- a/tests/unit/config/test_decomposer_config.py
+++ b/tests/unit/config/test_decomposer_config.py
@@ -1,0 +1,103 @@
+"""
+Unit tests for decomposer strategy selection (GH-320 PR 2).
+
+Tests the precedence order of ``resolve_decomposer``:
+1. Explicit options["decomposer"]
+2. MARCUS_DECOMPOSER env var
+3. Default: feature_based
+
+And the loud-warning behavior for unknown strategy values.
+"""
+
+import pytest
+
+from src.config.decomposer_config import (
+    DECOMPOSER_CONTRACT_FIRST,
+    DECOMPOSER_FEATURE_BASED,
+    ENV_VAR,
+    is_contract_first,
+    resolve_decomposer,
+)
+
+pytestmark = pytest.mark.unit
+
+
+class TestResolveDecomposer:
+    """Test suite for resolve_decomposer precedence and validation."""
+
+    def test_default_is_feature_based(self, monkeypatch):
+        """No env var, no options → feature_based."""
+        monkeypatch.delenv(ENV_VAR, raising=False)
+        assert resolve_decomposer() == DECOMPOSER_FEATURE_BASED
+        assert resolve_decomposer(None) == DECOMPOSER_FEATURE_BASED
+        assert resolve_decomposer({}) == DECOMPOSER_FEATURE_BASED
+
+    def test_options_dict_contract_first_wins(self, monkeypatch):
+        """options["decomposer"]=contract_first is selected."""
+        monkeypatch.delenv(ENV_VAR, raising=False)
+        result = resolve_decomposer({"decomposer": DECOMPOSER_CONTRACT_FIRST})
+        assert result == DECOMPOSER_CONTRACT_FIRST
+
+    def test_env_var_contract_first_wins_when_options_silent(self, monkeypatch):
+        """MARCUS_DECOMPOSER env var is consulted when options has no key."""
+        monkeypatch.setenv(ENV_VAR, DECOMPOSER_CONTRACT_FIRST)
+        assert resolve_decomposer(None) == DECOMPOSER_CONTRACT_FIRST
+        assert resolve_decomposer({}) == DECOMPOSER_CONTRACT_FIRST
+
+    def test_options_dict_overrides_env_var(self, monkeypatch):
+        """options["decomposer"] takes precedence over MARCUS_DECOMPOSER."""
+        monkeypatch.setenv(ENV_VAR, DECOMPOSER_CONTRACT_FIRST)
+        result = resolve_decomposer({"decomposer": DECOMPOSER_FEATURE_BASED})
+        assert result == DECOMPOSER_FEATURE_BASED
+
+    def test_unknown_strategy_in_options_falls_back(self, monkeypatch, caplog):
+        """Unknown options value → fall back to feature_based with warning."""
+        monkeypatch.delenv(ENV_VAR, raising=False)
+        import logging
+
+        with caplog.at_level(logging.WARNING, logger="src.config.decomposer_config"):
+            result = resolve_decomposer({"decomposer": "quantum_cluster"})
+        assert result == DECOMPOSER_FEATURE_BASED
+        assert any("quantum_cluster" in rec.message for rec in caplog.records)
+        assert any("falling back" in rec.message for rec in caplog.records)
+
+    def test_unknown_strategy_in_env_var_falls_back(self, monkeypatch, caplog):
+        """Unknown env value → fall back to feature_based with warning."""
+        monkeypatch.setenv(ENV_VAR, "banana_strategy")
+        import logging
+
+        with caplog.at_level(logging.WARNING, logger="src.config.decomposer_config"):
+            result = resolve_decomposer(None)
+        assert result == DECOMPOSER_FEATURE_BASED
+        assert any("banana_strategy" in rec.message for rec in caplog.records)
+
+    def test_feature_based_explicit_in_options(self, monkeypatch):
+        """Explicit feature_based in options returns feature_based."""
+        monkeypatch.setenv(ENV_VAR, DECOMPOSER_CONTRACT_FIRST)
+        result = resolve_decomposer({"decomposer": DECOMPOSER_FEATURE_BASED})
+        assert result == DECOMPOSER_FEATURE_BASED
+
+
+class TestIsContractFirst:
+    """Test suite for the is_contract_first convenience wrapper."""
+
+    def test_default_false(self, monkeypatch):
+        """No env var, no options → False."""
+        monkeypatch.delenv(ENV_VAR, raising=False)
+        assert is_contract_first() is False
+        assert is_contract_first(None) is False
+
+    def test_true_when_contract_first_selected(self, monkeypatch):
+        """options contract_first → True."""
+        monkeypatch.delenv(ENV_VAR, raising=False)
+        assert is_contract_first({"decomposer": DECOMPOSER_CONTRACT_FIRST}) is True
+
+    def test_false_when_feature_based_selected(self, monkeypatch):
+        """options feature_based → False."""
+        monkeypatch.delenv(ENV_VAR, raising=False)
+        assert is_contract_first({"decomposer": DECOMPOSER_FEATURE_BASED}) is False
+
+    def test_true_when_env_var_contract_first(self, monkeypatch):
+        """Env var contract_first → True."""
+        monkeypatch.setenv(ENV_VAR, DECOMPOSER_CONTRACT_FIRST)
+        assert is_contract_first(None) is True

--- a/tests/unit/integrations/test_contract_first_fallback.py
+++ b/tests/unit/integrations/test_contract_first_fallback.py
@@ -1,0 +1,373 @@
+"""
+Unit tests for contract-first fallback path (GH-320 PR 2).
+
+Tests that ``NaturalLanguageProjectCreator._try_contract_first_decomposition``
+returns None (triggering feature-based fallback) when any stage fails:
+
+- project_root missing (cannot write contracts)
+- PRD analysis fails
+- No functional requirements
+- Domain discovery fails
+- Contract generation fails or produces no usable artifacts
+- Decomposer raises ValueError or RuntimeError
+
+The caller in ``process_natural_language`` then falls back to
+feature-based decomposition with a visible warning — never a silent
+fallback.
+"""
+
+import os
+
+# Provide dummy API key so parser/creator instantiation succeeds in unit tests
+os.environ.setdefault("ANTHROPIC_API_KEY", "test-key-not-real")
+
+from unittest.mock import AsyncMock, MagicMock, patch  # noqa: E402
+
+import pytest  # noqa: E402
+
+from src.ai.advanced.prd.advanced_parser import PRDAnalysis  # noqa: E402
+from src.integrations.nlp_tools import NaturalLanguageProjectCreator  # noqa: E402
+
+pytestmark = pytest.mark.unit
+
+
+def _make_prd_analysis(with_requirements: bool = True) -> PRDAnalysis:
+    """Build a minimal PRDAnalysis for tests."""
+    return PRDAnalysis(
+        functional_requirements=(
+            [
+                {
+                    "id": "f1",
+                    "name": "Feature 1",
+                    "description": "Do the thing",
+                    "complexity": "simple",
+                }
+            ]
+            if with_requirements
+            else []
+        ),
+        non_functional_requirements=[],
+        technical_constraints=[],
+        business_objectives=[],
+        user_personas=[],
+        success_metrics=[],
+        implementation_approach="iterative",
+        complexity_assessment={"level": "low"},
+        risk_factors=[],
+        confidence=0.8,
+        original_description="Build a thing",
+    )
+
+
+def _make_creator() -> NaturalLanguageProjectCreator:
+    """Build a creator with mocked AI engine."""
+    return NaturalLanguageProjectCreator(
+        kanban_client=MagicMock(),
+        ai_engine=MagicMock(),
+        state=MagicMock(),
+    )
+
+
+class TestContractFirstFallback:
+    """Test suite for _try_contract_first_decomposition fallback conditions."""
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_project_root_missing(self):
+        """project_root=None → fallback (contracts have nowhere to land)."""
+        creator = _make_creator()
+        constraints = MagicMock()
+
+        result = await creator._try_contract_first_decomposition(
+            description="Build a thing",
+            project_name="Thing",
+            project_root=None,
+            constraints=constraints,
+            options={"decomposer": "contract_first"},
+        )
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_prd_analysis_fails(self):
+        """PRD analysis raises → fallback."""
+        creator = _make_creator()
+        constraints = MagicMock()
+
+        with patch.object(
+            creator.prd_parser,
+            "_analyze_prd_deeply",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("LLM timeout"),
+        ):
+            result = await creator._try_contract_first_decomposition(
+                description="Build a thing",
+                project_name="Thing",
+                project_root="/tmp/test",  # nosec B108
+                constraints=constraints,
+                options={"decomposer": "contract_first"},
+            )
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_no_functional_requirements(self):
+        """Empty functional_requirements → fallback."""
+        creator = _make_creator()
+        constraints = MagicMock()
+        empty_analysis = _make_prd_analysis(with_requirements=False)
+
+        with patch.object(
+            creator.prd_parser,
+            "_analyze_prd_deeply",
+            new_callable=AsyncMock,
+            return_value=empty_analysis,
+        ):
+            result = await creator._try_contract_first_decomposition(
+                description="Build a thing",
+                project_name="Thing",
+                project_root="/tmp/test",  # nosec B108
+                constraints=constraints,
+                options={"decomposer": "contract_first"},
+            )
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_domain_discovery_fails(self):
+        """Domain discovery raises → fallback."""
+        creator = _make_creator()
+        constraints = MagicMock()
+
+        with (
+            patch.object(
+                creator.prd_parser,
+                "_analyze_prd_deeply",
+                new_callable=AsyncMock,
+                return_value=_make_prd_analysis(),
+            ),
+            patch.object(
+                creator.prd_parser,
+                "_discover_domains",
+                new_callable=AsyncMock,
+                side_effect=RuntimeError("discovery failed"),
+            ),
+        ):
+            result = await creator._try_contract_first_decomposition(
+                description="Build a thing",
+                project_name="Thing",
+                project_root="/tmp/test",  # nosec B108
+                constraints=constraints,
+                options={"decomposer": "contract_first"},
+            )
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_no_domains_discovered(self):
+        """Empty domain groups → fallback."""
+        creator = _make_creator()
+        constraints = MagicMock()
+
+        with (
+            patch.object(
+                creator.prd_parser,
+                "_analyze_prd_deeply",
+                new_callable=AsyncMock,
+                return_value=_make_prd_analysis(),
+            ),
+            patch.object(
+                creator.prd_parser,
+                "_discover_domains",
+                new_callable=AsyncMock,
+                return_value={},
+            ),
+        ):
+            result = await creator._try_contract_first_decomposition(
+                description="Build a thing",
+                project_name="Thing",
+                project_root="/tmp/test",  # nosec B108
+                constraints=constraints,
+                options={"decomposer": "contract_first"},
+            )
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_contract_generation_fails(self):
+        """_generate_contracts_by_domain raises → fallback."""
+        creator = _make_creator()
+        constraints = MagicMock()
+
+        with (
+            patch.object(
+                creator.prd_parser,
+                "_analyze_prd_deeply",
+                new_callable=AsyncMock,
+                return_value=_make_prd_analysis(),
+            ),
+            patch.object(
+                creator.prd_parser,
+                "_discover_domains",
+                new_callable=AsyncMock,
+                return_value={"Main": ["f1"]},
+            ),
+            patch(
+                "src.integrations.nlp_tools._generate_contracts_by_domain",
+                new_callable=AsyncMock,
+                side_effect=RuntimeError("contract gen failed"),
+            ),
+        ):
+            result = await creator._try_contract_first_decomposition(
+                description="Build a thing",
+                project_name="Thing",
+                project_root="/tmp/test",  # nosec B108
+                constraints=constraints,
+                options={"decomposer": "contract_first"},
+            )
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_contracts_all_empty(self):
+        """All domains produce None artifacts → fallback."""
+        creator = _make_creator()
+        constraints = MagicMock()
+
+        with (
+            patch.object(
+                creator.prd_parser,
+                "_analyze_prd_deeply",
+                new_callable=AsyncMock,
+                return_value=_make_prd_analysis(),
+            ),
+            patch.object(
+                creator.prd_parser,
+                "_discover_domains",
+                new_callable=AsyncMock,
+                return_value={"Main": ["f1"]},
+            ),
+            patch(
+                "src.integrations.nlp_tools._generate_contracts_by_domain",
+                new_callable=AsyncMock,
+                return_value={"Main": None},
+            ),
+        ):
+            result = await creator._try_contract_first_decomposition(
+                description="Build a thing",
+                project_name="Thing",
+                project_root="/tmp/test",  # nosec B108
+                constraints=constraints,
+                options={"decomposer": "contract_first"},
+            )
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_decomposer_fails(self):
+        """decompose_by_contract raises RuntimeError → fallback."""
+        creator = _make_creator()
+        constraints = MagicMock()
+
+        with (
+            patch.object(
+                creator.prd_parser,
+                "_analyze_prd_deeply",
+                new_callable=AsyncMock,
+                return_value=_make_prd_analysis(),
+            ),
+            patch.object(
+                creator.prd_parser,
+                "_discover_domains",
+                new_callable=AsyncMock,
+                return_value={"Main": ["f1"]},
+            ),
+            patch(
+                "src.integrations.nlp_tools._generate_contracts_by_domain",
+                new_callable=AsyncMock,
+                return_value={
+                    "Main": {
+                        "artifacts": [
+                            {
+                                "filename": "contract.md",
+                                "artifact_type": "api",
+                                "content": "# Contract",
+                                "description": "api",
+                                "relative_path": "docs/api/contract.md",
+                            }
+                        ],
+                        "decisions": [],
+                    }
+                },
+            ),
+            patch.object(
+                creator.prd_parser,
+                "decompose_by_contract",
+                new_callable=AsyncMock,
+                side_effect=RuntimeError("LLM structured output failed"),
+            ),
+        ):
+            result = await creator._try_contract_first_decomposition(
+                description="Build a thing",
+                project_name="Thing",
+                project_root="/tmp/test",  # nosec B108
+                constraints=constraints,
+                options={"decomposer": "contract_first"},
+            )
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_happy_path_returns_tasks(self):
+        """All stages succeed → returns task list."""
+        creator = _make_creator()
+        constraints = MagicMock()
+
+        fake_tasks = [MagicMock()]  # decomposer returns at least one task
+
+        with (
+            patch.object(
+                creator.prd_parser,
+                "_analyze_prd_deeply",
+                new_callable=AsyncMock,
+                return_value=_make_prd_analysis(),
+            ),
+            patch.object(
+                creator.prd_parser,
+                "_discover_domains",
+                new_callable=AsyncMock,
+                return_value={"Main": ["f1"]},
+            ),
+            patch(
+                "src.integrations.nlp_tools._generate_contracts_by_domain",
+                new_callable=AsyncMock,
+                return_value={
+                    "Main": {
+                        "artifacts": [
+                            {
+                                "filename": "contract.md",
+                                "artifact_type": "api",
+                                "content": "# Contract",
+                                "description": "api",
+                                "relative_path": "docs/api/contract.md",
+                            }
+                        ],
+                        "decisions": [],
+                    }
+                },
+            ),
+            patch.object(
+                creator.prd_parser,
+                "decompose_by_contract",
+                new_callable=AsyncMock,
+                return_value=fake_tasks,
+            ),
+        ):
+            result = await creator._try_contract_first_decomposition(
+                description="Build a thing",
+                project_name="Thing",
+                project_root="/tmp/test",  # nosec B108
+                constraints=constraints,
+                options={"decomposer": "contract_first", "agent_count": 3},
+            )
+
+        assert result == fake_tasks

--- a/tests/unit/integrations/test_contract_first_fallback.py
+++ b/tests/unit/integrations/test_contract_first_fallback.py
@@ -16,17 +16,12 @@ feature-based decomposition with a visible warning — never a silent
 fallback.
 """
 
-import os
+from unittest.mock import AsyncMock, MagicMock, patch
 
-# Provide dummy API key so parser/creator instantiation succeeds in unit tests
-os.environ.setdefault("ANTHROPIC_API_KEY", "test-key-not-real")
+import pytest
 
-from unittest.mock import AsyncMock, MagicMock, patch  # noqa: E402
-
-import pytest  # noqa: E402
-
-from src.ai.advanced.prd.advanced_parser import PRDAnalysis  # noqa: E402
-from src.integrations.nlp_tools import NaturalLanguageProjectCreator  # noqa: E402
+from src.ai.advanced.prd.advanced_parser import PRDAnalysis
+from src.integrations.nlp_tools import NaturalLanguageProjectCreator
 
 pytestmark = pytest.mark.unit
 
@@ -60,12 +55,30 @@ def _make_prd_analysis(with_requirements: bool = True) -> PRDAnalysis:
 
 
 def _make_creator() -> NaturalLanguageProjectCreator:
-    """Build a creator with mocked AI engine."""
-    return NaturalLanguageProjectCreator(
-        kanban_client=MagicMock(),
-        ai_engine=MagicMock(),
-        state=MagicMock(),
-    )
+    """
+    Build a creator with ``LLMAbstraction`` stubbed.
+
+    ``NaturalLanguageProjectCreator.__init__`` instantiates
+    ``AdvancedPRDParser`` which in turn instantiates
+    ``LLMAbstraction``, and that calls ``get_config()`` which
+    requires a valid Marcus config. In CI there is no
+    ``config_marcus.json`` and no ``ANTHROPIC_API_KEY``, so
+    construction fails at ``LLMAbstraction.__init__``.
+
+    Matches the project convention from
+    ``tests/unit/ai/test_advanced_prd_parser.py``: stub
+    ``LLMAbstraction`` at the import site before constructing the
+    parser. Every test in this file patches the parser's methods
+    individually so the stubbed LLM client is never actually
+    invoked.
+    """
+    with patch("src.ai.advanced.prd.advanced_parser.LLMAbstraction") as mock_llm_class:
+        mock_llm_class.return_value = MagicMock()
+        return NaturalLanguageProjectCreator(
+            kanban_client=MagicMock(),
+            ai_engine=MagicMock(),
+            state=MagicMock(),
+        )
 
 
 class TestContractFirstFallback:

--- a/tests/unit/integrations/test_integration_verification.py
+++ b/tests/unit/integrations/test_integration_verification.py
@@ -387,6 +387,127 @@ class TestEnhanceProjectWithIntegration:
         assert len(result) == len(design_only)
 
 
+class TestIntegrationTaskContractFile:
+    """
+    GH-320 PR 2: Integration task names the contract file when
+    contract-first decomposition is active.
+
+    The integration agent must treat the contract as authoritative:
+    fix implementations that diverge, never edit the contract to
+    match a broken implementation. Without this instruction in the
+    task description, the integration agent could silently "fix" a
+    mismatch by editing the contract, breaking the invariant that
+    made contract-first decomposition work.
+    """
+
+    def test_integration_task_includes_contract_preamble_when_set(
+        self, sample_implementation_tasks: list[Task]
+    ) -> None:
+        """contract_file set → task description includes preamble."""
+        from src.integrations.integration_verification import (
+            IntegrationTaskGenerator,
+        )
+
+        task = IntegrationTaskGenerator.create_integration_task(
+            sample_implementation_tasks,
+            project_name="Snake Game",
+            contract_file="docs/api/types.ts",
+        )
+
+        assert task is not None
+        assert "CONTRACT-FIRST PROJECT" in task.description
+        assert "docs/api/types.ts" in task.description
+
+    def test_integration_task_preamble_forbids_contract_modification(
+        self, sample_implementation_tasks: list[Task]
+    ) -> None:
+        """
+        Preamble must instruct the agent NOT to modify the contract.
+
+        This is the load-bearing invariant. If an integration agent
+        can silently edit the contract to match a broken
+        implementation, contract-first decomposition breaks for
+        all future runs.
+        """
+        from src.integrations.integration_verification import (
+            IntegrationTaskGenerator,
+        )
+
+        task = IntegrationTaskGenerator.create_integration_task(
+            sample_implementation_tasks,
+            project_name="Snake Game",
+            contract_file="docs/api/types.ts",
+        )
+
+        assert task is not None
+        description_lower = task.description.lower()
+        assert "fix the implementation" in description_lower
+        assert "do not modify the contract" in description_lower or (
+            "do not" in description_lower and "contract" in description_lower
+        )
+
+    def test_integration_task_no_preamble_when_contract_file_none(
+        self, sample_implementation_tasks: list[Task]
+    ) -> None:
+        """Feature-based path (contract_file=None) → no preamble."""
+        from src.integrations.integration_verification import (
+            IntegrationTaskGenerator,
+        )
+
+        task = IntegrationTaskGenerator.create_integration_task(
+            sample_implementation_tasks,
+            project_name="Dashboard",
+            contract_file=None,
+        )
+
+        assert task is not None
+        assert "CONTRACT-FIRST PROJECT" not in task.description
+
+    def test_enhance_project_with_integration_passes_contract_file(
+        self, sample_implementation_tasks: list[Task]
+    ) -> None:
+        """
+        enhance_project_with_integration forwards contract_file to the
+        integration task description.
+        """
+        from src.integrations.integration_verification import (
+            enhance_project_with_integration,
+        )
+
+        result = enhance_project_with_integration(
+            sample_implementation_tasks,
+            project_description="Build a snake game",
+            project_name="Snake Game",
+            contract_file="docs/api/snake-types.ts",
+        )
+
+        integration_tasks = [t for t in result if "type:integration" in t.labels]
+        assert len(integration_tasks) == 1
+        assert "docs/api/snake-types.ts" in integration_tasks[0].description
+        assert "CONTRACT-FIRST PROJECT" in integration_tasks[0].description
+
+    def test_enhance_project_with_integration_default_no_contract(
+        self, sample_implementation_tasks: list[Task]
+    ) -> None:
+        """
+        Backward-compat: callers that don't pass contract_file get the
+        unchanged (non-contract-first) integration task.
+        """
+        from src.integrations.integration_verification import (
+            enhance_project_with_integration,
+        )
+
+        result = enhance_project_with_integration(
+            sample_implementation_tasks,
+            project_description="Build a dashboard",
+            project_name="Dashboard",
+        )
+
+        integration_tasks = [t for t in result if "type:integration" in t.labels]
+        assert len(integration_tasks) == 1
+        assert "CONTRACT-FIRST PROJECT" not in integration_tasks[0].description
+
+
 class TestPhaseEnumUpdates:
     """Test that INTEGRATION is properly added to phase enums."""
 

--- a/tests/unit/mcp/test_contract_responsibility_prompt.py
+++ b/tests/unit/mcp/test_contract_responsibility_prompt.py
@@ -1,0 +1,198 @@
+"""
+Unit tests for Task.responsibility surfacing in agent prompts (GH-320 PR 2).
+
+Tests that when a task carries ``Task.responsibility`` (set by
+contract-first decomposition), ``build_tiered_instructions`` adds a
+high-signal contract ownership layer that names the contract file and
+instructs the agent to read it before writing code.
+
+This layer is what makes contract-first decomposition work in practice:
+agents can't produce code that adheres to a contract they haven't read.
+"""
+
+from datetime import datetime, timezone
+
+import pytest
+
+from src.core.models import Priority, Task, TaskStatus
+from src.marcus_mcp.tools.task import build_tiered_instructions
+
+pytestmark = pytest.mark.unit
+
+
+def _make_task(
+    name: str = "Implement GameEngine",
+    responsibility: str = "implements GameEngine interface from types.ts",
+    contract_file: str = "docs/api/types.ts",
+) -> Task:
+    """Build a contract-first Task for testing prompt surfacing."""
+    return Task(
+        id="contract_task_1",
+        name=name,
+        description="Build the game loop and state transitions",
+        status=TaskStatus.TODO,
+        priority=Priority.HIGH,
+        assigned_to=None,
+        created_at=datetime.now(timezone.utc),
+        updated_at=datetime.now(timezone.utc),
+        due_date=None,
+        estimated_hours=0.15,
+        labels=["contract_first", "implementation"],
+        source_type="contract_first",
+        source_context={
+            "contract_file": contract_file,
+            "complexity_mode": "standard",
+        },
+        responsibility=responsibility,
+    )
+
+
+class TestContractResponsibilityLayer:
+    """Test suite for the contract responsibility layer in tiered instructions."""
+
+    def test_contract_responsibility_layer_fires_when_set(self):
+        """
+        Task.responsibility set → CONTRACT RESPONSIBILITY layer in output.
+
+        The layer must surface the contract interface the agent owns
+        so the LLM generating instructions emphasizes read-the-contract
+        behavior.
+        """
+        task = _make_task()
+
+        instructions = build_tiered_instructions(
+            base_instructions="Do the task",
+            task=task,
+            context_data=None,
+            dependency_awareness=None,
+            predictions=None,
+        )
+
+        assert "CONTRACT RESPONSIBILITY" in instructions
+        assert "implements GameEngine interface from types.ts" in instructions
+
+    def test_contract_file_named_in_instructions(self):
+        """The contract file path must appear so agents know what to Read()."""
+        task = _make_task(contract_file="docs/api/snake-types.ts")
+
+        instructions = build_tiered_instructions(
+            base_instructions="Do the task",
+            task=task,
+            context_data=None,
+            dependency_awareness=None,
+            predictions=None,
+        )
+
+        assert "docs/api/snake-types.ts" in instructions
+        # The instruction must tell the agent to Read() the contract
+        # before writing code.
+        assert "Read" in instructions
+        assert (
+            "before writing" in instructions.lower() or "read" in instructions.lower()
+        )
+
+    def test_no_contract_layer_when_responsibility_unset(self):
+        """Legacy tasks (no responsibility) → no contract layer."""
+        legacy_task = Task(
+            id="legacy_1",
+            name="Implement Feature",
+            description="Build a feature",
+            status=TaskStatus.TODO,
+            priority=Priority.HIGH,
+            assigned_to=None,
+            created_at=datetime.now(timezone.utc),
+            updated_at=datetime.now(timezone.utc),
+            due_date=None,
+            estimated_hours=0.2,
+            labels=["backend"],
+        )
+
+        instructions = build_tiered_instructions(
+            base_instructions="Do the task",
+            task=legacy_task,
+            context_data=None,
+            dependency_awareness=None,
+            predictions=None,
+        )
+
+        assert "CONTRACT RESPONSIBILITY" not in instructions
+
+    def test_contract_layer_instructs_no_silent_modification(self):
+        """
+        Agent must be told NOT to silently modify the contract.
+
+        If an implementation diverges from the contract, the agent
+        should report a blocker, not edit the contract to match the
+        implementation. This is the invariant that makes
+        contract-first decomposition work.
+        """
+        task = _make_task()
+
+        instructions = build_tiered_instructions(
+            base_instructions="Do the task",
+            task=task,
+            context_data=None,
+            dependency_awareness=None,
+            predictions=None,
+        )
+
+        # The exact wording is less important than the semantic signal.
+        # Must mention that modification is off-limits.
+        lower = instructions.lower()
+        assert "do not" in lower or "don't" in lower or "must not" in lower
+        assert "modify the contract" in lower or "silently" in lower
+
+    def test_contract_layer_fires_before_subtask_layer(self):
+        """
+        Contract responsibility layer fires BEFORE subtask context.
+
+        Ordering matters: contract ownership is structural. An agent
+        should understand which contract interface it owns before
+        considering whether this is a subtask of a larger task.
+        """
+        task = _make_task()
+        task._is_subtask = True  # type: ignore[attr-defined]
+        task._parent_task_name = "Parent Task"  # type: ignore[attr-defined]
+
+        instructions = build_tiered_instructions(
+            base_instructions="Do the task",
+            task=task,
+            context_data=None,
+            dependency_awareness=None,
+            predictions=None,
+        )
+
+        contract_idx = instructions.find("CONTRACT RESPONSIBILITY")
+        subtask_idx = instructions.find("SUBTASK CONTEXT")
+
+        assert contract_idx != -1
+        assert subtask_idx != -1
+        assert contract_idx < subtask_idx, (
+            "Contract responsibility must appear before subtask context "
+            f"in the instructions. Contract at {contract_idx}, "
+            f"subtask at {subtask_idx}."
+        )
+
+    def test_missing_contract_file_in_source_context_still_shows_responsibility(self):
+        """
+        Responsibility set but contract_file missing → still surfaces responsibility.
+
+        Degenerate but recoverable: the agent knows what interface to
+        implement even if the exact file path isn't specified. The
+        layer falls back to a generic "check docs/" instruction.
+        """
+        task = _make_task()
+        task.source_context = {}  # strip contract_file
+
+        instructions = build_tiered_instructions(
+            base_instructions="Do the task",
+            task=task,
+            context_data=None,
+            dependency_awareness=None,
+            predictions=None,
+        )
+
+        assert "CONTRACT RESPONSIBILITY" in instructions
+        assert "implements GameEngine interface from types.ts" in instructions
+        # Generic fallback guidance
+        assert "docs" in instructions.lower()

--- a/tests/unit/mcp/test_contract_responsibility_prompt.py
+++ b/tests/unit/mcp/test_contract_responsibility_prompt.py
@@ -196,3 +196,196 @@ class TestContractResponsibilityLayer:
         assert "implements GameEngine interface from types.ts" in instructions
         # Generic fallback guidance
         assert "docs" in instructions.lower()
+
+
+class TestContractMetadataPersistenceFallback:
+    """
+    Tests for the persistence fallback added in response to Codex P1
+    review on PR #327.
+
+    Kanban providers don't all round-trip Task.responsibility or
+    Task.source_context. SQLite persists source_context but not
+    responsibility as a top-level column. Planka persists neither.
+    Without a fallback path, the CONTRACT RESPONSIBILITY layer would
+    silently never fire for tasks reloaded from the board, even
+    though they were born contract-first.
+
+    The fix: ``decompose_by_contract`` embeds a MARCUS_CONTRACT_FIRST
+    marker in the task description (which every provider round-trips
+    as the core field), and ``_parse_contract_metadata`` reads from
+    multiple sources in priority order.
+    """
+
+    def _make_task_without_responsibility(
+        self,
+        description: str,
+        source_context=None,
+    ) -> Task:
+        """Simulate a task reloaded from a kanban provider that
+        stripped Task.responsibility."""
+        task = Task(
+            id="reloaded_task",
+            name="Implement GameEngine",
+            description=description,
+            status=TaskStatus.TODO,
+            priority=Priority.HIGH,
+            assigned_to=None,
+            created_at=datetime.now(timezone.utc),
+            updated_at=datetime.now(timezone.utc),
+            due_date=None,
+            estimated_hours=0.15,
+            labels=["contract_first"],
+            source_type=("contract_first" if source_context is not None else None),
+            source_context=source_context,
+            # NOTE: responsibility NOT set — simulates the provider
+            # stripping it during persistence
+        )
+        return task
+
+    def test_sqlite_reload_source_context_path(self):
+        """
+        SQLite reload: source_context round-trips but responsibility
+        doesn't. Layer should fire via priority-2 source_context path.
+        """
+        task = self._make_task_without_responsibility(
+            description="Build the game loop.",
+            source_context={
+                "contract_file": "docs/api/types.ts",
+                "responsibility": "implements GameEngine interface",
+                "complexity_mode": "standard",
+            },
+        )
+
+        instructions = build_tiered_instructions(
+            base_instructions="Do the task",
+            task=task,
+            context_data=None,
+            dependency_awareness=None,
+            predictions=None,
+        )
+
+        assert "CONTRACT RESPONSIBILITY" in instructions
+        assert "implements GameEngine interface" in instructions
+        assert "docs/api/types.ts" in instructions
+
+    def test_planka_reload_description_marker_path(self):
+        """
+        Planka reload: nothing but description round-trips. Layer
+        should fire via priority-3 description marker path.
+        """
+        description_with_marker = (
+            "Build the game loop and state transitions.\n\n"
+            "<!-- MARCUS_CONTRACT_FIRST\n"
+            "responsibility: implements GameEngine interface from types.ts\n"
+            "contract_file: docs/api/types.ts\n"
+            "-->"
+        )
+        task = self._make_task_without_responsibility(
+            description=description_with_marker,
+            source_context=None,  # Planka doesn't persist source_context
+        )
+
+        instructions = build_tiered_instructions(
+            base_instructions="Do the task",
+            task=task,
+            context_data=None,
+            dependency_awareness=None,
+            predictions=None,
+        )
+
+        assert "CONTRACT RESPONSIBILITY" in instructions
+        assert "implements GameEngine interface from types.ts" in instructions
+        assert "docs/api/types.ts" in instructions
+
+    def test_no_marker_and_no_source_context_no_layer(self):
+        """
+        Non-contract-first legacy task with no marker → no layer.
+        """
+        task = self._make_task_without_responsibility(
+            description="Build a generic feature.",
+            source_context=None,
+        )
+
+        instructions = build_tiered_instructions(
+            base_instructions="Do the task",
+            task=task,
+            context_data=None,
+            dependency_awareness=None,
+            predictions=None,
+        )
+
+        assert "CONTRACT RESPONSIBILITY" not in instructions
+
+    def test_malformed_marker_ignored(self):
+        """
+        Malformed marker (missing closing `-->`) → no layer fires.
+        Defensive: don't half-surface garbage to agents.
+        """
+        description_with_broken_marker = (
+            "Build the game loop.\n\n"
+            "<!-- MARCUS_CONTRACT_FIRST\n"
+            "responsibility: implements GameEngine\n"
+            "contract_file: docs/api/types.ts\n"
+            # No closing --> on purpose
+        )
+        task = self._make_task_without_responsibility(
+            description=description_with_broken_marker,
+            source_context=None,
+        )
+
+        instructions = build_tiered_instructions(
+            base_instructions="Do the task",
+            task=task,
+            context_data=None,
+            dependency_awareness=None,
+            predictions=None,
+        )
+
+        assert "CONTRACT RESPONSIBILITY" not in instructions
+
+    def test_priority_order_direct_responsibility_wins(self):
+        """
+        Priority order: Task.responsibility > source_context >
+        description marker. Direct field wins when present.
+        """
+        task = Task(
+            id="priority_test",
+            name="Test",
+            description=(
+                "Base description.\n\n"
+                "<!-- MARCUS_CONTRACT_FIRST\n"
+                "responsibility: from_marker\n"
+                "contract_file: marker/path.ts\n"
+                "-->"
+            ),
+            status=TaskStatus.TODO,
+            priority=Priority.HIGH,
+            assigned_to=None,
+            created_at=datetime.now(timezone.utc),
+            updated_at=datetime.now(timezone.utc),
+            due_date=None,
+            estimated_hours=0.15,
+            labels=[],
+            source_context={
+                "responsibility": "from_source_context",
+                "contract_file": "sc/path.ts",
+            },
+            responsibility="from_direct_field",
+        )
+
+        instructions = build_tiered_instructions(
+            base_instructions="Do the task",
+            task=task,
+            context_data=None,
+            dependency_awareness=None,
+            predictions=None,
+        )
+
+        # Direct field wins
+        assert "from_direct_field" in instructions
+        # The contract_file associated with the winning layer is
+        # source_context's (because that's where contract_file lives
+        # when task.responsibility is set) — NOT the marker's.
+        assert "sc/path.ts" in instructions
+        assert "from_source_context" not in instructions
+        assert "from_marker" not in instructions


### PR DESCRIPTION
## Summary

Contract-first task decomposition per GH-320 acceptance criteria. Experiment 1 (2026-04-10, hand-crafted TypeScript contract, snake game) validated the mechanism: ~30/70 contribution split, clean merge, first Marcus experiment on tight coupling that did not produce a Single-Author Product verdict. **This PR productionizes the path.**

Does NOT close #320 — Experiment 4 (LLM-generated contract snake game) is the real validation gate. Will be run after this PR merges.

## Core changes

### 1. \`Task.responsibility\` field (src/core/models.py)

Optional Task attribute naming the contract interface this task owns, e.g. \`"implements GameEngine interface from src/types.ts"\`. Orthogonal to \`provides\`/\`requires\`:

- \`provides\`/\`requires\` describe what the task satisfies at the dependency-wiring layer
- \`responsibility\` names the contract interface the task owns from the authoritative shared contract file

### 2. \`AdvancedPRDParser.decompose_by_contract\` (src/ai/advanced/prd/advanced_parser.py)

New method signature:

\`\`\`python
async def decompose_by_contract(
    self,
    prd_analysis: PRDAnalysis,
    contract_artifacts: Dict[str, Optional[Dict[str, Any]]],
    agent_count: int,
    constraints: Optional[ProjectConstraints] = None,
) -> List[Task]
\`\`\`

Takes PRD analysis + contract artifacts (from PR 1's \`_generate_contracts_by_domain\`) + agent count. Structured LLM output via \`AIAnalysisEngine.generate_structured_response\` produces task list where each task carries \`responsibility\`, \`contract_file\` in \`source_context\`, \`provides\`, \`requires\`, and \`estimated_minutes\`. Raises \`ValueError\` on all-empty contracts and \`RuntimeError\` on LLM failure so the caller can fall back gracefully.

### 3. \`MARCUS_DECOMPOSER\` feature flag (src/config/decomposer_config.py)

New module with \`resolve_decomposer(options)\` and \`is_contract_first(options)\`. Precedence:
1. \`options["decomposer"]\` (explicit per-call override)
2. \`MARCUS_DECOMPOSER\` env var
3. Default: \`feature_based\`

Unknown strategy values trigger a loud warning and fall back to \`feature_based\`. No silent fallbacks.

### 4. \`NaturalLanguageProjectCreator.process_natural_language\` (src/integrations/nlp_tools.py)

Branches on the flag. Contract-first path runs:
1. Deep PRD analysis (\`_analyze_prd_deeply\`)
2. Domain discovery (\`_discover_domains\`)
3. Contract generation (\`_generate_contracts_by_domain\`)
4. Contract-aware decomposition (\`decompose_by_contract\`)

Any failure at any stage returns \`None\` from the helper, and the caller falls back to feature-based with a visible warning. Fallback triggers: \`project_root\` missing, PRD analysis fails, no functional requirements, domain discovery fails, no domains discovered, contract generation fails, all contracts empty/None, decomposer raises \`ValueError\`/\`RuntimeError\`, decomposer returns empty list.

### 5. Agent prompt Layer 1.3 (src/marcus_mcp/tools/task.py)

New \`CONTRACT RESPONSIBILITY\` layer in \`build_tiered_instructions\`. Fires when \`Task.responsibility\` is set:

\`\`\`
📜 CONTRACT RESPONSIBILITY (contract-first decomposition):
You OWN: implements GameEngine interface from types.ts
Contract file: docs/api/types.ts

BEFORE writing any code, Read() the contract file at docs/api/types.ts.
...
Your implementation MUST conform to the contract. If the contract is
missing something you need, report a blocker — do NOT silently modify
the contract file.
\`\`\`

Fires BEFORE the subtask context layer because contract ownership is structural — an agent needs to understand which contract interface it owns before considering whether this is a subtask of a larger parent.

Also: \`AIAnalysisEngine.generate_task_instructions\` adds \`responsibility\` + \`contract_file\` + \`contract_first: true\` to the \`task_data\` dict so the LLM sees them when generating base instructions.

### 6. Integration task contract authority (src/integrations/integration_verification.py)

\`IntegrationTaskGenerator.create_integration_task\` and \`enhance_project_with_integration\` take an optional \`contract_file\` parameter. When set, the task description prepends a \`CONTRACT-FIRST PROJECT\` preamble:

> The contract is AUTHORITATIVE. Agents built their implementations against it. If any implementation diverges from the contract during your verification, FIX THE IMPLEMENTATION — do NOT modify the contract file.

Prevents the integration agent from silently \"fixing\" a mismatch by editing the contract, breaking the invariant that made contract-first decomposition work in the first place.

\`nlp_tools.process_natural_language\` picks up the contract file from the first contract-first task's \`source_context\` and passes it through \`enhance_project_with_integration\`.

## Tests (34 new, all marked \`@pytest.mark.unit\`)

### \`tests/unit/config/test_decomposer_config.py\` (11 tests)

Precedence order, unknown strategy fallback with warning, \`is_contract_first\` convenience wrapper.

### \`tests/unit/ai/test_decompose_by_contract.py\` (8 tests)

- \`test_happy_path_produces_tasks_with_responsibility\` — structured LLM → Task objects with responsibility set
- \`test_empty_contracts_raises_value_error\` — all-None → ValueError
- \`test_contracts_with_empty_artifacts_raises_value_error\` — \`{\"artifacts\": []}\` → ValueError
- \`test_llm_failure_raises_runtime_error\` — LLM exception → RuntimeError
- \`test_empty_task_list_in_response_raises\` — \`{\"tasks\": []}\` → RuntimeError
- \`test_labels_include_contract_first\` — tasks carry \`contract_first\` label
- \`test_contract_file_embedded_in_description\` — agents can discover contract from task.description
- \`test_mixed_none_and_usable_contracts\` — partial contracts → decomposer uses only usable ones

### \`tests/unit/integrations/test_contract_first_fallback.py\` (9 tests)

All failure paths for \`_try_contract_first_decomposition\` return \`None\` so the caller falls back to feature_based. Plus one happy path.

### \`tests/unit/mcp/test_contract_responsibility_prompt.py\` (6 tests)

- Contract responsibility layer fires when set
- Contract file named in instructions
- No layer when responsibility unset (legacy tasks)
- Layer forbids silent contract modification
- Layer fires BEFORE subtask layer (ordering)
- Graceful fallback when contract_file missing

### \`tests/unit/integrations/test_integration_verification.py\` (5 new)

- \`test_integration_task_includes_contract_preamble_when_set\`
- \`test_integration_task_preamble_forbids_contract_modification\`
- \`test_integration_task_no_preamble_when_contract_file_none\` (backward compat)
- \`test_enhance_project_with_integration_passes_contract_file\`
- \`test_enhance_project_with_integration_default_no_contract\`

## Test results

- \`pytest -m unit\`: **425/425 passed** (391 baseline + 34 new)
- mypy clean on all touched files

## Scope explicitly excluded (future work)

- **Experiment 2** (Python log analyzer): pending per #320
- **Experiment 3** (3-agent contract-based decomposition): pending — unknown territory for boundary discipline
- **Experiment 4** (LLM-generated contract snake game): pending — the real productionization validation gate, this is what proves LLM-generated contracts (not hand-crafted) can drive automatic decomposition
- **Contract amendment flow**: what happens when an agent discovers mid-implementation that the contract is missing something they need? Not scoped in this PR — follow-up issue

## Related

- GH-320 acceptance criteria: PR 2 items landed (decompose_by_contract, Task.responsibility, agent prompt, integration task, feature flag, fallback)
- GH-322: PR 1 (domain-keyed contract generation) — prerequisite
- GH-326: reconnect Phase A→B handoff — prerequisite (merged)
- Experiment 1 (2026-04-10): hand-crafted contract validation on snake game

## Test plan

- [x] Unit tests for decomposer (8)
- [x] Unit tests for feature flag precedence (11)
- [x] Unit tests for fallback on every failure path (9)
- [x] Unit tests for agent prompt surfacing (6)
- [x] Unit tests for integration task contract authority (5)
- [x] \`pytest -m unit\` green (425/425)
- [x] mypy clean on touched files
- [ ] **Experiment 3** (3-agent contract-based): post-merge
- [ ] **Experiment 4** (LLM-generated contract snake game): post-merge, this is the real validation gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)