### PR TITLE
fix: integration task suppression on 'test suite' + unknown task type histogram

### DIFF
--- a/src/integrations/integration_verification.py
+++ b/src/integrations/integration_verification.py
@@ -15,6 +15,7 @@ Related: #271, #267, #257
 """
 
 import logging
+import re
 import uuid
 from datetime import datetime, timezone
 from typing import List, Optional
@@ -161,6 +162,13 @@ class IntegrationTaskGenerator:
         agent coordination changes actually catch integration bugs
         at the merged-product level. See GH-320 PR 1 for context.
 
+        The ``test`` POC marker is distinguished from testing
+        *infrastructure* mentions (``test suite``, ``unit tests``,
+        ``test-driven``, ``testing framework``, etc.) by scrubbing
+        compound phrases before the word-boundary search so real
+        projects that happen to mention their test strategy do not
+        get their integration task suppressed.
+
         Parameters
         ----------
         project_description : str
@@ -171,15 +179,42 @@ class IntegrationTaskGenerator:
         bool
             True if integration verification should be added.
         """
-        skip_keywords = [
-            "poc",
-            "proof of concept",
-            "demo",
-            "test",
-        ]
         description_lower = project_description.lower()
 
-        if any(keyword in description_lower for keyword in skip_keywords):
+        # Plain substring checks — these are unambiguous POC markers.
+        for keyword in ("poc", "proof of concept", "demo"):
+            if re.search(rf"\b{re.escape(keyword)}\b", description_lower):
+                return False
+
+        # ``test`` is ambiguous: "Quick test of the new encoder" is
+        # POC intent, but "Build an app with a test suite" is not.
+        # Scrub compound phrases that describe testing infrastructure
+        # before running the word-boundary check.
+        test_compound_patterns = [
+            # "test suite", "test cases", "test coverage", etc.
+            r"\btests?\s+"
+            r"(suites?|cases?|coverage|harness|plan|plans|"
+            r"frameworks?|beds?|runners?|infrastructure|infra|"
+            r"strategy|strategies|approach|approaches)\b",
+            # "unit tests", "integration test", "e2e tests", etc.
+            r"\b(unit|integration|smoke|regression|acceptance|"
+            r"e2e|end[- ]to[- ]end|functional|performance|load|"
+            r"stress|api|contract|property|mutation|snapshot)"
+            r"\s+tests?\b",
+            # "test-driven", "tests-driven"
+            r"\btests?[-\s]driven\b",
+            # "testing framework/library/etc." — "testing" with a
+            # compound noun is infrastructure, not POC intent.
+            r"\btesting\s+"
+            r"(framework|frameworks|library|libraries|"
+            r"infrastructure|suite|suites|strategy|strategies|"
+            r"approach|approaches|harness)\b",
+        ]
+        scrubbed = description_lower
+        for pattern in test_compound_patterns:
+            scrubbed = re.sub(pattern, " ", scrubbed)
+
+        if re.search(r"\btest\b", scrubbed):
             return False
 
         return True

--- a/src/integrations/integration_verification.py
+++ b/src/integrations/integration_verification.py
@@ -181,9 +181,17 @@ class IntegrationTaskGenerator:
         """
         description_lower = project_description.lower()
 
-        # Plain substring checks — these are unambiguous POC markers.
-        for keyword in ("poc", "proof of concept", "demo"):
-            if re.search(rf"\b{re.escape(keyword)}\b", description_lower):
+        # Unambiguous POC markers — matched with word boundaries so
+        # ``contest``/``democracy``/etc. don't trip the rule, and with
+        # optional plural ``s`` so ``pocs``/``demos``/``proof of
+        # concepts`` still skip as expected (Codex P1 on PR #333).
+        poc_patterns = [
+            r"\bpocs?\b",
+            r"\bproof of concepts?\b",
+            r"\bdemos?\b",
+        ]
+        for pattern in poc_patterns:
+            if re.search(pattern, description_lower):
                 return False
 
         # ``test`` is ambiguous: "Quick test of the new encoder" is

--- a/src/integrations/nlp_tools.py
+++ b/src/integrations/nlp_tools.py
@@ -27,6 +27,9 @@ from src.core.models import Priority, Task, TaskStatus  # noqa: E402
 from src.core.resilience import RetryConfig, with_retry  # noqa: E402
 from src.detection.board_analyzer import BoardAnalyzer  # noqa: E402
 from src.detection.context_detector import ContextDetector, MarcusMode  # noqa: E402
+from src.integrations.enhanced_task_classifier import (  # noqa: E402
+    EnhancedTaskClassifier,
+)
 
 # Import refactored base classes and utilities
 from src.integrations.nlp_base import NaturalLanguageTaskCreator  # noqa: E402
@@ -34,6 +37,40 @@ from src.integrations.nlp_task_utils import TaskType  # noqa: E402
 from src.modes.adaptive.basic_adaptive import BasicAdaptiveMode  # noqa: E402
 
 logger = logging.getLogger(__name__)
+
+
+def _task_type_breakdown(
+    tasks: List[Task],
+    classifier: EnhancedTaskClassifier,
+) -> Dict[str, int]:
+    """
+    Compute a task-type histogram from a list of tasks.
+
+    Uses the :class:`EnhancedTaskClassifier` instead of reading a
+    non-existent ``task_type`` attribute off the ``Task`` dataclass,
+    which was the pre-existing bug that made every breakdown log
+    show ``{'unknown': N}`` regardless of the underlying decomposer.
+
+    Parameters
+    ----------
+    tasks : List[Task]
+        Tasks to classify.
+    classifier : EnhancedTaskClassifier
+        Classifier instance (keyword + label scoring, no LLM calls).
+
+    Returns
+    -------
+    Dict[str, int]
+        Mapping of ``TaskType`` value (e.g. ``"implementation"``) to
+        the count of tasks that classified as that type. Tasks that
+        the classifier rejects fall into the ``"other"`` bucket —
+        ``"unknown"`` never appears in the output.
+    """
+    breakdown: Dict[str, int] = {}
+    for task in tasks:
+        task_type = classifier.classify(task).value
+        breakdown[task_type] = breakdown.get(task_type, 0) + 1
+    return breakdown
 
 
 # ---------------------------------------------------------------------------
@@ -568,12 +605,14 @@ class NaturalLanguageProjectCreator(NaturalLanguageTaskCreator):
                 )
                 logger.info(f"process_natural_language returned {len(tasks)} tasks")
 
-                # Log detailed task breakdown for debugging
+                # Log detailed task breakdown for debugging. Uses the
+                # EnhancedTaskClassifier (via self.task_classifier,
+                # inherited from NaturalLanguageTaskCreator) rather
+                # than reading a non-existent ``task_type`` attribute
+                # off the Task dataclass — the pre-existing bug that
+                # made every breakdown show ``{'unknown': N}``.
                 if tasks:
-                    task_types: Dict[str, int] = {}
-                    for task in tasks:
-                        task_type = getattr(task, "task_type", "unknown")
-                        task_types[task_type] = task_types.get(task_type, 0) + 1
+                    task_types = _task_type_breakdown(tasks, self.task_classifier)
                     logger.info(f"Task type breakdown: {task_types}")
                 else:
                     desc_len = len(description)

--- a/tests/unit/integrations/test_integration_verification.py
+++ b/tests/unit/integrations/test_integration_verification.py
@@ -760,3 +760,44 @@ class TestShouldAddIntegrationTask:
         assert IntegrationTaskGenerator.should_add_integration_task(
             "Build a testing framework for browser automation"
         )
+
+    def test_plural_pocs_skip_integration(self) -> None:
+        """
+        Regression test for Codex P1 on PR #333: the word-boundary
+        regex must match plural ``pocs`` as well as singular ``poc``.
+        """
+        from src.integrations.integration_verification import (
+            IntegrationTaskGenerator,
+        )
+
+        assert not IntegrationTaskGenerator.should_add_integration_task(
+            "Build POCs to evaluate different approaches"
+        )
+
+    def test_plural_demos_skip_integration(self) -> None:
+        """
+        Regression test for Codex P1 on PR #333: the word-boundary
+        regex must match plural ``demos`` as well as singular
+        ``demo``.
+        """
+        from src.integrations.integration_verification import (
+            IntegrationTaskGenerator,
+        )
+
+        assert not IntegrationTaskGenerator.should_add_integration_task(
+            "Create demos for the stakeholder presentation"
+        )
+
+    def test_plural_proof_of_concepts_skip_integration(self) -> None:
+        """
+        Regression test for Codex P1 on PR #333: the word-boundary
+        regex must match ``proof of concepts`` as well as the
+        singular ``proof of concept``.
+        """
+        from src.integrations.integration_verification import (
+            IntegrationTaskGenerator,
+        )
+
+        assert not IntegrationTaskGenerator.should_add_integration_task(
+            "Proof of concepts for three candidate architectures"
+        )

--- a/tests/unit/integrations/test_integration_verification.py
+++ b/tests/unit/integrations/test_integration_verification.py
@@ -686,3 +686,77 @@ class TestShouldAddIntegrationTask:
         assert not IntegrationTaskGenerator.should_add_integration_task(
             "Quick test of the new encoder"
         )
+
+    def test_description_mentioning_test_suite_still_gets_integration(
+        self,
+    ) -> None:
+        """
+        Descriptions that mention a 'test suite' as a requirement
+        must NOT be classified as POC projects.
+
+        Regression test for the substring-match bug: the original
+        implementation used ``"test" in description_lower`` which
+        fired on any compound containing "test" — including the
+        word "test suite" — and silently suppressed the integration
+        verification task for real projects whose descriptions
+        happened to mention testing infrastructure.
+        """
+        from src.integrations.integration_verification import (
+            IntegrationTaskGenerator,
+        )
+
+        assert IntegrationTaskGenerator.should_add_integration_task(
+            "Build a dashboard web app with a comprehensive test suite"
+        )
+
+    def test_description_with_unit_tests_still_gets_integration(self) -> None:
+        """'Unit tests' is not a POC indicator."""
+        from src.integrations.integration_verification import (
+            IntegrationTaskGenerator,
+        )
+
+        assert IntegrationTaskGenerator.should_add_integration_task(
+            "Build an auth service with unit tests and integration tests"
+        )
+
+    def test_description_with_test_driven_still_gets_integration(self) -> None:
+        """'Test-driven development' is not a POC indicator."""
+        from src.integrations.integration_verification import (
+            IntegrationTaskGenerator,
+        )
+
+        assert IntegrationTaskGenerator.should_add_integration_task(
+            "Use test-driven development to build a REST API"
+        )
+
+    def test_description_with_latest_still_gets_integration(self) -> None:
+        """Word boundary: 'latest' must not match 'test'."""
+        from src.integrations.integration_verification import (
+            IntegrationTaskGenerator,
+        )
+
+        assert IntegrationTaskGenerator.should_add_integration_task(
+            "Build an app using the latest React version"
+        )
+
+    def test_description_with_contest_still_gets_integration(self) -> None:
+        """Word boundary: 'contest' must not match 'test'."""
+        from src.integrations.integration_verification import (
+            IntegrationTaskGenerator,
+        )
+
+        assert IntegrationTaskGenerator.should_add_integration_task(
+            "Build a contest voting platform for community events"
+        )
+
+    def test_description_with_testing_framework_still_gets_integration(
+        self,
+    ) -> None:
+        """'Testing framework' is infrastructure, not POC intent."""
+        from src.integrations.integration_verification import (
+            IntegrationTaskGenerator,
+        )
+
+        assert IntegrationTaskGenerator.should_add_integration_task(
+            "Build a testing framework for browser automation"
+        )

--- a/tests/unit/integrations/test_nlp_tools.py
+++ b/tests/unit/integrations/test_nlp_tools.py
@@ -1,0 +1,163 @@
+"""
+Unit tests for helpers in ``src.integrations.nlp_tools``.
+
+These tests cover small, pure helpers that can be exercised without
+spinning up a kanban client or AI engine. Integration behavior of
+``NaturalLanguageProjectCreator`` is covered in the integration test
+suite.
+"""
+
+from datetime import datetime
+
+import pytest
+
+from src.core.models import Priority, Task, TaskStatus
+from src.integrations.enhanced_task_classifier import EnhancedTaskClassifier
+from src.integrations.nlp_tools import _task_type_breakdown
+
+
+def _make_task(
+    *,
+    task_id: str,
+    name: str,
+    labels: list[str],
+    description: str = "",
+) -> Task:
+    """
+    Build a minimal Task instance for classifier tests.
+
+    Parameters
+    ----------
+    task_id : str
+        Unique task identifier.
+    name : str
+        Task name — strong classifier signal.
+    labels : list[str]
+        Task labels — strongest classifier signal.
+    description : str, optional
+        Task description — weak classifier signal.
+
+    Returns
+    -------
+    Task
+        Populated Task dataclass ready for classification.
+    """
+    return Task(
+        id=task_id,
+        name=name,
+        description=description,
+        status=TaskStatus.TODO,
+        priority=Priority.MEDIUM,
+        assigned_to=None,
+        created_at=datetime.utcnow(),
+        updated_at=datetime.utcnow(),
+        due_date=None,
+        estimated_hours=1.0,
+        labels=labels,
+    )
+
+
+class TestTaskTypeBreakdown:
+    """Test suite for ``_task_type_breakdown``."""
+
+    @pytest.fixture
+    def classifier(self) -> EnhancedTaskClassifier:
+        """Return a real classifier — fast, no external deps."""
+        return EnhancedTaskClassifier()
+
+    def test_contract_first_tasks_classify_as_implementation(
+        self, classifier: EnhancedTaskClassifier
+    ) -> None:
+        """
+        Regression test: contract-first tasks must not be labeled
+        'unknown' in the task-type breakdown.
+
+        Before this fix, the breakdown loop used
+        ``getattr(task, "task_type", "unknown")`` which always fell
+        back to ``"unknown"`` because Task has no ``task_type``
+        attribute. The fix routes through the EnhancedTaskClassifier,
+        which correctly recognizes the ``implementation`` label on
+        contract-first tasks.
+        """
+        tasks = [
+            _make_task(
+                task_id="t1",
+                name="Implement WeatherWidget",
+                labels=["contract_first", "implementation"],
+                description=(
+                    "implements WeatherWidget module from "
+                    "weather-information-system-interface-contracts.md"
+                ),
+            ),
+            _make_task(
+                task_id="t2",
+                name="Implement TimeWidget",
+                labels=["contract_first", "implementation"],
+                description=(
+                    "implements TimeWidget module from "
+                    "time-display-system-interface-contracts.md"
+                ),
+            ),
+            _make_task(
+                task_id="t3",
+                name="Implement Dashboard Container",
+                labels=["contract_first", "implementation"],
+                description=(
+                    "implements Dashboard Container from "
+                    "dashboard-presentation-layer-interface-contracts.md"
+                ),
+            ),
+        ]
+
+        breakdown = _task_type_breakdown(tasks, classifier)
+
+        assert "unknown" not in breakdown, (
+            f"Contract-first tasks must not classify as 'unknown': " f"{breakdown}"
+        )
+        assert (
+            breakdown.get("implementation", 0) == 3
+        ), f"Expected 3 implementation tasks, got: {breakdown}"
+
+    def test_mixed_task_types_produce_accurate_histogram(
+        self, classifier: EnhancedTaskClassifier
+    ) -> None:
+        """
+        Breakdown counts by TaskType enum value, not by string
+        attribute. A mix of design/implement/test tasks produces a
+        histogram with three non-zero buckets.
+        """
+        tasks = [
+            _make_task(
+                task_id="d1",
+                name="Design the API schema",
+                labels=["design"],
+            ),
+            _make_task(
+                task_id="i1",
+                name="Implement user authentication",
+                labels=["implementation"],
+            ),
+            _make_task(
+                task_id="i2",
+                name="Build the dashboard component",
+                labels=["implementation"],
+            ),
+            _make_task(
+                task_id="t1",
+                name="Write integration tests for auth",
+                labels=["testing"],
+            ),
+        ]
+
+        breakdown = _task_type_breakdown(tasks, classifier)
+
+        assert breakdown.get("design", 0) == 1, breakdown
+        assert breakdown.get("implementation", 0) == 2, breakdown
+        assert breakdown.get("testing", 0) == 1, breakdown
+        assert "unknown" not in breakdown, breakdown
+
+    def test_empty_task_list_returns_empty_breakdown(
+        self, classifier: EnhancedTaskClassifier
+    ) -> None:
+        """No tasks → empty histogram, not an error."""
+        assert _task_type_breakdown([], classifier) == {}


### PR DESCRIPTION
## Summary
Two pre-existing bugs surfaced by the GH-320 Experiment 4 smoke test run. Fixing them now so they don't bite the real Experiment 4 rerun.

### Bug 1: ``should_add_integration_task`` false-positive on "test suite"
``IntegrationTaskGenerator.should_add_integration_task`` used a plain substring match on ``"test"`` which suppressed the integration verification task for any project whose description mentioned:
- ``test suite``, ``unit tests``, ``integration tests``, ``test-driven`` development
- ``testing framework``, ``testing library``
- words containing "test" as substring: ``contest``, ``latest``, ``testing``

**Fix**: word-boundary regex + a scrub pass that removes test-infrastructure compound phrases before the POC-intent check. Existing "Quick test of the new encoder" → skip behavior preserved because "quick test" doesn't match any compound pattern.

### Bug 2: Task type histogram always shows `{'unknown': N}`
``NaturalLanguageProjectCreator`` logged task-type breakdowns as ``{'unknown': N}`` for every project because the loop read ``getattr(task, "task_type", "unknown")`` off the ``Task`` dataclass, which has no ``task_type`` attribute — labels carry that info.

**Fix**: extracted a testable ``_task_type_breakdown`` helper that routes tasks through the existing ``EnhancedTaskClassifier`` (label- and keyword-scoring, no LLM calls). Contract-first tasks with ``labels=["contract_first", "implementation"]`` now correctly classify as ``implementation``.

## Test plan
- [x] ``test_description_mentioning_test_suite_still_gets_integration``
- [x] ``test_description_with_unit_tests_still_gets_integration``
- [x] ``test_description_with_test_driven_still_gets_integration``
- [x] ``test_description_with_latest_still_gets_integration``
- [x] ``test_description_with_contest_still_gets_integration``
- [x] ``test_description_with_testing_framework_still_gets_integration``
- [x] Existing ``test_test_project_still_skips_integration`` preserved ("Quick test of the new encoder" still skips)
- [x] ``test_contract_first_tasks_classify_as_implementation``
- [x] ``test_mixed_task_types_produce_accurate_histogram``
- [x] ``test_empty_task_list_returns_empty_breakdown``
- [x] Full unit sweep: 435/435 green, mypy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)