### PR TITLE
feat(#320): Cato retrofit — synthetic design ghosts for contract-first

### DIFF
--- a/src/integrations/nlp_tools.py
+++ b/src/integrations/nlp_tools.py
@@ -491,7 +491,124 @@ class NaturalLanguageProjectCreator(NaturalLanguageTaskCreator):
             )
             return None
 
-        return tasks
+        # Cato retrofit (GH-320 PR after #333): synthesize one DONE
+        # design task per usable domain so the existing feature-based
+        # observability infrastructure fires for contract-first runs.
+        #
+        # Why this is necessary: contract_artifacts is generated in
+        # Phase A (above) and consumed by ``decompose_by_contract`` to
+        # build implementation task descriptions, then thrown away.
+        # No ``log_artifact`` call, no ``log_decision`` call, no
+        # structural task in marcus.db. Cato's display_role classifier
+        # at ``cato_src/core/aggregator.py`` only marks tasks as
+        # ``"structural"`` when they have ``"design"`` in labels — so
+        # without these ghosts, contract-first projects show up as
+        # all-work, no design phase, no decisions, no artifacts.
+        #
+        # The ghosts are honest: they represent "the design phase that
+        # produced this domain's contracts". They are born DONE because
+        # the work has already happened. The existing background
+        # ``_run_design_phase`` will pick them up via ``_is_design_task``
+        # and route the stashed contract content through Phase B
+        # (``_register_design_via_mcp``), which calls ``log_artifact``
+        # and ``log_decision`` against each ghost's kanban UUID.
+        usable_contracts = {
+            domain: payload
+            for domain, payload in contract_artifacts.items()
+            if payload is not None and payload.get("artifacts")
+        }
+
+        ghost_tasks: List[Task] = []
+        # Map ``contract_file`` -> ghost id so impl tasks can be wired
+        # back to their matching ghost regardless of dict ordering.
+        ghost_by_contract_file: Dict[str, str] = {}
+        # Rekeyed dict that ``_run_design_phase`` will receive in its
+        # ``pre_generated_content`` parameter — keyed by ghost task
+        # name so the existing Phase B name-join works unchanged.
+        stashed_design_content: Dict[str, Dict[str, Any]] = {}
+        now = datetime.now(timezone.utc)
+        import uuid as _uuid
+
+        for domain_name, payload in usable_contracts.items():
+            ghost_id = f"design_contract_{_uuid.uuid4().hex[:12]}"
+            ghost_name = f"Design {domain_name}"
+
+            # Pick the interface_contracts artifact as the canonical
+            # contract file for this domain. Falls back to the first
+            # artifact if no interface_contracts exists (defensive —
+            # ``_generate_contracts_by_domain`` always emits one in
+            # practice but the schema doesn't enforce it).
+            artifacts = payload.get("artifacts", [])
+            interface_artifact = next(
+                (
+                    a
+                    for a in artifacts
+                    if a.get("artifact_type") == "interface_contracts"
+                ),
+                artifacts[0] if artifacts else {},
+            )
+            contract_file = interface_artifact.get("relative_path", "")
+
+            ghost = Task(
+                id=ghost_id,
+                name=ghost_name,
+                description=(
+                    f"Contract-first design phase for domain "
+                    f"'{domain_name}'. Generated {len(artifacts)} "
+                    f"contract artifact(s). This task is born DONE — "
+                    f"the design work has already completed by the "
+                    f"time it lands on the kanban board."
+                ),
+                status=TaskStatus.DONE,
+                priority=Priority.HIGH,
+                assigned_to="Marcus",
+                created_at=now,
+                updated_at=now,
+                due_date=None,
+                estimated_hours=0.0,
+                labels=["design", "contract_first", "auto_completed"],
+                source_type="contract_first_design",
+                source_context={
+                    "contract_file": contract_file,
+                    "domain": domain_name,
+                },
+                dependencies=[],
+            )
+            ghost_tasks.append(ghost)
+            if contract_file:
+                ghost_by_contract_file[contract_file] = ghost_id
+            stashed_design_content[ghost_name] = payload
+
+        # Wire each impl task's dependencies to include its matching
+        # design ghost. The match key is ``source_context["contract_file"]``
+        # which the decomposer sets on every contract-first task.
+        # ``Task.dependencies`` is always a list (dataclass default
+        # factory), so no None check needed.
+        for task in tasks:
+            ctx = getattr(task, "source_context", None) or {}
+            task_contract_file = ctx.get("contract_file") or ""
+            matched_ghost_id = ghost_by_contract_file.get(task_contract_file)
+            if matched_ghost_id and matched_ghost_id not in task.dependencies:
+                task.dependencies.append(matched_ghost_id)
+
+        # Stash the rekeyed design content on the creator instance.
+        # The background design phase scheduler at the end of
+        # ``create_tasks_from_description`` reads this attribute via
+        # ``getattr`` and forwards it to ``_run_design_phase`` as
+        # ``pre_generated_content``, which causes Phase A to be
+        # skipped and Phase B to use the pre-generated content.
+        self._contract_first_design_content = stashed_design_content
+
+        logger.info(
+            f"[decomposer] contract_first: synthesized "
+            f"{len(ghost_tasks)} design ghost(s) for "
+            f"{len(usable_contracts)} domain(s); contract content "
+            f"stashed for background Phase B"
+        )
+
+        # Design ghosts come first so the integration task's
+        # dependency walk picks them up alongside impl tasks.
+        return ghost_tasks + tasks
 
     async def create_project_from_description(
         self,
@@ -931,6 +1048,17 @@ class NaturalLanguageProjectCreator(NaturalLanguageTaskCreator):
             if project_root and has_design_tasks:
                 import asyncio as _aio
 
+                # Contract-first Cato retrofit: when
+                # ``_try_contract_first_decomposition`` synthesizes
+                # design ghost tasks, it stashes the pre-generated
+                # contract content on the creator instance. Pass it
+                # through to ``_run_design_phase`` so Phase A is
+                # skipped (artifacts already generated upstream) and
+                # Phase B uses the stashed content directly. For the
+                # feature-based path this attribute is absent and
+                # ``pre_generated_content`` defaults to None, which
+                # runs Phase A normally.
+                pre_generated = getattr(self, "_contract_first_design_content", None)
                 _aio.ensure_future(
                     _run_design_phase(
                         state=self.state,
@@ -940,8 +1068,16 @@ class NaturalLanguageProjectCreator(NaturalLanguageTaskCreator):
                         description=description,
                         project_name=project_name,
                         project_root=project_root,
+                        pre_generated_content=pre_generated,
                     )
                 )
+                # Clear the stash so a subsequent feature-based
+                # project on the same creator instance doesn't pick
+                # up stale content. ``delattr`` matches the read
+                # pattern (``getattr(..., None)``) without confusing
+                # mypy about the attribute's type.
+                if hasattr(self, "_contract_first_design_content"):
+                    delattr(self, "_contract_first_design_content")
                 logger.info(
                     "[design_autocomplete] Phase A scheduled as " "background task"
                 )
@@ -2897,6 +3033,7 @@ async def _run_design_phase(
     description: str,
     project_name: str,
     project_root: str,
+    pre_generated_content: Optional[Dict[str, Dict[str, Any]]] = None,
 ) -> None:
     """
     Run the full background design phase: Phase A + Phase B + kanban + scaffold.
@@ -2975,6 +3112,19 @@ async def _run_design_phase(
         Project name (passed to Phase A and scaffold).
     project_root : str
         Absolute path where artifacts will be written.
+    pre_generated_content : Optional[Dict[str, Dict[str, Any]]]
+        Pre-generated Phase A output. When provided, Phase A
+        (``_generate_design_content``) is **skipped** entirely and
+        the supplied dict is used directly as ``design_content`` for
+        Phase B and the kanban DONE update. Used by the contract-first
+        decomposer (GH-320 PR after #333), which generates contract
+        artifacts upstream in ``_generate_contracts_by_domain`` and
+        synthesizes design ghost tasks to carry them through the
+        existing observability infrastructure. The dict must be
+        keyed by ghost task name (``f"Design {{domain_name}}"``) so
+        :func:`_register_design_via_mcp` can join it to
+        ``state.project_tasks``. When ``None`` (default), Phase A
+        runs normally.
 
     Returns
     -------
@@ -2996,24 +3146,40 @@ async def _run_design_phase(
     GH-304 : Parallelization (Phase A 25-33min → 1-3min).
     GH-314 : Moved Phase A to background (accidentally orphaned Phase B).
     GH-320 : Reconnected Phase A → Phase B handoff (this function).
+    GH-320 PR after #333 : ``pre_generated_content`` parameter for
+        contract-first Cato retrofit — Phase A skipped when contracts
+        are already generated upstream.
     """
     design_content: Dict[str, Any] = {}
-    try:
-        design_content = await _generate_design_content(
-            tasks=safe_tasks,
-            project_description=description,
-            project_name=project_name,
-            project_root=project_root,
+    if pre_generated_content is not None:
+        # Contract-first Cato retrofit path. Phase A artifacts and
+        # decisions were already generated upstream by
+        # ``_generate_contracts_by_domain`` in
+        # ``_try_contract_first_decomposition``. Use them directly
+        # without re-running Phase A.
+        design_content = pre_generated_content
+        logger.info(
+            f"[design_autocomplete] Skipping Phase A — using "
+            f"{len(design_content)} pre-generated design entries "
+            f"(contract-first path)"
         )
-        logger.info("[design_autocomplete] Background Phase A complete")
-    except Exception as e:
-        logger.warning(
-            f"[design_autocomplete] Background Phase A failed (non-fatal): {e}"
-        )
-        # Fail-fast semantics: partial design outputs silently
-        # corrupt downstream agent work (#304). Return early so no
-        # Phase B, no kanban DONE updates, no scaffold.
-        return
+    else:
+        try:
+            design_content = await _generate_design_content(
+                tasks=safe_tasks,
+                project_description=description,
+                project_name=project_name,
+                project_root=project_root,
+            )
+            logger.info("[design_autocomplete] Background Phase A complete")
+        except Exception as e:
+            logger.warning(
+                f"[design_autocomplete] Background Phase A failed (non-fatal): {e}"
+            )
+            # Fail-fast semantics: partial design outputs silently
+            # corrupt downstream agent work (#304). Return early so no
+            # Phase B, no kanban DONE updates, no scaffold.
+            return
 
     if not design_content:
         logger.info(

--- a/src/integrations/nlp_tools.py
+++ b/src/integrations/nlp_tools.py
@@ -566,7 +566,16 @@ class NaturalLanguageProjectCreator(NaturalLanguageTaskCreator):
                 updated_at=now,
                 due_date=None,
                 estimated_hours=0.0,
-                labels=["design", "contract_first", "auto_completed"],
+                # Codex P2 on PR #334: do NOT add a "contract_first"
+                # label here. ``SafetyChecker._find_related_tasks``
+                # treats any non-prefixed shared label as a relation,
+                # and ``apply_implementation_dependencies`` would link
+                # every contract-first impl task (which carries the
+                # "contract_first" label) to every ghost (which would
+                # also carry it), undoing the per-domain wiring below.
+                # Provenance lives on ``source_type`` instead, which
+                # is not consulted by the safety check.
+                labels=["design", "auto_completed"],
                 source_type="contract_first_design",
                 source_context={
                     "contract_file": contract_file,

--- a/tests/unit/integrations/test_contract_first_fallback.py
+++ b/tests/unit/integrations/test_contract_first_fallback.py
@@ -443,7 +443,11 @@ class TestContractFirstFallback:
 
         assert ghost.name == "Design Main"
         assert "design" in ghost.labels
-        assert "contract_first" in ghost.labels
+        # Codex P2 on PR #334: ghost MUST NOT carry "contract_first"
+        # label — that label is also on impl tasks and would cause
+        # SafetyChecker to over-link every impl to every ghost.
+        # Provenance lives on source_type instead.
+        assert "contract_first" not in ghost.labels
         assert ghost.status == TaskStatus.DONE
         assert ghost.assigned_to == "Marcus"
         assert ghost.source_type == "contract_first_design"
@@ -846,4 +850,177 @@ class TestContractFirstDesignGhosts:
         assert ghost_names == ["Design Good"], (
             f"Expected only 'Design Good' ghost (Empty domain failed), "
             f"got {ghost_names}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_safety_checker_does_not_over_link_ghosts_to_impl_tasks(
+        self,
+    ):
+        """
+        Regression test for Codex P2 on PR #334.
+
+        ``SafetyChecker.apply_implementation_dependencies`` calls
+        ``_find_related_tasks`` which treats any non-prefixed shared
+        label as a relation. If contract-first design ghosts and impl
+        tasks share the ``"contract_first"`` label, the safety check
+        would link every impl task to every ghost, undoing the
+        per-domain ``contract_file`` wiring done in
+        ``_try_contract_first_decomposition``.
+
+        This test runs the full pipeline (decomposition + safety
+        check) on a multi-domain project and asserts each impl task's
+        final dependency set contains only its matched domain ghost,
+        not all ghosts.
+        """
+        from datetime import datetime, timezone
+
+        from src.core.models import Priority, Task, TaskStatus
+        from src.integrations.nlp_task_utils import SafetyChecker
+
+        creator = _make_creator()
+        constraints = MagicMock()
+
+        weather_impl = Task(
+            id="contract_task_weather",
+            name="Implement WeatherWidget",
+            description="weather impl",
+            status=TaskStatus.TODO,
+            priority=Priority.HIGH,
+            assigned_to=None,
+            created_at=datetime.now(timezone.utc),
+            updated_at=datetime.now(timezone.utc),
+            due_date=None,
+            estimated_hours=0.2,
+            labels=["contract_first", "implementation"],
+            source_context={
+                "contract_file": (
+                    "docs/api/weather-information-system-" "interface-contracts.md"
+                ),
+            },
+        )
+        time_impl = Task(
+            id="contract_task_time",
+            name="Implement TimeWidget",
+            description="time impl",
+            status=TaskStatus.TODO,
+            priority=Priority.HIGH,
+            assigned_to=None,
+            created_at=datetime.now(timezone.utc),
+            updated_at=datetime.now(timezone.utc),
+            due_date=None,
+            estimated_hours=0.2,
+            labels=["contract_first", "implementation"],
+            source_context={
+                "contract_file": (
+                    "docs/api/time-display-system-interface-contracts.md"
+                ),
+            },
+        )
+
+        with (
+            patch.object(
+                creator.prd_parser,
+                "_analyze_prd_deeply",
+                new_callable=AsyncMock,
+                return_value=_make_prd_analysis(),
+            ),
+            patch.object(
+                creator.prd_parser,
+                "_discover_domains",
+                new_callable=AsyncMock,
+                return_value={
+                    "Weather Information System": ["f1"],
+                    "Time Display System": ["f2"],
+                },
+            ),
+            patch(
+                "src.integrations.nlp_tools._generate_contracts_by_domain",
+                new_callable=AsyncMock,
+                return_value={
+                    "Weather Information System": {
+                        "artifacts": [
+                            {
+                                "filename": (
+                                    "weather-information-system-"
+                                    "interface-contracts.md"
+                                ),
+                                "artifact_type": "interface_contracts",
+                                "content": "# Weather",
+                                "description": "weather",
+                                "relative_path": (
+                                    "docs/api/weather-information-system-"
+                                    "interface-contracts.md"
+                                ),
+                            }
+                        ],
+                        "decisions": [],
+                    },
+                    "Time Display System": {
+                        "artifacts": [
+                            {
+                                "filename": (
+                                    "time-display-system-" "interface-contracts.md"
+                                ),
+                                "artifact_type": "interface_contracts",
+                                "content": "# Time",
+                                "description": "time",
+                                "relative_path": (
+                                    "docs/api/time-display-system-"
+                                    "interface-contracts.md"
+                                ),
+                            }
+                        ],
+                        "decisions": [],
+                    },
+                },
+            ),
+            patch.object(
+                creator.prd_parser,
+                "decompose_by_contract",
+                new_callable=AsyncMock,
+                return_value=[weather_impl, time_impl],
+            ),
+        ):
+            result = await creator._try_contract_first_decomposition(
+                description="Build a dashboard",
+                project_name="Dashboard",
+                project_root="/tmp/test",  # nosec B108
+                constraints=constraints,
+                options={"decomposer": "contract_first"},
+            )
+
+        assert result is not None
+
+        # Now run the safety check that would normally fire in
+        # ``create_tasks_from_description``. This is the path that
+        # over-linked everything before the fix.
+        SafetyChecker().apply_implementation_dependencies(result)
+
+        weather_ghost = next(
+            t for t in result if t.name == "Design Weather Information System"
+        )
+        time_ghost = next(t for t in result if t.name == "Design Time Display System")
+
+        # After the safety check, each impl task must depend on its
+        # matched ghost ONLY, not the cross-domain ghost. The original
+        # bug: shared "contract_first" label caused
+        # _find_related_tasks to return all ghosts as related to all
+        # impl tasks, so weather_impl ended up depending on the time
+        # ghost and vice versa.
+        assert weather_ghost.id in weather_impl.dependencies, (
+            f"Weather impl should depend on weather ghost. "
+            f"Deps: {weather_impl.dependencies}"
+        )
+        assert time_ghost.id not in weather_impl.dependencies, (
+            f"Weather impl should NOT depend on time ghost (cross-domain). "
+            f"Deps: {weather_impl.dependencies}. "
+            f"This is the Codex P2 over-linking regression."
+        )
+        assert time_ghost.id in time_impl.dependencies, (
+            f"Time impl should depend on time ghost. " f"Deps: {time_impl.dependencies}"
+        )
+        assert weather_ghost.id not in time_impl.dependencies, (
+            f"Time impl should NOT depend on weather ghost (cross-domain). "
+            f"Deps: {time_impl.dependencies}. "
+            f"This is the Codex P2 over-linking regression."
         )

--- a/tests/unit/integrations/test_contract_first_fallback.py
+++ b/tests/unit/integrations/test_contract_first_fallback.py
@@ -330,12 +330,44 @@ class TestContractFirstFallback:
         assert result is None
 
     @pytest.mark.asyncio
-    async def test_happy_path_returns_tasks(self):
-        """All stages succeed → returns task list."""
+    async def test_happy_path_returns_design_ghosts_plus_impl_tasks(self):
+        """
+        All stages succeed → returns design ghost(s) + impl task(s).
+
+        After GH-320 PR 3 (Cato retrofit), the contract-first path
+        prepends one synthetic design ghost task per usable domain to
+        the impl tasks returned by ``decompose_by_contract``. The
+        ghosts make Cato's structural-task classifier fire so contract
+        generation work shows up in the dashboard the same way the
+        feature-based design phase does.
+        """
         creator = _make_creator()
         constraints = MagicMock()
 
-        fake_tasks = [MagicMock()]  # decomposer returns at least one task
+        # Build a real impl task so we can assert dependency wiring.
+        from datetime import datetime, timezone
+
+        from src.core.models import Priority, Task, TaskStatus
+
+        impl_task = Task(
+            id="contract_task_1",
+            name="Implement Auth Module",
+            description="Implement auth module from contract",
+            status=TaskStatus.TODO,
+            priority=Priority.HIGH,
+            assigned_to=None,
+            created_at=datetime.now(timezone.utc),
+            updated_at=datetime.now(timezone.utc),
+            due_date=None,
+            estimated_hours=0.2,
+            labels=["contract_first", "implementation"],
+            source_type="contract_first",
+            source_context={
+                "contract_file": "docs/api/main-interface-contracts.md",
+                "responsibility": "implements Auth interface",
+            },
+            responsibility="implements Auth interface",
+        )
 
         with (
             patch.object(
@@ -357,14 +389,29 @@ class TestContractFirstFallback:
                     "Main": {
                         "artifacts": [
                             {
-                                "filename": "contract.md",
-                                "artifact_type": "api",
-                                "content": "# Contract",
-                                "description": "api",
-                                "relative_path": "docs/api/contract.md",
+                                "filename": "main-interface-contracts.md",
+                                "artifact_type": "interface_contracts",
+                                "content": "# Interface Contracts",
+                                "description": "interfaces",
+                                "relative_path": (
+                                    "docs/api/main-interface-contracts.md"
+                                ),
+                            },
+                            {
+                                "filename": "main-architecture.md",
+                                "artifact_type": "architecture",
+                                "content": "# Arch",
+                                "description": "arch",
+                                "relative_path": "docs/api/main-architecture.md",
+                            },
+                        ],
+                        "decisions": [
+                            {
+                                "what": "Use REST",
+                                "why": "Simplicity",
+                                "impact": "All endpoints HTTP",
                             }
                         ],
-                        "decisions": [],
                     }
                 },
             ),
@@ -372,7 +419,7 @@ class TestContractFirstFallback:
                 creator.prd_parser,
                 "decompose_by_contract",
                 new_callable=AsyncMock,
-                return_value=fake_tasks,
+                return_value=[impl_task],
             ),
         ):
             result = await creator._try_contract_first_decomposition(
@@ -383,4 +430,420 @@ class TestContractFirstFallback:
                 options={"decomposer": "contract_first", "agent_count": 3},
             )
 
-        assert result == fake_tasks
+        # Result is design ghost(s) + impl task(s)
+        assert result is not None
+        assert len(result) == 2, (
+            f"Expected 1 design ghost + 1 impl task, got {len(result)}: "
+            f"{[(t.name, t.labels) for t in result]}"
+        )
+
+        # First task is the design ghost; second is the original impl task
+        ghost = result[0]
+        impl = result[1]
+
+        assert ghost.name == "Design Main"
+        assert "design" in ghost.labels
+        assert "contract_first" in ghost.labels
+        assert ghost.status == TaskStatus.DONE
+        assert ghost.assigned_to == "Marcus"
+        assert ghost.source_type == "contract_first_design"
+        assert (
+            ghost.source_context.get("contract_file")
+            == "docs/api/main-interface-contracts.md"
+        )
+
+        # Impl task is the same object the decomposer returned, with
+        # its dependencies updated to include the matching design ghost
+        assert impl is impl_task
+        assert ghost.id in impl.dependencies, (
+            f"Impl task should depend on its domain's design ghost. "
+            f"Ghost id: {ghost.id}, impl deps: {impl.dependencies}"
+        )
+
+        # The contract_artifacts dict was stashed on the creator instance
+        # so the background _run_design_phase can pick it up and route
+        # through the existing _register_design_via_mcp Phase B path.
+        stashed = getattr(creator, "_contract_first_design_content", None)
+        assert stashed is not None, (
+            "Contract-first design content must be stashed on the "
+            "creator instance for the background design phase to use."
+        )
+        assert "Design Main" in stashed, (
+            f"Stashed design content must be rekeyed by 'Design {{domain}}' "
+            f"to match Phase B's name-based join. Got keys: {list(stashed.keys())}"
+        )
+        # The artifacts and decisions are forwarded verbatim
+        assert len(stashed["Design Main"]["artifacts"]) == 2
+        assert len(stashed["Design Main"]["decisions"]) == 1
+
+
+class TestContractFirstDesignGhosts:
+    """
+    Test design ghost task creation in contract-first decomposition.
+
+    Synthetic design tasks are the Cato retrofit (GH-320 PR after #333):
+    contract-first generates contract artifacts and decisions in Phase A
+    via ``_generate_contracts_by_domain`` but, before this fix, those
+    were discarded after being passed to ``decompose_by_contract``. No
+    log_artifact, no log_decision, no structural task in marcus.db, no
+    ghost node in Cato.
+
+    The fix synthesizes one DONE design task per usable domain so the
+    existing feature-based Phase B infrastructure
+    (``_register_design_via_mcp``) and the marcus.db design-task
+    persistence block both fire naturally — zero Cato changes.
+    """
+
+    @pytest.mark.asyncio
+    async def test_design_ghost_satisfies_is_design_task_helper(self):
+        """
+        Synthesized ghosts must trip ``_is_design_task`` so the
+        background design phase fires and the marcus.db persistence
+        block at nlp_tools.py:820-873 picks them up. ``_is_design_task``
+        requires both ``"design"`` in labels AND name starting with
+        ``"design"``.
+        """
+        from datetime import datetime, timezone
+
+        from src.core.models import Priority, Task, TaskStatus
+        from src.integrations.nlp_tools import _is_design_task
+
+        creator = _make_creator()
+        constraints = MagicMock()
+
+        # Minimal impl task — the existing guard rejects empty task
+        # lists from decompose_by_contract as "no tasks generated".
+        stub_impl = Task(
+            id="contract_task_stub",
+            name="Implement Stub",
+            description="stub",
+            status=TaskStatus.TODO,
+            priority=Priority.HIGH,
+            assigned_to=None,
+            created_at=datetime.now(timezone.utc),
+            updated_at=datetime.now(timezone.utc),
+            due_date=None,
+            estimated_hours=0.1,
+            labels=["contract_first", "implementation"],
+            source_context={
+                "contract_file": (
+                    "docs/api/weather-information-system-" "interface-contracts.md"
+                ),
+            },
+        )
+
+        with (
+            patch.object(
+                creator.prd_parser,
+                "_analyze_prd_deeply",
+                new_callable=AsyncMock,
+                return_value=_make_prd_analysis(),
+            ),
+            patch.object(
+                creator.prd_parser,
+                "_discover_domains",
+                new_callable=AsyncMock,
+                return_value={
+                    "Weather Information System": ["f1"],
+                    "Time Display System": ["f2"],
+                },
+            ),
+            patch(
+                "src.integrations.nlp_tools._generate_contracts_by_domain",
+                new_callable=AsyncMock,
+                return_value={
+                    "Weather Information System": {
+                        "artifacts": [
+                            {
+                                "filename": (
+                                    "weather-information-system-"
+                                    "interface-contracts.md"
+                                ),
+                                "artifact_type": "interface_contracts",
+                                "content": "# Weather",
+                                "description": "weather",
+                                "relative_path": (
+                                    "docs/api/weather-information-system-"
+                                    "interface-contracts.md"
+                                ),
+                            }
+                        ],
+                        "decisions": [],
+                    },
+                    "Time Display System": {
+                        "artifacts": [
+                            {
+                                "filename": (
+                                    "time-display-system-" "interface-contracts.md"
+                                ),
+                                "artifact_type": "interface_contracts",
+                                "content": "# Time",
+                                "description": "time",
+                                "relative_path": (
+                                    "docs/api/time-display-system-"
+                                    "interface-contracts.md"
+                                ),
+                            }
+                        ],
+                        "decisions": [],
+                    },
+                },
+            ),
+            patch.object(
+                creator.prd_parser,
+                "decompose_by_contract",
+                new_callable=AsyncMock,
+                return_value=[stub_impl],
+            ),
+        ):
+            result = await creator._try_contract_first_decomposition(
+                description="Build a dashboard",
+                project_name="Dashboard",
+                project_root="/tmp/test",  # nosec B108
+                constraints=constraints,
+                options={"decomposer": "contract_first"},
+            )
+
+        assert result is not None
+        ghosts = [t for t in result if t.name.lower().startswith("design")]
+        assert len(ghosts) == 2, (
+            f"Expected one ghost per domain (2), got {len(ghosts)}: "
+            f"{[t.name for t in ghosts]}"
+        )
+        for ghost in ghosts:
+            assert _is_design_task(ghost), (
+                f"Ghost task {ghost.name!r} with labels {ghost.labels} "
+                f"does not satisfy _is_design_task — Cato/marcus.db "
+                f"persistence path will not fire for this task."
+            )
+
+    @pytest.mark.asyncio
+    async def test_impl_tasks_wired_to_matching_ghost_by_contract_file(
+        self,
+    ):
+        """
+        Each impl task must have its corresponding design ghost in
+        ``dependencies``, matched by ``source_context["contract_file"]``.
+        Restores the diamond DAG topology so the integration task ends
+        up depending on impl tasks transitively through the design
+        layer, same shape as feature-based.
+        """
+        from datetime import datetime, timezone
+
+        from src.core.models import Priority, Task, TaskStatus
+
+        creator = _make_creator()
+        constraints = MagicMock()
+
+        weather_impl = Task(
+            id="contract_task_weather",
+            name="Implement WeatherWidget",
+            description="weather impl",
+            status=TaskStatus.TODO,
+            priority=Priority.HIGH,
+            assigned_to=None,
+            created_at=datetime.now(timezone.utc),
+            updated_at=datetime.now(timezone.utc),
+            due_date=None,
+            estimated_hours=0.2,
+            labels=["contract_first", "implementation"],
+            source_context={
+                "contract_file": (
+                    "docs/api/weather-information-system-" "interface-contracts.md"
+                ),
+            },
+        )
+        time_impl = Task(
+            id="contract_task_time",
+            name="Implement TimeWidget",
+            description="time impl",
+            status=TaskStatus.TODO,
+            priority=Priority.HIGH,
+            assigned_to=None,
+            created_at=datetime.now(timezone.utc),
+            updated_at=datetime.now(timezone.utc),
+            due_date=None,
+            estimated_hours=0.2,
+            labels=["contract_first", "implementation"],
+            source_context={
+                "contract_file": (
+                    "docs/api/time-display-system-interface-contracts.md"
+                ),
+            },
+        )
+
+        with (
+            patch.object(
+                creator.prd_parser,
+                "_analyze_prd_deeply",
+                new_callable=AsyncMock,
+                return_value=_make_prd_analysis(),
+            ),
+            patch.object(
+                creator.prd_parser,
+                "_discover_domains",
+                new_callable=AsyncMock,
+                return_value={
+                    "Weather Information System": ["f1"],
+                    "Time Display System": ["f2"],
+                },
+            ),
+            patch(
+                "src.integrations.nlp_tools._generate_contracts_by_domain",
+                new_callable=AsyncMock,
+                return_value={
+                    "Weather Information System": {
+                        "artifacts": [
+                            {
+                                "filename": (
+                                    "weather-information-system-"
+                                    "interface-contracts.md"
+                                ),
+                                "artifact_type": "interface_contracts",
+                                "content": "# Weather",
+                                "description": "weather",
+                                "relative_path": (
+                                    "docs/api/weather-information-system-"
+                                    "interface-contracts.md"
+                                ),
+                            }
+                        ],
+                        "decisions": [],
+                    },
+                    "Time Display System": {
+                        "artifacts": [
+                            {
+                                "filename": (
+                                    "time-display-system-" "interface-contracts.md"
+                                ),
+                                "artifact_type": "interface_contracts",
+                                "content": "# Time",
+                                "description": "time",
+                                "relative_path": (
+                                    "docs/api/time-display-system-"
+                                    "interface-contracts.md"
+                                ),
+                            }
+                        ],
+                        "decisions": [],
+                    },
+                },
+            ),
+            patch.object(
+                creator.prd_parser,
+                "decompose_by_contract",
+                new_callable=AsyncMock,
+                return_value=[weather_impl, time_impl],
+            ),
+        ):
+            result = await creator._try_contract_first_decomposition(
+                description="Build a dashboard",
+                project_name="Dashboard",
+                project_root="/tmp/test",  # nosec B108
+                constraints=constraints,
+                options={"decomposer": "contract_first"},
+            )
+
+        assert result is not None
+
+        # Find the two ghosts by name
+        weather_ghost = next(
+            t for t in result if t.name == "Design Weather Information System"
+        )
+        time_ghost = next(t for t in result if t.name == "Design Time Display System")
+
+        # Each impl task depends on its matching ghost only — not the
+        # other ghost. This is the load-bearing assertion: a wrong
+        # match would still produce a green Cato but break the
+        # integration task's dependency closure.
+        assert weather_ghost.id in weather_impl.dependencies
+        assert time_ghost.id not in weather_impl.dependencies
+        assert time_ghost.id in time_impl.dependencies
+        assert weather_ghost.id not in time_impl.dependencies
+
+    @pytest.mark.asyncio
+    async def test_no_ghost_when_domain_produced_no_artifacts(self):
+        """
+        Domains where contract generation produced an empty/None
+        payload must NOT get a ghost task. The Phase B handoff joins
+        on name; a ghost without backing content would just dangle.
+        """
+        from datetime import datetime, timezone
+
+        from src.core.models import Priority, Task, TaskStatus
+
+        creator = _make_creator()
+        constraints = MagicMock()
+
+        impl_task = Task(
+            id="contract_task_1",
+            name="Implement Main",
+            description="impl",
+            status=TaskStatus.TODO,
+            priority=Priority.HIGH,
+            assigned_to=None,
+            created_at=datetime.now(timezone.utc),
+            updated_at=datetime.now(timezone.utc),
+            due_date=None,
+            estimated_hours=0.2,
+            labels=["contract_first", "implementation"],
+            source_context={
+                "contract_file": "docs/api/good-interface-contracts.md",
+            },
+        )
+
+        with (
+            patch.object(
+                creator.prd_parser,
+                "_analyze_prd_deeply",
+                new_callable=AsyncMock,
+                return_value=_make_prd_analysis(),
+            ),
+            patch.object(
+                creator.prd_parser,
+                "_discover_domains",
+                new_callable=AsyncMock,
+                return_value={"Good": ["f1"], "Empty": ["f2"]},
+            ),
+            patch(
+                "src.integrations.nlp_tools._generate_contracts_by_domain",
+                new_callable=AsyncMock,
+                return_value={
+                    "Good": {
+                        "artifacts": [
+                            {
+                                "filename": "good-interface-contracts.md",
+                                "artifact_type": "interface_contracts",
+                                "content": "# Good",
+                                "description": "good",
+                                "relative_path": (
+                                    "docs/api/good-interface-contracts.md"
+                                ),
+                            }
+                        ],
+                        "decisions": [],
+                    },
+                    "Empty": None,  # contract generation failed for this domain
+                },
+            ),
+            patch.object(
+                creator.prd_parser,
+                "decompose_by_contract",
+                new_callable=AsyncMock,
+                return_value=[impl_task],
+            ),
+        ):
+            result = await creator._try_contract_first_decomposition(
+                description="Build a thing",
+                project_name="Thing",
+                project_root="/tmp/test",  # nosec B108
+                constraints=constraints,
+                options={"decomposer": "contract_first"},
+            )
+
+        assert result is not None
+        ghost_names = [t.name for t in result if t.name.lower().startswith("design")]
+        assert ghost_names == ["Design Good"], (
+            f"Expected only 'Design Good' ghost (Empty domain failed), "
+            f"got {ghost_names}"
+        )

--- a/tests/unit/integrations/test_design_autocomplete.py
+++ b/tests/unit/integrations/test_design_autocomplete.py
@@ -1037,3 +1037,259 @@ class TestRunDesignPhaseHandoff:
         # Only the one created task got a kanban update (zip stopped
         # at the shorter list)
         assert kanban.update_task.call_count == 1
+
+
+class TestRunDesignPhasePreGeneratedContent:
+    """
+    Test ``_run_design_phase`` with the contract-first
+    ``pre_generated_content`` parameter (Cato retrofit, GH-320 PR
+    after #333).
+
+    When the contract-first decomposer synthesizes design ghost
+    tasks, the contract artifacts and decisions have already been
+    generated upstream by ``_generate_contracts_by_domain``. The
+    ghost tasks need the existing Phase B / kanban DONE / scaffold
+    pipeline to fire, but Phase A must be SKIPPED — re-running it
+    on synthetic ghosts would produce duplicate or wrong content.
+
+    The ``pre_generated_content`` parameter is the seam: when
+    provided, ``_run_design_phase`` skips ``_generate_design_content``
+    and uses the supplied dict directly as ``design_content``.
+    """
+
+    @pytest.fixture
+    def state(self):
+        """Mock MCP state with empty task_artifacts."""
+        state = MagicMock()
+        state.task_artifacts = {}
+        state.kanban_client = AsyncMock()
+        state.context = MagicMock()
+        state.refresh_project_state = AsyncMock()
+        return state
+
+    @pytest.fixture
+    def contract_first_design_content(self):
+        """Pre-generated content keyed by ghost task name."""
+        return {
+            "Design Weather Information System": {
+                "artifacts": [
+                    {
+                        "filename": (
+                            "weather-information-system-" "interface-contracts.md"
+                        ),
+                        "artifact_type": "interface_contracts",
+                        "content": "# Weather Contracts\n",
+                        "description": "Weather interfaces",
+                        "relative_path": (
+                            "docs/api/weather-information-system-"
+                            "interface-contracts.md"
+                        ),
+                    },
+                ],
+                "decisions": [
+                    {
+                        "what": "Refresh weather every 10 minutes",
+                        "why": "API rate limits + UX freshness",
+                        "impact": "WeatherWidget polling interval",
+                    }
+                ],
+            }
+        }
+
+    @pytest.fixture
+    def contract_first_tasks(self):
+        """Synthetic design ghost + impl task."""
+        ghost_safe = _make_task(
+            "Design Weather Information System",
+            labels=["design", "contract_first", "auto_completed"],
+            status=TaskStatus.DONE,
+            task_id="ghost_safe_1",
+        )
+        impl_safe = _make_task(
+            "Implement WeatherWidget",
+            labels=["contract_first", "implementation"],
+            task_id="impl_safe_1",
+        )
+        ghost_created = _make_task(
+            "Design Weather Information System",
+            labels=["design", "contract_first", "auto_completed"],
+            status=TaskStatus.DONE,
+            task_id="real_ghost_uuid",
+        )
+        impl_created = _make_task(
+            "Implement WeatherWidget",
+            labels=["contract_first", "implementation"],
+            task_id="real_impl_uuid",
+        )
+        return {
+            "safe": [ghost_safe, impl_safe],
+            "created": [ghost_created, impl_created],
+        }
+
+    @pytest.mark.asyncio
+    async def test_pre_generated_content_skips_phase_a(
+        self,
+        state,
+        contract_first_design_content,
+        contract_first_tasks,
+    ):
+        """
+        When ``pre_generated_content`` is supplied,
+        ``_generate_design_content`` MUST NOT be called. Re-running
+        Phase A on contract-first ghosts would either fail (no
+        design tasks for Phase A to expand) or burn LLM calls
+        regenerating content that already exists.
+        """
+        state.project_tasks = contract_first_tasks["created"]
+        kanban = state.kanban_client
+
+        with (
+            patch(
+                "src.integrations.nlp_tools._generate_design_content",
+                new_callable=AsyncMock,
+            ) as mock_gen,
+            patch(
+                "src.marcus_mcp.tools.attachment.log_artifact",
+                new_callable=AsyncMock,
+                return_value={
+                    "success": True,
+                    "data": {"location": "docs/x.md"},
+                },
+            ),
+            patch(
+                "src.marcus_mcp.tools.context.log_decision",
+                new_callable=AsyncMock,
+                return_value={"success": True},
+            ),
+            patch(
+                "src.integrations.nlp_tools._generate_project_scaffold",
+                new_callable=AsyncMock,
+            ),
+        ):
+            await _run_design_phase(
+                state=state,
+                kanban_client=kanban,
+                safe_tasks=contract_first_tasks["safe"],
+                created_tasks=contract_first_tasks["created"],
+                description="Build a dashboard",
+                project_name="Dashboard",
+                project_root="/var/folders/test",  # nosec B108
+                pre_generated_content=contract_first_design_content,
+            )
+
+        mock_gen.assert_not_called(), (
+            "_generate_design_content must NOT be called when "
+            "pre_generated_content is supplied — Phase A is skipped "
+            "for the contract-first path."
+        )
+
+    @pytest.mark.asyncio
+    async def test_pre_generated_content_drives_phase_b_registration(
+        self,
+        state,
+        contract_first_design_content,
+        contract_first_tasks,
+    ):
+        """
+        Phase B must call ``log_artifact`` and ``log_decision``
+        against the pre-generated content, joined to
+        ``state.project_tasks`` by ghost task name. This is the
+        whole point of the retrofit: Cato observability fires
+        because the artifacts and decisions land in
+        ``state.task_artifacts`` and ``state.context.decisions``
+        keyed by the real kanban UUID of the ghost.
+        """
+        state.project_tasks = contract_first_tasks["created"]
+        kanban = state.kanban_client
+
+        with (
+            patch(
+                "src.integrations.nlp_tools._generate_design_content",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "src.marcus_mcp.tools.attachment.log_artifact",
+                new_callable=AsyncMock,
+            ) as mock_log_artifact,
+            patch(
+                "src.marcus_mcp.tools.context.log_decision",
+                new_callable=AsyncMock,
+            ) as mock_log_decision,
+            patch(
+                "src.integrations.nlp_tools._generate_project_scaffold",
+                new_callable=AsyncMock,
+            ),
+        ):
+            mock_log_artifact.return_value = {
+                "success": True,
+                "data": {"location": "docs/x.md"},
+            }
+            mock_log_decision.return_value = {"success": True}
+
+            await _run_design_phase(
+                state=state,
+                kanban_client=kanban,
+                safe_tasks=contract_first_tasks["safe"],
+                created_tasks=contract_first_tasks["created"],
+                description="Build a dashboard",
+                project_name="Dashboard",
+                project_root="/var/folders/test",  # nosec B108
+                pre_generated_content=contract_first_design_content,
+            )
+
+        # log_artifact called against the ghost's real kanban UUID
+        assert mock_log_artifact.called, (
+            "log_artifact must be called against pre-generated "
+            "contract artifacts — without this Cato never sees them."
+        )
+        artifact_call = mock_log_artifact.call_args
+        assert artifact_call.kwargs["task_id"] == "real_ghost_uuid"
+        assert (
+            artifact_call.kwargs["filename"]
+            == "weather-information-system-interface-contracts.md"
+        )
+
+        # log_decision called against the same ghost UUID
+        assert mock_log_decision.called, (
+            "log_decision must be called against pre-generated "
+            "contract decisions — without this Cato never sees "
+            "decision history for contract-first projects."
+        )
+        decision_call = mock_log_decision.call_args
+        assert decision_call.kwargs["task_id"] == "real_ghost_uuid"
+        assert decision_call.kwargs["agent_id"] == "Marcus"
+
+    @pytest.mark.asyncio
+    async def test_phase_a_runs_when_pre_generated_content_is_none(
+        self, state, contract_first_tasks
+    ):
+        """
+        Default behavior preserved: when ``pre_generated_content``
+        is None (the feature-based path), Phase A runs as before.
+        """
+        state.project_tasks = contract_first_tasks["created"]
+        kanban = state.kanban_client
+
+        with (
+            patch(
+                "src.integrations.nlp_tools._generate_design_content",
+                new_callable=AsyncMock,
+                return_value={},
+            ) as mock_gen,
+            patch(
+                "src.integrations.nlp_tools._generate_project_scaffold",
+                new_callable=AsyncMock,
+            ),
+        ):
+            await _run_design_phase(
+                state=state,
+                kanban_client=kanban,
+                safe_tasks=contract_first_tasks["safe"],
+                created_tasks=contract_first_tasks["created"],
+                description="Build a dashboard",
+                project_name="Dashboard",
+                project_root="/var/folders/test",  # nosec B108
+                # pre_generated_content omitted — defaults to None
+            )
+
+        mock_gen.assert_called_once()


### PR DESCRIPTION
## Summary
Fixes the Cato observability regression for contract-first projects (GH-320 PR 2). Surfaced by Experiment 4 v2 — audit report could not pull conversation data from Cato, no design phase visible in the dashboard, no decisions, no artifacts, no impl→integration edges.

## Root cause
The contract-first decomposer added in #327 generated `contract_artifacts` and `decisions` in Phase A via `_generate_contracts_by_domain` but **discarded them** after passing them to `decompose_by_contract`. No `log_artifact`, no `log_decision`, no structural task in `marcus.db`. Cato's `display_role` classifier at `cato_src/core/aggregator.py` only marks tasks as `"structural"` when `"design"` is in labels — contract-first tasks have `labels=["contract_first", "implementation"]`, so they classified as `"work"` and the entire structural ghost layer was empty.

## Fix (Option A retrofit, ~50 LOC of new logic + tests)
Synthesize one DONE design ghost task per usable contract domain in `_try_contract_first_decomposition`. Each ghost has:
- `name=f"Design {domain}"` (matches `_is_design_task` name check)
- `labels=["design", "contract_first", "auto_completed"]` (matches `_is_design_task` AND Cato's classifier)
- `status=TaskStatus.DONE`, `assigned_to="Marcus"`
- `source_context["contract_file"]` = canonical interface contract path

Each impl task's dependencies get the matching ghost id appended (joined by `source_context["contract_file"]`), restoring the diamond DAG topology. The `contract_artifacts` dict is rekeyed to `{"Design {domain}": payload}` and stashed on `self._contract_first_design_content`.

`_run_design_phase` gains an optional `pre_generated_content` parameter. When supplied, Phase A is **skipped** and the dict is used directly as `design_content` for Phase B and the kanban DONE update. The background scheduler in `create_tasks_from_description` reads the stashed content via `getattr`, forwards it to `_run_design_phase`, then `delattr`s so subsequent feature-based runs don't pick up stale state.

**Zero Cato changes.** The existing `_register_design_via_mcp` Phase B infrastructure handles the new ghosts unchanged because they satisfy `_is_design_task`. `log_artifact` and `log_decision` fire against each ghost's real kanban UUID, `state.task_artifacts` and `state.context.decisions` populate, and the marcus.db design-task persistence block at `nlp_tools.py:820-873` picks them up.

## Test plan
- [x] `test_happy_path_returns_design_ghosts_plus_impl_tasks` — verifies result shape (ghosts prepended) and stashed content
- [x] `test_design_ghost_satisfies_is_design_task_helper` — verifies ghosts trip the existing helper
- [x] `test_impl_tasks_wired_to_matching_ghost_by_contract_file` — verifies dependency wiring is per-domain (not cross-contaminated)
- [x] `test_no_ghost_when_domain_produced_no_artifacts` — verifies empty/None payloads don't get dangling ghosts
- [x] `test_pre_generated_content_skips_phase_a` — verifies `_generate_design_content` not called when pre-generated supplied
- [x] `test_pre_generated_content_drives_phase_b_registration` — verifies `log_artifact` and `log_decision` fire against the ghost's real kanban UUID
- [x] `test_phase_a_runs_when_pre_generated_content_is_none` — verifies feature-based path unchanged
- [x] Full unit sweep: 438/438 green, mypy clean

## Validation post-merge
Next contract-first run via `/marcus ... --decomposer contract_first` should produce:
1. Design ghosts visible in Cato Network graph as hollow dashed rings (one per domain)
2. Decisions list non-empty when clicking a ghost
3. Artifacts list shows the contract `.md` files
4. Diamond DAG: ghosts → impl → integration
5. Marcus/Planning swim lane shows ghosts as DONE with dashed styling

## Refs
- #320 — Contract-first decomposition (PR 2 merged in #327)
- #329 — Smoke test harness that earlier validated the mechanism
- #331 — Validator parser fix
- #332 — `--decomposer contract_first` flag
- #333 — Pre-existing integration + classifier bug fixes

Surfaced by Experiment 4 v2 (~/experiments/dashboard-v53). Audit report verdict was "Multi-Agency Effective: Yes, Balanced 55.5/44.5" — mechanism validated, observability needed this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)