### PR TITLE
refactor(smoke): agent-declared start_command replaces stack detection

### DIFF
--- a/src/integrations/integration_verification.py
+++ b/src/integrations/integration_verification.py
@@ -462,18 +462,79 @@ dead code (remove it), a public API (document it in README), or \
 an integration gap (wire the consumer up)? Do not pass this step \
 with unaccounted-for routes.
 
-   **NOTE ON MARCUS-SIDE VERIFICATION**: Marcus runs an \
-independent product smoke test (ProductSmokeVerifier) AFTER you \
-mark this task complete. It runs the stack's build and start \
-commands as subprocess calls, verifies the product actually \
-boots, and catches missing-file and build-failure bugs \
-deterministically. If ProductSmokeVerifier fails, Marcus will \
-re-open this task with the real stderr output attached as a \
-blocker — regardless of what you reported. Your self-attested \
-verification is a first pass; Marcus's subprocess checks are \
-ground truth. Plan accordingly: don't mark complete without \
-actually running the commands yourself, because Marcus will \
-catch you if you skip them.
+   **MARCUS-SIDE VERIFICATION (REQUIRED DECLARATION)**: \
+When you mark this task complete, you MUST declare a \
+``start_command`` parameter on the ``report_task_progress`` call. \
+Marcus runs the declared command as an independent subprocess \
+check AFTER you mark the task complete. It is how Marcus \
+verifies — without trusting your self-report — that the \
+deliverable actually starts. This is strictly enforced: \
+integration-task completions that omit ``start_command`` are \
+rejected.
+
+   **How to declare it:**
+
+   For a one-shot command (build, type check, CLI --help, etc.) \
+— declare only ``start_command``. Marcus will run it with a 60s \
+timeout and require exit code 0:
+
+   ```python
+   report_task_progress(
+       task_id=task_id,
+       status="completed",
+       progress=100,
+       message="integration verified",
+       start_command="npm run build",
+   )
+   ```
+
+   For a long-running server (uvicorn, flask, node server, etc.) \
+— declare BOTH ``start_command`` (how to start it) AND \
+``readiness_probe`` (how to detect it's actually serving). Marcus \
+will start the server in the background, poll the probe once per \
+second for up to 15 seconds, and pass when the probe returns exit \
+0. Marcus always kills the background process afterward:
+
+   ```python
+   report_task_progress(
+       task_id=task_id,
+       status="completed",
+       progress=100,
+       message="integration verified",
+       start_command="uvicorn main:app --port 8000",
+       readiness_probe="curl -f http://localhost:8000/health",
+   )
+   ```
+
+   **Choosing the right values**: the ``start_command`` is \
+whatever YOU ran to verify the deliverable works. You already \
+ran it during Phase 1 verification. Write the EXACT command \
+that worked for you, including any flags. Marcus runs commands \
+with ``CI=true`` set in the environment — if your command needs \
+interactive prompts it will fail in Marcus's subprocess. Use \
+non-interactive flags where needed.
+
+   **What if there's no meaningful start_command?** There \
+always is. Some examples by stack:
+
+   - **Static HTML**: ``start_command="test -f index.html"`` \
+(file existence check — Marcus runs it, exit 0 passes)
+   - **Library with no entry point**: \
+``start_command="python -c 'import mypackage'"`` (import smoke)
+   - **Pure documentation project**: \
+``start_command="test -d docs && test -f README.md"``
+   - **Data pipeline with no server**: \
+``start_command="python -m mypipeline --dry-run"``
+
+   If you genuinely cannot think of a smoke command, that is a \
+signal you don't have a clear definition of "done" for this \
+deliverable — stop and ask yourself what "working" means, then \
+write the command that proves it.
+
+   **Fabrication check**: Marcus runs the command you declare. \
+If you invent a command that sounds reasonable but doesn't \
+actually work, Marcus will catch you. Declare the command you \
+actually ran.
 
 ## PHASE 2: FIX
 

--- a/src/integrations/product_smoke.py
+++ b/src/integrations/product_smoke.py
@@ -1,62 +1,110 @@
 """
-Marcus-side product smoke verification (Layer 1).
+Marcus-side deliverable verification — agent-declared start command.
 
 Deterministic, subprocess-based verification that the assembled
-product actually builds and boots. Runs AFTER the integration
+deliverable actually starts and works. Runs AFTER the integration
 verification agent marks its task complete — machine checks beat
 agent self-reports when they conflict.
 
-Catches the classes of bug that v71 exposed:
+Design
+------
+The previous version of this module auto-detected software stacks
+(Node, Python, Go, Rust, Java) and ran canonical build commands per
+stack. That baked software-stack assumptions into Marcus and duplicated
+PR #337's ``_validate_runtime`` layer (both ran pytest against the same
+Python code). Dashboard-v71 taught us that "tests pass" is the wrong
+check — the right check is "does the thing actually start and serve
+its purpose."
 
-1. **Product doesn't build** — missing required files (``public/index.html``
-   for React projects, ``__init__.py`` for Python packages), import errors
-   the unit tests didn't exercise, bad configuration. ``npm run build`` /
-   ``pytest`` / equivalent catches these in seconds.
+This version removes auto-detection entirely. The integration agent
+declares how to start their deliverable as part of ``report_task_progress``
+when marking the task complete. Marcus enforces that the declared command
+exits 0. The agent owns stack knowledge; Marcus owns enforcement.
 
-2. **Product doesn't boot** — build succeeds but the entry point crashes.
-   Optional start-command verification with bounded timeout.
+The contract
+------------
+Integration verification tasks must declare a ``start_command`` on
+completion. Optionally, they may also declare a ``readiness_probe``
+for long-running servers.
 
-3. **Silent integration gaps** — build + boot succeed but the consumer
-   never calls the producer. This layer does NOT catch those (that's
-   Layer 2 prompt guidance + Epictetus audit). This layer is scoped to
-   "does the thing build and start."
+**Mode 1 — one-shot (no readiness_probe):**
+    Marcus runs ``start_command`` with a 60s timeout. Pass requires
+    exit code 0. Timeout or non-zero exit is a failure. Examples:
 
-Why not just trust the integration verification agent?
-------------------------------------------------------
-The integration agent is LLM-driven. Its work is guided by prompt
-instructions, which can be skipped, misread, or fabricated. Machine
-verification via subprocess is the ground-truth check that cannot be
-talked around. This is the same pattern as PR #337's runtime-test
-precedence over LLM validation: when prompt-level and machine-level
-checks disagree, the machine wins.
+    - ``npm run build``
+    - ``python -m mypackage --help``
+    - ``tsc --noEmit``
+    - ``go build ./...``
 
-Extensibility
--------------
-New stack support is a new ``StackVerifier`` subclass plus a line
-in ``_pick_verifier``. No orchestrator rewrite. Initial support:
-Node (npm + react-scripts/Vite/plain), Python (pip + pytest,
-optional FastAPI/Flask start). Go, Rust, Java, .NET are stubs that
-detect the stack but no-op the verification (add in follow-up).
+**Mode 2 — server+probe (with readiness_probe):**
+    Marcus starts ``start_command`` in the background, then polls
+    ``readiness_probe`` once per second for up to 15 seconds. Pass
+    requires the probe to return exit 0 at least once before the
+    timeout. Fail if the probe never passes or the background process
+    exits non-zero before the probe succeeds. Marcus always kills the
+    background process before returning. Examples:
+
+    - start: ``uvicorn main:app --port 8000``,
+      probe: ``curl -f http://localhost:8000/health``
+    - start: ``node server.js``,
+      probe: ``curl -f http://localhost:3000/``
+    - start: ``flask run --port 5000``,
+      probe: ``curl -f http://localhost:5000/``
+
+Why two fields instead of one
+-----------------------------
+A single ``start_command`` that combines start-and-probe forces the
+agent to write shell plumbing: background the server, sleep, probe,
+capture exit code, kill the background process, propagate the probe's
+exit code through the ``timeout`` wrapper. Different agents write
+different buggy versions. ``timeout`` returns 124 on timeout (not 0),
+so even a healthy server running cleanly for 10s looks like a failure
+without extra bash handling.
+
+Splitting into ``start_command`` + ``readiness_probe`` moves the
+orchestration into Marcus where it can be tested once and reused. The
+agent declares intent; Marcus runs it correctly.
+
+Why no auto-detection
+---------------------
+Auto-detection sounds helpful but creates three problems:
+
+1. **Silent pass on unknown stacks.** Stacks Marcus doesn't recognize
+   return "no stack detected, success=True" which defeats the purpose
+   of the gate — every non-software project would pass.
+
+2. **Software bias.** Auto-detection hardcodes package.json,
+   pyproject.toml, Cargo.toml, etc. Marcus is supposed to be the
+   coordination layer for all agent work (marketing, research, content,
+   data pipelines — per docs/marcus-validation.md). A detection layer
+   that only knows code stacks tells every non-code deliverable that
+   Marcus doesn't understand it.
+
+3. **The agent knows better.** The integration agent just finished
+   verifying the deliverable manually. They already know the exact
+   command to start it because they ran it. Asking them to declare it
+   is a smaller ask than asking Marcus to guess.
 
 References
 ----------
-Dashboard-v71 Epictetus audit (2026-04-13) — the experiment that
-revealed the need for this layer. Agent reported integration
-complete; ``npm start`` later failed with "Could not find a
-required file. Name: index.html". This module exists so that
-failure mode never ships again.
+- Dashboard-v71 Epictetus audit (2026-04-13) — the experiment that
+  revealed the need for this layer. Missing ``public/index.html`` would
+  have been caught by ``npm run build``, which the agents never ran.
+- Simon decision 967555f6 — locked the two-field design after
+  considering single-command (shell wizardry), exit-0-or-alive (hung
+  server false pass), and single-field approaches.
 """
 
 from __future__ import annotations
 
 import asyncio
-import json
 import logging
-import shutil
+import os
+import shlex
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Dict, List, Literal, Optional
+from typing import Any, Dict, List, Optional
 
 logger = logging.getLogger(__name__)
 
@@ -65,21 +113,29 @@ logger = logging.getLogger(__name__)
 # Configuration constants
 # ---------------------------------------------------------------------------
 
-# Subprocess timeouts — bounded so a hung command doesn't block the
-# completion pipeline. Values tuned for MVP; revisit if we see legit
-# builds take longer.
-DEFAULT_INSTALL_TIMEOUT_SECONDS = 300  # 5 min — npm install can be slow
-DEFAULT_BUILD_TIMEOUT_SECONDS = 180  # 3 min
-DEFAULT_TEST_TIMEOUT_SECONDS = 180  # 3 min
-DEFAULT_START_TIMEOUT_SECONDS = 30  # 30s — if it hasn't started, it's wedged
+# One-shot command timeout. Covers npm run build, pip install + entry
+# point, cargo build, etc. Larger projects may exceed this — revisit if
+# we see legitimate one-shot builds timing out.
+DEFAULT_ONE_SHOT_TIMEOUT_SECONDS = 60
 
-# Output truncation — very long build logs are unhelpful in blocker
-# messages. Keep the last N chars so the tail (where the real error
-# lives) survives.
+# Server readiness window. How long we wait for a server to become
+# ready AFTER starting it in the background. Polled every
+# ``READINESS_POLL_INTERVAL_SECONDS``.
+DEFAULT_READINESS_TIMEOUT_SECONDS = 15
+READINESS_POLL_INTERVAL_SECONDS = 1.0
+
+# Probe command timeout. Each individual probe invocation (e.g. a
+# ``curl`` call) should complete quickly; if a probe takes longer than
+# this we treat it as a failed poll and move on to the next attempt.
+PROBE_INVOCATION_TIMEOUT_SECONDS = 3.0
+
+# Grace period for killing the background process after readiness
+# passes or fails. SIGTERM first, SIGKILL if the process ignores it.
+KILL_GRACE_PERIOD_SECONDS = 2.0
+
+# Output truncation — long logs aren't useful in blocker messages.
+# Keep the tail so the actual error survives.
 MAX_OUTPUT_CHARS = 8192
-
-# Stack types we know about
-StackType = Literal["node", "python", "go", "rust", "java"]
 
 
 # ---------------------------------------------------------------------------
@@ -88,65 +144,35 @@ StackType = Literal["node", "python", "go", "rust", "java"]
 
 
 @dataclass
-class DetectedStack:
-    """A stack discovered in the project root by ``StackDetector``.
-
-    Attributes
-    ----------
-    stack_type : StackType
-        Which language/framework family.
-    root_path : Path
-        Directory containing the stack's root marker. May be a
-        subdirectory of the project root for nested stacks (e.g.
-        ``src/frontend`` alongside ``src/backend``).
-    marker_file : Path
-        The file that identified the stack (``package.json``,
-        ``pyproject.toml``, etc.).
-    metadata : Dict[str, Any]
-        Parsed contents of the marker file (or key fields from it) —
-        used by verifiers to pick the right build/start commands.
-        For Node, contains ``scripts`` dict. For Python, may contain
-        detected framework hints.
-    """
-
-    stack_type: StackType
-    root_path: Path
-    marker_file: Path
-    metadata: Dict[str, Any] = field(default_factory=dict)
-
-
-@dataclass
 class VerificationStep:
-    """Result of one subprocess invocation during verification.
+    """Result of a single subprocess invocation during verification.
 
     Attributes
     ----------
     name : str
-        Human-readable step name (``"install"``, ``"build"``,
-        ``"test"``, ``"start"``).
-    command : List[str]
-        argv-form command that was executed. First element is the
-        program; subsequent are arguments. Never a shell string —
-        always argv to avoid shell injection and quoting bugs.
-    cwd : Path
-        Working directory the command ran in.
+        Human-readable step name: ``"start_command"``, ``"readiness_probe"``,
+        or ``"missing_start_command"``.
+    command : str
+        The command as it was declared by the agent. Stored as a string
+        (not argv) because agents declare it as a shell-style string and
+        we run it through ``shlex.split`` at execution time.
     exit_code : Optional[int]
-        Process return code. None if the process was killed by
-        timeout before completing.
+        Process return code. ``None`` if the process was killed by
+        timeout or never executed.
     stdout : str
-        Captured stdout, truncated to ``MAX_OUTPUT_CHARS`` from the
-        tail so errors at the end survive.
+        Captured stdout, tail-truncated to ``MAX_OUTPUT_CHARS``.
     stderr : str
-        Captured stderr, truncated similarly.
+        Captured stderr, tail-truncated similarly.
     duration_seconds : float
-        Wall-clock time from spawn to termination.
+        Wall-clock time from spawn to termination. ``0.0`` for steps
+        that didn't execute.
     success : bool
-        True iff ``exit_code == 0`` and the command wasn't killed.
+        True iff the step met its contract (exit 0 for one-shots;
+        probe returned 0 for server modes).
     """
 
     name: str
-    command: List[str]
-    cwd: Path
+    command: str
     exit_code: Optional[int]
     stdout: str
     stderr: str
@@ -156,40 +182,27 @@ class VerificationStep:
 
 @dataclass
 class ProductSmokeResult:
-    """Aggregate result of a full ProductSmokeVerifier run.
+    """Aggregate result of a deliverable verification run.
 
     Attributes
     ----------
     success : bool
-        True iff every verification step succeeded AND at least one
-        stack was detected. Empty-stack result is also ``True``
-        (nothing to verify = nothing to fail) but carries a
-        ``skipped_reason`` to distinguish it from a real pass.
-    detected_stacks : List[DetectedStack]
-        Stacks that were found. Empty list with ``success=True``
-        means no detectable stack (e.g. a pure-markdown doc project).
+        True iff all steps succeeded. ``False`` if any step failed or
+        if the required ``start_command`` was missing.
     steps : List[VerificationStep]
-        Every subprocess invocation in execution order, for audit
-        and debugging.
+        Every subprocess step in execution order. May contain one step
+        (one-shot mode) or two (server+probe mode).
     failure_summary : Optional[str]
-        One-line description of the first failure, if any. Suitable
-        for log headers.
+        One-line human-readable description of the first failure.
     blocker_message : Optional[str]
-        Ready-to-paste blocker description for the integration
-        agent. Includes the failing step name, command, and the
-        tail of stderr. None on success.
-    skipped_reason : Optional[str]
-        Non-None when verification was skipped (no detected stack,
-        no build script, etc.). Still a pass, but the caller may
-        want to log it.
+        Ready-to-paste blocker description for the integration agent.
+        Includes the failing step, the command, and the tail of stderr.
     """
 
     success: bool
-    detected_stacks: List[DetectedStack]
-    steps: List[VerificationStep]
+    steps: List[VerificationStep] = field(default_factory=list)
     failure_summary: Optional[str] = None
     blocker_message: Optional[str] = None
-    skipped_reason: Optional[str] = None
 
     def to_dict(self) -> Dict[str, Any]:
         """Serialize for logging/persistence.
@@ -197,23 +210,14 @@ class ProductSmokeResult:
         Returns
         -------
         Dict[str, Any]
-            JSON-ready dictionary.
+            JSON-ready dictionary with truncated outputs.
         """
         return {
             "success": self.success,
-            "detected_stacks": [
-                {
-                    "stack_type": s.stack_type,
-                    "root_path": str(s.root_path),
-                    "marker_file": str(s.marker_file),
-                }
-                for s in self.detected_stacks
-            ],
             "steps": [
                 {
                     "name": st.name,
                     "command": st.command,
-                    "cwd": str(st.cwd),
                     "exit_code": st.exit_code,
                     "stdout_tail": st.stdout[-1024:] if st.stdout else "",
                     "stderr_tail": st.stderr[-1024:] if st.stderr else "",
@@ -223,75 +227,101 @@ class ProductSmokeResult:
                 for st in self.steps
             ],
             "failure_summary": self.failure_summary,
-            "skipped_reason": self.skipped_reason,
         }
 
 
 # ---------------------------------------------------------------------------
-# Subprocess helper
+# Subprocess helpers
 # ---------------------------------------------------------------------------
 
 
-async def _run_subprocess(
-    name: str,
-    command: List[str],
-    cwd: Path,
-    timeout_seconds: float,
-    env: Optional[Dict[str, str]] = None,
+def _truncate_output(text: str) -> str:
+    """Tail-truncate captured output to MAX_OUTPUT_CHARS."""
+    if len(text) <= MAX_OUTPUT_CHARS:
+        return text
+    dropped = len(text) - MAX_OUTPUT_CHARS
+    return f"...[truncated {dropped} chars]...\n" + text[-MAX_OUTPUT_CHARS:]
+
+
+def _build_subprocess_env() -> Dict[str, str]:
+    """Environment for subprocess invocations.
+
+    Inherits the parent env so PATH, HOME, and framework-specific
+    variables propagate, then forces ``CI=true`` to disable interactive
+    prompts (react-scripts, Vite, etc.). Order matters: parent env
+    first, override second, so our override wins regardless of any
+    existing ``CI`` value in the parent. See Codex P2 review on PR #346.
+    """
+    return {**os.environ, "CI": "true"}
+
+
+async def _run_one_shot(
+    command: str, cwd: Path, timeout_seconds: float
 ) -> VerificationStep:
-    """Run a subprocess with bounded timeout, return a VerificationStep.
+    """Run a command and wait for it to exit.
+
+    Mode 1 of the verification contract. The command must exit 0
+    within ``timeout_seconds`` to succeed.
 
     Parameters
     ----------
-    name : str
-        Step name for the returned record.
-    command : List[str]
-        argv-form command. First element must be an executable name
-        that resolves via PATH or an absolute path.
+    command : str
+        Shell-style command string declared by the agent (e.g.
+        ``"npm run build"``). Parsed via ``shlex.split`` to argv form
+        before invocation, so no shell interpretation happens.
     cwd : Path
-        Working directory.
+        Working directory for the subprocess.
     timeout_seconds : float
-        Maximum wall-clock time. Process is killed on timeout and
-        the step is marked ``success=False`` with ``exit_code=None``.
-    env : Optional[Dict[str, str]]
-        Environment overrides. None means inherit.
+        Maximum wall-clock time. Process is killed on timeout and the
+        step is marked ``success=False``.
 
     Returns
     -------
     VerificationStep
         Structured result. Never raises on command failure — returns
-        the step with ``success=False``. Raises only on programmer
-        errors (bad cwd, invalid argv type).
-
-    Notes
-    -----
-    Uses ``asyncio.create_subprocess_exec`` (not ``_shell``) so the
-    command list goes through argv directly and no shell interpretation
-    happens. This avoids injection hazards from any dynamic component
-    of the command and makes quoting deterministic across platforms.
+        the step with ``success=False``.
     """
-    start = time.monotonic()
+    start_time = time.monotonic()
+
+    try:
+        argv = shlex.split(command)
+    except ValueError as exc:
+        return VerificationStep(
+            name="start_command",
+            command=command,
+            exit_code=None,
+            stdout="",
+            stderr=f"Could not parse command as shell-style string: {exc}",
+            duration_seconds=0.0,
+            success=False,
+        )
+    if not argv:
+        return VerificationStep(
+            name="start_command",
+            command=command,
+            exit_code=None,
+            stdout="",
+            stderr="start_command parsed to empty argv",
+            duration_seconds=0.0,
+            success=False,
+        )
+
     try:
         proc = await asyncio.create_subprocess_exec(
-            *command,
+            *argv,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
             cwd=str(cwd),
-            env=env,
+            env=_build_subprocess_env(),
         )
     except FileNotFoundError as exc:
-        # The command binary isn't on PATH. Return a failed step with
-        # a clear message — a missing binary is a legitimate failure
-        # mode (agent forgot to install Node, agent used wrong tool
-        # name) and the agent should see the actual error.
         return VerificationStep(
-            name=name,
+            name="start_command",
             command=command,
-            cwd=cwd,
             exit_code=None,
             stdout="",
-            stderr=f"Command not found: {command[0]!r} ({exc})",
-            duration_seconds=time.monotonic() - start,
+            stderr=f"Command not found: {argv[0]!r} ({exc})",
+            duration_seconds=time.monotonic() - start_time,
             success=False,
         )
 
@@ -300,725 +330,491 @@ async def _run_subprocess(
             proc.communicate(), timeout=timeout_seconds
         )
     except asyncio.TimeoutError:
-        # Kill the hung process so we don't leak it. Double-kill
-        # pattern (terminate then kill) for shells that ignore TERM.
-        try:
-            proc.terminate()
-            await asyncio.wait_for(proc.wait(), timeout=2.0)
-        except (asyncio.TimeoutError, ProcessLookupError):
-            try:
-                proc.kill()
-            except ProcessLookupError:
-                pass
-        duration = time.monotonic() - start
+        await _kill_process(proc)
         return VerificationStep(
-            name=name,
+            name="start_command",
             command=command,
-            cwd=cwd,
             exit_code=None,
             stdout="",
             stderr=(
                 f"Timed out after {timeout_seconds:.0f}s — process killed. "
-                f"Check for hung test / infinite loop / missing "
-                f"interactivity prompt."
+                f"Declare a readiness_probe if this is a long-running "
+                f"server, or shorten the start_command if this is a "
+                f"one-shot that ran long."
             ),
-            duration_seconds=duration,
+            duration_seconds=time.monotonic() - start_time,
             success=False,
         )
 
-    duration = time.monotonic() - start
-    stdout = stdout_bytes.decode("utf-8", errors="replace")
-    stderr = stderr_bytes.decode("utf-8", errors="replace")
-
-    # Truncate from the TAIL so the error at the end of a long log
-    # survives. head-truncation would drop the failure message.
-    if len(stdout) > MAX_OUTPUT_CHARS:
-        stdout = (
-            "...[truncated " + str(len(stdout) - MAX_OUTPUT_CHARS) + " chars]...\n"
-        ) + stdout[-MAX_OUTPUT_CHARS:]
-    if len(stderr) > MAX_OUTPUT_CHARS:
-        stderr = (
-            "...[truncated " + str(len(stderr) - MAX_OUTPUT_CHARS) + " chars]...\n"
-        ) + stderr[-MAX_OUTPUT_CHARS:]
-
+    stdout = _truncate_output(stdout_bytes.decode("utf-8", errors="replace"))
+    stderr = _truncate_output(stderr_bytes.decode("utf-8", errors="replace"))
     exit_code = proc.returncode
     return VerificationStep(
-        name=name,
+        name="start_command",
         command=command,
-        cwd=cwd,
         exit_code=exit_code,
         stdout=stdout,
         stderr=stderr,
-        duration_seconds=duration,
+        duration_seconds=time.monotonic() - start_time,
         success=exit_code == 0,
     )
 
 
-# ---------------------------------------------------------------------------
-# Stack detection
-# ---------------------------------------------------------------------------
-
-
-# Directories to skip during stack detection — node_modules and
-# friends produce false positives because they contain package.json
-# files for their dependencies. Virtual envs and build output also
-# noise up the scan.
-_SKIP_DIRS = {
-    "node_modules",
-    ".venv",
-    "venv",
-    "env",
-    ".env",  # some projects use .env as venv dir
-    "__pycache__",
-    ".git",
-    "dist",
-    "build",
-    "target",
-    ".next",
-    ".nuxt",
-    "coverage",
-    ".pytest_cache",
-    ".mypy_cache",
-    ".ruff_cache",
-    ".tox",
-}
-
-# Maximum depth to walk during detection — deep nesting is almost
-# always a sign of hitting node_modules-like directories we should
-# have skipped. 5 is generous for realistic project layouts.
-_MAX_DETECT_DEPTH = 5
-
-
-class StackDetector:
-    """Walk a project root and identify the technology stacks present.
-
-    A "stack" is a chunk of code organized around a well-known root
-    marker file — ``package.json`` for Node, ``pyproject.toml``
-    (or ``setup.py``/``requirements.txt``) for Python, ``Cargo.toml``
-    for Rust, ``go.mod`` for Go, ``pom.xml``/``build.gradle`` for
-    Java. Multiple stacks in one repo (e.g. a full-stack app with
-    frontend+backend) produce multiple ``DetectedStack`` records.
-
-    Notes
-    -----
-    Detection is filesystem-based, not git-based. It runs against
-    the actual files on disk in the project root. This means:
-
-    - Files listed in ``.gitignore`` are still detected (which is
-      correct for our purposes — we verify the checked-out state).
-    - Stacks in subdirectories are found if they carry their own
-      marker files (``src/frontend/package.json`` produces a Node
-      stack at ``src/frontend``).
-    - The walk skips ``node_modules``, virtual envs, and build
-      output dirs to avoid false positives from vendor files.
-    """
-
-    @staticmethod
-    def detect(project_root: Path) -> List[DetectedStack]:
-        """Walk the project root and return all detected stacks.
-
-        Parameters
-        ----------
-        project_root : Path
-            Repository root. Must exist and be a directory.
-
-        Returns
-        -------
-        List[DetectedStack]
-            Stacks found. Empty list is a valid result for projects
-            with no recognized technology (e.g. pure-markdown docs).
-
-        Raises
-        ------
-        ValueError
-            If ``project_root`` is not a directory.
-        """
-        if not project_root.is_dir():
-            raise ValueError(f"project_root is not a directory: {project_root}")
-
-        stacks: List[DetectedStack] = []
-        # Breadth-first-ish walk: we want shallower stacks first so
-        # the ordering is predictable for callers.
-        queue: List[tuple[Path, int]] = [(project_root, 0)]
-        while queue:
-            path, depth = queue.pop(0)
-            if depth > _MAX_DETECT_DEPTH:
-                continue
-            try:
-                entries = list(path.iterdir())
-            except (PermissionError, OSError) as exc:
-                logger.debug(f"Skipping {path}: {exc}")
-                continue
-
-            files = {e.name: e for e in entries if e.is_file()}
-            subdirs = [e for e in entries if e.is_dir() and e.name not in _SKIP_DIRS]
-
-            # Check markers at this level
-            for detector in _MARKER_DETECTORS:
-                stack = detector(path, files)
-                if stack is not None:
-                    stacks.append(stack)
-
-            queue.extend((d, depth + 1) for d in subdirs)
-
-        return stacks
-
-
-def _detect_node(path: Path, files: Dict[str, Path]) -> Optional[DetectedStack]:
-    """Detect a Node stack via package.json.
+async def _kill_process(proc: asyncio.subprocess.Process) -> None:
+    """Kill a subprocess with SIGTERM→SIGKILL escalation.
 
     Parameters
     ----------
-    path : Path
-        Directory being examined.
-    files : Dict[str, Path]
-        Files in the directory, keyed by filename.
-
-    Returns
-    -------
-    Optional[DetectedStack]
-        Stack record if package.json exists and is parseable.
+    proc : asyncio.subprocess.Process
+        Process to terminate. No-op if already dead.
     """
-    pkg = files.get("package.json")
-    if pkg is None:
-        return None
     try:
-        raw = pkg.read_text(encoding="utf-8")
-        data = json.loads(raw)
-    except (OSError, json.JSONDecodeError) as exc:
-        logger.warning(f"Failed to parse {pkg}: {exc}")
-        return DetectedStack(
-            stack_type="node",
-            root_path=path,
-            marker_file=pkg,
-            metadata={"parse_error": str(exc)},
-        )
-    if not isinstance(data, dict):
-        return None
-    scripts = data.get("scripts") if isinstance(data.get("scripts"), dict) else {}
-    return DetectedStack(
-        stack_type="node",
-        root_path=path,
-        marker_file=pkg,
-        metadata={
-            "scripts": scripts,
-            "name": data.get("name"),
-            "dependencies": (
-                list(data.get("dependencies", {}).keys())
-                if isinstance(data.get("dependencies"), dict)
-                else []
-            ),
-            "devDependencies": (
-                list(data.get("devDependencies", {}).keys())
-                if isinstance(data.get("devDependencies"), dict)
-                else []
-            ),
-        },
-    )
+        proc.terminate()
+        await asyncio.wait_for(proc.wait(), timeout=KILL_GRACE_PERIOD_SECONDS)
+    except (asyncio.TimeoutError, ProcessLookupError):
+        try:
+            proc.kill()
+            await proc.wait()
+        except ProcessLookupError:
+            pass
 
 
-def _detect_python(path: Path, files: Dict[str, Path]) -> Optional[DetectedStack]:
-    """Detect a Python stack via pyproject.toml or requirements.txt.
+async def _run_probe(probe_command: str, cwd: Path) -> tuple[int, str, str]:
+    """Run a single readiness probe invocation.
 
     Parameters
     ----------
-    path : Path
-        Directory being examined.
-    files : Dict[str, Path]
-        Files in the directory, keyed by filename.
+    probe_command : str
+        Shell-style probe command (e.g. ``"curl -f http://localhost:8000/health"``).
+    cwd : Path
+        Working directory for the probe.
 
     Returns
     -------
-    Optional[DetectedStack]
-        Stack record if a Python marker is present.
+    tuple[int, str, str]
+        ``(exit_code, stdout_tail, stderr_tail)``. Exit code -1 on
+        parse/launch failure, -2 on probe timeout.
     """
-    marker = files.get("pyproject.toml") or files.get("setup.py")
-    if marker is None:
-        # requirements.txt alone also counts, but is a weaker signal
-        marker = files.get("requirements.txt")
-    if marker is None:
-        return None
-    return DetectedStack(
-        stack_type="python",
-        root_path=path,
-        marker_file=marker,
-        metadata={
-            "has_pyproject": "pyproject.toml" in files,
-            "has_setup_py": "setup.py" in files,
-            "has_requirements": "requirements.txt" in files,
-        },
+    try:
+        argv = shlex.split(probe_command)
+    except ValueError:
+        return -1, "", f"could not parse probe: {probe_command!r}"
+    if not argv:
+        return -1, "", "empty probe command"
+
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            *argv,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            cwd=str(cwd),
+            env=_build_subprocess_env(),
+        )
+    except FileNotFoundError as exc:
+        return -1, "", f"probe binary not found: {argv[0]!r} ({exc})"
+
+    try:
+        stdout_bytes, stderr_bytes = await asyncio.wait_for(
+            proc.communicate(), timeout=PROBE_INVOCATION_TIMEOUT_SECONDS
+        )
+    except asyncio.TimeoutError:
+        await _kill_process(proc)
+        return -2, "", f"probe timed out after {PROBE_INVOCATION_TIMEOUT_SECONDS}s"
+
+    return (
+        proc.returncode if proc.returncode is not None else -1,
+        stdout_bytes.decode("utf-8", errors="replace"),
+        stderr_bytes.decode("utf-8", errors="replace"),
     )
 
 
-def _detect_go(path: Path, files: Dict[str, Path]) -> Optional[DetectedStack]:
-    """Detect a Go stack via go.mod (stub for future impl)."""
-    if "go.mod" not in files:
-        return None
-    return DetectedStack(stack_type="go", root_path=path, marker_file=files["go.mod"])
+async def _run_server_with_probe(
+    start_command: str,
+    readiness_probe: str,
+    cwd: Path,
+    readiness_timeout_seconds: float,
+) -> List[VerificationStep]:
+    """Start a background server and poll the readiness probe.
 
+    Mode 2 of the verification contract. The server is started as a
+    background subprocess and the probe is polled once per second for
+    up to ``readiness_timeout_seconds``. Pass requires the probe to
+    return exit 0 at least once within the window.
 
-def _detect_rust(path: Path, files: Dict[str, Path]) -> Optional[DetectedStack]:
-    """Detect a Rust stack via Cargo.toml (stub for future impl)."""
-    if "Cargo.toml" not in files:
-        return None
-    return DetectedStack(
-        stack_type="rust", root_path=path, marker_file=files["Cargo.toml"]
-    )
+    The background server is always killed before this function returns
+    — pass, fail, or exception.
 
+    Parameters
+    ----------
+    start_command : str
+        Shell-style command that starts the long-running process
+        (e.g. ``"uvicorn main:app --port 8000"``).
+    readiness_probe : str
+        Shell-style probe command polled for readiness (e.g.
+        ``"curl -f http://localhost:8000/health"``).
+    cwd : Path
+        Working directory for both the server and the probe.
+    readiness_timeout_seconds : float
+        Maximum wait for readiness before declaring failure.
 
-def _detect_java(path: Path, files: Dict[str, Path]) -> Optional[DetectedStack]:
-    """Detect a Java stack via pom.xml or build.gradle (stub)."""
-    marker = files.get("pom.xml") or files.get("build.gradle")
-    if marker is None:
-        return None
-    return DetectedStack(stack_type="java", root_path=path, marker_file=marker)
-
-
-_MARKER_DETECTORS = [
-    _detect_node,
-    _detect_python,
-    _detect_go,
-    _detect_rust,
-    _detect_java,
-]
-
-
-# ---------------------------------------------------------------------------
-# Verifier base + concrete implementations
-# ---------------------------------------------------------------------------
-
-
-class StackVerifier:
-    """Abstract base for per-stack verification.
-
-    Subclasses implement :meth:`verify` which returns an ordered list
-    of :class:`VerificationStep` records. A successful run is one
-    where every step has ``success=True``. Subclasses should NOT
-    raise on command failure — they should return a failed step so
-    the orchestrator can aggregate results.
+    Returns
+    -------
+    List[VerificationStep]
+        Two steps: one for the background start (always present,
+        reports whether the server even launched) and one for the
+        readiness probe (reports whether the probe eventually passed).
     """
+    server_start_time = time.monotonic()
 
-    def __init__(self, stack: DetectedStack) -> None:
-        self.stack = stack
-
-    async def verify(self) -> List[VerificationStep]:
-        """Run verification for this stack.
-
-        Returns
-        -------
-        List[VerificationStep]
-            Steps in execution order. Short-circuits on first failure
-            (no point running build if install failed).
-        """
-        raise NotImplementedError
-
-
-class NodeVerifier(StackVerifier):
-    """Verifies a Node/JavaScript/TypeScript stack.
-
-    Runs, in order:
-
-    1. ``npm install`` — installs dependencies
-    2. ``npm run build`` — only if the project has a build script
-
-    Rationale: ``npm install`` is universal for Node projects.
-    ``npm run build`` is the highest-value check — it's how
-    ``react-scripts``, ``vite``, ``webpack``, ``tsc`` and friends
-    verify that every required file exists and every import
-    resolves. Dashboard-v71's missing ``public/index.html`` would
-    have been caught here in seconds because ``react-scripts build``
-    errors out with "Could not find a required file. Name: index.html".
-
-    Not yet implemented for MVP:
-
-    - ``npm run dev`` / start verification — building is sufficient
-      for the "missing files / broken imports" class. Start
-      verification is a future extension for runtime-only failures.
-    - Alternate package managers (yarn, pnpm, bun) — detection
-      hooks exist but the executor hardcodes ``npm`` for MVP.
-    """
-
-    async def verify(self) -> List[VerificationStep]:
-        """Run the Node verification sequence.
-
-        Returns
-        -------
-        List[VerificationStep]
-            ``[install_step]`` on install failure.
-            ``[install_step, build_step]`` otherwise.
-            ``[install_step]`` if there's no build script in package.json.
-        """
-        steps: List[VerificationStep] = []
-
-        # Resolve the npm binary. If npm isn't on PATH, we want a
-        # clear error, not a cryptic FileNotFoundError deep in the
-        # subprocess helper.
-        npm = shutil.which("npm")
-        if npm is None:
-            return [
-                VerificationStep(
-                    name="install",
-                    command=["npm", "install"],
-                    cwd=self.stack.root_path,
-                    exit_code=None,
-                    stdout="",
-                    stderr=(
-                        "npm not found on PATH. Cannot verify Node stack "
-                        "at " + str(self.stack.root_path) + ". "
-                        "Install Node.js or ensure npm is accessible."
-                    ),
-                    duration_seconds=0.0,
-                    success=False,
-                )
-            ]
-
-        # Step 1: install
-        install_step = await _run_subprocess(
-            name="install",
-            command=[npm, "install", "--no-audit", "--no-fund"],
-            cwd=self.stack.root_path,
-            timeout_seconds=DEFAULT_INSTALL_TIMEOUT_SECONDS,
-            env=None,
-        )
-        steps.append(install_step)
-        if not install_step.success:
-            return steps
-
-        # Step 2: build (only if script exists)
-        scripts = self.stack.metadata.get("scripts") or {}
-        if "build" in scripts:
-            # Build env: inherit from parent FIRST so PATH, HOME,
-            # NODE_ENV, etc. propagate (without these the
-            # subprocess can't find npm itself), then override
-            # CI=true LAST so we always force non-interactive mode
-            # regardless of whether the parent already has a CI
-            # value set.
-            #
-            # Codex P2 review on PR #346 caught the original order
-            # ({"CI": "true", **os.environ}) which let an existing
-            # CI=false in the parent override our setting and
-            # silently change react-scripts/Vite build behavior in
-            # exactly the cases this gate is meant to standardize.
-            # Dict spread is left-to-right, last write wins.
-            import os as _os
-
-            build_env = {
-                **_os.environ,
-                "CI": "true",
-            }
-            build_step = await _run_subprocess(
-                name="build",
-                command=[npm, "run", "build"],
-                cwd=self.stack.root_path,
-                timeout_seconds=DEFAULT_BUILD_TIMEOUT_SECONDS,
-                env=build_env,
-            )
-            steps.append(build_step)
-        else:
-            # No build script — record an informational step so the
-            # result is transparent about what was (not) checked.
-            # This is NOT a failure; some Node projects are
-            # pure-library with no build step.
-            steps.append(
-                VerificationStep(
-                    name="build",
-                    command=[npm, "run", "build"],
-                    cwd=self.stack.root_path,
-                    exit_code=0,
-                    stdout="",
-                    stderr="",
-                    duration_seconds=0.0,
-                    success=True,
-                )
-            )
-
-        return steps
-
-
-class PythonVerifier(StackVerifier):
-    """Verifies a Python stack.
-
-    Runs, in order:
-
-    1. Install command (pip + pyproject or requirements.txt) — only
-       if we can infer one without being destructive.
-    2. ``python -c "import <package>"`` — basic import check if a
-       package is declared.
-    3. ``pytest`` — only if a tests directory is present.
-
-    Scope note: Python environments are messier than Node because
-    there's no equivalent of ``node_modules`` that isolates
-    installs. Running ``pip install`` can mutate the user's global
-    environment. For MVP we AVOID pip install — we trust that the
-    agent's environment is set up — and focus on build-time checks
-    (imports, test suite).
-
-    A future version should use ``uv`` or a temporary venv to get
-    the install step without environmental risk.
-    """
-
-    async def verify(self) -> List[VerificationStep]:
-        """Run the Python verification sequence.
-
-        Returns
-        -------
-        List[VerificationStep]
-            Steps run, in execution order.
-        """
-        steps: List[VerificationStep] = []
-
-        python = shutil.which("python3") or shutil.which("python")
-        if python is None:
-            return [
-                VerificationStep(
-                    name="test",
-                    command=["python"],
-                    cwd=self.stack.root_path,
-                    exit_code=None,
-                    stdout="",
-                    stderr=(
-                        "python not found on PATH. Cannot verify Python "
-                        "stack at " + str(self.stack.root_path)
-                    ),
-                    duration_seconds=0.0,
-                    success=False,
-                )
-            ]
-
-        # Step: run pytest if a test dir exists
-        tests_dir = self.stack.root_path / "tests"
-        if tests_dir.is_dir():
-            pytest_bin = shutil.which("pytest")
-            if pytest_bin is None:
-                # pytest not installed — inform rather than fail.
-                # Absence of pytest is not a build error; it's a
-                # missing tool the agent should know about.
-                steps.append(
-                    VerificationStep(
-                        name="test",
-                        command=["pytest"],
-                        cwd=self.stack.root_path,
-                        exit_code=0,
-                        stdout="",
-                        stderr="pytest not installed, skipping test step",
-                        duration_seconds=0.0,
-                        success=True,
-                    )
-                )
-                return steps
-
-            import os as _os
-
-            test_step = await _run_subprocess(
-                name="test",
-                command=[pytest_bin, "-q", "--tb=short", "tests/"],
-                cwd=self.stack.root_path,
-                timeout_seconds=DEFAULT_TEST_TIMEOUT_SECONDS,
-                env=dict(_os.environ),
-            )
-            steps.append(test_step)
-            return steps
-
-        # No tests dir — nothing to verify at build-level for Python.
-        # Return a skipped-step marker so the caller knows we looked.
-        steps.append(
-            VerificationStep(
-                name="test",
-                command=["pytest"],
-                cwd=self.stack.root_path,
-                exit_code=0,
-                stdout="",
-                stderr="no tests/ directory, skipping test step",
-                duration_seconds=0.0,
-                success=True,
-            )
-        )
-        return steps
-
-
-class _UnsupportedVerifier(StackVerifier):
-    """Stub verifier for stacks we haven't implemented yet.
-
-    Returns a single informational step indicating the stack was
-    detected but not verified. This is NOT a failure — skipping
-    unknown stacks is the safe default for MVP.
-    """
-
-    async def verify(self) -> List[VerificationStep]:
-        """Return a single skipped-step marker."""
+    try:
+        argv = shlex.split(start_command)
+    except ValueError as exc:
         return [
             VerificationStep(
-                name="skip",
-                command=[],
-                cwd=self.stack.root_path,
-                exit_code=0,
+                name="start_command",
+                command=start_command,
+                exit_code=None,
                 stdout="",
-                stderr=(
-                    f"Stack type {self.stack.stack_type!r} detected at "
-                    f"{self.stack.root_path} but no verifier implemented. "
-                    f"Skipped."
-                ),
+                stderr=f"Could not parse start_command: {exc}",
                 duration_seconds=0.0,
-                success=True,
+                success=False,
+            )
+        ]
+    if not argv:
+        return [
+            VerificationStep(
+                name="start_command",
+                command=start_command,
+                exit_code=None,
+                stdout="",
+                stderr="start_command parsed to empty argv",
+                duration_seconds=0.0,
+                success=False,
             )
         ]
 
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            *argv,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            cwd=str(cwd),
+            env=_build_subprocess_env(),
+        )
+    except FileNotFoundError as exc:
+        return [
+            VerificationStep(
+                name="start_command",
+                command=start_command,
+                exit_code=None,
+                stdout="",
+                stderr=f"Command not found: {argv[0]!r} ({exc})",
+                duration_seconds=time.monotonic() - server_start_time,
+                success=False,
+            )
+        ]
 
-def _pick_verifier(stack: DetectedStack) -> StackVerifier:
-    """Map a detected stack to its concrete verifier class.
+    # Poll the readiness probe. The server runs in the background;
+    # we poll once per second until either:
+    # - the probe succeeds (pass)
+    # - the server process exits before readiness (fail — server crashed)
+    # - the readiness timeout fires (fail — server never became ready)
+    probe_success = False
+    last_probe_stdout = ""
+    last_probe_stderr = ""
+    last_probe_exit = -1
+    probe_attempts = 0
+    probe_start_time = time.monotonic()
+    deadline = probe_start_time + readiness_timeout_seconds
+
+    while time.monotonic() < deadline:
+        # If the server process exited before readiness, that's a
+        # fatal fail — no point continuing to probe a dead server.
+        if proc.returncode is not None:
+            break
+
+        probe_attempts += 1
+        last_probe_exit, last_probe_stdout, last_probe_stderr = await _run_probe(
+            readiness_probe, cwd
+        )
+        if last_probe_exit == 0:
+            probe_success = True
+            break
+
+        await asyncio.sleep(READINESS_POLL_INTERVAL_SECONDS)
+
+    # Capture the server's output before killing it. This gives us
+    # early-crash stack traces in the blocker message.
+    server_stdout = ""
+    server_stderr = ""
+    server_exit_code: Optional[int] = proc.returncode
+
+    # If the process has already exited, grab its output. Otherwise
+    # kill it and then grab what came out before the kill.
+    if server_exit_code is None:
+        await _kill_process(proc)
+
+    try:
+        stdout_bytes, stderr_bytes = await asyncio.wait_for(
+            proc.communicate(), timeout=2.0
+        )
+        server_stdout = _truncate_output(stdout_bytes.decode("utf-8", errors="replace"))
+        server_stderr = _truncate_output(stderr_bytes.decode("utf-8", errors="replace"))
+    except (asyncio.TimeoutError, ValueError):
+        # ValueError raised by communicate() if already consumed.
+        pass
+
+    server_exit_code = proc.returncode
+
+    # The start_command step is successful if the server stayed alive
+    # long enough to be probed. It's unsuccessful if it exited before
+    # the probe could run.
+    server_step = VerificationStep(
+        name="start_command",
+        command=start_command,
+        exit_code=server_exit_code,
+        stdout=server_stdout,
+        stderr=server_stderr,
+        duration_seconds=time.monotonic() - server_start_time,
+        success=(
+            # Success = server was still running when we started
+            # probing OR readiness probe eventually passed.
+            probe_success
+            or (server_exit_code is None or server_exit_code < 0)
+        ),
+    )
+
+    probe_duration = time.monotonic() - probe_start_time
+    probe_step = VerificationStep(
+        name="readiness_probe",
+        command=readiness_probe,
+        exit_code=last_probe_exit if probe_attempts else None,
+        stdout=last_probe_stdout,
+        stderr=(
+            last_probe_stderr
+            if probe_success
+            else (
+                f"Readiness probe failed after {probe_attempts} attempt(s) "
+                f"over {probe_duration:.1f}s. "
+                f"Last exit={last_probe_exit}. "
+                + (
+                    "Server process exited before readiness "
+                    f"(exit code {server_exit_code})."
+                    if server_exit_code is not None and not probe_success
+                    else "Probe never returned exit 0 within the window."
+                )
+                + (f" Last stderr: {last_probe_stderr}" if last_probe_stderr else "")
+            )
+        ),
+        duration_seconds=probe_duration,
+        success=probe_success,
+    )
+
+    return [server_step, probe_step]
+
+
+# ---------------------------------------------------------------------------
+# Public runner
+# ---------------------------------------------------------------------------
+
+
+async def verify_deliverable(
+    start_command: Optional[str],
+    readiness_probe: Optional[str],
+    cwd: Path,
+    one_shot_timeout_seconds: float = DEFAULT_ONE_SHOT_TIMEOUT_SECONDS,
+    readiness_timeout_seconds: float = DEFAULT_READINESS_TIMEOUT_SECONDS,
+) -> ProductSmokeResult:
+    """Verify a deliverable via its declared start command.
+
+    This is Marcus-side enforcement that an integration task's declared
+    deliverable actually runs. Runs in one of two modes based on whether
+    ``readiness_probe`` was declared:
+
+    **Mode 1 — one-shot** (no readiness_probe):
+        Runs ``start_command`` as a subprocess and waits for it to exit.
+        Success requires exit code 0 within ``one_shot_timeout_seconds``.
+
+    **Mode 2 — server+probe** (with readiness_probe):
+        Starts ``start_command`` as a background subprocess, then polls
+        ``readiness_probe`` once per second for up to
+        ``readiness_timeout_seconds``. Success requires the probe to
+        return exit 0 at least once. The background process is always
+        killed before this function returns.
 
     Parameters
     ----------
-    stack : DetectedStack
-        The stack to verify.
+    start_command : Optional[str]
+        Shell-style command to start the deliverable. When ``None`` or
+        empty, the verification is rejected as missing a required field.
+    readiness_probe : Optional[str]
+        Shell-style command that probes whether the deliverable is
+        ready. When provided, switches the runner into server+probe
+        mode. When absent, uses one-shot mode.
+    cwd : Path
+        Working directory for both commands. Typically the project
+        root as resolved from the kanban workspace state.
+    one_shot_timeout_seconds : float
+        Maximum wait for one-shot commands. Default 60s.
+    readiness_timeout_seconds : float
+        Maximum wait for a server to become ready. Default 15s.
 
     Returns
     -------
-    StackVerifier
-        Concrete verifier. Unsupported stacks get ``_UnsupportedVerifier``.
-    """
-    if stack.stack_type == "node":
-        return NodeVerifier(stack)
-    if stack.stack_type == "python":
-        return PythonVerifier(stack)
-    return _UnsupportedVerifier(stack)
+    ProductSmokeResult
+        Structured result with steps, pass/fail status, and a
+        ready-to-paste blocker message on failure.
 
-
-# ---------------------------------------------------------------------------
-# Orchestrator
-# ---------------------------------------------------------------------------
-
-
-class ProductSmokeVerifier:
-    """Top-level orchestrator for product smoke verification.
-
-    Detects all stacks in a project root, runs each one's verifier,
-    aggregates the results, and produces a structured report
-    suitable for both logging and blocker-message rendering.
-
-    Usage
+    Notes
     -----
-    >>> verifier = ProductSmokeVerifier()
-    >>> result = await verifier.verify(Path("/path/to/project"))
-    >>> if not result.success:
-    ...     print(result.blocker_message)
+    Never raises on command failure — returns a ``ProductSmokeResult``
+    with ``success=False`` and populated blocker fields. Programmer
+    errors (e.g. invalid ``cwd``) propagate as exceptions so the caller
+    can distinguish infrastructure problems from deliverable failures.
     """
-
-    async def verify(self, project_root: Path) -> ProductSmokeResult:
-        """Run verification on all detected stacks.
-
-        Parameters
-        ----------
-        project_root : Path
-            Project root directory to scan and verify.
-
-        Returns
-        -------
-        ProductSmokeResult
-            Aggregate result. ``success=True`` with empty
-            ``detected_stacks`` is a legitimate pass (no stacks to
-            check) but carries a ``skipped_reason``.
-        """
-        logger.info(f"ProductSmokeVerifier starting at {project_root}")
-        try:
-            stacks = StackDetector.detect(project_root)
-        except ValueError as exc:
-            return ProductSmokeResult(
-                success=False,
-                detected_stacks=[],
-                steps=[],
-                failure_summary=str(exc),
-                blocker_message=(
-                    f"Product smoke verification could not start: "
-                    f"{exc}. The project root path is invalid or "
-                    f"inaccessible."
-                ),
-            )
-
-        if not stacks:
-            logger.info(
-                f"No stacks detected in {project_root}; "
-                f"skipping product smoke verification"
-            )
-            return ProductSmokeResult(
-                success=True,
-                detected_stacks=[],
-                steps=[],
-                skipped_reason="no recognized stack markers found",
-            )
-
-        logger.info(
-            f"Detected {len(stacks)} stack(s): "
-            + ", ".join(f"{s.stack_type}@{s.root_path.name}" for s in stacks)
+    if not start_command or not start_command.strip():
+        missing_step = VerificationStep(
+            name="missing_start_command",
+            command="",
+            exit_code=None,
+            stdout="",
+            stderr=(
+                "No start_command declared. Integration tasks must "
+                "declare start_command when marking the task complete "
+                "via report_task_progress."
+            ),
+            duration_seconds=0.0,
+            success=False,
         )
-
-        all_steps: List[VerificationStep] = []
-        first_failure: Optional[VerificationStep] = None
-        for stack in stacks:
-            verifier = _pick_verifier(stack)
-            steps = await verifier.verify()
-            all_steps.extend(steps)
-            if first_failure is None:
-                for step in steps:
-                    if not step.success:
-                        first_failure = step
-                        break
-
-        success = first_failure is None
-        failure_summary: Optional[str] = None
-        blocker_message: Optional[str] = None
-        if not success and first_failure is not None:
-            failure_summary = (
-                f"{first_failure.name} failed at {first_failure.cwd} "
-                f"(exit={first_failure.exit_code})"
-            )
-            blocker_message = _build_blocker_message(first_failure, stacks)
-
         return ProductSmokeResult(
-            success=success,
-            detected_stacks=stacks,
-            steps=all_steps,
-            failure_summary=failure_summary,
-            blocker_message=blocker_message,
+            success=False,
+            steps=[missing_step],
+            failure_summary="integration task missing required start_command",
+            blocker_message=_render_missing_blocker(),
         )
 
+    if not cwd.is_dir():
+        raise ValueError(f"cwd is not a directory: {cwd}")
 
-def _build_blocker_message(
-    failed_step: VerificationStep, stacks: List[DetectedStack]
+    logger.info(
+        f"verify_deliverable: cwd={cwd} start_command={start_command!r} "
+        f"readiness_probe={readiness_probe!r}"
+    )
+
+    if readiness_probe and readiness_probe.strip():
+        steps = await _run_server_with_probe(
+            start_command=start_command,
+            readiness_probe=readiness_probe.strip(),
+            cwd=cwd,
+            readiness_timeout_seconds=readiness_timeout_seconds,
+        )
+    else:
+        steps = [
+            await _run_one_shot(
+                command=start_command,
+                cwd=cwd,
+                timeout_seconds=one_shot_timeout_seconds,
+            )
+        ]
+
+    # Overall success = every step succeeded.
+    success = all(step.success for step in steps)
+    if success:
+        total_duration = sum(s.duration_seconds for s in steps)
+        logger.info(f"verify_deliverable PASSED in {total_duration:.1f}s")
+        return ProductSmokeResult(success=True, steps=steps)
+
+    first_failure = next(step for step in steps if not step.success)
+    failure_summary = (
+        f"{first_failure.name} failed " f"(exit={first_failure.exit_code}) in {cwd}"
+    )
+    blocker_message = _render_failure_blocker(first_failure, steps)
+    logger.warning(f"verify_deliverable FAILED: {failure_summary}")
+
+    return ProductSmokeResult(
+        success=False,
+        steps=steps,
+        failure_summary=failure_summary,
+        blocker_message=blocker_message,
+    )
+
+
+def _render_missing_blocker() -> str:
+    """Blocker message for integration tasks that omit start_command."""
+    return (
+        "## Integration task rejected: missing start_command\n\n"
+        "Marcus requires integration verification tasks to declare a "
+        "`start_command` when marking the task complete. This is how "
+        "Marcus independently verifies that the assembled deliverable "
+        "actually runs — agent self-reports alone are not sufficient, "
+        "as dashboard-v71 demonstrated when a React app shipped missing "
+        "`public/index.html` but passed every agent-level check.\n\n"
+        "**What to do:**\n\n"
+        "1. Decide how to start your deliverable. Examples:\n"
+        "   - Node build: `npm run build`\n"
+        "   - Python CLI: `python -m mypackage --help`\n"
+        "   - Type check: `tsc --noEmit`\n"
+        "   - Python web server: `uvicorn main:app --port 8000`\n"
+        "     (also declare a readiness_probe for servers — see below)\n"
+        "   - Flask: `flask run --port 5000`\n\n"
+        "2. If the command is a long-running server, also declare a "
+        "`readiness_probe`. Examples:\n"
+        "   - `curl -f http://localhost:8000/health`\n"
+        "   - `curl -f http://localhost:3000/`\n\n"
+        "3. Call `report_task_progress` with both fields:\n\n"
+        "   ```python\n"
+        "   report_task_progress(\n"
+        "       task_id=task_id,\n"
+        "       status='completed',\n"
+        "       progress=100,\n"
+        "       message='...',\n"
+        "       start_command='uvicorn main:app --port 8000',\n"
+        "       readiness_probe='curl -f http://localhost:8000/health',\n"
+        "   )\n"
+        "   ```\n\n"
+        "Marcus will run the command (with a bounded timeout) and "
+        "accept the completion only if it exits 0 (one-shot) or the "
+        "readiness_probe returns exit 0 within 15s (server mode)."
+    )
+
+
+def _render_failure_blocker(
+    failed_step: VerificationStep, all_steps: List[VerificationStep]
 ) -> str:
-    """Render a failed step into an actionable blocker message.
+    """Blocker message for a start_command/readiness_probe failure.
 
     Parameters
     ----------
     failed_step : VerificationStep
         The first step that failed.
-    stacks : List[DetectedStack]
-        All detected stacks (for context in the message).
+    all_steps : List[VerificationStep]
+        All steps in the run (for context in the blocker).
 
     Returns
     -------
     str
-        Multi-line blocker description the agent can read and act on.
+        Multi-line actionable blocker description.
     """
-    stack_summary = ", ".join(f"{s.stack_type} at {s.root_path.name}" for s in stacks)
-    cmd_str = " ".join(failed_step.command)
     tail = failed_step.stderr or failed_step.stdout or "(no output)"
+    mode_description = (
+        "readiness probe never returned exit 0"
+        if failed_step.name == "readiness_probe"
+        else "start_command did not exit 0"
+    )
     return (
-        "## Product smoke verification FAILED\n\n"
-        f"Marcus ran product smoke verification after you marked the "
-        f"integration task complete and found that the assembled "
-        f"product does not build/run.\n\n"
-        f"**Detected stacks**: {stack_summary}\n\n"
-        f"**Failing step**: `{failed_step.name}` "
-        f"(exit code: {failed_step.exit_code})\n\n"
-        f"**Command**: `{cmd_str}`\n"
-        f"**Working directory**: `{failed_step.cwd}`\n\n"
+        "## Deliverable verification FAILED\n\n"
+        "Marcus ran the declared start_command/readiness_probe and "
+        "the deliverable did not meet the pass contract.\n\n"
+        f"**Failing step**: `{failed_step.name}` — {mode_description}\n"
+        f"**Exit code**: {failed_step.exit_code}\n"
+        f"**Command**: `{failed_step.command}`\n\n"
         f"**Output (tail)**:\n```\n{tail}\n```\n\n"
-        "**What to do**: Fix the underlying issue, commit the fix, "
-        "and re-mark the integration task complete. Marcus will "
-        "re-run product smoke verification. Do NOT mark the task "
-        "complete again until the product builds cleanly. If the "
-        "error is not actionable from this output, run the failing "
-        "command yourself in the working directory to get the full "
-        "output and root-cause from there."
+        "**What to do**: Run the same command locally. If it fails for "
+        "you too, fix the underlying issue (missing file, broken "
+        "import, bad config, etc.), commit, and re-mark the integration "
+        "task complete. If it passes for you but not for Marcus, check "
+        "the working directory, environment variables, and any "
+        "side-effects that differ between your environment and a clean "
+        "subprocess run. Marcus runs commands with `CI=true` set; if "
+        "your command relies on interactive prompts it will fail here."
     )

--- a/src/marcus_mcp/handlers.py
+++ b/src/marcus_mcp/handlers.py
@@ -187,7 +187,12 @@ def get_tool_definitions(role: str = "agent") -> List[types.Tool]:
         ),
         types.Tool(
             name="report_task_progress",
-            description="Report progress on a task",
+            description=(
+                "Report progress on a task. For integration verification "
+                "tasks, you MUST declare start_command when marking the "
+                "task complete — Marcus runs the declared command as a "
+                "subprocess and rejects the completion if it fails."
+            ),
             inputSchema={
                 "type": "object",
                 "properties": {
@@ -209,6 +214,30 @@ def get_tool_definitions(role: str = "agent") -> List[types.Tool]:
                         "type": "string",
                         "description": "Progress message",
                         "default": "",
+                    },
+                    "start_command": {
+                        "type": "string",
+                        "description": (
+                            "Shell command Marcus runs to verify the "
+                            "deliverable starts. REQUIRED for integration "
+                            "verification tasks (type:integration label) "
+                            "when status='completed'; ignored on other "
+                            "tasks. Examples: 'npm run build', "
+                            "'python -m mypackage --help', "
+                            "'tsc --noEmit', 'uvicorn main:app --port 8000'."
+                        ),
+                    },
+                    "readiness_probe": {
+                        "type": "string",
+                        "description": (
+                            "Optional shell command Marcus polls to detect "
+                            "when a long-running server is ready. Pair with "
+                            "start_command for servers. When provided, "
+                            "Marcus starts the command in the background, "
+                            "polls this probe every 1s for up to 15s, and "
+                            "passes when the probe returns exit 0. Example: "
+                            "'curl -f http://localhost:8000/health'."
+                        ),
                     },
                 },
                 "required": ["agent_id", "task_id", "status"],
@@ -1082,6 +1111,8 @@ async def handle_tool_call(
                     progress=arguments.get("progress", 0),
                     message=arguments.get("message", ""),
                     state=state,
+                    start_command=arguments.get("start_command"),
+                    readiness_probe=arguments.get("readiness_probe"),
                 )
 
         elif name == "report_blocker":

--- a/src/marcus_mcp/server.py
+++ b/src/marcus_mcp/server.py
@@ -1205,8 +1205,18 @@ class MarcusServer:
             status: str,
             progress: int = 0,
             message: str = "",
+            start_command: Optional[str] = None,
+            readiness_probe: Optional[str] = None,
         ) -> Dict[str, Any]:
-            """Report progress on a task."""
+            """Report progress on a task.
+
+            For integration verification tasks (type:integration
+            label), the agent MUST declare ``start_command`` when
+            marking the task complete. Marcus runs the declared
+            command as a subprocess and rejects the completion if
+            it fails. See the report_task_progress docstring in
+            tools/task.py for the full contract and examples.
+            """
             from .tools.task import report_task_progress as impl
 
             return await impl(
@@ -1216,6 +1226,8 @@ class MarcusServer:
                 progress=progress,
                 message=message,
                 state=server,
+                start_command=start_command,
+                readiness_probe=readiness_probe,
             )
 
         @self._fastmcp.tool()  # type: ignore[misc]
@@ -1385,8 +1397,18 @@ class MarcusServer:
                 status: str,
                 progress: int = 0,
                 message: str = "",
+                start_command: Optional[str] = None,
+                readiness_probe: Optional[str] = None,
             ) -> Dict[str, Any]:
-                """Report progress on a task."""
+                """Report progress on a task.
+
+                For integration verification tasks (type:integration
+                label), the agent MUST declare ``start_command``
+                when marking the task complete. Marcus runs the
+                declared command as a subprocess and rejects the
+                completion if it fails. See the report_task_progress
+                docstring in tools/task.py for the full contract.
+                """
                 from src.logging.mcp_tool_logger import log_mcp_tool_response
 
                 from .tools.task import report_task_progress as impl
@@ -1398,6 +1420,8 @@ class MarcusServer:
                     progress=progress,
                     message=message,
                     state=server,
+                    start_command=start_command,
+                    readiness_probe=readiness_probe,
                 )
 
                 # Log MCP tool response
@@ -1409,6 +1433,8 @@ class MarcusServer:
                         "status": status,
                         "progress": progress,
                         "message": message,
+                        "start_command": start_command,
+                        "readiness_probe": readiness_probe,
                     },
                     response=result,
                 )

--- a/src/marcus_mcp/tools/task.py
+++ b/src/marcus_mcp/tools/task.py
@@ -416,14 +416,25 @@ def _is_integration_task(task: Task) -> bool:
 
 
 async def _run_product_smoke_gate(
-    task: Task, agent_id: str, state: Any
+    task: Task,
+    agent_id: str,
+    state: Any,
+    start_command: Optional[str],
+    readiness_probe: Optional[str],
 ) -> Optional[Dict[str, Any]]:
-    """Run product smoke verification for a completing integration task.
+    """Run deliverable verification for a completing integration task.
 
     Resolves the project root from the kanban workspace state, runs
-    ``ProductSmokeVerifier``, and returns either ``None`` (smoke
-    passed — completion may proceed) or a stale-completion-style
-    rejection dict that the caller returns directly to the agent.
+    the agent-declared start_command (and optional readiness_probe) as
+    subprocess, and returns either ``None`` (verification passed —
+    completion may proceed) or a rejection dict that the caller
+    returns directly to the agent.
+
+    **Strict enforcement**: integration tasks MUST declare a
+    start_command. Completions that omit it are rejected with the
+    missing-declaration blocker message, regardless of any other
+    state. This is the explicit design choice locked in Simon decision
+    967555f6 — no fallback auto-detection. Agents own stack knowledge.
 
     Parameters
     ----------
@@ -434,28 +445,32 @@ async def _run_product_smoke_gate(
     state : Any
         Marcus server state (provides kanban_client for workspace
         state lookup).
+    start_command : Optional[str]
+        Agent-declared shell command that starts the deliverable.
+        Required — missing → rejection.
+    readiness_probe : Optional[str]
+        Agent-declared probe command for long-running servers.
+        Optional — absent means the start_command is treated as a
+        one-shot that must exit 0 within the configured timeout.
 
     Returns
     -------
     Optional[Dict[str, Any]]
-        ``None`` if smoke verification passed (or was skipped because
-        no stack was detected). A dict with ``success=False`` and a
-        ``smoke_blocker`` payload if verification failed and the
-        completion should be rejected.
+        ``None`` if verification passed. A rejection dict with
+        ``success=False``, ``status="smoke_verification_failed"``,
+        and a ``blocker`` payload if verification failed or the
+        start_command was missing.
 
     Notes
     -----
-    Verification system errors (not smoke failures — those produce
-    a returned response) are raised so the caller can decide whether
-    to log-and-continue or hard-fail. Current policy is log and
-    continue: if the verifier itself crashed, we don't know if the
-    product is OK or not, but blocking completion on a Marcus
-    internal bug would be worse than letting a possibly-bad task
-    through.
+    Verification system errors (programmer errors in the runner
+    itself, not deliverable failures) propagate as exceptions so the
+    caller can log-and-continue. Deliverable failures return a
+    rejection dict.
     """
     from pathlib import Path as _Path
 
-    from src.integrations.product_smoke import ProductSmokeVerifier
+    from src.integrations.product_smoke import verify_deliverable
 
     # Resolve project root via the kanban client's workspace state.
     # This is the same source of truth used by
@@ -490,17 +505,21 @@ async def _run_product_smoke_gate(
         return None
 
     logger.info(
-        f"PRODUCT SMOKE GATE: Running product smoke verification "
-        f"for integration task {task.id} at {project_root_path}"
+        f"PRODUCT SMOKE GATE: Running deliverable verification for "
+        f"integration task {task.id} at {project_root_path}. "
+        f"start_command={start_command!r} "
+        f"readiness_probe={readiness_probe!r}"
     )
-    verifier = ProductSmokeVerifier()
-    result = await verifier.verify(project_root_path)
+    result = await verify_deliverable(
+        start_command=start_command,
+        readiness_probe=readiness_probe,
+        cwd=project_root_path,
+    )
 
     if result.success:
         logger.info(
             f"PRODUCT SMOKE GATE: Verification passed for {task.id} "
-            f"({len(result.detected_stacks)} stack(s) checked, "
-            f"{len(result.steps)} step(s))"
+            f"({len(result.steps)} step(s))"
         )
         return None
 
@@ -520,13 +539,10 @@ async def _run_product_smoke_gate(
         "blocker": result.blocker_message,
         "smoke_result": result.to_dict(),
         "message": (
-            "Marcus product smoke verification rejected this "
-            "completion. The integration task cannot be marked "
-            "complete because the assembled product does not "
-            "build/run. See the `blocker` field for details and "
-            "the failing command output. Fix the issue, commit, "
-            "and re-mark the task complete — Marcus will re-run "
-            "verification."
+            "Marcus rejected this integration-task completion. Either "
+            "the declared start_command failed, the readiness_probe "
+            "never passed, or the start_command was not declared at "
+            "all. See the `blocker` field for details."
         ),
     }
 
@@ -2062,7 +2078,14 @@ async def _merge_agent_branch_to_main(
 
 
 async def report_task_progress(
-    agent_id: str, task_id: str, status: str, progress: int, message: str, state: Any
+    agent_id: str,
+    task_id: str,
+    status: str,
+    progress: int,
+    message: str,
+    state: Any,
+    start_command: Optional[str] = None,
+    readiness_probe: Optional[str] = None,
 ) -> Dict[str, Any]:
     """
     Agents report their task progress.
@@ -2084,6 +2107,36 @@ async def report_task_progress(
         Progress update message
     state : Any
         Marcus server state instance
+    start_command : Optional[str]
+        Shell-style command that Marcus should run to verify the
+        deliverable actually starts. REQUIRED when completing an
+        integration verification task (``"type:integration"`` label);
+        ignored on all other tasks. Examples:
+
+        - ``"npm run build"`` for a Node build
+        - ``"python -m mypackage --help"`` for a Python CLI
+        - ``"tsc --noEmit"`` for a TypeScript type check
+        - ``"uvicorn main:app --port 8000"`` for a long-running server
+          (pair with a ``readiness_probe``)
+
+        When the agent declares this on an integration task, Marcus
+        runs it as a subprocess with a 60s timeout (one-shot mode) or
+        15s readiness window (server mode). Missing on an integration
+        task completion → the completion is rejected.
+    readiness_probe : Optional[str]
+        Optional shell-style command that Marcus polls to detect when
+        a long-running server is ready. When provided alongside
+        ``start_command``, Marcus starts the command in the background
+        and polls the probe every 1s for up to 15s. Pass requires the
+        probe to return exit 0 at least once within that window.
+        Marcus always kills the background process before accepting
+        the completion. Examples:
+
+        - ``"curl -f http://localhost:8000/health"``
+        - ``"curl -f http://localhost:3000/"``
+
+        Absent ``readiness_probe``, Marcus treats the start_command as
+        a one-shot that must exit 0 within 60s.
 
     Returns
     -------
@@ -2338,25 +2391,29 @@ async def report_task_progress(
             # tasks have label "type:integration" and are NOT
             # validated by the citation-based LLM validator above
             # (they aren't implementation tasks). Their entire job
-            # is to assemble the product and prove it works — so the
-            # right gate for them is a deterministic Marcus-side
-            # check that the product actually builds. This catches
-            # the dashboard-v71 class of bug where the integration
-            # agent self-reports success but the assembled product
-            # fails to boot (e.g. missing public/index.html).
+            # is to assemble the deliverable and prove it works —
+            # so the right gate for them is a deterministic
+            # Marcus-side check that the declared start_command
+            # actually runs. This catches the dashboard-v71 class
+            # of bug where the integration agent self-reports
+            # success but the assembled deliverable fails to boot
+            # (e.g. missing public/index.html).
             #
-            # The smoke gate runs ProductSmokeVerifier.verify() as
-            # a subprocess-level check. If it fails, the task is
-            # rejected with the real stderr attached as a blocker —
-            # regardless of what the agent claimed. This is the
-            # same machine-beats-prompt pattern as PR #337's runtime
-            # tests overriding LLM validation opinions.
+            # The smoke gate runs ``verify_deliverable`` as a
+            # subprocess-level check against the agent-declared
+            # start_command + optional readiness_probe. If the
+            # start_command is missing (strict enforcement) or the
+            # declared command fails, the task is rejected. This is
+            # the same machine-beats-prompt pattern as PR #337's
+            # runtime tests overriding LLM validation opinions.
             if task is not None and _is_integration_task(task):
                 try:
                     smoke_response = await _run_product_smoke_gate(
                         task=task,
                         agent_id=agent_id,
                         state=state,
+                        start_command=start_command,
+                        readiness_probe=readiness_probe,
                     )
                     if smoke_response is not None:
                         return smoke_response

--- a/tests/unit/integrations/test_product_smoke.py
+++ b/tests/unit/integrations/test_product_smoke.py
@@ -1,158 +1,54 @@
-"""Unit tests for product_smoke (Layer 1 of the systemic fix).
+"""Unit tests for the deliverable verification runner.
 
-Verifies that ``ProductSmokeVerifier`` actually catches the
-classes of bug it's designed to catch — most importantly the
-dashboard-v71 regression where a React project shipped without
-``public/index.html`` and Marcus accepted the integration task as
-complete because nobody ran ``npm run build``.
+Covers ``verify_deliverable`` and its two execution modes:
 
-Test strategy
--------------
-Each test creates a tmp directory shaped like a real project root
-(via ``tmp_path``), then runs ``StackDetector`` and/or one of the
-verifier classes against it. Subprocess-running tests are gated
-by a feature-detect of ``npm`` / ``python3`` on PATH so they
-degrade gracefully on CI runners that don't have the toolchains
-installed — the assertion strategy is "the verifier reports the
-right structured outcome", not "the build actually succeeds".
+- **One-shot**: no readiness_probe → run start_command, wait for exit,
+  require exit 0 within the timeout.
+- **Server+probe**: with readiness_probe → start command in background,
+  poll probe once per second, pass when probe returns exit 0.
 
-When subprocess-running tests are skipped, we still verify the
-dispatch logic, the failure message rendering, and the
-integration with ``ProductSmokeVerifier`` orchestration via
-mocked subprocess invocation.
+Regression tests for the v71 bug class: a declared start_command that
+fails (missing file, bad import, etc.) must produce a structured
+failure with the real stderr in the blocker message.
+
+The runner is deterministic subprocess orchestration, so tests mock
+the subprocess helpers at the boundary and verify the runner's
+decisions (what it runs, in what order, how it handles timeouts and
+crashes) rather than actually spawning shells.
 """
 
 from __future__ import annotations
 
-import json
-import shutil
 from pathlib import Path
-from typing import Any
 from unittest.mock import AsyncMock, patch
 
 import pytest
 
 from src.integrations.product_smoke import (
-    DetectedStack,
-    NodeVerifier,
     ProductSmokeResult,
-    ProductSmokeVerifier,
-    PythonVerifier,
-    StackDetector,
     VerificationStep,
-    _build_blocker_message,
-    _pick_verifier,
-    _UnsupportedVerifier,
+    _render_failure_blocker,
+    _render_missing_blocker,
+    verify_deliverable,
 )
 
 pytestmark = pytest.mark.unit
 
 
-# ---------------------------------------------------------------------------
-# StackDetector tests
-# ---------------------------------------------------------------------------
-
-
-class TestStackDetector:
-    """Stack detection from filesystem markers."""
-
-    def test_empty_directory_returns_no_stacks(self, tmp_path: Path) -> None:
-        """Empty repo → empty stack list, no exceptions."""
-        stacks = StackDetector.detect(tmp_path)
-        assert stacks == []
-
-    def test_node_project_at_root(self, tmp_path: Path) -> None:
-        """package.json at repo root → one Node stack."""
-        (tmp_path / "package.json").write_text(
-            json.dumps(
-                {
-                    "name": "test-project",
-                    "version": "1.0.0",
-                    "scripts": {"build": "react-scripts build"},
-                    "dependencies": {"react": "^18.0.0"},
-                }
-            )
-        )
-        stacks = StackDetector.detect(tmp_path)
-        assert len(stacks) == 1
-        assert stacks[0].stack_type == "node"
-        assert stacks[0].root_path == tmp_path
-        assert "build" in stacks[0].metadata["scripts"]
-
-    def test_python_project_at_root(self, tmp_path: Path) -> None:
-        """pyproject.toml at repo root → one Python stack."""
-        (tmp_path / "pyproject.toml").write_text(
-            "[project]\nname='test'\nversion='1.0'\n"
-        )
-        stacks = StackDetector.detect(tmp_path)
-        assert len(stacks) == 1
-        assert stacks[0].stack_type == "python"
-
-    def test_full_stack_project_detects_both(self, tmp_path: Path) -> None:
-        """Frontend + backend in subdirs → two stacks detected."""
-        # Frontend
-        frontend = tmp_path / "src" / "frontend"
-        frontend.mkdir(parents=True)
-        (frontend / "package.json").write_text(
-            json.dumps({"name": "fe", "scripts": {"build": "vite build"}})
-        )
-        # Backend
-        backend = tmp_path / "src" / "backend"
-        backend.mkdir(parents=True)
-        (backend / "pyproject.toml").write_text("[project]\nname='backend'\n")
-        stacks = StackDetector.detect(tmp_path)
-        stack_types = sorted(s.stack_type for s in stacks)
-        assert stack_types == ["node", "python"]
-
-    def test_node_modules_is_skipped(self, tmp_path: Path) -> None:
-        """Vendor package.json files in node_modules must not match."""
-        # Real package.json at root
-        (tmp_path / "package.json").write_text(
-            json.dumps({"name": "app", "scripts": {}})
-        )
-        # Fake vendor package.json that should be skipped
-        nm = tmp_path / "node_modules" / "react"
-        nm.mkdir(parents=True)
-        (nm / "package.json").write_text(json.dumps({"name": "react", "scripts": {}}))
-        stacks = StackDetector.detect(tmp_path)
-        # Only the root package.json counts
-        assert len(stacks) == 1
-        assert stacks[0].root_path == tmp_path
-
-    def test_invalid_root_raises(self, tmp_path: Path) -> None:
-        """Passing a non-directory raises ValueError."""
-        bogus = tmp_path / "does-not-exist"
-        with pytest.raises(ValueError, match="not a directory"):
-            StackDetector.detect(bogus)
-
-    def test_malformed_package_json_does_not_crash(self, tmp_path: Path) -> None:
-        """A package.json that isn't valid JSON returns a stack
-        with parse_error metadata, not a crash."""
-        (tmp_path / "package.json").write_text("{not valid json")
-        stacks = StackDetector.detect(tmp_path)
-        assert len(stacks) == 1
-        assert "parse_error" in stacks[0].metadata
-
-
-# ---------------------------------------------------------------------------
-# Helper to build a fake successful subprocess for verifier tests
-# ---------------------------------------------------------------------------
-
-
 def _make_step(
     name: str,
+    command: str = "fake",
     success: bool = True,
     exit_code: int = 0,
     stderr: str = "",
-    cwd: Path | None = None,
+    stdout: str = "",
 ) -> VerificationStep:
-    """Build a VerificationStep without running a subprocess."""
+    """Build a VerificationStep for test setup."""
     return VerificationStep(
         name=name,
-        command=["fake"],
-        cwd=cwd or Path.cwd(),
+        command=command,
         exit_code=exit_code,
-        stdout="",
+        stdout=stdout,
         stderr=stderr,
         duration_seconds=0.0,
         success=success,
@@ -160,507 +56,332 @@ def _make_step(
 
 
 # ---------------------------------------------------------------------------
-# NodeVerifier tests
+# Missing start_command rejection
 # ---------------------------------------------------------------------------
 
 
-class TestNodeVerifier:
-    """Node verifier dispatches subprocess correctly per stack metadata."""
+class TestMissingStartCommand:
+    """The runner strictly rejects missing/empty start_command."""
 
     @pytest.mark.asyncio
-    async def test_node_verifier_runs_install_then_build_when_script_present(
+    async def test_none_start_command_returns_rejection(self, tmp_path: Path) -> None:
+        """start_command=None → structured rejection, not an exception."""
+        result = await verify_deliverable(
+            start_command=None, readiness_probe=None, cwd=tmp_path
+        )
+        assert result.success is False
+        assert len(result.steps) == 1
+        assert result.steps[0].name == "missing_start_command"
+        assert result.failure_summary is not None
+        assert "missing required start_command" in result.failure_summary
+        assert result.blocker_message is not None
+        assert "missing start_command" in result.blocker_message
+
+    @pytest.mark.asyncio
+    async def test_empty_string_start_command_returns_rejection(
         self, tmp_path: Path
     ) -> None:
-        """package.json with build script → install + build steps."""
-        (tmp_path / "package.json").write_text(
-            json.dumps({"name": "x", "scripts": {"build": "echo built"}})
+        """Empty string is treated the same as None."""
+        result = await verify_deliverable(
+            start_command="", readiness_probe=None, cwd=tmp_path
         )
-        stack = DetectedStack(
-            stack_type="node",
-            root_path=tmp_path,
-            marker_file=tmp_path / "package.json",
-            metadata={"scripts": {"build": "echo built"}},
-        )
-
-        with (
-            patch(
-                "src.integrations.product_smoke._run_subprocess",
-                new_callable=AsyncMock,
-            ) as mock_run,
-            patch("shutil.which", return_value="/usr/bin/npm"),
-        ):
-            mock_run.side_effect = [
-                _make_step("install", success=True),
-                _make_step("build", success=True),
-            ]
-            verifier = NodeVerifier(stack)
-            steps = await verifier.verify()
-
-        assert len(steps) == 2
-        assert [s.name for s in steps] == ["install", "build"]
-        assert all(s.success for s in steps)
-        assert mock_run.call_count == 2
+        assert result.success is False
+        assert result.steps[0].name == "missing_start_command"
 
     @pytest.mark.asyncio
-    async def test_node_verifier_skips_build_when_no_script(
+    async def test_whitespace_only_start_command_returns_rejection(
         self, tmp_path: Path
     ) -> None:
-        """No build script → install only, build step is a skip marker."""
-        stack = DetectedStack(
-            stack_type="node",
-            root_path=tmp_path,
-            marker_file=tmp_path / "package.json",
-            metadata={"scripts": {}},
+        """Whitespace-only is also rejected."""
+        result = await verify_deliverable(
+            start_command="   \t  ", readiness_probe=None, cwd=tmp_path
         )
-        with (
-            patch(
-                "src.integrations.product_smoke._run_subprocess",
-                new_callable=AsyncMock,
-            ) as mock_run,
-            patch("shutil.which", return_value="/usr/bin/npm"),
-        ):
-            mock_run.return_value = _make_step("install", success=True)
-            verifier = NodeVerifier(stack)
-            steps = await verifier.verify()
-
-        # install ran via subprocess; build was a skip marker (success
-        # without subprocess call)
-        assert mock_run.call_count == 1
-        assert len(steps) == 2
-        assert steps[1].name == "build"
-        assert steps[1].duration_seconds == 0.0  # didn't actually run
-
-    @pytest.mark.asyncio
-    async def test_node_verifier_short_circuits_on_install_failure(
-        self, tmp_path: Path
-    ) -> None:
-        """Install failure → no build attempt."""
-        stack = DetectedStack(
-            stack_type="node",
-            root_path=tmp_path,
-            marker_file=tmp_path / "package.json",
-            metadata={"scripts": {"build": "build cmd"}},
-        )
-        with (
-            patch(
-                "src.integrations.product_smoke._run_subprocess",
-                new_callable=AsyncMock,
-            ) as mock_run,
-            patch("shutil.which", return_value="/usr/bin/npm"),
-        ):
-            mock_run.return_value = _make_step(
-                "install", success=False, exit_code=1, stderr="no internet"
-            )
-            verifier = NodeVerifier(stack)
-            steps = await verifier.verify()
-
-        assert len(steps) == 1
-        assert steps[0].name == "install"
-        assert steps[0].success is False
-        assert mock_run.call_count == 1  # build was never attempted
-
-    @pytest.mark.asyncio
-    async def test_node_verifier_handles_missing_npm(self, tmp_path: Path) -> None:
-        """npm not on PATH → returns a clear failure step."""
-        stack = DetectedStack(
-            stack_type="node",
-            root_path=tmp_path,
-            marker_file=tmp_path / "package.json",
-            metadata={"scripts": {}},
-        )
-        with patch("shutil.which", return_value=None):
-            verifier = NodeVerifier(stack)
-            steps = await verifier.verify()
-
-        assert len(steps) == 1
-        assert steps[0].success is False
-        assert "npm not found" in steps[0].stderr.lower()
-
-    @pytest.mark.asyncio
-    async def test_build_env_forces_ci_true_over_parent_env(
-        self, tmp_path: Path
-    ) -> None:
-        """
-        Codex P2 regression on PR #346.
-
-        The build env must override any pre-existing CI value from
-        the parent process. The original order
-        (``{"CI": "true", **os.environ}``) silently let
-        ``CI=false`` from the parent override our setting,
-        defeating the non-interactive mode this gate is meant to
-        standardize. Order matters in dict spread — last write
-        wins, so the override must come AFTER the spread.
-
-        This test pins the fix: even with ``CI=false`` set in the
-        parent, the env passed to the build subprocess has
-        ``CI=true``. PATH is still inherited (sanity check we
-        didn't accidentally drop the parent env entirely).
-        """
-        stack = DetectedStack(
-            stack_type="node",
-            root_path=tmp_path,
-            marker_file=tmp_path / "package.json",
-            metadata={"scripts": {"build": "react-scripts build"}},
-        )
-
-        captured_env: dict = {}
-
-        async def _capture_env(
-            name: str,
-            command: list,
-            cwd: Path,
-            timeout_seconds: float,
-            env=None,
-        ) -> VerificationStep:
-            if name == "build" and env is not None:
-                captured_env.update(env)
-            return _make_step(name, success=True)
-
-        with (
-            patch(
-                "src.integrations.product_smoke._run_subprocess",
-                new=_capture_env,
-            ),
-            patch("shutil.which", return_value="/usr/bin/npm"),
-            patch.dict("os.environ", {"CI": "false", "PATH": "/usr/bin"}, clear=False),
-        ):
-            verifier = NodeVerifier(stack)
-            await verifier.verify()
-
-        # CI must be "true" even though parent env had "false"
-        assert captured_env.get("CI") == "true", (
-            f"CI must be forced to 'true' regardless of parent env. "
-            f"Got: {captured_env.get('CI')!r}"
-        )
-        # PATH must still be inherited (we didn't drop parent env)
-        assert "PATH" in captured_env
+        assert result.success is False
+        assert result.steps[0].name == "missing_start_command"
 
 
 # ---------------------------------------------------------------------------
-# PythonVerifier tests
+# One-shot mode (no readiness_probe)
 # ---------------------------------------------------------------------------
 
 
-class TestPythonVerifier:
-    """Python verifier detects pytest and runs it when tests/ exists."""
+class TestOneShotMode:
+    """One-shot commands: run, wait for exit, require exit 0."""
 
     @pytest.mark.asyncio
-    async def test_python_verifier_runs_pytest_when_tests_dir_exists(
-        self, tmp_path: Path
-    ) -> None:
-        """tests/ directory present → pytest invoked."""
-        (tmp_path / "pyproject.toml").write_text("[project]\nname='x'\n")
-        (tmp_path / "tests").mkdir()
-        stack = DetectedStack(
-            stack_type="python",
-            root_path=tmp_path,
-            marker_file=tmp_path / "pyproject.toml",
-        )
-        with (
-            patch(
-                "src.integrations.product_smoke._run_subprocess",
-                new_callable=AsyncMock,
-            ) as mock_run,
-            patch(
-                "shutil.which",
-                side_effect=lambda name: f"/usr/bin/{name}",
-            ),
-        ):
-            mock_run.return_value = _make_step("test", success=True)
-            verifier = PythonVerifier(stack)
-            steps = await verifier.verify()
-
-        assert len(steps) == 1
-        assert steps[0].name == "test"
-        assert steps[0].success is True
-        mock_run.assert_called_once()
-
-    @pytest.mark.asyncio
-    async def test_python_verifier_skips_when_no_tests_dir(
-        self, tmp_path: Path
-    ) -> None:
-        """No tests/ directory → skipped, success=True."""
-        stack = DetectedStack(
-            stack_type="python",
-            root_path=tmp_path,
-            marker_file=tmp_path / "pyproject.toml",
-        )
+    async def test_one_shot_success(self, tmp_path: Path) -> None:
+        """Command exits 0 → success=True with one step."""
         with patch(
-            "shutil.which",
-            side_effect=lambda name: f"/usr/bin/{name}",
-        ):
-            verifier = PythonVerifier(stack)
-            steps = await verifier.verify()
-
-        assert len(steps) == 1
-        assert steps[0].success is True
-        assert "no tests" in steps[0].stderr.lower()
-
-
-# ---------------------------------------------------------------------------
-# Verifier dispatch
-# ---------------------------------------------------------------------------
-
-
-class TestVerifierDispatch:
-    """``_pick_verifier`` returns the right concrete class per stack type."""
-
-    def test_node_stack_picks_node_verifier(self, tmp_path: Path) -> None:
-        stack = DetectedStack(
-            stack_type="node",
-            root_path=tmp_path,
-            marker_file=tmp_path,
-        )
-        assert isinstance(_pick_verifier(stack), NodeVerifier)
-
-    def test_python_stack_picks_python_verifier(self, tmp_path: Path) -> None:
-        stack = DetectedStack(
-            stack_type="python",
-            root_path=tmp_path,
-            marker_file=tmp_path,
-        )
-        assert isinstance(_pick_verifier(stack), PythonVerifier)
-
-    def test_unsupported_stack_picks_unsupported(self, tmp_path: Path) -> None:
-        """Go/Rust/Java fall through to the no-op stub."""
-        stack = DetectedStack(
-            stack_type="go",
-            root_path=tmp_path,
-            marker_file=tmp_path,
-        )
-        assert isinstance(_pick_verifier(stack), _UnsupportedVerifier)
-
-
-# ---------------------------------------------------------------------------
-# ProductSmokeVerifier orchestrator
-# ---------------------------------------------------------------------------
-
-
-class TestProductSmokeVerifier:
-    """Top-level orchestrator behavior."""
-
-    @pytest.mark.asyncio
-    async def test_empty_repo_returns_success_with_skip_reason(
-        self, tmp_path: Path
-    ) -> None:
-        """No detected stacks → pass with skipped_reason set."""
-        result = await ProductSmokeVerifier().verify(tmp_path)
-        assert result.success is True
-        assert result.detected_stacks == []
-        assert result.skipped_reason is not None
-
-    @pytest.mark.asyncio
-    async def test_single_stack_success(self, tmp_path: Path) -> None:
-        """One Node stack, all steps pass → overall success."""
-        (tmp_path / "package.json").write_text(json.dumps({"name": "x", "scripts": {}}))
-        with (
-            patch(
-                "src.integrations.product_smoke._run_subprocess",
-                new_callable=AsyncMock,
-            ) as mock_run,
-            patch("shutil.which", return_value="/usr/bin/npm"),
-        ):
-            mock_run.return_value = _make_step("install", success=True)
-            result = await ProductSmokeVerifier().verify(tmp_path)
+            "src.integrations.product_smoke._run_one_shot",
+            new_callable=AsyncMock,
+        ) as mock_run:
+            mock_run.return_value = _make_step(
+                name="start_command", command="npm run build", success=True
+            )
+            result = await verify_deliverable(
+                start_command="npm run build",
+                readiness_probe=None,
+                cwd=tmp_path,
+            )
 
         assert result.success is True
-        assert len(result.detected_stacks) == 1
+        assert len(result.steps) == 1
+        assert result.steps[0].name == "start_command"
+        assert result.steps[0].success is True
         assert result.failure_summary is None
         assert result.blocker_message is None
 
     @pytest.mark.asyncio
-    async def test_first_failure_short_circuits_summary(self, tmp_path: Path) -> None:
-        """When a step fails, failure_summary names that step."""
-        (tmp_path / "package.json").write_text(
-            json.dumps({"name": "x", "scripts": {"build": "x"}})
-        )
-        with (
-            patch(
-                "src.integrations.product_smoke._run_subprocess",
-                new_callable=AsyncMock,
-            ) as mock_run,
-            patch("shutil.which", return_value="/usr/bin/npm"),
-        ):
+    async def test_one_shot_failure_surfaces_stderr(self, tmp_path: Path) -> None:
+        """Command exits non-zero → failure with stderr in blocker."""
+        with patch(
+            "src.integrations.product_smoke._run_one_shot",
+            new_callable=AsyncMock,
+        ) as mock_run:
             mock_run.return_value = _make_step(
-                "install", success=False, exit_code=2, stderr="boom"
+                name="start_command",
+                command="npm run build",
+                success=False,
+                exit_code=1,
+                stderr="Could not find a required file.\n  Name: index.html",
             )
-            result = await ProductSmokeVerifier().verify(tmp_path)
+            result = await verify_deliverable(
+                start_command="npm run build",
+                readiness_probe=None,
+                cwd=tmp_path,
+            )
 
         assert result.success is False
         assert result.failure_summary is not None
-        assert "install" in result.failure_summary
+        assert "start_command failed" in result.failure_summary
         assert result.blocker_message is not None
-        assert "boom" in result.blocker_message
+        assert "index.html" in result.blocker_message
+        assert "Could not find a required file" in result.blocker_message
 
     @pytest.mark.asyncio
-    async def test_v71_regression_missing_index_html_is_caught(
-        self, tmp_path: Path
-    ) -> None:
+    async def test_one_shot_v71_regression(self, tmp_path: Path) -> None:
         """
-        REGRESSION TEST FOR DASHBOARD-V71.
+        REGRESSION for dashboard-v71.
 
-        A React project missing public/index.html must produce a
-        verification failure when ProductSmokeVerifier runs. This
-        is the exact bug shape that v71 shipped: every src/ file
-        was correct, all unit tests passed, but `npm start` fails
-        with "Could not find a required file. Name: index.html"
-        because react-scripts requires the HTML shell.
-
-        We simulate the failure by mocking the build subprocess to
-        return the actual react-scripts error message. The test
-        proves that the orchestrator correctly:
-        1. Detects the Node stack
-        2. Runs the build step
-        3. Surfaces the build error in the blocker message
-        4. Returns success=False
+        A React project missing public/index.html must fail
+        verification when the agent declares `npm run build` as
+        their start_command. This is the exact bug shape that
+        shipped broken in v71 because no one ran `npm run build`
+        before marking the task complete.
         """
-        # Build a v71-shaped React project (everything except index.html)
-        (tmp_path / "package.json").write_text(
-            json.dumps(
-                {
-                    "name": "dashboard",
-                    "version": "1.0.0",
-                    "scripts": {
-                        "start": "react-scripts start",
-                        "build": "react-scripts build",
-                    },
-                    "dependencies": {"react": "^18.0.0"},
-                }
-            )
-        )
-        (tmp_path / "src").mkdir()
-        (tmp_path / "src" / "index.tsx").write_text(
-            "import React from 'react';\n"
-            "import ReactDOM from 'react-dom/client';\n"
-            "ReactDOM.createRoot(document.getElementById('root')!)"
-            ".render(<div>hi</div>);\n"
-        )
-        (tmp_path / "public").mkdir()
-        # NO index.html — this is the v71 bug shape
-
-        with (
-            patch(
-                "src.integrations.product_smoke._run_subprocess",
-                new_callable=AsyncMock,
-            ) as mock_run,
-            patch("shutil.which", return_value="/usr/bin/npm"),
-        ):
-            # First call: install succeeds. Second call: build fails
-            # with the actual react-scripts error message.
-            mock_run.side_effect = [
-                _make_step("install", success=True),
-                _make_step(
-                    "build",
-                    success=False,
-                    exit_code=1,
-                    stderr=(
-                        "Could not find a required file.\n"
-                        "  Name: index.html\n"
-                        "  Searched in: " + str(tmp_path / "public")
-                    ),
+        with patch(
+            "src.integrations.product_smoke._run_one_shot",
+            new_callable=AsyncMock,
+        ) as mock_run:
+            # Simulate the real react-scripts error
+            mock_run.return_value = _make_step(
+                name="start_command",
+                command="npm run build",
+                success=False,
+                exit_code=1,
+                stderr=(
+                    "Failed to compile.\n\n"
+                    "Could not find a required file.\n"
+                    "  Name: index.html\n"
+                    f"  Searched in: {tmp_path}/public"
                 ),
-            ]
-            result = await ProductSmokeVerifier().verify(tmp_path)
+            )
+            result = await verify_deliverable(
+                start_command="npm run build",
+                readiness_probe=None,
+                cwd=tmp_path,
+            )
 
         assert result.success is False, (
             "v71 regression: missing public/index.html must fail "
-            "product smoke verification"
+            "declared start_command"
         )
-        assert result.blocker_message is not None
-        assert "index.html" in result.blocker_message, (
-            "blocker must surface the actual react-scripts error so "
-            "the agent knows what to fix"
-        )
-        # The build step should be the failing one
-        build_steps = [s for s in result.steps if s.name == "build"]
-        assert len(build_steps) == 1
-        assert build_steps[0].success is False
+        assert "index.html" in (result.blocker_message or "")
+
+
+# ---------------------------------------------------------------------------
+# Server+probe mode (with readiness_probe)
+# ---------------------------------------------------------------------------
+
+
+class TestServerWithProbeMode:
+    """Server mode: start in background, poll probe until ready."""
 
     @pytest.mark.asyncio
-    async def test_multi_stack_runs_all_stacks(self, tmp_path: Path) -> None:
-        """Frontend + backend → both verified."""
-        frontend = tmp_path / "frontend"
-        frontend.mkdir()
-        (frontend / "package.json").write_text(
-            json.dumps({"name": "fe", "scripts": {}})
-        )
-        backend = tmp_path / "backend"
-        backend.mkdir()
-        (backend / "pyproject.toml").write_text("[project]\nname='be'\n")
+    async def test_server_with_probe_success(self, tmp_path: Path) -> None:
+        """Server starts, probe passes → overall success."""
+        with patch(
+            "src.integrations.product_smoke._run_server_with_probe",
+            new_callable=AsyncMock,
+        ) as mock_run:
+            mock_run.return_value = [
+                _make_step(
+                    name="start_command",
+                    command="uvicorn main:app",
+                    success=True,
+                ),
+                _make_step(
+                    name="readiness_probe",
+                    command="curl -f http://localhost:8000/health",
+                    success=True,
+                ),
+            ]
+            result = await verify_deliverable(
+                start_command="uvicorn main:app --port 8000",
+                readiness_probe="curl -f http://localhost:8000/health",
+                cwd=tmp_path,
+            )
 
-        with (
-            patch(
-                "src.integrations.product_smoke._run_subprocess",
-                new_callable=AsyncMock,
-            ) as mock_run,
-            patch(
-                "shutil.which",
-                side_effect=lambda name: f"/usr/bin/{name}",
-            ),
-        ):
-            mock_run.return_value = _make_step("install", success=True)
-            result = await ProductSmokeVerifier().verify(tmp_path)
-
-        stack_types = sorted(s.stack_type for s in result.detected_stacks)
-        assert stack_types == ["node", "python"]
         assert result.success is True
+        assert len(result.steps) == 2
+        assert result.steps[0].name == "start_command"
+        assert result.steps[1].name == "readiness_probe"
+        mock_run.assert_called_once()
 
     @pytest.mark.asyncio
-    async def test_invalid_project_root_returns_failure(self, tmp_path: Path) -> None:
-        """Bogus path → structured failure, not exception."""
-        bogus = tmp_path / "does-not-exist"
-        result = await ProductSmokeVerifier().verify(bogus)
+    async def test_server_with_probe_fails_when_probe_never_passes(
+        self, tmp_path: Path
+    ) -> None:
+        """
+        Server runs but probe never returns exit 0 → failure.
+        This catches the hung-server-no-error case: server binds
+        port, deadlocks on init, looks alive but can't serve.
+        """
+        with patch(
+            "src.integrations.product_smoke._run_server_with_probe",
+            new_callable=AsyncMock,
+        ) as mock_run:
+            mock_run.return_value = [
+                _make_step(
+                    name="start_command",
+                    command="uvicorn main:app",
+                    success=True,
+                ),
+                _make_step(
+                    name="readiness_probe",
+                    command="curl -f http://localhost:8000/health",
+                    success=False,
+                    stderr="Readiness probe failed after 15 attempts. Last exit=7.",
+                ),
+            ]
+            result = await verify_deliverable(
+                start_command="uvicorn main:app --port 8000",
+                readiness_probe="curl -f http://localhost:8000/health",
+                cwd=tmp_path,
+            )
+
         assert result.success is False
         assert result.failure_summary is not None
+        assert "readiness_probe failed" in result.failure_summary
+        assert result.blocker_message is not None
+        assert "readiness probe never returned exit 0" in result.blocker_message
+
+    @pytest.mark.asyncio
+    async def test_server_with_probe_fails_when_server_crashes(
+        self, tmp_path: Path
+    ) -> None:
+        """Server exits non-zero before readiness → failure."""
+        with patch(
+            "src.integrations.product_smoke._run_server_with_probe",
+            new_callable=AsyncMock,
+        ) as mock_run:
+            mock_run.return_value = [
+                _make_step(
+                    name="start_command",
+                    command="uvicorn main:app",
+                    success=False,
+                    exit_code=1,
+                    stderr="ImportError: No module named 'main'",
+                ),
+                _make_step(
+                    name="readiness_probe",
+                    command="curl -f http://localhost:8000/health",
+                    success=False,
+                    stderr="Server exited before readiness",
+                ),
+            ]
+            result = await verify_deliverable(
+                start_command="uvicorn main:app --port 8000",
+                readiness_probe="curl -f http://localhost:8000/health",
+                cwd=tmp_path,
+            )
+
+        assert result.success is False
+        assert result.failure_summary is not None
+        assert "start_command failed" in result.failure_summary
 
 
 # ---------------------------------------------------------------------------
-# Result serialization & blocker rendering
+# Result rendering
 # ---------------------------------------------------------------------------
 
 
-class TestResultRendering:
-    """``ProductSmokeResult`` serializes cleanly for logs/blockers."""
+class TestBlockerMessages:
+    """Blocker messages render actionable info for agents."""
 
-    def test_to_dict_has_required_keys(self, tmp_path: Path) -> None:
+    def test_missing_blocker_explains_how_to_declare(self) -> None:
+        msg = _render_missing_blocker()
+        assert "missing start_command" in msg
+        assert "report_task_progress" in msg
+        assert "npm run build" in msg  # one-shot example
+        assert "uvicorn" in msg  # server example
+        assert "readiness_probe" in msg
+
+    def test_failure_blocker_includes_command_and_stderr(self, tmp_path: Path) -> None:
+        failed = _make_step(
+            name="start_command",
+            command="npm run build",
+            success=False,
+            exit_code=1,
+            stderr="ENOENT: index.html",
+        )
+        msg = _render_failure_blocker(failed, [failed])
+        assert "FAILED" in msg
+        assert "npm run build" in msg
+        assert "ENOENT" in msg
+        assert "start_command did not exit 0" in msg
+
+    def test_failure_blocker_for_probe_failure_names_probe_mode(self) -> None:
+        failed = _make_step(
+            name="readiness_probe",
+            command="curl -f http://localhost:8000/health",
+            success=False,
+            stderr="Probe never passed",
+        )
+        msg = _render_failure_blocker(failed, [failed])
+        assert "readiness probe never returned exit 0" in msg
+
+
+# ---------------------------------------------------------------------------
+# Result serialization
+# ---------------------------------------------------------------------------
+
+
+class TestResultSerialization:
+    """``ProductSmokeResult.to_dict`` produces JSON-ready output."""
+
+    def test_to_dict_has_required_keys(self) -> None:
         result = ProductSmokeResult(
             success=False,
-            detected_stacks=[
-                DetectedStack(
-                    stack_type="node",
-                    root_path=tmp_path,
-                    marker_file=tmp_path,
-                )
-            ],
-            steps=[_make_step("install", success=False, stderr="bad")],
-            failure_summary="install failed",
+            steps=[_make_step("start_command", success=False, stderr="bad")],
+            failure_summary="start_command failed",
             blocker_message="fix it",
         )
         d = result.to_dict()
         assert d["success"] is False
-        assert len(d["detected_stacks"]) == 1
+        assert d["failure_summary"] == "start_command failed"
         assert len(d["steps"]) == 1
-        assert d["failure_summary"] == "install failed"
+        assert d["steps"][0]["name"] == "start_command"
+        assert d["steps"][0]["success"] is False
 
-    def test_blocker_message_includes_command_and_stderr_tail(
-        self, tmp_path: Path
-    ) -> None:
-        """The blocker message must contain enough info to debug."""
-        step = VerificationStep(
-            name="build",
-            command=["npm", "run", "build"],
-            cwd=tmp_path,
-            exit_code=1,
-            stdout="",
-            stderr="ENOENT: index.html",
-            duration_seconds=2.5,
+    def test_to_dict_truncates_long_outputs(self) -> None:
+        long_stderr = "x" * 10000
+        result = ProductSmokeResult(
             success=False,
+            steps=[_make_step("start_command", success=False, stderr=long_stderr)],
+            failure_summary="x",
+            blocker_message="x",
         )
-        stacks = [
-            DetectedStack(stack_type="node", root_path=tmp_path, marker_file=tmp_path)
-        ]
-        msg = _build_blocker_message(step, stacks)
-        assert "FAILED" in msg
-        assert "npm run build" in msg
-        assert "ENOENT" in msg
-        assert "exit code: 1" in msg.lower() or "exit code: 1" in msg
+        d = result.to_dict()
+        # Serialized stderr tail is limited to 1024 chars
+        assert len(d["steps"][0]["stderr_tail"]) <= 1024

--- a/tests/unit/marcus_mcp/test_integration_smoke_gate.py
+++ b/tests/unit/marcus_mcp/test_integration_smoke_gate.py
@@ -1,20 +1,19 @@
-"""Unit tests for the product smoke gate in report_task_progress.
+"""Unit tests for the integration smoke gate in report_task_progress.
 
-When an integration verification task (label ``"type:integration"``)
-reports completion, Marcus must run ``ProductSmokeVerifier`` as an
-independent check — and reject the completion if verification
-fails, regardless of what the agent claimed.
+Covers the wiring between ``report_task_progress`` and the deliverable
+verification runner. The gate fires only on integration verification
+tasks (``"type:integration"`` label), strictly requires the agent to
+declare ``start_command`` on completion, and rejects the completion
+if verification fails or the declaration is missing.
 
-These tests cover the wiring at the ``report_task_progress`` level:
-- Integration tasks invoke the smoke gate
-- Non-integration tasks do NOT invoke the smoke gate (no overhead)
-- A failing smoke gate rejects the completion with a structured error
-- A passing smoke gate lets the completion proceed
-- Verifier crashes log-and-continue (don't block on infrastructure)
+Non-integration tasks bypass the gate entirely — ``start_command``
+and ``readiness_probe`` are ignored for implementation tasks so the
+API surface doesn't accidentally block normal agent work.
 """
 
 from __future__ import annotations
 
+import tempfile
 from datetime import datetime, timezone
 from pathlib import Path
 from unittest.mock import AsyncMock, Mock, patch
@@ -23,7 +22,6 @@ import pytest
 
 from src.core.models import Priority, Task, TaskAssignment, TaskStatus
 from src.integrations.product_smoke import (
-    DetectedStack,
     ProductSmokeResult,
     VerificationStep,
 )
@@ -88,18 +86,9 @@ def _make_state(
     agent_id: str = "agent-001",
     project_root: str | None = None,
 ) -> Mock:
-    """Build a Mock state suitable for report_task_progress.
-
-    ``project_root`` defaults to a stable subdirectory under the
-    system temp dir (resolved via ``tempfile.gettempdir()``) when
-    not provided, so we don't hardcode ``/tmp`` paths that bandit
-    flags as B108. Tests that need a specific directory should
-    pass their own ``tmp_path``.
-    """
-    import tempfile as _tempfile
-
+    """Build a Mock state for report_task_progress."""
     if project_root is None:
-        project_root = str(Path(_tempfile.gettempdir()) / "marcus_smoke_gate_test")
+        project_root = str(Path(tempfile.gettempdir()) / "marcus_smoke_gate_test")
     state = Mock()
     state.initialize_kanban = AsyncMock()
     state.kanban_client = Mock()
@@ -126,12 +115,10 @@ class TestIsIntegrationTask:
     """``_is_integration_task`` correctly identifies integration tasks."""
 
     def test_label_present_returns_true(self) -> None:
-        task = _make_integration_task()
-        assert _is_integration_task(task) is True
+        assert _is_integration_task(_make_integration_task()) is True
 
     def test_label_absent_returns_false(self) -> None:
-        task = _make_impl_task()
-        assert _is_integration_task(task) is False
+        assert _is_integration_task(_make_impl_task()) is False
 
     def test_no_labels_returns_false(self) -> None:
         task = Task(
@@ -151,138 +138,214 @@ class TestIsIntegrationTask:
 
 
 class TestProductSmokeGate:
-    """Direct tests of ``_run_product_smoke_gate``."""
+    """Direct tests of ``_run_product_smoke_gate`` with new signature."""
 
     @pytest.mark.asyncio
-    async def test_smoke_gate_passes_returns_none(self, tmp_path: Path) -> None:
-        """Passing smoke verification → gate returns None (proceed)."""
+    async def test_gate_rejects_missing_start_command(self, tmp_path: Path) -> None:
+        """
+        Missing start_command on an integration task → rejection
+        with the missing-declaration blocker. STRICT.
+        """
         task = _make_integration_task()
         state = _make_state(task, project_root=str(tmp_path))
 
-        passing_result = ProductSmokeResult(
-            success=True,
-            detected_stacks=[],
-            steps=[],
-            skipped_reason="no stack detected",
-        )
-        with patch(
-            "src.integrations.product_smoke.ProductSmokeVerifier.verify",
-            new_callable=AsyncMock,
-            return_value=passing_result,
-        ):
-            response = await _run_product_smoke_gate(
-                task=task, agent_id="agent-001", state=state
-            )
-        assert response is None
-
-    @pytest.mark.asyncio
-    async def test_smoke_gate_failure_returns_rejection(self, tmp_path: Path) -> None:
-        """Failing smoke verification → gate returns a rejection dict."""
-        task = _make_integration_task()
-        state = _make_state(task, project_root=str(tmp_path))
-
-        failing_step = VerificationStep(
-            name="build",
-            command=["npm", "run", "build"],
-            cwd=tmp_path,
-            exit_code=1,
-            stdout="",
-            stderr="Could not find a required file. Name: index.html",
-            duration_seconds=1.5,
+        # The runner returns a missing-declaration result
+        missing_result = ProductSmokeResult(
             success=False,
-        )
-        failing_result = ProductSmokeResult(
-            success=False,
-            detected_stacks=[
-                DetectedStack(
-                    stack_type="node", root_path=tmp_path, marker_file=tmp_path
+            steps=[
+                VerificationStep(
+                    name="missing_start_command",
+                    command="",
+                    exit_code=None,
+                    stdout="",
+                    stderr="No start_command declared.",
+                    duration_seconds=0.0,
+                    success=False,
                 )
             ],
-            steps=[failing_step],
-            failure_summary="build failed",
-            blocker_message="## Product smoke verification FAILED\nindex.html missing",
+            failure_summary="integration task missing required start_command",
+            blocker_message="## Integration task rejected: missing start_command",
         )
         with patch(
-            "src.integrations.product_smoke.ProductSmokeVerifier.verify",
+            "src.integrations.product_smoke.verify_deliverable",
             new_callable=AsyncMock,
-            return_value=failing_result,
+            return_value=missing_result,
         ):
             response = await _run_product_smoke_gate(
-                task=task, agent_id="agent-001", state=state
+                task=task,
+                agent_id="agent-001",
+                state=state,
+                start_command=None,
+                readiness_probe=None,
             )
 
         assert response is not None
         assert response["success"] is False
         assert response["status"] == "smoke_verification_failed"
         assert response["error"] == "product_smoke_failed"
-        assert response["task_id"] == task.id
-        assert "index.html" in response["blocker"]
-        assert response["smoke_result"]["success"] is False
+        assert "missing start_command" in response["blocker"]
 
     @pytest.mark.asyncio
-    async def test_smoke_gate_skips_when_no_workspace_state(self) -> None:
-        """No project_root in workspace state → gate skips, returns None."""
+    async def test_gate_passes_with_valid_start_command(self, tmp_path: Path) -> None:
+        """Valid start_command + runner success → gate returns None."""
+        task = _make_integration_task()
+        state = _make_state(task, project_root=str(tmp_path))
+
+        passing = ProductSmokeResult(
+            success=True,
+            steps=[
+                VerificationStep(
+                    name="start_command",
+                    command="npm run build",
+                    exit_code=0,
+                    stdout="built",
+                    stderr="",
+                    duration_seconds=5.0,
+                    success=True,
+                )
+            ],
+        )
+        with patch(
+            "src.integrations.product_smoke.verify_deliverable",
+            new_callable=AsyncMock,
+            return_value=passing,
+        ) as mock_verify:
+            response = await _run_product_smoke_gate(
+                task=task,
+                agent_id="agent-001",
+                state=state,
+                start_command="npm run build",
+                readiness_probe=None,
+            )
+
+        assert response is None
+        # Verify the runner was called with the declared params
+        call_kwargs = mock_verify.call_args.kwargs
+        assert call_kwargs["start_command"] == "npm run build"
+        assert call_kwargs["readiness_probe"] is None
+
+    @pytest.mark.asyncio
+    async def test_gate_rejects_failing_start_command(self, tmp_path: Path) -> None:
+        """Declared start_command fails → gate rejects with stderr."""
+        task = _make_integration_task()
+        state = _make_state(task, project_root=str(tmp_path))
+
+        failing = ProductSmokeResult(
+            success=False,
+            steps=[
+                VerificationStep(
+                    name="start_command",
+                    command="npm run build",
+                    exit_code=1,
+                    stdout="",
+                    stderr="Could not find index.html",
+                    duration_seconds=2.0,
+                    success=False,
+                )
+            ],
+            failure_summary="start_command failed (exit=1)",
+            blocker_message="## Deliverable verification FAILED\nindex.html missing",
+        )
+        with patch(
+            "src.integrations.product_smoke.verify_deliverable",
+            new_callable=AsyncMock,
+            return_value=failing,
+        ):
+            response = await _run_product_smoke_gate(
+                task=task,
+                agent_id="agent-001",
+                state=state,
+                start_command="npm run build",
+                readiness_probe=None,
+            )
+
+        assert response is not None
+        assert response["success"] is False
+        assert "index.html" in response["blocker"]
+
+    @pytest.mark.asyncio
+    async def test_gate_passes_server_mode_with_probe(self, tmp_path: Path) -> None:
+        """Both start_command and readiness_probe are forwarded to the runner."""
+        task = _make_integration_task()
+        state = _make_state(task, project_root=str(tmp_path))
+
+        passing = ProductSmokeResult(
+            success=True,
+            steps=[
+                VerificationStep(
+                    name="start_command",
+                    command="uvicorn main:app",
+                    exit_code=None,
+                    stdout="",
+                    stderr="",
+                    duration_seconds=4.0,
+                    success=True,
+                ),
+                VerificationStep(
+                    name="readiness_probe",
+                    command="curl -f http://localhost:8000/health",
+                    exit_code=0,
+                    stdout="OK",
+                    stderr="",
+                    duration_seconds=0.5,
+                    success=True,
+                ),
+            ],
+        )
+        with patch(
+            "src.integrations.product_smoke.verify_deliverable",
+            new_callable=AsyncMock,
+            return_value=passing,
+        ) as mock_verify:
+            response = await _run_product_smoke_gate(
+                task=task,
+                agent_id="agent-001",
+                state=state,
+                start_command="uvicorn main:app --port 8000",
+                readiness_probe="curl -f http://localhost:8000/health",
+            )
+
+        assert response is None
+        call_kwargs = mock_verify.call_args.kwargs
+        assert call_kwargs["start_command"] == "uvicorn main:app --port 8000"
+        assert call_kwargs["readiness_probe"] == "curl -f http://localhost:8000/health"
+
+    @pytest.mark.asyncio
+    async def test_gate_skips_when_no_workspace_state(self) -> None:
+        """No project_root → gate skips with None, no crash."""
         task = _make_integration_task()
         state = _make_state(task)
         state.kanban_client._load_workspace_state = Mock(return_value=None)
 
         response = await _run_product_smoke_gate(
-            task=task, agent_id="agent-001", state=state
-        )
-        assert response is None
-
-    @pytest.mark.asyncio
-    async def test_smoke_gate_skips_when_workspace_load_raises(self) -> None:
-        """Workspace state load crash → gate skips with warning, returns None."""
-        task = _make_integration_task()
-        state = _make_state(task)
-        state.kanban_client._load_workspace_state = Mock(
-            side_effect=RuntimeError("kanban down")
-        )
-
-        response = await _run_product_smoke_gate(
-            task=task, agent_id="agent-001", state=state
-        )
-        assert response is None
-
-    @pytest.mark.asyncio
-    async def test_smoke_gate_skips_when_project_root_not_a_dir(
-        self, tmp_path: Path
-    ) -> None:
-        """project_root that doesn't exist as dir → skip, no crash."""
-        task = _make_integration_task()
-        state = _make_state(task, project_root=str(tmp_path / "does-not-exist"))
-
-        response = await _run_product_smoke_gate(
-            task=task, agent_id="agent-001", state=state
+            task=task,
+            agent_id="agent-001",
+            state=state,
+            start_command="npm run build",
+            readiness_probe=None,
         )
         assert response is None
 
 
 class TestReportTaskProgressIntegration:
-    """End-to-end test: report_task_progress invokes the smoke gate."""
+    """End-to-end: report_task_progress forwards declared commands to the gate."""
 
     @pytest.mark.asyncio
-    async def test_integration_task_completion_triggers_smoke_gate(
+    async def test_integration_task_completion_runs_gate_with_declared_command(
         self, tmp_path: Path
     ) -> None:
         """
-        When report_task_progress receives status=completed for an
-        integration task, ProductSmokeVerifier.verify is called.
+        When an integration task completes with a declared
+        start_command, the gate runs with that exact command.
         """
         task = _make_integration_task()
         state = _make_state(task, project_root=str(tmp_path))
 
-        passing_result = ProductSmokeResult(
-            success=True,
-            detected_stacks=[],
-            steps=[],
-            skipped_reason="no stack",
-        )
+        passing = ProductSmokeResult(success=True, steps=[])
         with patch(
-            "src.integrations.product_smoke.ProductSmokeVerifier.verify",
+            "src.integrations.product_smoke.verify_deliverable",
             new_callable=AsyncMock,
-            return_value=passing_result,
+            return_value=passing,
         ) as mock_verify:
             await report_task_progress(
                 agent_id="agent-001",
@@ -291,44 +354,44 @@ class TestReportTaskProgressIntegration:
                 progress=100,
                 message="done",
                 state=state,
+                start_command="npm run build",
+                readiness_probe=None,
             )
             mock_verify.assert_called_once()
+            call_kwargs = mock_verify.call_args.kwargs
+            assert call_kwargs["start_command"] == "npm run build"
 
     @pytest.mark.asyncio
-    async def test_failing_smoke_gate_rejects_completion(self, tmp_path: Path) -> None:
+    async def test_integration_completion_without_start_command_rejected(
+        self, tmp_path: Path
+    ) -> None:
         """
-        Failing smoke verification rejects the completion. Kanban
-        DONE write must NOT happen.
+        Integration task completes without declaring start_command
+        → rejected. Kanban DONE write must NOT happen.
         """
         task = _make_integration_task()
         state = _make_state(task, project_root=str(tmp_path))
 
-        failing_result = ProductSmokeResult(
+        missing = ProductSmokeResult(
             success=False,
-            detected_stacks=[
-                DetectedStack(
-                    stack_type="node", root_path=tmp_path, marker_file=tmp_path
-                )
-            ],
             steps=[
                 VerificationStep(
-                    name="build",
-                    command=["npm", "run", "build"],
-                    cwd=tmp_path,
-                    exit_code=1,
+                    name="missing_start_command",
+                    command="",
+                    exit_code=None,
                     stdout="",
-                    stderr="missing index.html",
-                    duration_seconds=1.0,
+                    stderr="missing",
+                    duration_seconds=0.0,
                     success=False,
                 )
             ],
-            failure_summary="build failed",
-            blocker_message="missing index.html in public/",
+            failure_summary="integration task missing required start_command",
+            blocker_message="## Integration task rejected: missing start_command",
         )
         with patch(
-            "src.integrations.product_smoke.ProductSmokeVerifier.verify",
+            "src.integrations.product_smoke.verify_deliverable",
             new_callable=AsyncMock,
-            return_value=failing_result,
+            return_value=missing,
         ):
             response = await report_task_progress(
                 agent_id="agent-001",
@@ -337,25 +400,27 @@ class TestReportTaskProgressIntegration:
                 progress=100,
                 message="done",
                 state=state,
+                # No start_command passed — strict rejection
             )
 
         assert response["success"] is False
         assert response["status"] == "smoke_verification_failed"
-        # Kanban DONE write was blocked because the smoke gate
-        # short-circuited before the completion path.
         state.kanban_client.update_task.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_non_integration_task_skips_smoke_gate(self, tmp_path: Path) -> None:
+    async def test_non_integration_task_ignores_start_command(
+        self, tmp_path: Path
+    ) -> None:
         """
-        Implementation tasks completing should NOT trigger the smoke
-        gate — only integration tasks do.
+        Implementation tasks do NOT trigger the smoke gate even if
+        the caller accidentally passes start_command. Parameter is
+        silently ignored for non-integration tasks.
         """
         task = _make_impl_task()
         state = _make_state(task, project_root=str(tmp_path))
 
         with patch(
-            "src.integrations.product_smoke.ProductSmokeVerifier.verify",
+            "src.integrations.product_smoke.verify_deliverable",
             new_callable=AsyncMock,
         ) as mock_verify:
             await report_task_progress(
@@ -365,34 +430,31 @@ class TestReportTaskProgressIntegration:
                 progress=100,
                 message="done",
                 state=state,
+                start_command="npm run build",  # ignored on impl tasks
+                readiness_probe=None,
             )
             mock_verify.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_smoke_gate_system_error_falls_through(self, tmp_path: Path) -> None:
+    async def test_non_integration_task_completes_without_declaration(
+        self, tmp_path: Path
+    ) -> None:
         """
-        ProductSmokeVerifier crashes (not a smoke failure — an
-        actual exception) → log-and-continue. The task completion
-        proceeds to avoid blocking on infrastructure problems.
+        Implementation tasks can complete without declaring a
+        start_command. The strict requirement only applies to
+        integration tasks.
         """
-        task = _make_integration_task()
+        task = _make_impl_task()
         state = _make_state(task, project_root=str(tmp_path))
 
-        with patch(
-            "src.integrations.product_smoke.ProductSmokeVerifier.verify",
-            new_callable=AsyncMock,
-            side_effect=RuntimeError("verifier internal error"),
-        ):
-            response = await report_task_progress(
-                agent_id="agent-001",
-                task_id=task.id,
-                status="completed",
-                progress=100,
-                message="done",
-                state=state,
-            )
+        response = await report_task_progress(
+            agent_id="agent-001",
+            task_id=task.id,
+            status="completed",
+            progress=100,
+            message="done",
+            state=state,
+        )
 
-        # Completion proceeds (kanban WAS called) — verifier crash
-        # doesn't block, just logs.
-        assert response.get("success") is True
+        assert response["success"] is True
         state.kanban_client.update_task.assert_called_once()


### PR DESCRIPTION
## Summary

Follow-up to PR #346. The original `product_smoke.py` had two design flaws surfaced in review:

1. **`PythonVerifier` ran pytest**, duplicating PR #337's existing `_validate_runtime` layer. Three validation layers running the same test suite catch nothing new — and tests passing is precisely what let v71 ship broken (Larry's pointed critique: *"tests will pass and the app still won't work"*).
2. **Hardcoded stack detection baked software bias into Marcus.** `StackDetector` only knew code stacks. Non-software deliverables (marketing campaigns, research reports, data pipelines — per `docs/marcus-validation.md`) silently passed with "no stack detected," recreating the false-confidence failure mode.

This PR rewrites the module: agents declare `start_command` (and optional `readiness_probe`) when marking integration tasks complete; Marcus runs the declared command as subprocess and enforces exit 0. No auto-detection.

## The new contract

Integration verification tasks must now call `report_task_progress` with a declared `start_command` on completion. Missing declaration → rejected. Strict, by design.

**Mode 1 — one-shot** (no readiness_probe):

```python
report_task_progress(
    task_id=task_id,
    status="completed",
    progress=100,
    message="integration verified",
    start_command="npm run build",  # or python -m pkg --help, tsc --noEmit, etc.
)
```

Marcus runs the command with a 60s timeout, requires exit 0.

**Mode 2 — server+probe** (with readiness_probe):

```python
report_task_progress(
    task_id=task_id,
    status="completed",
    progress=100,
    message="integration verified",
    start_command="uvicorn main:app --port 8000",
    readiness_probe="curl -f http://localhost:8000/health",
)
```

Marcus starts the command in the background, polls the readiness_probe once per second for up to 15s, passes when the probe returns exit 0, always kills the background process.

## Why two fields instead of one combined command

A single `start_command` that bakes in both start-and-probe forces the agent into shell wizardry:

```bash
(timeout 10s uvicorn main:app & SERVER=$!; sleep 3 && curl -f localhost:8000/health; EXIT=$?; kill $SERVER; wait; exit $EXIT)
```

`timeout` exits 124 (not 0) on timeout, so even a healthy server running cleanly for 10s reports failure. Different agents will write different buggy versions. Marcus would be rejecting integration tasks for bash mistakes instead of catching product bugs.

Splitting into two fields moves the start/poll/kill orchestration into Marcus where it's tested once and reused. Agents write two simple strings; Marcus owns the state machine.

## Deleted

- `StackDetector` + all marker detectors (`_detect_node`, `_detect_python`, `_detect_go`, `_detect_rust`, `_detect_java`)
- `StackVerifier` abstract base + `NodeVerifier`, `PythonVerifier`, `_UnsupportedVerifier`
- `_pick_verifier` dispatcher
- `DetectedStack` dataclass
- `ProductSmokeVerifier` orchestrator
- `_MARKER_DETECTORS`, `_SKIP_DIRS`, `_MAX_DETECT_DEPTH`
- Per-stack subprocess helpers
- The `_build_blocker_message` stack-aware blocker renderer

## Added

- `verify_deliverable(start_command, readiness_probe, cwd)` — the new public async runner
- `_run_one_shot` — mode 1 implementation
- `_run_server_with_probe` — mode 2 implementation
- `_run_probe` — single probe invocation with bounded timeout
- `_kill_process` — SIGTERM → SIGKILL escalation for background servers
- `_render_missing_blocker` / `_render_failure_blocker` — actionable blocker messages with examples

## Changed

- `report_task_progress` grew two optional parameters (`start_command`, `readiness_probe`). Backward compatible — non-integration tasks ignore them.
- `_run_product_smoke_gate` accepts and forwards the new params.
- `integration_verification.py` prompt updated to instruct the agent to declare `start_command` via `report_task_progress`, with examples for one-shot, server+probe, static HTML, library import, and data pipeline edge cases. Old "Marcus auto-detects your stack" disclosure replaced.

## Test plan

- [x] `tests/unit/integrations/test_product_smoke.py` — 14 tests
  - `TestMissingStartCommand` (3): None, empty, whitespace-only all rejected
  - `TestOneShotMode` (3): success, failure with stderr surface, **v71 regression** (React missing `public/index.html`)
  - `TestServerWithProbeMode` (3): success, probe-never-passes (hung server), server-crashes-before-ready
  - `TestBlockerMessages` (3): missing blocker explains declaration, failure blocker includes command+stderr, probe failure names the mode
  - `TestResultSerialization` (2): to_dict schema, output tail truncation
- [x] `tests/unit/marcus_mcp/test_integration_smoke_gate.py` — 12 tests
  - `TestIsIntegrationTask` (3): label detection
  - `TestProductSmokeGate` (5): missing start_command rejected, valid passes through, failing rejects with stderr, server+probe forwards both params, no-workspace-state skips gracefully
  - `TestReportTaskProgressIntegration` (4): forwards declared command, missing declaration rejected (kanban not mutated), non-integration tasks ignore params, non-integration completes without declaration
- [x] `pytest -m unit -x -q` — 525 passing (same count as PR #346, tests reshuffled)
- [x] `mypy src/integrations/product_smoke.py src/integrations/integration_verification.py src/marcus_mcp/tools/task.py` — clean
- [x] `black + isort` — clean
- [x] flake8 — clean (after one line-length fix during commit)

## Relationship to the conversation

Simon decision `967555f6` records the design rationale. Key decision points along the way:

- **Option 1 (single command, exit 0 required)** — rejected: bash wizardry, `timeout` exit-code gotchas
- **Option 2 (exit 0 OR stayed-alive-N-seconds)** — rejected: hung-server false pass
- **Option 3 (two fields with optional readiness_probe)** — chosen

## What this changes about Marcus's trajectory

The original `product_smoke.py` implicitly assumed Marcus's job was to understand project shapes. The rewrite assumes Marcus's job is to enforce agent declarations. That's a structural shift from "Marcus is a project-aware tool" to "Marcus is a contract enforcer" — and it's the right one for a coordination layer that aims to work across software, marketing, research, data, and whatever else Build Kits targets in the future.

🤖 Generated with [Claude Code](https://claude.com/claude-code)