### PR TITLE
feat(marcus-skill): add --decomposer contract_first flag for GH-320

### DIFF
--- a/dev-tools/experiments/templates/config.yaml.template
+++ b/dev-tools/experiments/templates/config.yaml.template
@@ -13,6 +13,26 @@ project_options:
   provider: "sqlite"      # sqlite | planka | github | linear
   mode: "new_project"     # new_project | auto | select_project
 
+  # Task decomposition strategy (GH-320).
+  #
+  # - "feature_based" (default): split tasks by functional requirement.
+  #   Works well for loosely-coupled projects where features map to
+  #   independent files. Can produce Single-Author Product verdicts
+  #   on tightly-coupled problems where features collide in shared
+  #   files (see #267, v0.3.0 CHANGELOG "Known limitations").
+  #
+  # - "contract_first": generate interface contracts before
+  #   decomposition, then produce tasks where each task owns one
+  #   side of a contract interface. Validated on the snake game on
+  #   2026-04-10 as the first Marcus experiment on a tightly-coupled
+  #   problem that avoided the Single-Author Product verdict. Use
+  #   this for multi-widget dashboards, state-machine projects,
+  #   games, or any problem where features share infrastructure.
+  #
+  # When unset, Marcus uses the MARCUS_DECOMPOSER env var, or
+  # "feature_based" if that is also unset.
+  decomposer: "feature_based"
+
 # Agent definitions
 # NOTE: All agents are "unicorn" full-stack developers capable of any task
 # The skills list is a preference hint to Marcus, NOT a limitation

--- a/skills/marcus/SKILL.md
+++ b/skills/marcus/SKILL.md
@@ -135,9 +135,13 @@ timeouts:
 - "standard" — Most projects (APIs, full-stack apps, moderate features)
 - "enterprise" — Large systems with many components, microservices, complex auth
 
-**Decomposer heuristic (when `--decomposer` is not explicitly provided):**
-- Default to `"feature_based"` in all cases. Do NOT auto-select `contract_first` based on keywords in the project description — it's an opt-in feature the user chooses deliberately. If the user wants it, they'll pass `--decomposer contract_first` or say "contract first" in their request.
-- If the user's request contains the phrase "contract first", "contract-based", or "contract-aware" anywhere (case-insensitive), set `decomposer: "contract_first"`.
+**Decomposer rule:** Only use `contract_first` when the user passes
+`--decomposer contract_first` explicitly. Do NOT infer the decomposer
+from phrases in the project description — "don't use contract first"
+and "use contract first" both contain the same substring, and a
+substring match would pick the wrong strategy half the time. If the
+flag is absent, always set `decomposer: "feature_based"` (Codex P2 on
+PR #332).
 
 **Agent count:** Generate one agent block per requested agent. Use incrementing IDs:
 `agent_unicorn_1`, `agent_unicorn_2`, etc.

--- a/skills/marcus/SKILL.md
+++ b/skills/marcus/SKILL.md
@@ -12,7 +12,7 @@ description: >
   The /marcus skill launches experiments that USE the Marcus MCP server — they are
   complementary, not competing. The MCP server must be running before invoking this skill.
 user-invocable: true
-argument-hint: "<project description> [--name \"Project Name\"] [--agents N] [--complexity prototype|standard|enterprise]"
+argument-hint: "<project description> [--name \"Project Name\"] [--agents N] [--complexity prototype|standard|enterprise] [--decomposer feature_based|contract_first]"
 ---
 
 # Marcus Multi-Agent Experiment Launcher
@@ -53,12 +53,17 @@ The user's input comes in as `$ARGUMENTS`. Extract:
 - **Project name**: Look for `--name "Some Name"` or `--name some_name`. If not provided, derive a short name from the description.
 - **Agent count**: Look for patterns like "N agents", "--agents N", "with N workers". Default: 2
 - **Complexity**: Look for "--complexity prototype|standard|enterprise". Default: "prototype"
+- **Decomposer**: Look for "--decomposer feature_based|contract_first". Default: "feature_based". This controls Marcus's task decomposition strategy (GH-320):
+  - `feature_based` — legacy path, splits tasks by functional requirement. Fine for loosely-coupled projects. Can produce Single-Author Product verdicts on tightly-coupled problems (games, multi-widget dashboards, state machines) where features collide in shared files.
+  - `contract_first` — generates interface contracts before decomposition, produces tasks where each agent owns one side of a contract. Validated 2026-04-10 on the snake game as the first Marcus experiment on a tightly-coupled problem that avoided Single-Author Product.
 
 Examples:
-- `/marcus Build a snake game with 3 agents` -> description="Build a snake game", name="snake_game", agents=3, complexity="prototype"
-- `/marcus Build a REST API for task management` -> description="Build a REST API for task management", name="task_management_api", agents=2, complexity="prototype"
-- `/marcus Build a chat app --name "ChatBuddy" with 4 agents` -> description="Build a chat app", name="ChatBuddy", agents=4, complexity="prototype"
-- `/marcus Use 2 agents to build a pomodoro timer --complexity standard --name "FocusTimer"` -> description="build a pomodoro timer", name="FocusTimer", agents=2, complexity="standard"
+- `/marcus Build a snake game with 3 agents` -> description="Build a snake game", name="snake_game", agents=3, complexity="prototype", decomposer="feature_based"
+- `/marcus Build a REST API for task management` -> description="Build a REST API for task management", name="task_management_api", agents=2, complexity="prototype", decomposer="feature_based"
+- `/marcus Build a chat app --name "ChatBuddy" with 4 agents` -> description="Build a chat app", name="ChatBuddy", agents=4, complexity="prototype", decomposer="feature_based"
+- `/marcus Use 2 agents to build a pomodoro timer --complexity standard --name "FocusTimer"` -> description="build a pomodoro timer", name="FocusTimer", agents=2, complexity="standard", decomposer="feature_based"
+- `/marcus Build a snake game with 2 agents --decomposer contract_first` -> description="Build a snake game", name="snake_game", agents=2, complexity="prototype", decomposer="contract_first"
+- `/marcus --decomposer contract_first Build a weather dashboard with 3 agents` -> description="Build a weather dashboard", name="weather_dashboard", agents=3, complexity="prototype", decomposer="contract_first"
 
 ## Step-by-Step Execution
 
@@ -97,6 +102,7 @@ project_options:
   complexity: "<parsed complexity>"  # "prototype" (default), "standard" for medium, "enterprise" for large
   provider: "sqlite"        # Uses local SQLite DB. Also supports: "planka", "github", "linear"
   mode: "new_project"       # Always new_project
+  decomposer: "<parsed decomposer>"  # "feature_based" (default) or "contract_first" (GH-320)
 
 agents:
   - id: "agent_unicorn_1"
@@ -128,6 +134,10 @@ timeouts:
 - "prototype" — Simple single-page apps, scripts, small tools
 - "standard" — Most projects (APIs, full-stack apps, moderate features)
 - "enterprise" — Large systems with many components, microservices, complex auth
+
+**Decomposer heuristic (when `--decomposer` is not explicitly provided):**
+- Default to `"feature_based"` in all cases. Do NOT auto-select `contract_first` based on keywords in the project description — it's an opt-in feature the user chooses deliberately. If the user wants it, they'll pass `--decomposer contract_first` or say "contract first" in their request.
+- If the user's request contains the phrase "contract first", "contract-based", or "contract-aware" anywhere (case-insensitive), set `decomposer: "contract_first"`.
 
 **Agent count:** Generate one agent block per requested agent. Use incrementing IDs:
 `agent_unicorn_1`, `agent_unicorn_2`, etc.


### PR DESCRIPTION
## Summary
- Exposes task decomposition strategy at the /marcus skill level so users can run contract-first experiments without hand-editing config.yaml.
- `skills/marcus/SKILL.md`: parses `--decomposer feature_based|contract_first`, defaults to `feature_based`, emits the value into the generated config.yaml. Also matches the phrases "contract first", "contract-based", "contract-aware" (case-insensitive). Does NOT auto-select `contract_first` from project keywords — it remains deliberately opt-in.
- `dev-tools/experiments/templates/config.yaml.template`: documents the `decomposer` field under `project_options` with `feature_based` as default and pointers to GH-320.

No runner code changes needed — `spawn_agents.py` already forwards `project_options` via `json.dumps` to `create_project`, so the new key passes through automatically.

## Test plan
- [ ] `/marcus Build a snake game with 2 agents --decomposer contract_first` produces a config.yaml with `decomposer: "contract_first"`
- [ ] `/marcus Build a weather dashboard with 3 agents` (no flag) produces a config.yaml with `decomposer: "feature_based"`
- [ ] Smoke test still passes (Phase A reads the new decomposer value from options dict)

🤖 Generated with [Claude Code](https://claude.com/claude-code)