### PR TITLE
fix(experiments): teach agents the real completion signal (v73 premature exit)

### DIFF
--- a/dev-tools/experiments/runners/spawn_agents.py
+++ b/dev-tools/experiments/runners/spawn_agents.py
@@ -490,7 +490,12 @@ STARTUP SEQUENCE:
 4. Call mcp__marcus__request_next_task:
    - No parameters needed
    - This will find tasks suitable for your skills
-   - If you get "no suitable tasks", wait 30 seconds and try again (max 3 retries)
+   - If you get "no suitable tasks": Marcus will tell you EXACTLY how
+     long to sleep in the response (`retry_after_seconds`) and instruct
+     you to keep retrying. TRUST that signal. Sleep the requested
+     duration, then call request_next_task again. There is NO retry
+     cap — keep looping. Marcus knows when work is genuinely done and
+     will signal experiment completion separately.
 
 5. When you get a task:
    - FIRST: run `git merge main --no-edit` to get latest completed work
@@ -500,7 +505,20 @@ STARTUP SEQUENCE:
    - Commit to your branch: {branch} (git add, commit)
    - When 100% complete, IMMEDIATELY call request_next_task again
 
-6. Repeat step 5 until NO_TASKS_AVAILABLE or all retries exhausted
+6. Repeat step 4-5 until the experiment ends. To check if the
+   experiment has ended, call mcp__marcus__get_experiment_status
+   and inspect the `is_running` field:
+     - `is_running: true`  → keep working. Sleep retry_after_seconds
+                             from your last request_next_task response,
+                             then call request_next_task again.
+     - `is_running: false` → the experiment is over. Print a summary
+                             of your work and exit.
+
+   Marcus owns the completion decision. It computes project completion
+   from kanban state (`completed_tasks == total_tasks` AND
+   `in_progress_tasks == 0`) and flips `is_running` to false when the
+   condition is met. Your only job is to read `is_running` and act
+   on it. You do not compute completion yourself.
 
 ---
 
@@ -515,7 +533,14 @@ CRITICAL REMINDERS:
 - Use get_task_context for tasks with dependencies
 - Use log_decision for architectural choices
 - Use log_artifact with project_root: {work_dir}
-- If "no suitable tasks", wait 30s and try again (max 3 retries)
+- A "no suitable tasks" response from request_next_task means
+  "sleep retry_after_seconds, then call request_next_task again."
+  That is your only correct action. Lease recovery and dependency
+  unblocking can take minutes — keep polling until is_running goes
+  false in get_experiment_status.
+- The single source of truth for "should I stop?" is
+  get_experiment_status → is_running. When is_running is true, keep
+  polling. When is_running is false, exit.
 
 START NOW!
 """
@@ -554,28 +579,35 @@ EXECUTE NOW - DO NOT ASK FOR CONFIRMATION:
 3. Enter monitoring loop:
    REPEAT every 2 minutes (120 seconds):
 
-   a. Call mcp__marcus__get_experiment_status
+   a. Call mcp__marcus__get_experiment_status. The MCP tool
+      description documents every field in the response — read it
+      if you need to know what a field means.
 
-   b. If is_running is true:
-      - Call mcp__marcus__get_project_status
-      - Print: "Project Status: {{completed}}/{{total_tasks}} tasks complete \
-({{completion_percentage}}%)"
-      - Print: "  In Progress: {{in_progress}}, Blocked: {{blocked}}"
-      - Print: "  Workers: {{active}}/{{total}} active"
-      - Wait 120 seconds and repeat
+   b. If status["is_running"] is true:
+      - done = status["completed_tasks"]
+      - total = status["total_tasks"]
+      - percent = round(100 * done / total, 1) if total else 0.0
+      - Print:
+        "Project Status: {{done}}/{{total}} tasks complete \
+({{percent}}%)"
+        "  In Progress: {{status['in_progress_tasks']}}, \
+Blocked: {{status['blocked_tasks']}}"
+        "  Registered agents: {{status['registered_agents']}}"
+      - Sleep 120 seconds, then loop back to (a)
 
-   c. If is_running is false:
-      - The experiment has ended automatically
-      - Print: "EXPERIMENT COMPLETE!"
-      - Display final statistics from get_experiment_status
+   c. If status["is_running"] is false:
+      - Print "EXPERIMENT COMPLETE!"
+      - Print the final values of total_tasks, completed_tasks,
+        in_progress_tasks, blocked_tasks, and registered_agents
       - Exit
 
 CRITICAL INSTRUCTIONS:
 - Work in: {self.config.implementation_dir}
-- Poll interval: EXACTLY 120 seconds (2 minutes)
-- DO NOT call end_experiment — it is called automatically by Marcus
-  when all tasks complete. Your job is to DISPLAY progress, not control it.
-- When get_experiment_status shows is_running: false, print summary and exit
+- Poll interval: 120 seconds (2 minutes) between get_experiment_status
+  calls.
+- Marcus owns the completion decision. It flips is_running to false
+  when the project is done. Your job is to display progress while
+  is_running is true and exit when it goes false.
 - This is an automated process - no human interaction needed
 """
         return prompt

--- a/dev-tools/experiments/runners/spawn_agents.py
+++ b/dev-tools/experiments/runners/spawn_agents.py
@@ -505,20 +505,31 @@ STARTUP SEQUENCE:
    - Commit to your branch: {branch} (git add, commit)
    - When 100% complete, IMMEDIATELY call request_next_task again
 
-6. Repeat step 4-5 until the experiment ends. To check if the
-   experiment has ended, call mcp__marcus__get_experiment_status
-   and inspect the `is_running` field:
-     - `is_running: true`  → keep working. Sleep retry_after_seconds
-                             from your last request_next_task response,
-                             then call request_next_task again.
-     - `is_running: false` → the experiment is over. Print a summary
-                             of your work and exit.
+6. Repeat step 4-5 until the experiment ends. To check experiment
+   state, call mcp__marcus__get_experiment_status and read TWO
+   fields together:
+     status["experiment_started"]  and  status["is_running"]
+
+   These describe a 3-state lifecycle:
+     - experiment_started=False                  → startup window.
+       The project creator hasn't called start_experiment yet. Sleep
+       10 seconds and re-poll. Do NOT exit; the experiment hasn't
+       begun.
+     - experiment_started=True, is_running=True  → active. Keep
+       working. Sleep retry_after_seconds from your last
+       request_next_task response, then call request_next_task again.
+     - experiment_started=True, is_running=False → finished. Print a
+       summary of your work and exit.
 
    Marcus owns the completion decision. It computes project completion
-   from kanban state (`completed_tasks == total_tasks` AND
-   `in_progress_tasks == 0`) and flips `is_running` to false when the
-   condition is met. Your only job is to read `is_running` and act
-   on it. You do not compute completion yourself.
+   from kanban state using this formula:
+     in_progress_tasks == 0
+     AND (completed_tasks + blocked_tasks) == total_tasks
+   and flips is_running to false when the condition is met. blocked
+   tasks count toward "done" because Marcus treats a blocked task as
+   terminal — the project should not stall waiting for it. Your only
+   job is to read the lifecycle fields and act on them. You do not
+   compute completion yourself.
 
 ---
 
@@ -576,14 +587,20 @@ EXECUTE NOW - DO NOT ASK FOR CONFIRMATION:
      - role: "monitor"
      - skills: ["monitoring", "analytics"]
 
-3. Enter monitoring loop:
-   REPEAT every 2 minutes (120 seconds):
+3. Enter monitoring loop. Read the lifecycle fields
+   (experiment_started, is_running) from the response and branch on
+   the 3-state lifecycle:
 
    a. Call mcp__marcus__get_experiment_status. The MCP tool
       description documents every field in the response — read it
       if you need to know what a field means.
 
-   b. If status["is_running"] is true:
+   b. If status["experiment_started"] is False:
+      - Print "Waiting for experiment to start..."
+      - Sleep 10 seconds, then loop back to (a)
+
+   c. If status["experiment_started"] is True and \
+status["is_running"] is True:
       - done = status["completed_tasks"]
       - total = status["total_tasks"]
       - percent = round(100 * done / total, 1) if total else 0.0
@@ -595,7 +612,8 @@ Blocked: {{status['blocked_tasks']}}"
         "  Registered agents: {{status['registered_agents']}}"
       - Sleep 120 seconds, then loop back to (a)
 
-   c. If status["is_running"] is false:
+   d. If status["experiment_started"] is True and \
+status["is_running"] is False:
       - Print "EXPERIMENT COMPLETE!"
       - Print the final values of total_tasks, completed_tasks,
         in_progress_tasks, blocked_tasks, and registered_agents
@@ -604,10 +622,13 @@ Blocked: {{status['blocked_tasks']}}"
 CRITICAL INSTRUCTIONS:
 - Work in: {self.config.implementation_dir}
 - Poll interval: 120 seconds (2 minutes) between get_experiment_status
-  calls.
-- Marcus owns the completion decision. It flips is_running to false
-  when the project is done. Your job is to display progress while
-  is_running is true and exit when it goes false.
+  calls during the active state. Use 10 seconds while waiting for
+  experiment_started to become True.
+- Marcus owns the completion decision. It flips is_running to False
+  when the project is done — when in_progress_tasks == 0 AND
+  (completed_tasks + blocked_tasks) == total_tasks. Your job is to
+  display progress while the experiment is active and exit when it
+  finishes.
 - This is an automated process - no human interaction needed
 """
         return prompt

--- a/src/experiments/live_experiment_monitor.py
+++ b/src/experiments/live_experiment_monitor.py
@@ -473,21 +473,42 @@ class LiveExperimentMonitor:
 
         logger.debug(f"Recorded context request: {agent_id} for {task_id}")
 
-    def get_status(self) -> Dict[str, Any]:
+    async def get_status(self) -> Dict[str, Any]:
         """
         Get current experiment status.
+
+        Includes both the legacy in-monitor counters
+        (``task_assignments`` / ``task_completions`` — running tallies
+        of events the monitor has *observed* during this run) and
+        ground-truth project totals queried directly from the kanban
+        backend (``total_tasks``, ``completed_tasks``, etc.).
+
+        Consumers deciding whether the project is done MUST use
+        ``completed_tasks`` / ``total_tasks`` from the kanban truth
+        block, not the running tallies. The running tallies grow as
+        events fire and never represent project totals — they will
+        always *appear* equal to themselves once both initial agent
+        assignments complete, even if many more tasks remain in the
+        project (lease recovery cases, dependent tasks unblocking
+        later, etc.). v73 surfaced this hazard: agents reading the
+        running tallies as a denominator concluded "all work done"
+        with 4 tasks still pending.
 
         Returns
         -------
         Dict[str, Any]
-            Current status and metrics
+            Current status and metrics. Always includes the legacy
+            counters; includes the kanban-truth task counts when a
+            kanban client is wired and reachable.
         """
-        return {
+        status: Dict[str, Any] = {
             "is_running": self.is_running,
             "run_name": self.run_name,
             "experiment_name": self.experiment_name,
             "board_id": self.board_id,
             "registered_agents": len(self.registered_agents),
+            # Legacy in-monitor running tallies. NOT project totals.
+            # See docstring — do not use as a denominator for "done".
             "task_assignments": len(self.task_assignments),
             "task_completions": len(self.task_completions),
             "blockers_reported": self.blockers_reported,
@@ -495,6 +516,21 @@ class LiveExperimentMonitor:
             "decisions_logged": self.decisions_logged,
             "context_requests": self.context_requests,
         }
+
+        # Ground truth from the kanban backend. This is what
+        # consumers should use to decide whether the project is done.
+        if self.kanban_client is not None:
+            try:
+                metrics = await self.kanban_client.get_project_metrics()
+                status["total_tasks"] = metrics.get("total_tasks", 0)
+                status["completed_tasks"] = metrics.get("completed_tasks", 0)
+                status["in_progress_tasks"] = metrics.get("in_progress_tasks", 0)
+                status["backlog_tasks"] = metrics.get("backlog_tasks", 0)
+                status["blocked_tasks"] = metrics.get("blocked_tasks", 0)
+            except Exception as e:
+                logger.warning(f"get_status: kanban metrics fetch failed: {e}")
+
+        return status
 
     def _generate_summary(self) -> str:
         """Generate experiment summary."""

--- a/src/marcus_mcp/server.py
+++ b/src/marcus_mcp/server.py
@@ -1848,31 +1848,49 @@ class MarcusServer:
             async def get_experiment_status() -> Dict[str, Any]:
                 """Get current experiment status and project task counts.
 
-                Returns a dict with run metadata and kanban-sourced task
-                counts. Key fields:
+                Returns a dict with lifecycle signals, run metadata,
+                and kanban-sourced task counts.
 
-                - is_running (bool): canonical "should I keep polling?"
-                  signal. False means Marcus has finalized the experiment.
-                - total_tasks (int): total tasks in the project (kanban).
-                - completed_tasks (int): tasks marked DONE on the board.
-                - in_progress_tasks (int): tasks currently being worked on.
-                - backlog_tasks (int): tasks not yet started.
-                - blocked_tasks (int): tasks blocked on dependencies.
-                - registered_agents (int): worker agents registered.
+                Lifecycle signals:
+                - experiment_started (bool): True once start_experiment
+                  has been called and a monitor is active. False during
+                  the startup window between create_project and
+                  start_experiment. Agents must NOT exit while this is
+                  False — the experiment hasn't begun yet.
+                - is_running (bool): True while the experiment is
+                  active, False once it has finished. Combine with
+                  experiment_started to distinguish three states:
+                    * not_started=False, is_running=False → startup
+                      window. Wait and re-poll.
+                    * started=True,  is_running=True  → active.
+                    * started=True,  is_running=False → finished. Exit.
 
-                Compute completion percentage as
-                round(100 * completed_tasks / total_tasks, 1).
+                Kanban truth task counts (present when started=True):
+                - total_tasks, completed_tasks, in_progress_tasks,
+                  backlog_tasks, blocked_tasks (all int).
 
-                Marcus auto-ends the experiment when
-                completed_tasks == total_tasks and in_progress_tasks == 0;
-                at that point is_running flips to false. Reading
-                is_running is the recommended way to detect completion.
+                Computing project progress:
+                    percent = round(100 * completed_tasks / total_tasks, 1)
+                    project_done = (
+                        in_progress_tasks == 0
+                        and (completed_tasks + blocked_tasks) == total_tasks
+                    )
 
-                Other fields (task_assignments, task_completions,
-                blockers_reported, artifacts_created, decisions_logged,
-                context_requests) are observability event counters that
-                feed MLflow. Use the kanban-truth fields above for any
-                completion or progress math.
+                Note: blocked_tasks count toward "done" because Marcus
+                treats a blocked task as terminal — the project should
+                not stall waiting for it. Marcus uses the same formula
+                in LiveExperimentMonitor._check_completion to flip
+                is_running to false, so reading is_running is equivalent
+                to evaluating the formula yourself.
+
+                Run metadata (present when started=True):
+                - run_name, experiment_name, registered_agents.
+
+                Observability counters (event tallies for MLflow):
+                - task_assignments, task_completions, blockers_reported,
+                  artifacts_created, decisions_logged, context_requests.
+                  These are not project totals; use the kanban-truth
+                  fields above for completion or progress math.
                 """
                 from .tools.experiments import get_experiment_status as impl
 

--- a/src/marcus_mcp/server.py
+++ b/src/marcus_mcp/server.py
@@ -1846,7 +1846,34 @@ class MarcusServer:
 
             @app.tool()  # type: ignore[misc]
             async def get_experiment_status() -> Dict[str, Any]:
-                """Get the status of the current experiment."""
+                """Get current experiment status and project task counts.
+
+                Returns a dict with run metadata and kanban-sourced task
+                counts. Key fields:
+
+                - is_running (bool): canonical "should I keep polling?"
+                  signal. False means Marcus has finalized the experiment.
+                - total_tasks (int): total tasks in the project (kanban).
+                - completed_tasks (int): tasks marked DONE on the board.
+                - in_progress_tasks (int): tasks currently being worked on.
+                - backlog_tasks (int): tasks not yet started.
+                - blocked_tasks (int): tasks blocked on dependencies.
+                - registered_agents (int): worker agents registered.
+
+                Compute completion percentage as
+                round(100 * completed_tasks / total_tasks, 1).
+
+                Marcus auto-ends the experiment when
+                completed_tasks == total_tasks and in_progress_tasks == 0;
+                at that point is_running flips to false. Reading
+                is_running is the recommended way to detect completion.
+
+                Other fields (task_assignments, task_completions,
+                blockers_reported, artifacts_created, decisions_logged,
+                context_requests) are observability event counters that
+                feed MLflow. Use the kanban-truth fields above for any
+                completion or progress math.
+                """
                 from .tools.experiments import get_experiment_status as impl
 
                 return await impl()

--- a/src/marcus_mcp/tools/experiments.py
+++ b/src/marcus_mcp/tools/experiments.py
@@ -282,35 +282,81 @@ async def get_experiment_status() -> Dict[str, Any]:
     """
     Get the status of the current experiment.
 
-    Returns current metrics and status of the running experiment,
-    or indicates if no experiment is active.
+    Returns current run metadata and project task counts. Use this to
+    decide when to stop polling: when ``is_running`` is false, the
+    experiment is over and Marcus has finalized results.
 
     Returns
     -------
     Dict[str, Any]
-        Current experiment status including:
-        - is_running: bool
-        - run_name: str
-        - experiment_name: str
-        - registered_agents: int
-        - task_completions: int
-        - blockers_reported: int
-        - artifacts_created: int
-        - decisions_logged: int
+        Status payload. Top-level fields:
+
+        Run metadata:
+            - is_running (bool): True while the experiment is active.
+              Flips to False when Marcus auto-ends the experiment
+              (all tasks done) or end_experiment is called explicitly.
+              **This is the canonical "should I stop?" signal.**
+            - run_name (str): MLflow run identifier.
+            - experiment_name (str): Experiment identifier.
+            - registered_agents (int): Number of worker agents
+              currently registered with Marcus.
+
+        Project task counts (kanban truth, sourced from the backend):
+            - total_tasks (int): Total tasks in the project.
+            - completed_tasks (int): Tasks marked DONE on the board.
+            - in_progress_tasks (int): Tasks currently being worked on.
+            - backlog_tasks (int): Tasks not yet started.
+            - blocked_tasks (int): Tasks blocked on dependencies.
+
+        Use these for completion math::
+
+            percent = round(100 * completed_tasks / total_tasks, 1)
+            project_done = (
+                completed_tasks == total_tasks
+                and in_progress_tasks == 0
+            )
+
+        Marcus uses the same formula internally to decide when to flip
+        ``is_running`` to false, so reading ``is_running`` is equivalent
+        to evaluating the formula yourself — and is the recommended path
+        for agents.
+
+        Observability counters (running event tallies for MLflow):
+            - task_assignments (int): Number of times tasks were ever
+              assigned to agents during this run (grows with each
+              recovery/reassignment).
+            - task_completions (int): Number of completion events the
+              monitor has observed during this run.
+            - blockers_reported (int)
+            - artifacts_created (int)
+            - decisions_logged (int)
+            - context_requests (int)
+
+        These counters track *events seen by the monitor*, not project
+        totals. They feed MLflow metrics and dashboards. For project
+        completion math, use the kanban truth fields above.
 
     Examples
     --------
-    >>> status = await get_experiment_status()
-    >>> if status["is_running"]:
-    ...     print(f"Agents: {status['registered_agents']}")
-    ...     print(f"Tasks: {status['task_completions']}")
+    Polling loop until the experiment ends::
+
+        while True:
+            status = await get_experiment_status()
+            if not status["is_running"]:
+                print("EXPERIMENT COMPLETE")
+                break
+            done = status["completed_tasks"]
+            total = status["total_tasks"]
+            percent = round(100 * done / total, 1) if total else 0.0
+            print(f"Project: {done}/{total} ({percent}%)")
+            await asyncio.sleep(120)
     """
     monitor = get_active_monitor()
 
     if monitor is None:
         return {"is_running": False, "message": "No experiment is currently running"}
 
-    return monitor.get_status()
+    return await monitor.get_status()
 
 
 # Tool metadata for MCP registration

--- a/src/marcus_mcp/tools/experiments.py
+++ b/src/marcus_mcp/tools/experiments.py
@@ -282,44 +282,63 @@ async def get_experiment_status() -> Dict[str, Any]:
     """
     Get the status of the current experiment.
 
-    Returns current run metadata and project task counts. Use this to
-    decide when to stop polling: when ``is_running`` is false, the
-    experiment is over and Marcus has finalized results.
+    Returns current run metadata and project task counts. Agents use
+    this to decide whether the experiment is in its startup window,
+    actively running, or finished.
 
     Returns
     -------
     Dict[str, Any]
         Status payload. Top-level fields:
 
-        Run metadata:
-            - is_running (bool): True while the experiment is active.
-              Flips to False when Marcus auto-ends the experiment
-              (all tasks done) or end_experiment is called explicitly.
-              **This is the canonical "should I stop?" signal.**
+        Lifecycle signals:
+            - experiment_started (bool): True once the experiment has
+              been started (start_experiment was called and a monitor
+              is active). False during the startup window between
+              create_project and start_experiment.
+              **Agents must not exit while experiment_started is False
+              — the experiment hasn't started yet.**
+            - is_running (bool): True while the experiment is active
+              and Marcus is monitoring it. False when the experiment
+              has finished. Combine with experiment_started to
+              distinguish "not started yet" from "started and ended":
+                * experiment_started=False, is_running=False → startup
+                  window. Wait and re-poll.
+                * experiment_started=True,  is_running=True  → active.
+                  Keep working.
+                * experiment_started=True,  is_running=False → done.
+                  Print summary and exit.
+
+        Run metadata (only present when experiment_started is True):
             - run_name (str): MLflow run identifier.
             - experiment_name (str): Experiment identifier.
             - registered_agents (int): Number of worker agents
               currently registered with Marcus.
 
-        Project task counts (kanban truth, sourced from the backend):
+        Project task counts (kanban truth, sourced from the backend;
+        only present when experiment_started is True):
             - total_tasks (int): Total tasks in the project.
             - completed_tasks (int): Tasks marked DONE on the board.
             - in_progress_tasks (int): Tasks currently being worked on.
             - backlog_tasks (int): Tasks not yet started.
-            - blocked_tasks (int): Tasks blocked on dependencies.
+            - blocked_tasks (int): Tasks blocked on dependencies that
+              cannot make further progress.
 
         Use these for completion math::
 
             percent = round(100 * completed_tasks / total_tasks, 1)
             project_done = (
-                completed_tasks == total_tasks
-                and in_progress_tasks == 0
+                in_progress_tasks == 0
+                and (completed_tasks + blocked_tasks) == total_tasks
             )
 
-        Marcus uses the same formula internally to decide when to flip
-        ``is_running`` to false, so reading ``is_running`` is equivalent
-        to evaluating the formula yourself — and is the recommended path
-        for agents.
+        Note: blocked_tasks count toward "done" because Marcus treats
+        a blocked task as a terminal state — work cannot proceed and
+        the project should not stall waiting for it. Marcus uses the
+        same formula internally (LiveExperimentMonitor._check_completion)
+        to decide when to flip is_running to false, so reading
+        is_running is equivalent to evaluating the formula yourself
+        and is the recommended path.
 
         Observability counters (running event tallies for MLflow):
             - task_assignments (int): Number of times tasks were ever
@@ -332,16 +351,20 @@ async def get_experiment_status() -> Dict[str, Any]:
             - decisions_logged (int)
             - context_requests (int)
 
-        These counters track *events seen by the monitor*, not project
-        totals. They feed MLflow metrics and dashboards. For project
+        These track events seen by the monitor, not project totals.
+        They feed MLflow metrics and dashboards. For project
         completion math, use the kanban truth fields above.
 
     Examples
     --------
-    Polling loop until the experiment ends::
+    Polling loop that handles startup, active, and finished states::
 
         while True:
             status = await get_experiment_status()
+            if not status.get("experiment_started", False):
+                # Startup window — experiment hasn't begun yet
+                await asyncio.sleep(5)
+                continue
             if not status["is_running"]:
                 print("EXPERIMENT COMPLETE")
                 break
@@ -354,9 +377,18 @@ async def get_experiment_status() -> Dict[str, Any]:
     monitor = get_active_monitor()
 
     if monitor is None:
-        return {"is_running": False, "message": "No experiment is currently running"}
+        # Startup window — create_project may have run but
+        # start_experiment hasn't fired yet. Agents must not exit
+        # on this state; they should poll again after a short wait.
+        return {
+            "experiment_started": False,
+            "is_running": False,
+            "message": "No experiment is currently running",
+        }
 
-    return await monitor.get_status()
+    status = await monitor.get_status()
+    status["experiment_started"] = True
+    return status
 
 
 # Tool metadata for MCP registration

--- a/tests/unit/experiments/test_live_experiment_monitor.py
+++ b/tests/unit/experiments/test_live_experiment_monitor.py
@@ -1,0 +1,177 @@
+"""
+Unit tests for LiveExperimentMonitor.get_status.
+
+Covers the v73 fix: get_status must expose ground-truth task counts
+from the kanban backend (total_tasks, completed_tasks, etc.) in
+addition to the legacy in-monitor running tallies. Consumers
+(monitor agent, downstream tooling, future MCP wrappers) rely on
+the kanban-truth block to make "is the project done" decisions —
+the legacy task_assignments/task_completions counters are running
+event tallies that do NOT represent project totals and were the
+root of the v73 premature-exit cascade.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from src.experiments.live_experiment_monitor import LiveExperimentMonitor
+
+pytestmark = pytest.mark.unit
+
+
+def _make_monitor(kanban_client: Any = None) -> LiveExperimentMonitor:
+    """Build a LiveExperimentMonitor with a mock MLflow experiment."""
+    monitor = LiveExperimentMonitor.__new__(LiveExperimentMonitor)
+    monitor.experiment_name = "test_exp"
+    monitor.board_id = "board-1"
+    monitor.project_id = "proj-1"
+    monitor.tracking_interval = 30
+    monitor.kanban_client = kanban_client
+    monitor.mlflow_experiment = MagicMock()
+    monitor.is_running = True
+    monitor.monitor_task = None
+    monitor.run_name = "run-1"
+    monitor.run_dir = None
+    monitor.registered_agents = {}
+    monitor.task_assignments = {}
+    monitor.task_completions = {}
+    monitor.blockers_reported = 0
+    monitor.artifacts_created = 0
+    monitor.decisions_logged = 0
+    monitor.context_requests = 0
+    return monitor
+
+
+class TestGetStatusKanbanTruth:
+    """get_status must expose kanban-truth task counts."""
+
+    @pytest.mark.asyncio
+    async def test_get_status_includes_kanban_truth_fields(self) -> None:
+        """When kanban_client is wired, get_status must include all 5 truth fields."""
+        kanban_client = MagicMock()
+        kanban_client.get_project_metrics = AsyncMock(
+            return_value={
+                "total_tasks": 6,
+                "completed_tasks": 4,
+                "in_progress_tasks": 1,
+                "backlog_tasks": 1,
+                "blocked_tasks": 0,
+            }
+        )
+        monitor = _make_monitor(kanban_client=kanban_client)
+
+        status = await monitor.get_status()
+
+        # Ground-truth fields — what consumers MUST use for done-checks
+        assert status["total_tasks"] == 6
+        assert status["completed_tasks"] == 4
+        assert status["in_progress_tasks"] == 1
+        assert status["backlog_tasks"] == 1
+        assert status["blocked_tasks"] == 0
+
+    @pytest.mark.asyncio
+    async def test_get_status_preserves_legacy_running_counters(self) -> None:
+        """Legacy task_assignments/task_completions must still be present.
+
+        They are misleading as "project totals" but mlflow + summary
+        rendering still consume them as running tallies.
+        """
+        monitor = _make_monitor()
+        monitor.task_assignments = {"t1": "agent-1", "t2": "agent-2"}
+        monitor.task_completions = {"t1": 100.0}
+
+        status = await monitor.get_status()
+
+        assert status["task_assignments"] == 2
+        assert status["task_completions"] == 1
+        assert status["is_running"] is True
+        assert status["run_name"] == "run-1"
+
+    @pytest.mark.asyncio
+    async def test_get_status_omits_kanban_fields_when_no_client(self) -> None:
+        """No kanban client → no truth fields, but call still succeeds."""
+        monitor = _make_monitor(kanban_client=None)
+
+        status = await monitor.get_status()
+
+        # Legacy fields present
+        assert status["is_running"] is True
+        assert status["task_assignments"] == 0
+        # Truth fields absent
+        assert "total_tasks" not in status
+        assert "completed_tasks" not in status
+
+    @pytest.mark.asyncio
+    async def test_get_status_handles_kanban_failure_gracefully(self) -> None:
+        """Kanban fetch failure → log warning, return legacy fields only."""
+        kanban_client = MagicMock()
+        kanban_client.get_project_metrics = AsyncMock(
+            side_effect=RuntimeError("kanban down")
+        )
+        monitor = _make_monitor(kanban_client=kanban_client)
+
+        status = await monitor.get_status()
+
+        # Must not raise; legacy fields still present
+        assert status["is_running"] is True
+        # Truth fields absent because fetch failed
+        assert "total_tasks" not in status
+
+    @pytest.mark.asyncio
+    async def test_get_status_v73_regression_total_tasks_distinct_from_assignments(
+        self,
+    ) -> None:
+        """
+        REGRESSION for dashboard-v73.
+
+        v73 had 6 project tasks but only 2 had ever been assigned to
+        agents (Build + Integrate; the other 4 were either pre-baked
+        DONE, gated on dependencies, or about to be created later).
+        The legacy task_assignments counter showed 2; consumers
+        misread it as "total tasks = 2" and concluded the project
+        was done.
+
+        After the fix, get_status must expose total_tasks=6 from the
+        kanban backend so consumers have an unambiguous denominator.
+        """
+        kanban_client = MagicMock()
+        kanban_client.get_project_metrics = AsyncMock(
+            return_value={
+                "total_tasks": 6,
+                "completed_tasks": 2,
+                "in_progress_tasks": 0,
+                "backlog_tasks": 4,
+                "blocked_tasks": 0,
+            }
+        )
+        monitor = _make_monitor(kanban_client=kanban_client)
+        # Simulate the v73 state: 2 assignments observed, 2 completions observed
+        monitor.task_assignments = {"build-id": "agent-1", "integrate-id": "agent-2"}
+        monitor.task_completions = {"build-id": 100.0, "integrate-id": 200.0}
+
+        status = await monitor.get_status()
+
+        # The legacy tallies still report 2/2 — that's NOT a bug, that's
+        # what they semantically are. The fix is exposing the kanban
+        # truth alongside them.
+        assert status["task_assignments"] == 2
+        assert status["task_completions"] == 2
+        # The truth: 6 total, 2 done, 4 still pending. Consumers
+        # making done-checks now have an unambiguous denominator.
+        assert status["total_tasks"] == 6
+        assert status["completed_tasks"] == 2
+        assert status["backlog_tasks"] == 4
+        # Therefore: completed_tasks != total_tasks → project NOT done
+        assert status["completed_tasks"] != status["total_tasks"]
+
+    @pytest.mark.asyncio
+    async def test_get_status_is_awaitable(self) -> None:
+        """get_status must be async (was sync before v73 fix)."""
+        import inspect
+
+        monitor = _make_monitor()
+        assert inspect.iscoroutinefunction(monitor.get_status)

--- a/tests/unit/experiments/test_live_experiment_monitor.py
+++ b/tests/unit/experiments/test_live_experiment_monitor.py
@@ -175,3 +175,117 @@ class TestGetStatusKanbanTruth:
 
         monitor = _make_monitor()
         assert inspect.iscoroutinefunction(monitor.get_status)
+
+
+class TestGetExperimentStatusLifecycle:
+    """The MCP wrapper distinguishes startup, active, and finished states.
+
+    Codex P1 on PR #349: workers wait on project_info.json which
+    the creator writes BEFORE calling start_experiment. There's a
+    real window where get_experiment_status returns "no monitor"
+    and a worker reading is_running=False would exit. The fix is
+    to expose experiment_started so consumers can distinguish
+    "not started yet" from "started and ended."
+    """
+
+    @pytest.mark.asyncio
+    async def test_status_returns_not_started_when_no_monitor(self) -> None:
+        """Startup window: monitor is None → experiment_started=False."""
+        from src.marcus_mcp.tools import experiments as experiments_module
+
+        # Patch get_active_monitor to return None (startup window)
+        original = experiments_module.get_active_monitor
+        experiments_module.get_active_monitor = lambda: None  # type: ignore[assignment]
+        try:
+            status = await experiments_module.get_experiment_status()
+        finally:
+            experiments_module.get_active_monitor = original  # type: ignore[assignment]
+
+        assert status["experiment_started"] is False
+        assert status["is_running"] is False
+        # The two-flag combination unambiguously says "not started"
+        # (vs "started=True, is_running=False" which means "ended")
+
+    @pytest.mark.asyncio
+    async def test_status_returns_started_when_monitor_active(self) -> None:
+        """Active state: monitor exists → experiment_started=True."""
+        from src.marcus_mcp.tools import experiments as experiments_module
+
+        kanban_client = MagicMock()
+        kanban_client.get_project_metrics = AsyncMock(
+            return_value={
+                "total_tasks": 6,
+                "completed_tasks": 2,
+                "in_progress_tasks": 2,
+                "backlog_tasks": 2,
+                "blocked_tasks": 0,
+            }
+        )
+        monitor = _make_monitor(kanban_client=kanban_client)
+
+        original = experiments_module.get_active_monitor
+        experiments_module.get_active_monitor = (  # type: ignore[assignment]
+            lambda: monitor
+        )
+        try:
+            status = await experiments_module.get_experiment_status()
+        finally:
+            experiments_module.get_active_monitor = original  # type: ignore[assignment]
+
+        assert status["experiment_started"] is True
+        assert status["is_running"] is True
+        assert status["total_tasks"] == 6
+
+
+class TestCompletionFormulaAlignment:
+    """The documented completion formula must match _check_completion.
+
+    Codex P2 on PR #349: prior PR docstrings said
+    `completed_tasks == total_tasks AND in_progress_tasks == 0`,
+    but the runtime check at LiveExperimentMonitor._check_completion
+    uses `(completed + blocked) == total AND in_progress == 0`.
+    Blocked tasks count toward "done" because the project shouldn't
+    stall waiting for them. Consumers following the wrong formula
+    would think work is incomplete even after Marcus finishes.
+    """
+
+    @pytest.mark.asyncio
+    async def test_completion_with_blocked_tasks_matches_runtime(self) -> None:
+        """When blocked + completed == total, the project IS done."""
+        # Build a state where: total=5, completed=3, blocked=2,
+        # in_progress=0. Per the runtime formula, this is "done"
+        # because (3+2)==5 and in_progress==0. Consumers using the
+        # documented formula must reach the same verdict.
+        kanban_client = MagicMock()
+        kanban_client.get_project_metrics = AsyncMock(
+            return_value={
+                "total_tasks": 5,
+                "completed_tasks": 3,
+                "in_progress_tasks": 0,
+                "backlog_tasks": 0,
+                "blocked_tasks": 2,
+            }
+        )
+        monitor = _make_monitor(kanban_client=kanban_client)
+
+        status = await monitor.get_status()
+
+        completed = status["completed_tasks"]
+        blocked = status["blocked_tasks"]
+        total = status["total_tasks"]
+        in_progress = status["in_progress_tasks"]
+
+        # The documented formula
+        project_done = in_progress == 0 and (completed + blocked) == total
+        assert project_done is True, (
+            "Documented formula must match runtime: blocked tasks "
+            "count toward done. Codex P2 on PR #349."
+        )
+
+        # The OLD/wrong formula would say not done
+        wrong_formula = completed == total and in_progress == 0
+        assert wrong_formula is False, (
+            "Sanity check: the OLD formula would (incorrectly) say "
+            "not done in this state — that's the bug we're guarding "
+            "against."
+        )

--- a/tests/unit/experiments/test_spawn_agents.py
+++ b/tests/unit/experiments/test_spawn_agents.py
@@ -496,13 +496,37 @@ class TestWorkerPromptRetryContract:
         agent's role in the computation entirely.
         """
         prompt = spawner.create_worker_prompt(agent_config)
-        # Marcus owns the formula
-        assert "completed_tasks == total_tasks" in prompt
+        # Marcus owns the formula — must match runtime check at
+        # LiveExperimentMonitor._check_completion (Codex P2 on PR #349)
+        assert "(completed_tasks + blocked_tasks) == total_tasks" in prompt
         assert "in_progress_tasks == 0" in prompt
         # Agent reads is_running, doesn't compute
         prompt_lower = prompt.lower()
         assert "marcus owns the completion" in prompt_lower or (
             "marcus computes" in prompt_lower
+        )
+
+    def test_worker_prompt_handles_startup_window(
+        self, spawner: Any, agent_config: dict
+    ) -> None:
+        """Worker prompt must distinguish "not started" from "ended".
+
+        Codex P1 on PR #349: workers wait on project_info.json which
+        the creator writes BEFORE calling start_experiment. There's a
+        real window where get_experiment_status returns
+        is_running=False because the experiment hasn't started yet.
+        The worker must not exit during that window — the prompt
+        must instruct it to check experiment_started first.
+        """
+        prompt = spawner.create_worker_prompt(agent_config)
+        # Must reference the lifecycle field
+        assert "experiment_started" in prompt
+        # Must reference the 3-state lifecycle by name or by branching
+        prompt_lower = prompt.lower()
+        assert (
+            "startup window" in prompt_lower
+            or "3-state" in prompt_lower
+            or ("hasn't started" in prompt_lower)
         )
 
 
@@ -564,3 +588,25 @@ class TestMonitorPromptKanbanTruth:
         assert "marcus owns the completion" in prompt_lower or (
             "marcus" in prompt_lower and "flips is_running" in prompt_lower
         )
+
+    def test_monitor_prompt_handles_startup_window(self, spawner: Any) -> None:
+        """Monitor prompt must branch on experiment_started.
+
+        Codex P1 on PR #349: same race as workers — monitor registers
+        and starts polling before the creator calls start_experiment.
+        The monitor must wait, not crash or exit, during that window.
+        """
+        prompt = spawner.create_monitor_prompt()
+        assert "experiment_started" in prompt
+        # Should poll faster while waiting for startup
+        assert "Sleep 10 seconds" in prompt or "10 seconds" in prompt
+
+    def test_monitor_prompt_uses_correct_completion_formula(self, spawner: Any) -> None:
+        """Monitor prompt must document the runtime formula.
+
+        Codex P2 on PR #349: blocked tasks count toward "done."
+        The displayed/explained formula must match
+        LiveExperimentMonitor._check_completion.
+        """
+        prompt = spawner.create_monitor_prompt()
+        assert "(completed_tasks + blocked_tasks) == total_tasks" in prompt

--- a/tests/unit/experiments/test_spawn_agents.py
+++ b/tests/unit/experiments/test_spawn_agents.py
@@ -391,3 +391,176 @@ class TestPretrustDirectory:
 
         output = capsys.readouterr().out
         assert "Could not pre-trust" in output
+
+
+class TestWorkerPromptRetryContract:
+    """Worker prompt must not cap "no work" retries.
+
+    Regression for dashboard-v73: worker prompts shipped with
+    "max 3 retries" hard-coded, which caused agent_unicorn_2 to
+    exit 90 seconds after a partner agent took over a recovered
+    lease. Marcus's request_next_task no-task response explicitly
+    instructs agents to keep retrying indefinitely (sleep the
+    duration Marcus tells you, then retry); the worker prompt
+    must respect that contract instead of overriding it.
+    """
+
+    @pytest.fixture
+    def spawner(self, tmp_path: Path) -> Any:
+        """Build an AgentSpawner with minimal config for prompt rendering."""
+        config = MagicMock()
+        config.implementation_dir = tmp_path / "impl"
+        config.project_info_file = tmp_path / "project_info.json"
+        config.prompts_dir = tmp_path / "prompts"
+        config.prompts_dir.mkdir()
+
+        # AgentSpawner reads agent_prompt_template from disk; provide a
+        # tiny stub so create_worker_prompt's read() succeeds.
+        template = tmp_path / "agent_template.md"
+        template.write_text("# Base agent template\n")
+
+        instance = MagicMock(spec=spawn_agents.AgentSpawner)
+        instance.config = config
+        instance.agent_prompt_template = template
+        # Bind the real method to the mock so we can call it like a method.
+        instance.create_worker_prompt = (
+            spawn_agents.AgentSpawner.create_worker_prompt.__get__(
+                instance, spawn_agents.AgentSpawner
+            )
+        )
+        return instance
+
+    @pytest.fixture
+    def agent_config(self) -> dict:
+        """Minimal agent config dict for prompt rendering."""
+        return {
+            "id": "agent_test_1",
+            "name": "Test Agent 1",
+            "role": "full-stack",
+            "skills": ["python", "javascript"],
+            "subagents": 0,
+        }
+
+    def test_worker_prompt_has_no_max_retries_cap(
+        self, spawner: Any, agent_config: dict
+    ) -> None:
+        """Worker prompt must not impose a max-retries cap on no-task responses."""
+        prompt = spawner.create_worker_prompt(agent_config)
+        # Hard fail on the literal phrase that v73 used:
+        assert "max 3 retries" not in prompt, (
+            "Worker prompt regressed: 'max 3 retries' present. v73 "
+            "demonstrated this causes premature agent exit when a partner "
+            "holds a recovered lease. Marcus tells agents how long to "
+            "sleep — trust that signal, do not impose a cap."
+        )
+        # Also forbid generic retry caps that would have the same effect:
+        assert "max retries" not in prompt.lower()
+        assert "retries exhausted" not in prompt.lower()
+
+    def test_worker_prompt_loops_until_experiment_ends(
+        self, spawner: Any, agent_config: dict
+    ) -> None:
+        """Worker prompt must define the loop termination as experiment-end.
+
+        Positive instruction (no negation): the prompt says "loop until
+        the experiment ends" rather than "do not stop after N retries."
+        The exit condition is is_running going false in
+        get_experiment_status, not a retry counter.
+        """
+        prompt = spawner.create_worker_prompt(agent_config)
+        prompt_lower = prompt.lower()
+        # Loop termination tied to experiment ending, not retry count
+        assert "until the experiment ends" in prompt_lower
+        # Sleep instruction tied to retry_after_seconds from Marcus
+        assert "retry_after_seconds" in prompt
+
+    def test_worker_prompt_names_experiment_status_as_exit_signal(
+        self, spawner: Any, agent_config: dict
+    ) -> None:
+        """The only exit signal must be is_running:false from experiment status."""
+        prompt = spawner.create_worker_prompt(agent_config)
+        # Critical: agents must know the canonical "stop polling" signal
+        assert "get_experiment_status" in prompt
+        assert "is_running" in prompt
+
+    def test_worker_prompt_delegates_completion_to_marcus(
+        self, spawner: Any, agent_config: dict
+    ) -> None:
+        """Worker prompt must say Marcus owns the completion decision.
+
+        Positive instruction (no negation): the prompt tells the agent
+        that Marcus computes completion from the kanban formula and
+        flips is_running. The agent's only job is to read is_running
+        and act on it. v73 broke because the agent computed completion
+        itself from running tallies; the fix is to remove the
+        agent's role in the computation entirely.
+        """
+        prompt = spawner.create_worker_prompt(agent_config)
+        # Marcus owns the formula
+        assert "completed_tasks == total_tasks" in prompt
+        assert "in_progress_tasks == 0" in prompt
+        # Agent reads is_running, doesn't compute
+        prompt_lower = prompt.lower()
+        assert "marcus owns the completion" in prompt_lower or (
+            "marcus computes" in prompt_lower
+        )
+
+
+class TestMonitorPromptKanbanTruth:
+    """Monitor prompt must read kanban-truth fields, not running tallies.
+
+    Regression for v73: the monitor agent's display showed
+    "Project Status: 2/3 tasks complete" because its prompt template
+    referenced fields that came from the running tallies rather than
+    the kanban-truth fields. The monitor itself was confused — it
+    even noted "3 more tasks from the board still not yet visible."
+    """
+
+    @pytest.fixture
+    def spawner(self, tmp_path: Path) -> Any:
+        """Build an AgentSpawner with minimal config for monitor prompt rendering."""
+        config = MagicMock()
+        config.implementation_dir = tmp_path / "impl"
+        config.project_info_file = tmp_path / "project_info.json"
+        config.prompts_dir = tmp_path / "prompts"
+        config.prompts_dir.mkdir()
+
+        instance = MagicMock(spec=spawn_agents.AgentSpawner)
+        instance.config = config
+        instance.create_monitor_prompt = (
+            spawn_agents.AgentSpawner.create_monitor_prompt.__get__(
+                instance, spawn_agents.AgentSpawner
+            )
+        )
+        return instance
+
+    def test_monitor_prompt_uses_kanban_truth_for_display(self, spawner: Any) -> None:
+        """Monitor display template must use total_tasks / completed_tasks."""
+        prompt = spawner.create_monitor_prompt()
+        assert "total_tasks" in prompt
+        assert "completed_tasks" in prompt
+        assert "in_progress_tasks" in prompt
+        assert "blocked_tasks" in prompt
+
+    def test_monitor_prompt_gives_explicit_percent_formula(self, spawner: Any) -> None:
+        """Monitor prompt must give an explicit completion-percent formula.
+
+        Positive instruction: the monitor needs to know HOW to compute
+        the percentage, not just which fields exist. The formula uses
+        completed_tasks / total_tasks with a guard for total == 0.
+        """
+        prompt = spawner.create_monitor_prompt()
+        # The formula appears in the prompt, not buried in code Marcus runs
+        assert "100 * done / total" in prompt or (
+            "100 * completed_tasks / total_tasks" in prompt
+        )
+
+    def test_monitor_prompt_uses_is_running_as_exit_signal(self, spawner: Any) -> None:
+        """Monitor exits when is_running goes false, not on its own clock."""
+        prompt = spawner.create_monitor_prompt()
+        assert "is_running" in prompt
+        prompt_lower = prompt.lower()
+        # Must say Marcus owns the decision
+        assert "marcus owns the completion" in prompt_lower or (
+            "marcus" in prompt_lower and "flips is_running" in prompt_lower
+        )


### PR DESCRIPTION
## Summary

Fixes the dashboard-v73 premature-exit failure mode where ``agent_unicorn_2`` polled ``get_experiment_status``, read ``task_assignments=2`` and ``task_completions=2`` as if they were project totals, computed *2/2 = 100% complete*, and exited — leaving 4 board tasks unworked. The agent's own pane logged it verbatim:

> "All tasks complete! Project at 100% completion (**2/2 tasks done**)."

The monitor agent did the same thing, displaying *Project Status: 2/3 tasks complete* while noting *3 more tasks from the board still not yet visible* — it could not see the full project because it was reading running event tallies instead of kanban-truth task counts.

## Root cause

Two layered bugs:

1. **MCP tool description was stale and taught the bug by example.** ``get_experiment_status``'s docstring documented only ``task_completions: int`` (running event tally, not a project total) and the worked example literally showed an agent printing ``status['task_completions']`` as ``"Tasks:"``. fastmcp generates the MCP tool description from the docstring, so every agent calling the tool was being taught the wrong field by Marcus itself.

2. **Worker prompt capped retries at 3.** When agent_unicorn_2 finished work and there were no immediately-eligible tasks (Build was held by partner agent, Integration verification was blocked on Build), Marcus's ``request_next_task`` no-task response correctly said *"DO NOT terminate, sleep ``retry_after_seconds``, keep retrying."* The worker prompt overrode that with ``max 3 retries / wait 30s``, causing the agent to give up after 90 seconds. This was the exit accelerant on top of (1).

## What changed

**Code (the canonical fix is in the MCP tool docstring):**
- ``src/experiments/live_experiment_monitor.py::get_status`` — now async, queries kanban backend, exposes ``total_tasks``, ``completed_tasks``, ``in_progress_tasks``, ``backlog_tasks``, ``blocked_tasks`` alongside legacy fields. Docstring documents the trap.
- ``src/marcus_mcp/tools/experiments.py`` — ``get_experiment_status`` impl docstring rewritten with full field reference, Marcus's completion formula, and a corrected polling-loop example.
- ``src/marcus_mcp/server.py:1849`` — fastmcp ``@app.tool()`` wrapper docstring rewritten to match. **This is what agents actually see when they look up the tool.**
- ``src/marcus_mcp/tools/experiments.py:313`` — caller updated to ``await monitor.get_status()``.

**Prompts (positive instruction only — no negation, no ""do not use X""):**
- Worker prompt — removed ``max 3 retries`` entirely. Replaced with ``loop until experiment ends`` tied to ``is_running``. Tells the agent Marcus owns the completion decision using the kanban formula (``completed_tasks == total_tasks AND in_progress_tasks == 0``). Agent reads ``is_running``, doesn't compute.
- Monitor prompt — display template now reads ``completed_tasks`` / ``total_tasks`` from kanban truth and computes percent inline with an explicit formula. ``is_running`` is the exit signal.

**Tests (TDD, all positive contracts):**
- ``tests/unit/experiments/test_live_experiment_monitor.py`` (NEW, 6 tests) — kanban-truth field exposure, async signature, graceful kanban failure, and a v73 regression test that proves ``total_tasks=6`` is exposed even when ``task_assignments=2``.
- ``tests/unit/experiments/test_spawn_agents.py`` — 6 new tests covering the worker prompt retry contract, the monitor prompt's kanban-truth display, and the explicit percent formula.

## Test plan

- [x] ``black`` + ``mypy`` clean on all touched source files
- [x] ``pytest tests/unit -m unit`` — **517 passed, 0 regressions** (was 511; +6 net new)
- [x] v73 regression test reproduces the v73 state and proves the new fields are distinct from the legacy tallies
- [ ] Restart Marcus and run dashboard-v74 against post-merge develop — confirm both agents stay alive past the recovery window and the monitor displays correct totals

🤖 Generated with [Claude Code](https://claude.com/claude-code)