### PR TITLE
feat(#320): upstream intent preservation for contract-first

### DIFF
--- a/docs/source/concepts/README.md
+++ b/docs/source/concepts/README.md
@@ -24,6 +24,9 @@ The seven principles that guide Marcus's design: Sacred Repository, Guided Auton
 ### **[Hierarchical Task Decomposition](hierarchical-task-decomposition.md)**
 How Marcus intelligently breaks down large, complex tasks into manageable subtasks with clear interfaces, dependencies, and shared conventions for effective agent collaboration.
 
+### **[Contract-First Decomposition](contract-first-decomposition.md)**
+How Marcus uses interface contracts to solve the Single-Author Problem in tightly-coupled multi-agent projects. Covers the motivation, experimental validation, architectural decisions, and what remains to be built.
+
 ### **[Activity Tracking vs. Diagnostics](activity-tracking-vs-diagnostics.md)**
 The philosophy behind Marcus's separation of activity tracking (recording what happened) and diagnostics (analyzing why it happened). Learn why mixing these concerns leads to false assumptions and how proper separation improves maintainability.
 

--- a/docs/source/concepts/contract-first-decomposition.md
+++ b/docs/source/concepts/contract-first-decomposition.md
@@ -1,0 +1,157 @@
+# Contract-First Task Decomposition
+
+## Overview
+
+Contract-first decomposition is Marcus's strategy for splitting tightly-coupled multi-agent projects into tasks that produce balanced agent contributions. It replaces the default feature-based decomposition when the user selects `--decomposer contract_first` via the `/marcus` skill.
+
+The core idea: generate interface contracts between domains **before** splitting the project into implementation tasks, so each agent owns a distinct contract boundary rather than a feature silo.
+
+## The Single-Author Problem
+
+Marcus's original decomposition strategy (feature-based) splits a project by user-visible features. Each feature becomes one task. This works well for loosely-coupled projects where features are independent (e.g., a snake game where rendering, input handling, and game logic have minimal overlap).
+
+For tightly-coupled projects, feature-based decomposition produces a **Single-Author Product**: one agent absorbs most of the work while others contribute negligibly.
+
+**Why it happens:** In tightly-coupled systems, one feature depends heavily on another. The first agent to run builds shared infrastructure (data models, API layer, configuration) because its feature needs it. The second agent arrives, discovers the infrastructure already exists, and has little left to build. The contribution split skews to 90/10 or worse.
+
+**Evidence:** Multiple experiments before GH-320 showed Single-Author Products on tightly-coupled prompts. The dashboard experiment (v53 predecessor) consistently produced 85-95% contribution from a single agent.
+
+## How Contract-First Solves It
+
+Contract-first decomposition introduces an intermediate step: **domain discovery and contract generation**. Instead of mapping features directly to tasks, Marcus:
+
+1. Identifies the functional domains in the project (e.g., "weather service", "time service", "dashboard layout")
+2. Generates interface contracts between those domains (data types, API shapes, shared schemas)
+3. Splits implementation tasks along domain boundaries, with contracts as the glue
+
+Each agent receives:
+- A domain to implement
+- The interface contracts its domain must honor
+- Dependencies on design ghost tasks that carry the contract artifacts
+
+Because the contracts define boundaries explicitly, agents cannot accidentally absorb each other's work. Agent A implements the weather service contract; Agent B implements the time widget contract. Even though both need shared types, the contracts specify those types once and both agents code to the same specification.
+
+## Experimental Validation
+
+### Experiment 4 v2 (dashboard-v53)
+
+- **Project**: "Build a dashboard with weather and time widgets"
+- **Strategy**: `--decomposer contract_first`, 2 agents
+- **Result**: Multi-Agency Effective with Balanced contribution (55.5% / 44.5%)
+- **Grade**: B- (3.65/5), 168 tests passing, 92% Python coverage
+
+This was the second consecutive anti-Single-Author result (the first was the snake game at 30/70 with feature-based decomposition on a loosely-coupled project). The dashboard is a tightly-coupled project that previously produced Single-Author Products under feature-based decomposition.
+
+### What Worked
+
+Contract-first successfully distributed implementation work across agents. Both agents built meaningful, non-overlapping components. The 55/45 split is close to ideal for a two-agent project.
+
+### What Did Not Work
+
+The product scored B- because both agents built API plumbing rather than a visible dashboard. The contracts had an API-shape structural prior: they specified data models and service interfaces but not user-facing behavior like "display" and "render."
+
+**Root cause (diagnosed by Kaia):** "Locally rigorous, globally amnesiac." Each translation step in the pipeline (requirements to domains to contracts to tasks) is correct in isolation, but the contract generation prompt has a structural bias toward API-shape contracts. User-facing verbs like "display" and "render" are silently dropped because they do not map to interface types.
+
+The old feature-based system preserved user intent for free because features and tasks were the same object. Contract-first introduced abstraction layers without a discipline for carrying PRD information across them.
+
+### Schema Divergence
+
+The experiment also exposed WidgetPosition schema divergence: the Python contract defined one shape while the TypeScript contract defined another. This type of cross-domain inconsistency is now caught by Invariant 5 (see [Contract Validation](../systems/quality/contract-validation.md)).
+
+## Architectural Decisions
+
+### 1. Cato Observability Uses Synthetic Design Ghosts
+
+**Decision**: When contract-first generates contracts, Marcus synthesizes one DONE design ghost task per usable contract domain. These ghosts carry the contract artifacts and appear in Cato's DAG view.
+
+**Alternatives considered**:
+- **Option B (new emitter path)**: Create a dedicated contract emitter in Cato. Rejected because it required Cato changes and a new data model.
+- **Option C (Cato classifier fix)**: Teach Cato to infer contract provenance from task metadata. Rejected because it was fragile and pushed domain logic into the visualization layer.
+
+**Rationale**: Option A (synthetic ghosts) reuses four existing code paths: `_run_design_phase`, `log_artifact`, the `auto_completed` label filter, and the dependency graph. Zero Cato changes needed. Implementation tasks depend on their matching design ghost via `source_context["contract_file"]`.
+
+### 2. Invariant 5 Is the Only Hard Gate
+
+**Decision**: The only condition that triggers fallback from contract-first to feature-based decomposition is a type contradiction across contract domains (Invariant 5). All other quality signals are additive.
+
+**Rationale**: Type contradictions are correctness failures. If domain A says `WidgetPosition.x` is an `int` and domain B says it is a `string`, no amount of downstream work can reconcile them. Fallback is the only safe response. Other issues (missing verbs, incomplete coverage) degrade quality but do not produce incorrect code. Those are better addressed by enriching prompts than by throwing away the contract-first coordination win.
+
+### 3. Verb-Coverage Gate Was Rejected
+
+**Decision**: A proposed gate that would reject contracts missing user-facing verbs (display, render, etc.) from the PRD was removed after review.
+
+**Rationale**: A six-verb hard-coded checklist was too brittle (false positives on projects that genuinely have no UI verbs) and too destructive (throwing away the 55/45 coordination win to fix a prompt quality issue). The requirement coverage problem will be handled additively in task #64 by threading functional requirements through the contract generation prompt and enriching the integration task with the full requirements list.
+
+### 4. No PRD Information May Be Dropped Across Decomposition Boundaries
+
+**Decision**: This is the general principle that Invariant 5 and the future #64 intent preservation are instances of. Any future decomposer strategy must prove it does not drop PRD information between pipeline stages.
+
+**Rationale**: The "globally amnesiac" failure mode is structural, not accidental. Each abstraction layer is a lossy compression of the one above it. Without explicit discipline, information loss is the default. The general rule forces every new pipeline stage to account for what it carries forward and what it drops.
+
+### 5. Contract-First Experiments Are Atomic
+
+**Decision**: `/marcus` runs Phase A through integration with no pause point. There is no interactive "review contracts before decomposing" step.
+
+**Rationale**: The smoke test harness is the pre-check vehicle. Pausing for human review would break the autonomous experiment model and add latency without clear benefit (the human cannot evaluate contract quality faster than Invariant 5 can check type consistency).
+
+## The Pipeline
+
+The full contract-first pipeline runs inside `_try_contract_first_decomposition` in `src/integrations/nlp_tools.py`:
+
+```
+PRD Analysis
+  |
+  v
+Domain Discovery (identify functional domains from requirements)
+  |
+  v
+Contract Generation (_generate_contracts_by_domain)
+  |  - One LLM call per domain
+  |  - Generates interface contracts, data models, API shapes
+  |  - FORBIDDEN PATTERNS prevent cross-domain scope drift
+  |
+  v
+Invariant 5 Gate (check_contract_cross_file_consistency)
+  |  - Scans all contracts for type contradictions
+  |  - FAIL: fallback to feature-based decomposition
+  |  - PASS: continue
+  |
+  v
+decompose_by_contract (split into implementation tasks)
+  |
+  v
+Ghost Synthesis (one DONE design ghost per domain)
+  |  - labels=["design", "auto_completed"]
+  |  - assigned_to="Marcus"
+  |  - Implementation tasks depend on their domain's ghost
+  |
+  v
+Phase B Handoff (pre_generated_content parameter)
+  |  - _run_design_phase skips Phase A when pre_generated_content is supplied
+  |  - Phase B registers pre-generated contracts as artifacts
+  |
+  v
+Integration Task (verifies cross-domain contract compliance)
+```
+
+For technical details of each pipeline stage, see [Contract-First Pipeline](../systems/coordination/53-contract-first-pipeline.md).
+
+For the Invariant 5 consistency check, see [Contract Validation](../systems/quality/contract-validation.md).
+
+## What Remains: Task #64
+
+The "globally amnesiac" problem requires upstream intent preservation. Two parts:
+
+1. **Thread functional requirements into the contract generation prompt** so the LLM sees "this domain must support: [requirements list]." This is preventive -- it stops the information loss at the source.
+
+2. **Enrich the integration verification task with ALL functional requirements** as `acceptance_criteria` so the integration agent verifies user intent was realized, not just contract compliance. This is detective/additive -- it catches anything that slipped through.
+
+Together, these close the loop between what the user asked for and what the agents build.
+
+## Related Documentation
+
+- [Hierarchical Task Decomposition](hierarchical-task-decomposition.md) -- The original decomposition concept
+- [Design Autocomplete](../systems/coordination/52-design-autocomplete.md) -- Phase A/B mechanism that contract-first builds on
+- [Contract-First Pipeline](../systems/coordination/53-contract-first-pipeline.md) -- Technical specification of the pipeline
+- [Contract Validation](../systems/quality/contract-validation.md) -- Invariant 5 specification
+- [Philosophy](philosophy.md) -- Marcus's Stoic principles, particularly "Safety Through Guardrails"

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -190,6 +190,7 @@ Here's how an agent works with Marcus:
    concepts/README
    concepts/philosophy
    concepts/core-values
+   concepts/contract-first-decomposition
    roadmap/index
    roadmap/evolution
    roadmap/public-release-roadmap

--- a/docs/source/systems/coordination/53-contract-first-pipeline.md
+++ b/docs/source/systems/coordination/53-contract-first-pipeline.md
@@ -1,0 +1,186 @@
+# Contract-First Pipeline
+
+## Status
+
+| Field | Value |
+|-------|-------|
+| Status | Implemented |
+| Version | 1.0 |
+| Date | 2026-04-11 |
+| Issue | GH-320 (PRs #330-#335) |
+
+## Problem
+
+Feature-based decomposition produces Single-Author Products on tightly-coupled projects. One agent absorbs shared infrastructure and the contribution split skews to 90/10 or worse. See [Contract-First Decomposition](../../concepts/contract-first-decomposition.md) for the conceptual background.
+
+## Solution
+
+Contract-first decomposition generates interface contracts between functional domains before splitting the project into tasks. The pipeline lives in `_try_contract_first_decomposition` in `src/integrations/nlp_tools.py` and integrates with the existing design autocomplete system via a `pre_generated_content` parameter on `_run_design_phase`.
+
+## Pipeline Stages
+
+```
+_try_contract_first_decomposition()
+  ├── 1. Domain discovery from PRD analysis
+  ├── 2. _generate_contracts_by_domain()
+  │     └── one LLM call per domain, FORBIDDEN PATTERNS enforced
+  ├── 3. check_contract_cross_file_consistency()  [Invariant 5]
+  │     ├── FAIL → fallback to feature-based
+  │     └── PASS → continue
+  ├── 4. decompose_by_contract()
+  │     └── splits requirements into domain-scoped tasks
+  ├── 5. Ghost synthesis
+  │     └── one DONE design task per domain
+  └── 6. Return tasks + pre_generated_content for Phase B
+```
+
+### Stage 1: Domain Discovery
+
+The PRD analysis identifies functional domains in the project. Each domain represents a coherent area of responsibility (e.g., "weather-service", "time-widget", "dashboard-layout"). Domain boundaries are derived from the project requirements, not from file structure or technology choices.
+
+### Stage 2: Contract Generation
+
+`_generate_contracts_by_domain` makes one LLM call per domain. Each call produces an interface contract document specifying:
+
+- Data types shared with other domains
+- API surface (endpoints, function signatures, event schemas)
+- Integration points (what this domain consumes from others)
+
+**Scope clamping (PR #330):** The `_ARTIFACT_PROMPT` and `_INTERFACE_CONTRACTS_PROMPT` templates include FORBIDDEN PATTERNS that prevent the LLM from generating contracts outside the domain's scope. Without this, the LLM would routinely generate contracts for adjacent domains, causing duplication and divergence.
+
+The generated contracts are stored as an artifacts dict keyed by domain name on the `NaturalLanguageProjectCreator` instance.
+
+### Stage 3: Invariant 5 Gate
+
+`check_contract_cross_file_consistency` (in `src/integrations/contract_validation.py`) scans all generated contracts for type contradictions. A type contradiction occurs when two domains define the same named type with incompatible field types (e.g., domain A says `WidgetPosition.x: int` while domain B says `WidgetPosition.x: string`).
+
+- **If contradictions are found**: the entire contract-first attempt is abandoned and the system falls back to feature-based decomposition. The rationale is that type contradictions are correctness failures that no amount of downstream work can fix.
+- **If no contradictions**: the pipeline continues.
+
+The filter matches contracts by filename pattern (`"interface-contracts" in filename`), not by `artifact_type`. This is important because the live generator emits `artifact_type="specification"` despite the contracts being interface contracts by content. This mismatch was caught by Codex P1 review.
+
+For full specification, see [Contract Validation](../quality/contract-validation.md).
+
+### Stage 4: Decomposition
+
+`decompose_by_contract` receives the validated contracts and splits the project requirements into domain-scoped implementation tasks. Each task:
+
+- Owns one domain
+- References its domain's contract as the source of truth for interfaces
+- Has a dependency on its domain's design ghost (Stage 5)
+
+### Stage 5: Ghost Synthesis
+
+For each usable contract domain, Marcus synthesizes one DONE design ghost task:
+
+```python
+{
+    "name": f"Design {domain}",
+    "assigned_to": "Marcus",
+    "labels": ["design", "auto_completed"],
+    "source_type": "contract_first_design",
+    "status": "done"
+}
+```
+
+Implementation tasks are linked to their domain's ghost via `source_context["contract_file"]`. This provides:
+
+- **Cato observability**: ghosts appear in the DAG, showing that contract generation happened
+- **Artifact discovery**: implementation agents call `get_task_context`, which walks dependencies and finds contract artifacts on the ghost
+- **Provenance**: `source_type="contract_first_design"` identifies ghosts as contract-generated rather than manually created
+
+**Label design (Codex P2 fix):** An earlier design used a shared `contract_first` label on all ghosts. This caused `SafetyChecker._find_related_tasks` to over-link every implementation task to every ghost (because label matching is set intersection). The fix was to drop the shared label entirely. Provenance lives on `source_type`, not labels.
+
+### Stage 6: Phase B Handoff
+
+The generated contracts are passed to `_run_design_phase` via the `pre_generated_content` parameter. When this parameter is supplied:
+
+- **Phase A is skipped** entirely (no additional LLM calls needed; contracts already exist)
+- **Phase B runs normally**, registering the pre-generated contracts as artifacts via `log_artifact` and `log_decision`
+
+This reuses the existing design autocomplete infrastructure without modification. See [Design Autocomplete](52-design-autocomplete.md) for the Phase A/B lifecycle.
+
+## Fallback Behavior
+
+If any stage fails, the system falls back gracefully:
+
+| Failure | Behavior |
+|---------|----------|
+| Domain discovery returns no domains | Feature-based decomposition |
+| LLM call fails during contract generation | Feature-based decomposition |
+| Invariant 5 detects type contradiction | Feature-based decomposition |
+| `decompose_by_contract` fails | Feature-based decomposition |
+
+Fallback is always to feature-based decomposition, never to an error state. The experiment continues regardless of which decomposition strategy runs.
+
+## Supporting Fixes (PR #331, #333)
+
+Two pre-existing bugs were fixed as part of the GH-320 work because they affected contract-first experiment evaluation.
+
+### Validator Parser Rewrite (PR #331)
+
+`_parse_text_response` in `src/ai/validation/work_analyzer.py` was silently dropping evidence and remediation fields for every validation issue. The parser assumed each `### CRITERION` header started a new block, but `### Evidence` and `### Remediation` subheadings were also being treated as block terminators.
+
+The fix is a two-pass block-based parser:
+1. First pass: split text into blocks at `### CRITERION` headers only (not generic markdown subheadings)
+2. Second pass: within each block, case-insensitive keyword scan extracts evidence and remediation
+
+A prose fallback handles LLM responses that do not follow the expected heading structure.
+
+### Integration Task Suppression Fix (PR #333)
+
+`should_add_integration_task` in `src/integrations/integration_verification.py` used substring match on `"test"` to detect test-only projects. This suppressed integration tasks for any project description mentioning "test suite", "unit tests", "test coverage", etc.
+
+The fix uses word-boundary regex plus compound phrase scrubbing: known compound phrases like "test suite" and "unit tests" are stripped before checking for standalone "test" as a keyword.
+
+### Task Type Breakdown Fix (PR #333)
+
+The task type breakdown in experiment logging always showed `{'unknown': N}` because `getattr(task, "task_type", "unknown")` read a non-existent attribute. The fix extracts a `_task_type_breakdown` helper that uses `EnhancedTaskClassifier` to infer task types from task metadata.
+
+## Skill Integration (PR #332)
+
+The `/marcus` skill accepts a `--decomposer contract_first` flag:
+
+- `skills/marcus/SKILL.md` documents the flag
+- `dev-tools/experiments/templates/config.yaml.template` includes a `decomposer` field
+- `spawn_agents.py` forwards `project_options` (including `decomposer`) via `json.dumps` to `create_project`
+- No runner code changes were needed because the `project_options` forwarding path already existed
+
+## Test-Mode Event Suppression
+
+`MarcusServer.publish_event` and `Memory.__init__` use fire-and-forget `asyncio.create_task` calls that produce "Task was destroyed but it is pending" warnings at test teardown. These are suppressed in test mode to eliminate noise in the test suite. This is not specific to contract-first but was fixed as part of the GH-320 test health work (PR #323).
+
+## Implementation Files
+
+| File | Purpose |
+|------|---------|
+| `src/integrations/nlp_tools.py` | Pipeline orchestration, contract generation, ghost synthesis, Phase B handoff |
+| `src/integrations/contract_validation.py` | Invariant 5 cross-contract consistency check |
+| `src/integrations/integration_verification.py` | Integration task generation with "test" substring fix |
+| `src/ai/validation/work_analyzer.py` | Validator parser (two-pass block-based) |
+| `src/marcus_mcp/server.py` | Test-mode event suppression |
+| `src/core/memory.py` | Test-mode persistence task suppression |
+| `skills/marcus/SKILL.md` | `--decomposer` flag documentation |
+| `dev-tools/experiments/templates/config.yaml.template` | Decomposer config field |
+
+## Test Files
+
+| File | Tests | Coverage |
+|------|-------|----------|
+| `tests/unit/integrations/test_contract_first_fallback.py` | 14 | Decomposition fallback, ghost synthesis, safety checker |
+| `tests/unit/integrations/test_contract_validation.py` | 7 | Invariant 5 type contradiction detection |
+| `tests/unit/integrations/test_design_autocomplete.py` | 3 | `pre_generated_content` Phase A skip |
+| `tests/unit/integrations/test_nlp_tools.py` | 3 | Task type breakdown helper |
+| `tests/unit/ai/validation/test_work_analyzer.py` | 18 | Validator parser block splitting and extraction |
+| `tests/unit/integrations/test_integration_verification.py` | 43 | Integration task generation edge cases |
+
+## See Also
+
+- [Contract-First Decomposition](../../concepts/contract-first-decomposition.md) -- Conceptual overview, decisions, and experiment results
+- [Design Autocomplete](52-design-autocomplete.md) -- Phase A/B lifecycle that contract-first builds on
+- [Contract Validation](../quality/contract-validation.md) -- Invariant 5 specification
+- [Task Dependency System](36-task-dependency-system.md) -- How implementation tasks depend on design ghosts
+- GitHub Issues:
+  - [#320](https://github.com/lwgray/marcus/issues/320) -- Contract-first task decomposition
+  - [#267](https://github.com/lwgray/marcus/issues/267) -- Topology-aware decomposition (predecessor)
+  - [#64](https://github.com/lwgray/marcus/issues/64) -- Upstream intent preservation (next step)

--- a/docs/source/systems/coordination/index.rst
+++ b/docs/source/systems/coordination/index.rst
@@ -15,5 +15,7 @@ Systems managing agent coordination and task assignment.
    36-task-dependency-system
    37-optimal-agent-scheduling
    38-smart-retry-strategy
+   52-design-autocomplete
+   53-contract-first-pipeline
    cpm-analysis-overview
    cpm-subtask-timing-analysis

--- a/docs/source/systems/quality/contract-validation.md
+++ b/docs/source/systems/quality/contract-validation.md
@@ -1,0 +1,131 @@
+# Contract Validation (Invariant 5)
+
+## Status
+
+| Field | Value |
+|-------|-------|
+| Status | Implemented |
+| Version | 1.0 |
+| Date | 2026-04-11 |
+| Issue | GH-320 (PR #335) |
+
+## Problem
+
+When contract-first decomposition generates interface contracts for multiple domains, those contracts may define the same named type with incompatible field types. For example:
+
+- Weather service contract: `WidgetPosition { x: int, y: int, width: int }`
+- Time widget contract: `WidgetPosition { x: string, y: string, width: string }`
+
+If both contracts reach implementation agents, each agent writes code that compiles against its own contract but fails at integration. The type mismatch is invisible until runtime.
+
+## Solution
+
+`check_contract_cross_file_consistency` in `src/integrations/contract_validation.py` scans all in-memory contract artifacts for type contradictions before decomposition proceeds. This is called **Invariant 5** and is the only hard gate in the contract-first pipeline.
+
+## How It Works
+
+The function receives the contract artifacts dict (keyed by domain name) and:
+
+1. **Filters to interface contracts** by filename pattern: keeps only artifacts where `"interface-contracts"` appears in the filename. This is a deliberate choice over filtering by `artifact_type` because the live generator emits `artifact_type="specification"` for interface contracts (a naming mismatch caught by Codex P1 review).
+
+2. **Extracts type definitions** from each contract document. Types are identified by common patterns: `class`/`interface`/`type`/`struct` declarations, TypeScript interfaces, Python dataclasses, and Pydantic models.
+
+3. **Cross-references types across domains**. When the same type name appears in multiple domains, the function compares field names and field types.
+
+4. **Reports contradictions**. A contradiction exists when two domains define a type with the same field name but different field types. Field presence differences (domain A has a field that domain B lacks) are not contradictions -- they indicate one contract is a superset, which is safe.
+
+## Gate Behavior
+
+```
+check_contract_cross_file_consistency(contract_artifacts)
+  ├── No contradictions found → returns success, pipeline continues
+  └── Contradictions found → returns failure with details
+        └── _try_contract_first_decomposition falls back to feature-based
+```
+
+The gate is binary: any type contradiction triggers fallback. There is no "partial accept" mode because a single type mismatch can cascade through the entire integration boundary.
+
+## Why Only Type Contradictions
+
+Invariant 5 checks only for type contradictions, not for:
+- Missing types (a domain references a type no other domain defines)
+- Missing verbs (contracts omit user-facing actions from the PRD)
+- Incomplete coverage (contracts do not cover all requirements)
+
+These are quality issues, not correctness failures. A missing verb produces a product that lacks a feature; a type contradiction produces a product where two modules cannot communicate. The first is fixable by the integration agent; the second is not.
+
+A verb-coverage gate was proposed and rejected during GH-320 review. A six-verb hard-coded checklist was too brittle (false positives on non-UI projects) and too destructive (discarding the 55/45 coordination win). See [Contract-First Decomposition](../../concepts/contract-first-decomposition.md) for the full rationale.
+
+## What Invariant 5 Does NOT Catch
+
+- **Semantic contradictions**: domain A says "temperature in Celsius" while domain B assumes Fahrenheit. These are natural-language disagreements that text parsing cannot detect reliably.
+- **Behavioral contradictions**: domain A expects synchronous calls while domain B provides async-only APIs. These require deeper analysis than type comparison.
+- **Schema shape differences**: domain A nests `position` inside `widget` while domain B uses a flat structure. Both may define `WidgetPosition` consistently but use it differently.
+
+These gaps are acknowledged. Invariant 5 catches the most common and most dangerous class of cross-contract error. Future invariants may extend coverage.
+
+## Implementation
+
+### Module
+
+`src/integrations/contract_validation.py`
+
+### Public API
+
+```python
+def check_contract_cross_file_consistency(
+    contract_artifacts: dict[str, list[dict[str, str]]]
+) -> tuple[bool, list[str]]:
+    """
+    Check generated contracts for type contradictions across domains.
+
+    Parameters
+    ----------
+    contract_artifacts : dict[str, list[dict[str, str]]]
+        Contract artifacts keyed by domain name. Each value is a list
+        of artifact dicts with "filename" and "content" keys.
+
+    Returns
+    -------
+    tuple[bool, list[str]]
+        (is_consistent, contradiction_descriptions).
+        is_consistent is True when no type contradictions are found.
+        contradiction_descriptions lists human-readable descriptions
+        of each contradiction found.
+    """
+```
+
+### Integration Point
+
+Called inside `_try_contract_first_decomposition` in `src/integrations/nlp_tools.py`, between contract generation and `decompose_by_contract`:
+
+```python
+is_consistent, contradictions = check_contract_cross_file_consistency(
+    contract_artifacts
+)
+if not is_consistent:
+    logger.warning(
+        "Contract cross-file inconsistency detected, "
+        "falling back to feature-based: %s",
+        contradictions,
+    )
+    return self._feature_based_fallback(...)
+```
+
+## Test Coverage
+
+`tests/unit/integrations/test_contract_validation.py` -- 7 tests:
+
+- Consistent contracts pass validation
+- Type contradictions are detected across two domains
+- Type contradictions are detected across three or more domains
+- Field presence differences (superset) do not trigger contradiction
+- Non-interface-contract artifacts are ignored
+- Empty contract artifacts pass validation
+- Single-domain contracts pass validation (no cross-reference possible)
+
+## See Also
+
+- [Contract-First Pipeline](../coordination/53-contract-first-pipeline.md) -- Full pipeline specification
+- [Contract-First Decomposition](../../concepts/contract-first-decomposition.md) -- Conceptual overview and decisions
+- [Quality Assurance](18-quality-assurance.md) -- Marcus's broader quality framework

--- a/docs/source/systems/quality/index.rst
+++ b/docs/source/systems/quality/index.rst
@@ -13,3 +13,4 @@ Systems for monitoring, testing, and quality assurance.
    30-testing-framework
    37-board-health-analyzer
    41-assignment-monitor
+   contract-validation

--- a/src/integrations/integration_verification.py
+++ b/src/integrations/integration_verification.py
@@ -18,7 +18,7 @@ import logging
 import re
 import uuid
 from datetime import datetime, timezone
-from typing import List, Optional
+from typing import Any, Dict, List, Optional
 
 from src.core.models import Priority, Task, TaskStatus
 from src.integrations.nlp_task_utils import TaskType
@@ -570,6 +570,7 @@ def enhance_project_with_integration(
     project_description: str,
     project_name: str = "Project",
     contract_file: Optional[str] = None,
+    functional_requirements: Optional[List[Dict[str, Any]]] = None,
 ) -> List[Task]:
     """
     Add integration verification task to project if appropriate.
@@ -590,6 +591,16 @@ def enhance_project_with_integration(
         decomposition is active (GH-320 PR 2). Forwarded to the
         integration task generator so the verification agent treats
         the contract as read-only authoritative.
+    functional_requirements : Optional[List[Dict[str, Any]]]
+        PRD functional requirements from ``PRDAnalysis``. When
+        provided (contract-first path, GH-320 task #64), each
+        requirement's ``name`` is appended to the integration task's
+        ``acceptance_criteria`` so the integration agent verifies
+        the user's original intent was realized — not just that the
+        code compiles and tests pass. This was the gap in Experiment
+        4 v2 where both agents built clean plumbing but no visible
+        UI because the integration agent had no reference back to
+        the user's "display weather" ask.
 
     Returns
     -------
@@ -605,6 +616,21 @@ def enhance_project_with_integration(
     )
 
     if task:
+        # Intent preservation (GH-320 task #64): append functional
+        # requirements as acceptance criteria so the integration agent
+        # verifies the user's original ask, not just code correctness.
+        if functional_requirements:
+            for req in functional_requirements:
+                req_name = req.get("name", "")
+                if req_name:
+                    task.acceptance_criteria.append(
+                        f"User requirement verified: {req_name}"
+                    )
+            logger.info(
+                f"Enriched integration task with "
+                f"{len(functional_requirements)} functional "
+                f"requirement(s) as acceptance criteria"
+            )
         logger.info(f"Added integration verification task: {task.name}")
         return tasks + [task]
 

--- a/src/integrations/nlp_tools.py
+++ b/src/integrations/nlp_tools.py
@@ -416,6 +416,7 @@ class NaturalLanguageProjectCreator(NaturalLanguageTaskCreator):
         }
         for domain_name, feature_ids in domain_groups.items():
             bullets = []
+            req_bullets = []
             for feature_id in feature_ids:
                 feature = feature_map.get(feature_id)
                 if feature is None:
@@ -423,8 +424,31 @@ class NaturalLanguageProjectCreator(NaturalLanguageTaskCreator):
                 name = feature.get("name", feature_id)
                 feature_desc = feature.get("description", "")
                 bullets.append(f"- {name}: {feature_desc}")
+                # Preserve the requirement name as a user-facing
+                # behavior the domain must support (GH-320 #64).
+                req_bullets.append(f"- {name}")
+            # Intent preservation (GH-320 #64): include the user-
+            # facing requirements in the domain description so the
+            # LLM sees them as constraints on the contract design,
+            # not just technical context. When the requirement says
+            # "Display weather temperature", the LLM should generate
+            # a contract that includes a rendering interface — not
+            # just an API endpoint. This was the root cause of the
+            # "locally rigorous, globally amnesiac" failure mode in
+            # Experiment 4 v2 where user-facing verbs were dropped
+            # across the requirements → domains → contracts chain.
+            req_section = ""
+            if req_bullets:
+                req_section = (
+                    "\n\nUser-Facing Requirements (the user expects "
+                    "to SEE or EXPERIENCE these behaviors — your "
+                    "contracts must define interfaces that make them "
+                    "visible, not just back-end plumbing):\n" + "\n".join(req_bullets)
+                )
             domains_for_contracts[domain_name] = (
-                f"Domain: {domain_name}\n\nFeatures:\n" + "\n".join(bullets)
+                f"Domain: {domain_name}\n\nFeatures:\n"
+                + "\n".join(bullets)
+                + req_section
             )
 
         try:
@@ -648,6 +672,12 @@ class NaturalLanguageProjectCreator(NaturalLanguageTaskCreator):
         # skipped and Phase B to use the pre-generated content.
         self._contract_first_design_content = stashed_design_content
 
+        # Intent preservation (GH-320 task #64): stash the functional
+        # requirements so ``create_project_from_description`` can
+        # forward them to ``enhance_project_with_integration``, which
+        # appends them as acceptance_criteria on the integration task.
+        self._contract_first_requirements = functional_reqs
+
         logger.info(
             f"[decomposer] contract_first: synthesized "
             f"{len(ghost_tasks)} design ghost(s) for "
@@ -845,11 +875,22 @@ class NaturalLanguageProjectCreator(NaturalLanguageTaskCreator):
                         contract_file_for_integration = candidate
                         break
 
+                # Intent preservation (GH-320 task #64): pass
+                # functional requirements to the integration task
+                # so it verifies the user's original ask. The
+                # requirements were stashed by
+                # _try_contract_first_decomposition; for the
+                # feature-based path the attribute is absent and
+                # defaults to None (no enrichment).
+                stashed_requirements = getattr(
+                    self, "_contract_first_requirements", None
+                )
                 safe_tasks = enhance_project_with_integration(
                     safe_tasks,
                     description,
                     project_name,
                     contract_file=contract_file_for_integration,
+                    functional_requirements=stashed_requirements,
                 )
                 logger.info(
                     "After integration enhancement: " f"{len(safe_tasks)} tasks"

--- a/src/integrations/nlp_tools.py
+++ b/src/integrations/nlp_tools.py
@@ -1168,6 +1168,11 @@ class NaturalLanguageProjectCreator(NaturalLanguageTaskCreator):
                 # mypy about the attribute's type.
                 if hasattr(self, "_contract_first_design_content"):
                     delattr(self, "_contract_first_design_content")
+                # Same cleanup for stashed requirements (Codex P1
+                # on PR #336: prevent stale requirements leaking
+                # into subsequent feature-based runs).
+                if hasattr(self, "_contract_first_requirements"):
+                    delattr(self, "_contract_first_requirements")
                 logger.info(
                     "[design_autocomplete] Phase A scheduled as " "background task"
                 )

--- a/tests/unit/integrations/test_contract_first_fallback.py
+++ b/tests/unit/integrations/test_contract_first_fallback.py
@@ -16,6 +16,7 @@ feature-based decomposition with a visible warning — never a silent
 fallback.
 """
 
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -1121,4 +1122,137 @@ class TestContractFirstDesignGhosts:
             f"Time impl should NOT depend on weather ghost (cross-domain). "
             f"Deps: {time_impl.dependencies}. "
             f"This is the Codex P2 over-linking regression."
+        )
+
+    @pytest.mark.asyncio
+    async def test_domain_descriptions_include_user_facing_requirements(
+        self,
+    ):
+        """
+        Upstream intent preservation (GH-320 task #64).
+
+        The domain descriptions passed to ``_generate_contracts_by_domain``
+        must include the user-facing requirements for that domain, not
+        just the feature names. This makes the LLM see "this domain must
+        support: Display weather temperature" alongside the domain's
+        technical description, so the generated contracts include
+        interfaces for user-visible behaviors (not just API shapes).
+
+        The test captures the ``domains`` argument passed to
+        ``_generate_contracts_by_domain`` and verifies it contains
+        the requirement names from the PRD analysis.
+        """
+        creator = _make_creator()
+        constraints = MagicMock()
+
+        prd_with_display = PRDAnalysis(
+            functional_requirements=[
+                {
+                    "id": "f1",
+                    "name": "Display current weather temperature",
+                    "description": "User sees temp on dashboard",
+                    "complexity": "simple",
+                },
+            ],
+            non_functional_requirements=[],
+            technical_constraints=[],
+            business_objectives=[],
+            user_personas=[],
+            success_metrics=[],
+            implementation_approach="iterative",
+            complexity_assessment={"level": "low"},
+            risk_factors=[],
+            confidence=0.8,
+            original_description="Build a dashboard with weather",
+        )
+
+        captured_domains: dict = {}
+
+        async def capture_domains(**kwargs: Any) -> dict:
+            captured_domains.update(kwargs.get("domains", {}))
+            return {
+                "Weather": {
+                    "artifacts": [
+                        {
+                            "filename": ("weather-interface-contracts.md"),
+                            "artifact_type": "specification",
+                            "content": "# Weather",
+                            "description": "weather",
+                            "relative_path": (
+                                "docs/specifications/" "weather-interface-contracts.md"
+                            ),
+                        }
+                    ],
+                    "decisions": [],
+                },
+            }
+
+        from datetime import datetime, timezone
+
+        from src.core.models import Priority, Task, TaskStatus
+
+        impl_task = Task(
+            id="contract_task_1",
+            name="Implement WeatherWidget",
+            description="weather impl",
+            status=TaskStatus.TODO,
+            priority=Priority.HIGH,
+            assigned_to=None,
+            created_at=datetime.now(timezone.utc),
+            updated_at=datetime.now(timezone.utc),
+            due_date=None,
+            estimated_hours=0.2,
+            labels=["contract_first", "implementation"],
+            source_context={
+                "contract_file": (
+                    "docs/specifications/" "weather-interface-contracts.md"
+                ),
+            },
+        )
+
+        with (
+            patch.object(
+                creator.prd_parser,
+                "_analyze_prd_deeply",
+                new_callable=AsyncMock,
+                return_value=prd_with_display,
+            ),
+            patch.object(
+                creator.prd_parser,
+                "_discover_domains",
+                new_callable=AsyncMock,
+                return_value={"Weather": ["f1"]},
+            ),
+            patch(
+                "src.integrations.nlp_tools._generate_contracts_by_domain",
+                new_callable=AsyncMock,
+                side_effect=capture_domains,
+            ),
+            patch.object(
+                creator.prd_parser,
+                "decompose_by_contract",
+                new_callable=AsyncMock,
+                return_value=[impl_task],
+            ),
+        ):
+            await creator._try_contract_first_decomposition(
+                description="Build a dashboard with weather",
+                project_name="Dashboard",
+                project_root="/tmp/test",  # nosec B108
+                constraints=constraints,
+                options={"decomposer": "contract_first"},
+            )
+
+        # The domain description must contain the requirement name
+        # so the LLM sees the user-facing intent when generating
+        # the interface contracts.
+        assert "Weather" in captured_domains, (
+            f"Expected Weather domain in captured domains, "
+            f"got: {list(captured_domains.keys())}"
+        )
+        weather_desc = captured_domains["Weather"]
+        assert "Display current weather temperature" in weather_desc, (
+            f"Domain description must include the functional "
+            f"requirement name so the LLM preserves user-facing "
+            f"intent in the generated contracts. Got:\n{weather_desc}"
         )

--- a/tests/unit/integrations/test_integration_verification.py
+++ b/tests/unit/integrations/test_integration_verification.py
@@ -801,3 +801,93 @@ class TestShouldAddIntegrationTask:
         assert not IntegrationTaskGenerator.should_add_integration_task(
             "Proof of concepts for three candidate architectures"
         )
+
+
+class TestIntegrationTaskFunctionalRequirements:
+    """
+    Test that functional requirements are attached to the integration
+    task as acceptance criteria (GH-320 task #64).
+
+    The integration agent already verifies the merged product — giving
+    it the full requirements list means it checks whether user intent
+    was realized, even if no individual impl task carries a specific
+    verb. This was the gap in Experiment 4 v2 where both agents built
+    API plumbing but no UI because no task carried "display" forward
+    and the integration agent had no reference back to the user's ask.
+    """
+
+    @pytest.fixture
+    def sample_tasks(self) -> list[Task]:
+        """Two implementation tasks for a dashboard project."""
+        return [
+            create_test_task(
+                "t1",
+                "Implement WeatherWidget",
+                labels=["contract_first", "implementation"],
+            ),
+            create_test_task(
+                "t2",
+                "Implement TimeWidget",
+                labels=["contract_first", "implementation"],
+            ),
+        ]
+
+    def test_requirements_appended_to_acceptance_criteria(
+        self, sample_tasks: list[Task]
+    ) -> None:
+        """
+        When functional_requirements are provided, each requirement's
+        name must appear in the integration task's acceptance_criteria.
+        """
+        from src.integrations.integration_verification import (
+            enhance_project_with_integration,
+        )
+
+        requirements = [
+            {"id": "f1", "name": "Display current weather temperature"},
+            {"id": "f2", "name": "Display current time with timezone"},
+        ]
+
+        result = enhance_project_with_integration(
+            sample_tasks,
+            "Build a dashboard",
+            "Dashboard",
+            functional_requirements=requirements,
+        )
+
+        integration_task = next((t for t in result if "integration" in t.labels), None)
+        assert integration_task is not None, "Integration task not created"
+
+        for req in requirements:
+            assert any(
+                req["name"] in criterion
+                for criterion in integration_task.acceptance_criteria
+            ), (
+                f"Requirement {req['name']!r} not found in "
+                f"acceptance_criteria: {integration_task.acceptance_criteria}"
+            )
+
+    def test_no_requirements_preserves_default_criteria(
+        self, sample_tasks: list[Task]
+    ) -> None:
+        """
+        When no functional_requirements are provided (feature-based
+        path), the integration task keeps its default acceptance
+        criteria unchanged.
+        """
+        from src.integrations.integration_verification import (
+            enhance_project_with_integration,
+        )
+
+        result = enhance_project_with_integration(
+            sample_tasks,
+            "Build a dashboard",
+            "Dashboard",
+        )
+
+        integration_task = next((t for t in result if "integration" in t.labels), None)
+        assert integration_task is not None
+        # Default criteria include "Tests run with full terminal output"
+        assert any("Tests run" in c for c in integration_task.acceptance_criteria)
+        # No requirement-specific criteria
+        assert not any("Display" in c for c in integration_task.acceptance_criteria)


### PR DESCRIPTION
## Summary
Closes the "locally rigorous, globally amnesiac" information gap from Experiment 4 v2. Two changes, ~50 LOC total.

### 1. Upstream: enrich domain descriptions with user-facing requirements
Domain descriptions passed to `_generate_contracts_by_domain` now include a "User-Facing Requirements" section listing the PRD functional requirements mapped to that domain. The LLM sees "this domain must support: Display weather temperature" alongside the technical feature list, so generated contracts include interfaces for user-visible behaviors — not just API shapes.

### 2. Downstream: enrich integration task with functional requirements
`enhance_project_with_integration` gains an optional `functional_requirements` parameter. Each requirement's name is appended as `"User requirement verified: {name}"` to the integration task's `acceptance_criteria`. The integration agent verifies whether the user's original intent was realized — not just that code compiles.

This was the gap in Experiment 4 v2: both agents built clean plumbing but no UI because the integration agent had no reference back to the user's "display weather" ask.

### Design choice
**Option A** (enrich integration task) over **Option B** (gap-task synthesis) per Kaia's recommendation. The integration task IS the detection mechanism. Gap tasks can be added later with empirical data if the integration agent can't remediate the gaps it finds.

## Test plan
- [x] `test_requirements_appended_to_acceptance_criteria` — verifies requirement names appear in acceptance_criteria
- [x] `test_no_requirements_preserves_default_criteria` — feature-based path unchanged
- [x] `test_domain_descriptions_include_user_facing_requirements` — captures the domains arg and verifies requirement names are present
- [x] Full unit sweep: 447/447 green, mypy clean

## What this completes
With this PR, the contract-first pipeline:
1. **Extracts** intent from the project description (PRD analysis)
2. **Carries** that intent through contract generation (this PR — requirements in domain descriptions)
3. **Catches** broken contracts before agents see them (Invariant 5, PR #335)
4. **Verifies** intent was realized at integration time (this PR — requirements as acceptance criteria)
5. **Observes** everything in Cato (design ghosts, PR #334)

🤖 Generated with [Claude Code](https://claude.com/claude-code)