### PR TITLE
fix(#342, #343): recovery progress capture + stale completion guard

### DIFF
--- a/src/core/assignment_lease.py
+++ b/src/core/assignment_lease.py
@@ -412,6 +412,38 @@ class AssignmentLeaseManager:
                 return None
 
             if lease.is_expired:
+                # Capture the progress value before giving up on the
+                # renewal. The lease itself cannot be renewed — that
+                # decision belongs to the monitor — but
+                # ``lease.progress_percentage`` must reflect the
+                # agent's latest self-reported value so that when the
+                # monitor eventually recovers this lease, the
+                # recovery context carries the agent's actual
+                # progress, not a stale pre-expiry snapshot.
+                #
+                # Issue #342 (dashboard-v70 Epictetus audit): agent
+                # reported 25% then 50%, but the 50% report arrived
+                # after the lease silently expired. Without this
+                # capture, the progress value is dropped on the
+                # floor here and the recovering agent sees 25% (or
+                # 0%) and rebuilds from scratch — dashboard-v70
+                # produced 341 lines of ghost source + 506 lines of
+                # ghost tests this way.
+                #
+                # Guard with ``>`` so we never regress the snapshot
+                # (e.g. if two out-of-order late reports arrive, the
+                # higher value wins).
+                if progress > lease.progress_percentage:
+                    old_progress = lease.progress_percentage
+                    lease.progress_percentage = progress
+                    if message:
+                        lease.last_progress_message = message
+                    logger.info(
+                        f"Captured late progress on expired lease "
+                        f"{task_id}: {old_progress}% → {progress}% "
+                        f"(lease still expired, recovery context "
+                        f"will use the updated snapshot)"
+                    )
                 logger.warning(f"Cannot renew expired lease for task {task_id}")
                 return None
 
@@ -613,6 +645,17 @@ class AssignmentLeaseManager:
             # In worktree mode, each agent works on branch marcus/<agent_id>
             previous_branch = f"marcus/{lease.agent_id}"
 
+            # ``lease.progress_percentage`` reflects the agent's
+            # latest self-reported progress including late reports
+            # that arrived after the lease silently expired. The
+            # expired-lease progress capture in ``renew_lease``
+            # (Issue #342 fix) updates the snapshot even when the
+            # lease itself cannot be renewed, so recovery context
+            # now shows what the agent actually reached rather than
+            # a pre-expiry snapshot. Dashboard-v70's ghost code was
+            # caused by the pre-fix renew_lease path silently
+            # dropping the 50% progress report when the lease had
+            # already expired.
             recovery_info = RecoveryInfo(
                 recovered_at=now,
                 recovered_from_agent=lease.agent_id,

--- a/src/marcus_mcp/tools/task.py
+++ b/src/marcus_mcp/tools/task.py
@@ -1819,28 +1819,76 @@ async def report_task_progress(
                 else None
             )
             if assignment_task_id != task_id:
-                logger.warning(
-                    f"Rejecting stale completion: agent {agent_id} "
-                    f"tried to complete task {task_id} but is no "
-                    f"longer assigned to it (current assignment: "
-                    f"{assignment_task_id!r}). This usually means "
-                    f"the task's lease expired and was recovered to "
-                    f"another agent while the original agent was "
-                    f"still working on it. Issue #343."
-                )
-                return {
-                    "success": False,
-                    "status": "stale_completion",
-                    "error": "task_recovered",
-                    "message": (
-                        f"Cannot complete task {task_id}: your "
-                        f"assignment was revoked because the lease "
-                        f"expired and another agent took ownership. "
-                        f"Your work on branch marcus/{agent_id} is "
-                        f"preserved in git — request your next task "
-                        f"to continue."
-                    ),
-                }
+                # Cold-cache fallback (Codex P1 review on PR #345).
+                # ``state.agent_tasks`` is in-memory only and starts
+                # empty on Marcus restart; ``MarcusServer.__init__``
+                # never rehydrates it from ``assignment_persistence``.
+                # The lease manager, by contrast, IS rebuilt from
+                # persistence on startup (see
+                # ``AssignmentLeaseManager`` setup in server.py),
+                # which makes it the authoritative source for
+                # "who currently holds this task" across a restart.
+                #
+                # Without this fallback, every legitimate post-
+                # restart completion would be rejected as stale
+                # and the task would stay stuck in progress until
+                # manual intervention. We only declare the
+                # completion stale when BOTH in-memory cache AND
+                # the lease manager say this agent isn't the holder.
+                lease_holder_matches = False
+                if hasattr(state, "lease_manager") and state.lease_manager is not None:
+                    try:
+                        lease = state.lease_manager.active_leases.get(task_id)
+                        if (
+                            lease is not None
+                            and getattr(lease, "agent_id", None) == agent_id
+                        ):
+                            lease_holder_matches = True
+                            logger.info(
+                                f"Stale completion guard: in-memory "
+                                f"agent_tasks cache miss for "
+                                f"{agent_id}/{task_id}, but lease "
+                                f"manager confirms this agent holds "
+                                f"the task — allowing completion "
+                                f"(cold-cache recovery, Codex P1 on "
+                                f"PR #345)"
+                            )
+                    except Exception as lease_err:
+                        # Lease lookup failed for some reason.
+                        # Don't crash the completion path; fall
+                        # through to the rejection. Worst case the
+                        # agent retries and we eventually rebuild
+                        # the cache.
+                        logger.warning(
+                            f"Stale completion guard: lease lookup "
+                            f"raised for {task_id}: {lease_err}. "
+                            f"Falling through to default rejection."
+                        )
+
+                if not lease_holder_matches:
+                    logger.warning(
+                        f"Rejecting stale completion: agent {agent_id} "
+                        f"tried to complete task {task_id} but is no "
+                        f"longer assigned to it (current assignment: "
+                        f"{assignment_task_id!r}, lease holder check "
+                        f"failed). This usually means the task's "
+                        f"lease expired and was recovered to another "
+                        f"agent while the original agent was still "
+                        f"working on it. Issue #343."
+                    )
+                    return {
+                        "success": False,
+                        "status": "stale_completion",
+                        "error": "task_recovered",
+                        "message": (
+                            f"Cannot complete task {task_id}: your "
+                            f"assignment was revoked because the "
+                            f"lease expired and another agent took "
+                            f"ownership. Your work on branch "
+                            f"marcus/{agent_id} is preserved in git "
+                            f"— request your next task to continue."
+                        ),
+                    }
 
         # Update task in kanban
         update_data: Dict[str, Any] = {"progress": progress}

--- a/src/marcus_mcp/tools/task.py
+++ b/src/marcus_mcp/tools/task.py
@@ -1792,6 +1792,56 @@ async def report_task_progress(
             {"task_id": task_id, "status": status, "progress": progress},
         )
 
+        # Stale-completion guard for recovered tasks (Issue #343).
+        # When a task's lease expires and is recovered to another
+        # agent, the original agent's in-memory assignment is
+        # cleared by ``on_recovery_callback`` (see server.py:699).
+        # If that original agent keeps working locally and later
+        # reports completion (unaware their assignment was revoked),
+        # Marcus must reject the stale completion — otherwise we
+        # accept a second completion on a task another agent is
+        # actively working on, and the two implementations collide
+        # at merge time. Dashboard-v70 produced 341 lines of ghost
+        # source + 506 lines of ghost tests this way.
+        #
+        # The guard fires on ``status == "completed"`` only. Agents
+        # can still report intermediate progress even if their
+        # assignment was cleared — that path recreates the lease
+        # (see "No active lease" fallback below) rather than
+        # producing a persistent kanban mutation. Completions, by
+        # contrast, write DONE to kanban and trigger branch merges
+        # that cannot be undone cleanly.
+        if status == "completed":
+            current_assignment = state.agent_tasks.get(agent_id)
+            assignment_task_id = (
+                getattr(current_assignment, "task_id", None)
+                if current_assignment is not None
+                else None
+            )
+            if assignment_task_id != task_id:
+                logger.warning(
+                    f"Rejecting stale completion: agent {agent_id} "
+                    f"tried to complete task {task_id} but is no "
+                    f"longer assigned to it (current assignment: "
+                    f"{assignment_task_id!r}). This usually means "
+                    f"the task's lease expired and was recovered to "
+                    f"another agent while the original agent was "
+                    f"still working on it. Issue #343."
+                )
+                return {
+                    "success": False,
+                    "status": "stale_completion",
+                    "error": "task_recovered",
+                    "message": (
+                        f"Cannot complete task {task_id}: your "
+                        f"assignment was revoked because the lease "
+                        f"expired and another agent took ownership. "
+                        f"Your work on branch marcus/{agent_id} is "
+                        f"preserved in git — request your next task "
+                        f"to continue."
+                    ),
+                }
+
         # Update task in kanban
         update_data: Dict[str, Any] = {"progress": progress}
 

--- a/tests/unit/core/test_assignment_lease.py
+++ b/tests/unit/core/test_assignment_lease.py
@@ -938,3 +938,198 @@ class TestRecoveryHandoffDualWrite:
             assert "marcus/agent-001" in instructions  # Branch name
             assert "git merge" in instructions  # Merge dead agent's branch
             assert "30%" in instructions
+
+
+class TestExpiredLeaseProgressCapture:
+    """
+    Regression coverage for Issue #342: ``renew_lease`` must
+    capture the agent's latest progress value even when the lease
+    itself cannot be renewed because it's already expired.
+
+    The dashboard-v70 Epictetus audit documented the exact bug:
+    agent reported 25% then 50%, but the 50% report arrived after
+    the lease silently expired. Without this capture, the renewal
+    path returned None and dropped the 50% value on the floor.
+    When the monitor later recovered the lease, the recovery
+    context showed 25% (or 0% after a false-positive recovery
+    recreated the lease), causing the recovering agent to rebuild
+    from scratch — 341 lines of ghost source + 506 lines of ghost
+    tests.
+
+    The fix: on the ``lease.is_expired`` path in ``renew_lease``,
+    still mutate ``lease.progress_percentage`` to reflect the
+    agent's latest self-reported value before returning None.
+    Guarded with ``>`` so the snapshot never regresses.
+    """
+
+    @pytest.fixture
+    def mock_kanban_client(self):
+        client = Mock()
+        client.update_task_status = AsyncMock()
+        client.update_task = AsyncMock()
+        client.add_comment = AsyncMock()
+        return client
+
+    @pytest.fixture
+    def mock_persistence(self):
+        persistence = Mock()
+        persistence.get_assignment = AsyncMock(return_value=None)
+        persistence.save_assignment = AsyncMock()
+        persistence.remove_assignment = AsyncMock()
+        persistence.load_assignments = AsyncMock(return_value={})
+        return persistence
+
+    @pytest.fixture
+    def lease_manager(self, mock_kanban_client, mock_persistence):
+        return AssignmentLeaseManager(
+            mock_kanban_client, mock_persistence, default_lease_hours=4.0
+        )
+
+    @pytest.fixture
+    def real_task(self):
+        """
+        Use a REAL ``Task`` dataclass, not a Mock. This is the
+        anti-trap from the first attempt at this fix: Mock()
+        allowed inventing a ``progress`` attribute that the real
+        Task class doesn't have, so the fix looked right in test
+        but was a no-op in production. Real Task objects here
+        force the fix to work on fields that actually exist.
+        """
+        return Task(
+            id="task-342",
+            name="Stale Progress Task",
+            description="Test",
+            status=TaskStatus.IN_PROGRESS,
+            priority=Priority.HIGH,
+            estimated_hours=0.1,
+            dependencies=[],
+            labels=[],
+            assigned_to="agent-001",
+            created_at=datetime.now(timezone.utc),
+            updated_at=datetime.now(timezone.utc),
+            due_date=None,
+        )
+
+    async def _insert_expired_lease(
+        self,
+        manager: AssignmentLeaseManager,
+        task_id: str,
+        agent_id: str,
+        initial_progress: int,
+    ) -> AssignmentLease:
+        """
+        Insert an expired lease directly into ``active_leases`` so
+        ``renew_lease`` has a target to operate on. Bypasses
+        ``create_lease`` to avoid tripping on side effects.
+        """
+        now = datetime.now(timezone.utc)
+        expired = AssignmentLease(
+            task_id=task_id,
+            agent_id=agent_id,
+            assigned_at=now - timedelta(hours=2),
+            lease_expires=now - timedelta(hours=1),
+            last_renewed=now - timedelta(hours=2),
+            progress_percentage=initial_progress,
+        )
+        async with manager.lease_lock:
+            manager.active_leases[task_id] = expired
+        return expired
+
+    @pytest.mark.asyncio
+    async def test_expired_lease_renewal_captures_higher_progress(self, lease_manager):
+        """
+        The bug scenario: lease expired at 25%, agent reports 50%
+        via renew_lease. Renewal fails (lease is expired), but the
+        50% value must land in ``lease.progress_percentage`` so
+        the later recovery carries it forward.
+        """
+        expired = await self._insert_expired_lease(
+            lease_manager, "task-342", "agent-001", initial_progress=25
+        )
+
+        result = await lease_manager.renew_lease(
+            task_id="task-342", progress=50, message="halfway"
+        )
+
+        # Renewal still fails — lease can't be un-expired
+        assert result is None
+        # But the snapshot was updated
+        assert expired.progress_percentage == 50
+        assert expired.last_progress_message == "halfway"
+
+    @pytest.mark.asyncio
+    async def test_expired_lease_renewal_does_not_regress_progress(self, lease_manager):
+        """
+        Defensive: if a late report arrives out of order with a
+        lower progress value, we must not regress the snapshot.
+        Only strictly-higher values replace the stored progress.
+        """
+        expired = await self._insert_expired_lease(
+            lease_manager, "task-342", "agent-001", initial_progress=50
+        )
+
+        result = await lease_manager.renew_lease(
+            task_id="task-342", progress=30, message="out of order"
+        )
+
+        assert result is None
+        assert expired.progress_percentage == 50  # preserved
+        # last_progress_message also preserved because we only
+        # update it when progress actually advances
+        assert expired.last_progress_message != "out of order"
+
+    @pytest.mark.asyncio
+    async def test_recovery_uses_captured_progress_after_expired_update(
+        self, lease_manager, real_task
+    ):
+        """
+        End-to-end: agent reports 50% via renew_lease on an
+        expired lease, then the monitor recovers the lease. The
+        recovery context must show 50%, not the original 25%.
+        This closes the dashboard-v70 loop.
+        """
+        # 1. Lease is expired at 25%
+        expired = await self._insert_expired_lease(
+            lease_manager, "task-342", "agent-001", initial_progress=25
+        )
+
+        # 2. Agent reports late progress — renewal fails, but
+        #    capture fires.
+        await lease_manager.renew_lease(
+            task_id="task-342", progress=50, message="halfway"
+        )
+        assert expired.progress_percentage == 50
+
+        # 3. Monitor recovers the lease. Recovery context must
+        #    reflect the captured value, not the stale snapshot.
+        with patch.object(lease_manager, "_find_task", return_value=real_task):
+            success = await lease_manager.recover_expired_lease(expired)
+
+        assert success
+        assert real_task.recovery_info is not None
+        assert real_task.recovery_info.previous_progress == 50
+        assert "50%" in real_task.recovery_info.instructions
+        # Lease history also tracks the corrected value
+        assert lease_manager.lease_history[-1]["progress_at_recovery"] == 50
+
+    @pytest.mark.asyncio
+    async def test_expired_lease_renewal_still_returns_none(self, lease_manager):
+        """
+        The capture must not accidentally un-expire the lease.
+        ``renew_lease`` still returns None on expired leases so
+        the caller's "No active lease" fallback path triggers
+        correctly. This test pins that contract explicitly so a
+        future refactor doesn't silently start returning the
+        lease object from the expired branch.
+        """
+        expired = await self._insert_expired_lease(
+            lease_manager, "task-342", "agent-001", initial_progress=0
+        )
+
+        result = await lease_manager.renew_lease(
+            task_id="task-342", progress=80, message="almost done"
+        )
+
+        assert result is None
+        assert expired.is_expired  # lease remains expired
+        assert expired.progress_percentage == 80  # but progress captured

--- a/tests/unit/core/test_progressive_timeout.py
+++ b/tests/unit/core/test_progressive_timeout.py
@@ -43,14 +43,27 @@ def mock_assignment_persistence():
 
 @pytest.fixture
 def lease_manager_aggressive(mock_kanban_client, mock_assignment_persistence):
-    """Create lease manager with aggressive (90s) initial timeout."""
+    """Create lease manager with the post-#341 progressive timeouts.
+
+    Updated 2026-04-13 to match the widened defaults that ship in
+    ``src/config/marcus_config.py::TaskLeaseSettings``. PR #341
+    raised these from the pre-experiment-66 values
+    (90s default / 60s min / 120s max / 30s grace) to the values
+    below after experiment 66 evidence showed agents routinely
+    go 2+ minutes between progress reports during contract-first
+    implementation bursts. The fixture name "aggressive" is now
+    a misnomer relative to the original — these are still the
+    aggressive end of the spectrum compared to the conservative
+    multi-hour leases used in non-experiment mode, but the
+    absolute values are higher.
+    """
     return AssignmentLeaseManager(
         kanban_client=mock_kanban_client,
         assignment_persistence=mock_assignment_persistence,
-        default_lease_hours=0.025,  # 90 seconds
-        grace_period_minutes=0.5,  # 30 seconds
-        min_lease_hours=0.0167,  # 60 seconds minimum
-        max_lease_hours=0.0333,  # 120 seconds maximum
+        default_lease_hours=0.0667,  # 240 seconds (Phase 1 default)
+        grace_period_minutes=1.0,  # 60 seconds
+        min_lease_hours=0.05,  # 180 seconds minimum (Phase 1/4)
+        max_lease_hours=0.1,  # 360 seconds maximum (Phase 3 ceiling)
     )
 
 
@@ -58,36 +71,43 @@ class TestProgressiveTimeoutCalculation:
     """Test progressive timeout calculation based on task state."""
 
     def test_calculate_timeout_no_updates_yet(self, lease_manager_aggressive):
-        """Test timeout for task with no progress updates yet (strict)."""
-        # Phase 1: No updates - strict timeout
+        """Test timeout for task with no progress updates yet (Phase 1).
+
+        Updated 2026-04-13 to match the widened defaults from PR #341,
+        which raised the progressive timeout phases after experiment 66
+        showed agents routinely go 2+ minutes between progress reports
+        during implementation bursts.
+        """
+        # Phase 1: No updates - widened to accommodate setup time
         lease_seconds, grace_seconds = (
             lease_manager_aggressive.calculate_adaptive_timeout(
                 progress=0, update_count=0, has_recent_activity=False
             )
         )
 
-        # Should use strict timeout (60s)
-        assert lease_seconds == 60
-        assert grace_seconds == 20
-        assert lease_seconds + grace_seconds == 80  # Total: 80s
+        # Phase 1 widened: 180s + 60s = 240s total (was 60s + 20s)
+        assert lease_seconds == 180
+        assert grace_seconds == 60
+        assert lease_seconds + grace_seconds == 240
 
     def test_calculate_timeout_first_update(self, lease_manager_aggressive):
-        """Test timeout after first progress update (moderate)."""
-        # Phase 2: First update received - moderate timeout
+        """Test timeout after first progress update (Phase 2)."""
+        # Phase 2: First update received
         lease_seconds, grace_seconds = (
             lease_manager_aggressive.calculate_adaptive_timeout(
                 progress=5, update_count=1, has_recent_activity=True
             )
         )
 
-        # Should use moderate timeout (90s)
-        assert lease_seconds == 90
-        assert grace_seconds == 30
-        assert lease_seconds + grace_seconds == 120  # Total: 2 min
+        # Phase 2 widened: 240s + 60s = 300s total (was 90s + 30s)
+        assert lease_seconds == 240
+        assert grace_seconds == 60
+        assert lease_seconds + grace_seconds == 300
 
     def test_calculate_timeout_good_progress(self, lease_manager_aggressive):
-        """Test timeout for task with good progress (25-75%) (conservative)."""
-        # Phase 3: Task making progress - conservative timeout
+        """Test timeout for task with good progress (25-75%, Phase 3)."""
+        # Phase 3: Task making progress — most generous timeout
+        # because this is where implementation bursts happen.
         for progress in [25, 40, 50, 65, 74]:
             lease_seconds, grace_seconds = (
                 lease_manager_aggressive.calculate_adaptive_timeout(
@@ -95,14 +115,16 @@ class TestProgressiveTimeoutCalculation:
                 )
             )
 
-            # Should use conservative timeout (120s)
-            assert lease_seconds == 120
-            assert grace_seconds == 30
-            assert lease_seconds + grace_seconds == 150  # Total: 2.5 min
+            # Phase 3 widened: 300s + 60s = 360s total (was 120s + 30s)
+            assert lease_seconds == 300
+            assert grace_seconds == 60
+            assert lease_seconds + grace_seconds == 360
 
     def test_calculate_timeout_near_completion(self, lease_manager_aggressive):
-        """Test timeout for task near completion (>75%) (fast)."""
-        # Phase 4: Near completion - fast detection
+        """Test timeout for task near completion (>75%, Phase 4)."""
+        # Phase 4: Near completion - faster recovery if it stalls
+        # right before the finish line, but still tolerant of the
+        # final test/commit cycle.
         for progress in [75, 80, 90, 95]:
             lease_seconds, grace_seconds = (
                 lease_manager_aggressive.calculate_adaptive_timeout(
@@ -110,10 +132,10 @@ class TestProgressiveTimeoutCalculation:
                 )
             )
 
-            # Should use fast timeout (60s)
-            assert lease_seconds == 60
-            assert grace_seconds == 15
-            assert lease_seconds + grace_seconds == 75  # Total: 1.25 min
+            # Phase 4 widened: 180s + 30s = 210s total (was 60s + 15s)
+            assert lease_seconds == 180
+            assert grace_seconds == 30
+            assert lease_seconds + grace_seconds == 210
 
 
 class TestCadenceBasedRecovery:
@@ -354,40 +376,47 @@ class TestAggressiveVsConservativeTimeouts:
         # Check lease duration
         duration = (lease.lease_expires - lease.assigned_at).total_seconds()
 
-        # Phase 1 (unproven agent) = 60s, clamped to min_lease_hours (60s)
-        assert 55 <= duration <= 65  # Allow small variance
+        # Phase 1 (unproven agent) widened by PR #341 to 180s,
+        # bounded by min_lease_hours/max_lease_hours from the
+        # config. Allow a 5s window for setup variance.
+        assert 175 <= duration <= 185
 
-        # Total recovery time with grace (60s lease + 30s grace = 90s)
+        # Total recovery time = lease + grace period.
         total_recovery = duration + (lease_manager_aggressive.grace_period_minutes * 60)
 
-        # Should be ~90 seconds total for unproven agents
-        assert 85 <= total_recovery <= 95
+        # Phase 1 widened: ~180s lease + 60s grace = ~240s total.
+        assert 235 <= total_recovery <= 245
 
     def test_progressive_timeout_phases(self, lease_manager_aggressive):
-        """Test all four phases of progressive timeout."""
-        # Phase 1: Unproven (60s + 20s = 80s)
+        """Test all four phases of progressive timeout.
+
+        Updated 2026-04-13 for the widened defaults from PR #341.
+        Phase totals: P1=240s, P2=300s, P3=360s, P4=210s. The
+        relative ordering (P4 < P1 < P2 < P3) is preserved.
+        """
+        # Phase 1: Unproven (180s + 60s = 240s)
         p1_lease, p1_grace = lease_manager_aggressive.calculate_adaptive_timeout(
             progress=0, update_count=0, has_recent_activity=False
         )
-        assert p1_lease + p1_grace == 80
+        assert p1_lease + p1_grace == 240
 
-        # Phase 2: Working (90s + 30s = 120s)
+        # Phase 2: Working (240s + 60s = 300s)
         p2_lease, p2_grace = lease_manager_aggressive.calculate_adaptive_timeout(
             progress=10, update_count=1, has_recent_activity=True
         )
-        assert p2_lease + p2_grace == 120
+        assert p2_lease + p2_grace == 300
 
-        # Phase 3: Proven (120s + 30s = 150s)
+        # Phase 3: Proven (300s + 60s = 360s)
         p3_lease, p3_grace = lease_manager_aggressive.calculate_adaptive_timeout(
             progress=50, update_count=3, has_recent_activity=True
         )
-        assert p3_lease + p3_grace == 150
+        assert p3_lease + p3_grace == 360
 
-        # Phase 4: Finishing (60s + 15s = 75s)
+        # Phase 4: Finishing (180s + 30s = 210s)
         p4_lease, p4_grace = lease_manager_aggressive.calculate_adaptive_timeout(
             progress=85, update_count=5, has_recent_activity=True
         )
-        assert p4_lease + p4_grace == 75
+        assert p4_lease + p4_grace == 210
 
         # Verify progression: P4 < P1 < P2 < P3
         # (Finishing < Unproven < Working < Proven)
@@ -507,19 +536,20 @@ class TestDataDrivenDecisions:
         assert lease_seconds + grace_seconds >= 118  # Covers 75th percentile
 
     def test_aggressive_timeout_accepts_calculated_risk(self, lease_manager_aggressive):
-        """Test that 90s timeout accepts ~36% false positive risk."""
-        # At 90s timeout:
-        # - Coverage: 64% of normal updates
-        # - False positive: 36% risk
-        # - But with smart checks, reduces to ~5-8%
+        """Test that the Phase 2 timeout is the calculated-risk value.
 
+        Updated 2026-04-13 for the widened defaults from PR #341.
+        Phase 2 was 90s (64th percentile of update intervals), now
+        240s after experiment 66 evidence showed agents routinely
+        go 2+ minutes between progress reports during contract-
+        first implementation bursts. The new value trades a smaller
+        false-positive rate for slightly slower failure detection,
+        which is the right tradeoff at the observed cadence.
+        """
         lease_seconds, _ = lease_manager_aggressive.calculate_adaptive_timeout(
             progress=10, update_count=1, has_recent_activity=True
         )
 
-        # 90s = 64th percentile (from data analysis)
-        assert lease_seconds == 90
-
-        # This is aggressive by design:
-        # User can't spawn agents on demand, so fast detection
-        # is more important than avoiding false positives
+        # Phase 2 widened to accommodate 116-120s implementation
+        # gaps observed in experiments 66-70.
+        assert lease_seconds == 240

--- a/tests/unit/marcus_mcp/test_stale_completion_guard.py
+++ b/tests/unit/marcus_mcp/test_stale_completion_guard.py
@@ -215,3 +215,120 @@ class TestStaleCompletionGuard:
         assert result["status"] == "stale_completion"
         assert result["error"] == "task_recovered"
         state.kanban_client.update_task.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_cold_cache_completion_allowed_via_lease_manager(
+        self,
+    ) -> None:
+        """
+        Codex P1 regression on PR #345.
+
+        ``state.agent_tasks`` is in-memory only and starts EMPTY on
+        Marcus restart. ``MarcusServer.__init__`` never rehydrates
+        it from ``assignment_persistence``. The lease manager, on
+        the other hand, IS rebuilt from persistence on startup.
+
+        Without a fallback path, every legitimate post-restart
+        completion gets rejected as stale because the in-memory
+        cache is empty. The fix: when ``agent_tasks`` misses, also
+        consult ``state.lease_manager.active_leases`` — if a lease
+        for this task exists AND is held by this agent, allow the
+        completion. The lease manager is the authoritative
+        cross-restart source of truth for "who holds this task."
+
+        This test simulates a restart by giving the state an EMPTY
+        ``agent_tasks`` but a lease manager with a matching lease.
+        Pre-fix this would reject; post-fix it must allow.
+        """
+        state = _make_state_with_assignment("agent-001", task_id=None)
+        # Cold cache: no in-memory entry for this agent
+        assert state.agent_tasks == {}
+
+        # But the lease manager has a lease (rebuilt from
+        # persistence on restart in the real system)
+        fake_lease = Mock()
+        fake_lease.agent_id = "agent-001"
+        fake_lease.task_id = "task-343"
+        state.lease_manager = Mock()
+        state.lease_manager.active_leases = {"task-343": fake_lease}
+
+        result = await report_task_progress(
+            agent_id="agent-001",
+            task_id="task-343",
+            status="completed",
+            progress=100,
+            message="finished",
+            state=state,
+        )
+
+        # Completion proceeds — the cold-cache fallback recognized
+        # this agent as the legitimate lease holder.
+        assert result["success"] is True
+        # Kanban DONE write happened (completion path ran).
+        state.kanban_client.update_task.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_cold_cache_rejects_when_lease_held_by_different_agent(
+        self,
+    ) -> None:
+        """
+        Cold cache fallback must NOT allow a completion when the
+        lease manager says a DIFFERENT agent holds the task. This
+        is the actual stale-completion case post-recovery: lease
+        manager has been updated to the new holder, in-memory
+        cache may or may not have been cleared, original agent
+        tries to complete — both checks correctly reject.
+        """
+        state = _make_state_with_assignment("agent-001", task_id=None)
+
+        fake_lease = Mock()
+        fake_lease.agent_id = "different-agent"  # NOT the requester
+        fake_lease.task_id = "task-343"
+        state.lease_manager = Mock()
+        state.lease_manager.active_leases = {"task-343": fake_lease}
+
+        result = await report_task_progress(
+            agent_id="agent-001",
+            task_id="task-343",
+            status="completed",
+            progress=100,
+            message="finished",
+            state=state,
+        )
+
+        assert result["success"] is False
+        assert result["status"] == "stale_completion"
+        state.kanban_client.update_task.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_cold_cache_lease_lookup_error_falls_through_to_reject(
+        self,
+    ) -> None:
+        """
+        If the lease manager lookup raises (e.g. corrupt state,
+        race during reload), don't crash the completion path —
+        fall through to the default rejection. The agent will
+        retry, the cache will eventually rebuild, and the next
+        attempt will succeed.
+        """
+        state = _make_state_with_assignment("agent-001", task_id=None)
+
+        broken_lease_manager = Mock()
+        # Make .active_leases.get raise
+        broken_active_leases = Mock()
+        broken_active_leases.get = Mock(side_effect=RuntimeError("corrupt"))
+        broken_lease_manager.active_leases = broken_active_leases
+        state.lease_manager = broken_lease_manager
+
+        result = await report_task_progress(
+            agent_id="agent-001",
+            task_id="task-343",
+            status="completed",
+            progress=100,
+            message="finished",
+            state=state,
+        )
+
+        # Falls through to rejection — defensive, not a crash.
+        assert result["success"] is False
+        assert result["status"] == "stale_completion"

--- a/tests/unit/marcus_mcp/test_stale_completion_guard.py
+++ b/tests/unit/marcus_mcp/test_stale_completion_guard.py
@@ -1,0 +1,217 @@
+"""
+Unit tests for the stale-completion guard in report_task_progress.
+
+Regression coverage for Issue #343 (simultaneous completion guard
+for recovered tasks). When a task's lease expires and is recovered
+to another agent, the original agent's in-memory assignment is
+cleared. If that original agent keeps working locally and later
+reports completion — unaware their assignment was revoked — Marcus
+must reject the stale completion. Otherwise we accept a second
+completion on a task another agent is actively working on, and the
+two implementations collide at merge time.
+
+Dashboard-v70 Epictetus audit: 341 lines of ghost source + 506
+lines of ghost tests were produced by exactly this race.
+"""
+
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from src.core.models import Priority, TaskAssignment
+from src.marcus_mcp.tools.task import report_task_progress
+
+pytestmark = pytest.mark.unit
+
+
+def _make_assignment(task_id: str, agent_id: str = "agent-001") -> TaskAssignment:
+    """Build a minimal TaskAssignment for state.agent_tasks."""
+    return TaskAssignment(
+        task_id=task_id,
+        task_name="Test Task",
+        description="desc",
+        instructions="do it",
+        estimated_hours=0.1,
+        priority=Priority.HIGH,
+        dependencies=[],
+        assigned_to=agent_id,
+        assigned_at=datetime.now(timezone.utc),
+        due_date=None,
+    )
+
+
+def _make_state_with_assignment(agent_id: str, task_id: str | None) -> Mock:
+    """
+    Build a Mock state with agent_tasks populated appropriately.
+    ``task_id=None`` simulates the post-recovery state where the
+    agent's assignment was cleared by on_recovery_callback.
+    """
+    state = Mock()
+    state.initialize_kanban = AsyncMock()
+    state.kanban_client = Mock()
+    state.kanban_client.get_all_tasks = AsyncMock(return_value=[])
+    state.kanban_client.update_task = AsyncMock()
+    state.kanban_client.update_task_progress = AsyncMock()
+    # _load_workspace_state is consulted by _merge_agent_branch_to_main
+    # via ``if ws_state and "project_root" in ws_state``. Returning None
+    # short-circuits the merge path so the test stays focused on the
+    # guard rather than git worktree behavior.
+    state.kanban_client._load_workspace_state = Mock(return_value=None)
+    state.agent_tasks = {}
+    if task_id is not None:
+        state.agent_tasks[agent_id] = _make_assignment(task_id, agent_id)
+    state.project_tasks = []
+    state.lease_manager = None
+    state.agent_status = {}
+    state.assignment_persistence = Mock()
+    state.assignment_persistence.remove_assignment = AsyncMock()
+    state.memory = None
+    state.provider = "sqlite"
+    state.code_analyzer = None
+    state.subtask_manager = None
+    return state
+
+
+class TestStaleCompletionGuard:
+    """
+    ``report_task_progress`` must reject stale completions from
+    agents whose assignments were cleared by recovery callback.
+    """
+
+    @pytest.mark.asyncio
+    async def test_rejects_completion_when_assignment_cleared(self) -> None:
+        """
+        Original agent had task X, recovery cleared agent_tasks,
+        agent still tries to complete X → rejected with
+        stale_completion status.
+        """
+        state = _make_state_with_assignment("agent-001", task_id=None)
+
+        result = await report_task_progress(
+            agent_id="agent-001",
+            task_id="task-343",
+            status="completed",
+            progress=100,
+            message="finished",
+            state=state,
+        )
+
+        assert result["success"] is False
+        assert result["status"] == "stale_completion"
+        assert result["error"] == "task_recovered"
+        assert "task-343" in result["message"]
+        assert "marcus/agent-001" in result["message"]
+        # Kanban must NOT have been written — the whole point of
+        # the guard is to prevent the double-completion side
+        # effects. The completion path never runs.
+        state.kanban_client.update_task.assert_not_called()
+        state.kanban_client.update_task_progress.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_rejects_completion_when_agent_reassigned_to_different_task(
+        self,
+    ) -> None:
+        """
+        Original agent was recovered off task X, then picked up
+        task Y. They still try to complete X from their local
+        work → rejected. The agent IS in agent_tasks but their
+        assignment points to a different task.
+        """
+        state = _make_state_with_assignment("agent-001", task_id="task-Y")
+
+        result = await report_task_progress(
+            agent_id="agent-001",
+            task_id="task-X",
+            status="completed",
+            progress=100,
+            message="finished",
+            state=state,
+        )
+
+        assert result["success"] is False
+        assert result["status"] == "stale_completion"
+        assert "task-X" in result["message"]
+        state.kanban_client.update_task.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_allows_completion_when_assignment_matches(self) -> None:
+        """
+        Legitimate completion: agent is assigned to task X and
+        reports completion on X → guard passes, completion flows
+        through the normal pipeline.
+        """
+        state = _make_state_with_assignment("agent-001", task_id="task-343")
+        # Skip the validation gate by returning no matching task
+        # from get_all_tasks (task_filter sees no task, skips).
+        # This isolates the guard test from validator logic.
+
+        result = await report_task_progress(
+            agent_id="agent-001",
+            task_id="task-343",
+            status="completed",
+            progress=100,
+            message="finished",
+            state=state,
+        )
+
+        # Kanban WAS written — guard did not block the path
+        state.kanban_client.update_task.assert_called_once()
+        # Final response surfaces success
+        assert result["success"] is True
+
+    @pytest.mark.asyncio
+    async def test_allows_progress_update_even_when_assignment_cleared(
+        self,
+    ) -> None:
+        """
+        The guard fires only on status=completed. Intermediate
+        progress updates (25%, 50%, etc.) from an agent whose
+        assignment was cleared still flow through — the "No
+        active lease" fallback in the lease path recreates the
+        lease, so the agent can continue working. Only
+        completions are blocked, because completions have
+        irreversible kanban side effects (DONE status + branch
+        merge).
+        """
+        state = _make_state_with_assignment("agent-001", task_id=None)
+
+        result = await report_task_progress(
+            agent_id="agent-001",
+            task_id="task-343",
+            status="in_progress",
+            progress=50,
+            message="halfway",
+            state=state,
+        )
+
+        # Progress update goes through
+        assert result["success"] is True
+        state.kanban_client.update_task.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_rejects_completion_when_no_assignment_for_agent(
+        self,
+    ) -> None:
+        """
+        Agent is completely unknown to state.agent_tasks (never
+        registered or was removed entirely) → reject with the
+        stale-completion response. This covers the "recovery
+        callback cleared our entry" path where ``agent_tasks[agent_id]``
+        is missing rather than pointing to a different task.
+        """
+        state = _make_state_with_assignment("other-agent", task_id="task-X")
+
+        result = await report_task_progress(
+            agent_id="agent-001",
+            task_id="task-343",
+            status="completed",
+            progress=100,
+            message="finished",
+            state=state,
+        )
+
+        assert result["success"] is False
+        assert result["status"] == "stale_completion"
+        assert result["error"] == "task_recovered"
+        state.kanban_client.update_task.assert_not_called()


### PR DESCRIPTION
## Summary

Two coordination bugs caught by the dashboard-v70 Epictetus audit. Combined, they produced 341 lines of ghost source + 506 lines of ghost tests when agent_unicorn_1 rebuilt the Dashboard Composition domain from scratch after a recovery handoff that misreported the previous agent's progress, then agent_unicorn_2 completed the same task out from under them.

Closes #342 — Recovery context uses stale lease-expiry snapshot
Closes #343 — Simultaneous completion guard for recovered tasks

## Issue #342 — Expired-lease progress capture

### Root cause
`renew_lease` silently dropped progress updates when the lease had already expired:

```python
if lease.is_expired:
    logger.warning(f"Cannot renew expired lease for task {task_id}")
    return None  # progress value discarded
```

Dashboard-v70 race:
1. Agent reports 25% → renew_lease succeeds, snapshot = 25
2. Progressive timeout (240s) passes without monitor tick
3. Agent reports 50% → `lease.is_expired` → returns None → **50% dropped**
4. Monitor fires recovery → uses `lease.progress_percentage = 25`
5. Recovering agent sees "previous agent reached 25%" and rebuilds from scratch

### Fix
On the `lease.is_expired` branch in `renew_lease`, still mutate `lease.progress_percentage` before returning None. The lease itself cannot be renewed — that decision belongs to the monitor — but the snapshot must reflect the agent's latest self-reported value so recovery carries it forward.

Guarded with `>` so the snapshot never regresses if out-of-order late reports arrive.

### Why not query kanban?
An earlier attempt queried kanban for authoritative progress via `getattr(kanban_task, "progress", None)`. That was a **silent no-op in production**: the `Task` dataclass has no `progress` field (`src/core/models.py:253-292`), and SQLite kanban stores progress only as a comment. The tests passed against a `Mock()` that accepted any invented attribute. Catching that hazard was the lesson — when mocking external objects in correctness tests, use a real fixture. The renew_lease capture fix works against real Task objects with no Mock attribute trap.

## Issue #343 — Stale completion guard

### Root cause
`report_task_progress` accepted completions from any agent calling with a task_id, regardless of whether that agent still held the assignment. When a task's lease expired and was recovered to another agent, `on_recovery_callback` cleared `state.agent_tasks[agent_id]`, but the original agent — still working locally, unaware their assignment was revoked — could finish and call `report_task_progress(status="completed")`. Marcus accepted the second completion, wrote DONE to kanban, triggered a branch merge.

### Fix
Inline guard in `report_task_progress`: when `status == "completed"`, compare `state.agent_tasks.get(agent_id).task_id` to the incoming task_id. If they don't match, reject with a `stale_completion` response.

Guard fires ONLY on completion. Intermediate progress updates still flow through — only completions have irreversible kanban side effects (DONE status + branch merge) and need to be blocked.

Subtask handling verified: `state.agent_tasks[agent_id].task_id` is set from `optimal_task.id` in `request_next_task`, and subtasks pass through the same assignment path with their own IDs. The equality check works identically for top-level tasks and subtasks.

## Relationship to PR #341 (widened leases)

PR #341 widened progressive lease timeouts from 60s → 240s, dramatically reducing lease-expiration frequency. But wider leases don't eliminate expirations — when one DOES fire, these two bugs still bit. #341 is the frequency fix; #342/#343 are the correctness fix for when recovery actually runs.

## Test plan

- [x] `TestExpiredLeaseProgressCapture` (4 tests) — real Task fixtures, no Mock attribute trap:
  - Expired renewal captures higher progress into snapshot
  - Expired renewal does not regress on out-of-order lower progress
  - End-to-end: captured progress flows into RecoveryInfo after monitor recovery
  - Expired renewal still returns None so fallback path triggers correctly
- [x] `TestStaleCompletionGuard` (5 tests):
  - Assignment cleared → completion rejected, kanban untouched
  - Agent reassigned to different task → reject, kanban untouched
  - Assignment matches → completion proceeds normally
  - Progress update still flows even when assignment cleared
  - Unknown agent_id → reject with stale_completion response
- [x] Full unit suite: 482 passing
- [x] mypy clean on `src/core/assignment_lease.py` and `src/marcus_mcp/tools/task.py`
- [x] black + isort clean

## Known related gap (out of scope for this PR)

The "No active lease" fallback in `report_task_progress` (task.py:2099) still recreates a lease for any agent reporting intermediate progress on a recovered task. A stale agent can keep accumulating state until they try to complete — at which point the #343 guard kicks in. A cleaner design would reject intermediate progress too when the agent has been recovered, but that's a pre-existing hole orthogonal to #342/#343 and should be a separate issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)