### PR TITLE
fix(lease): widen initial lease defaults to match Phase 1 timeout

### DIFF
--- a/src/config/marcus_config.py
+++ b/src/config/marcus_config.py
@@ -237,13 +237,13 @@ class TaskLeaseSettings:
         Complexity-based duration multipliers
     """
 
-    default_hours: float = 0.025  # 90 seconds — fast failure detection
+    default_hours: float = 0.0667  # 240 seconds (matches Phase 1)
     max_renewals: int = 10
-    warning_hours: float = 0.01  # ~36 seconds before expiry
-    grace_period_minutes: float = 0.5  # 30 seconds grace
+    warning_hours: float = 0.0167  # ~60 seconds before expiry
+    grace_period_minutes: float = 1.0  # 60 seconds grace
     renewal_decay_factor: float = 0.9
-    min_lease_hours: float = 0.0167  # 60 seconds minimum
-    max_lease_hours: float = 0.0833  # 5 minutes maximum
+    min_lease_hours: float = 0.05  # 180 seconds minimum
+    max_lease_hours: float = 0.1  # 360 seconds maximum (matches Phase 3)
     stuck_threshold_renewals: int = 5
     enable_adaptive: bool = True
     silence_multiplier: float = 1.5

--- a/src/core/assignment_lease.py
+++ b/src/core/assignment_lease.py
@@ -178,15 +178,15 @@ class AssignmentLeaseManager:
         self,
         kanban_client: KanbanInterface,
         assignment_persistence: AssignmentPersistence,
-        default_lease_hours: float = 0.025,  # 90 seconds (aggressive)
+        default_lease_hours: float = 0.0667,  # 240s (matches Phase 1)
         max_renewals: int = 10,
         warning_threshold_hours: float = 0.0167,  # 1 min (was 1.0 hr)
         priority_multipliers: Optional[Dict[str, float]] = None,
         complexity_multipliers: Optional[Dict[str, float]] = None,
-        grace_period_minutes: float = 0.5,  # 30 seconds grace period
+        grace_period_minutes: float = 1.0,  # 60 seconds grace period
         renewal_decay_factor: float = 0.9,
-        min_lease_hours: float = 0.0167,  # Minimum 60 seconds
-        max_lease_hours: float = 0.0333,  # Maximum 120 seconds
+        min_lease_hours: float = 0.05,  # Minimum 180 seconds
+        max_lease_hours: float = 0.1,  # Maximum 360 seconds (Phase 3)
         stuck_task_threshold_renewals: int = 5,
         enable_adaptive_leases: bool = True,
         task_list: Optional[List[Task]] = None,


### PR DESCRIPTION
## Summary
PR #339 widened the progressive timeout phases (Phase 1: 180s, Phase 2: 240s, Phase 3: 300s, Phase 4: 180s), but experiment dashboard-v70 showed the fix wasn't taking effect on initial lease creation — leases were still expiring after ~120s. Root cause: \`create_lease\` uses a **separate code path** with its own \`min_lease_hours\` / \`max_lease_hours\` bounds that silently clamp the progressive timeout result.

## The silent clamp

\`\`\`python
# aggressive mode (default_lease_hours < 1.0):
lease_seconds, _ = self.calculate_adaptive_timeout(
    progress=0, update_count=0, has_recent_activity=False
)  # returns 180s after #339
base_hours = lease_seconds / 3600  # = 0.05

# Later:
base_hours = max(
    self.min_lease_hours,     # 0.0167 (60s)
    min(self.max_lease_hours, # 0.0333 (120s)  ← CEILING
        base_hours)           # 0.05 (180s)
)
# Result: 0.0333 = 120s, not 180s
\`\`\`

The max_lease_hours=0.0333 was set when the progressive Phase 1 was 60s+20s=80s. After #339 bumped Phase 1 to 180s+60s=240s, the ceiling should have been raised to match. It wasn't.

## Evidence from dashboard-v70
Task \`d4c523cc73614437bed6b051ed36d66e\` (Dashboard Composition Domain):

\`\`\`
23:38:19 assigned to agent_unicorn_2
23:40:19 first lease expiry (120s — NOT 240s)
23:43:57 renewed expiry (Phase 2 post-renewal: 240+60=300s, worked correctly)
23:47:29 recreated after recovery, updates=0, ~2 min later
23:52:12 reassigned to agent_unicorn_1
\`\`\`

Phase 2+ renewals worked fine because they called \`calculate_adaptive_timeout\` directly without the clamp. Only the initial lease (and post-recovery recreation) hit the 120s ceiling.

## Changes

| Constant | Before | After |
|----------|--------|-------|
| \`default_lease_hours\` | 0.025 (90s) | 0.0667 (240s, matches Phase 1) |
| \`min_lease_hours\` | 0.0167 (60s) | 0.05 (180s) |
| \`max_lease_hours\` | 0.0333 (120s) | 0.1 (360s, matches Phase 3) |
| \`grace_period_minutes\` | 0.5 (30s) | 1.0 (60s, matches progressive) |

## Test plan
- [x] Full unit sweep: 450/450 green, mypy clean
- [x] Existing lease tests pass \`default_lease_hours=4.0\` explicitly (conservative mode) so they're unaffected
- [ ] Next contract-first experiment: initial lease should survive >2 minute implementation bursts without expiring

## Related
- PR #339 — progressive timeout widening (this PR completes it)
- Experiment dashboard-v70 — surfaced the silent clamp

🤖 Generated with [Claude Code](https://claude.com/claude-code)