### PR TITLE
fix(lease): merge-conflict-aware extension via worktree git state

### DIFF
--- a/src/core/assignment_lease.py
+++ b/src/core/assignment_lease.py
@@ -19,6 +19,7 @@ from collections import deque
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
 from enum import Enum
+from pathlib import Path
 from typing import Any, Callable, Deque, Dict, List, Optional
 
 from src.core.assignment_persistence import AssignmentPersistence
@@ -27,6 +28,24 @@ from src.core.models import RecoveryInfo, Task, TaskStatus
 from src.integrations.kanban_interface import KanbanInterface
 
 logger = logging.getLogger(__name__)
+
+# Merge-conflict-aware lease extension (dashboard-v73 fix).
+#
+# When an agent's lease is about to expire and the agent's worktree has
+# unresolved git merge conflicts, Marcus grants a one-shot extension to
+# give the agent more time to finish conflict resolution. The extension
+# is bounded so a permanently-stuck agent cannot hold a lease forever.
+#
+# Truth-grounded: the worktree git state IS the source of truth — no
+# new agent API surface, no agent self-declaration, agent cannot lie
+# or forget. Same mechanism handles the mid-rebase case for free.
+MAX_MERGE_CONFLICT_EXTENSIONS = 2  # max grants per lease (=10 min total)
+MERGE_CONFLICT_EXTENSION_SECONDS = 300  # 5 min per grant
+
+# Git porcelain status prefixes that indicate unmerged paths. Any of
+# these on a line means the working tree has an unresolved conflict.
+# See ``man git-status`` "Output → Short Format" for the full grammar.
+_GIT_UNMERGED_PREFIXES = ("UU", "AA", "DD", "DU", "UD", "AU", "UA")
 
 
 class LeaseStatus(Enum):
@@ -53,6 +72,10 @@ class AssignmentLease:
     last_progress_message: str = ""
     grace_period_seconds: Optional[float] = None  # Per-lease adaptive grace
     update_timestamps: list[datetime] = field(default_factory=list)
+    # Number of merge-conflict extensions already granted to this
+    # lease. Bounded by ``MAX_MERGE_CONFLICT_EXTENSIONS`` so a stuck
+    # agent cannot hold the lease forever.
+    merge_conflict_extensions: int = 0
 
     @property
     def median_update_interval(self) -> Optional[float]:
@@ -562,6 +585,12 @@ class AssignmentLeaseManager:
         """
         Check for expired leases that need recovery.
 
+        Before returning a lease as expired, attempts a one-shot
+        merge-conflict extension if the agent's worktree has unresolved
+        git conflicts. Up to ``MAX_MERGE_CONFLICT_EXTENSIONS`` extensions
+        per lease, ``MERGE_CONFLICT_EXTENSION_SECONDS`` each. See the
+        constants at the top of this module for the rationale.
+
         Returns
         -------
             List of expired leases (considering grace period)
@@ -581,6 +610,14 @@ class AssignmentLeaseManager:
                     # Check if grace period has also expired
                     grace_deadline = lease.lease_expires + grace_delta
                     if now > grace_deadline:
+                        # Last-chance check: is the agent stuck on a
+                        # merge conflict? If so, grant an extension.
+                        # dashboard-v73 demonstrated this case: agent
+                        # was actively resolving conflicts when the
+                        # lease expired, work was lost on recovery.
+                        extended = await self._try_extend_for_merge_conflict(lease, now)
+                        if extended:
+                            continue
                         expired_leases.append(lease)
                         logger.info(
                             f"Found expired lease: task {task_id} "
@@ -594,6 +631,158 @@ class AssignmentLeaseManager:
                         )
 
         return expired_leases
+
+    def _resolve_worktree_path(self, lease: AssignmentLease) -> Optional[Path]:
+        """
+        Resolve the worktree path for an agent's lease.
+
+        Marcus's worktree convention (set by the experiment runner at
+        ``dev-tools/experiments/runners/spawn_agents.py``) places agent
+        worktrees at ``<experiment_dir>/worktrees/<agent_id>``, where
+        ``experiment_dir`` is the parent of the project ``implementation``
+        directory. The kanban client exposes the project root via its
+        workspace state.
+
+        Defensive: any failure (no workspace state method, malformed
+        state, missing or non-string project_root, missing worktree
+        directory) returns None. The caller treats None as "not
+        eligible for merge-conflict extension" and proceeds with
+        normal recovery.
+
+        Parameters
+        ----------
+        lease : AssignmentLease
+            The lease whose agent's worktree we want to find.
+
+        Returns
+        -------
+        Optional[Path]
+            The worktree path if it exists on disk, or None for any
+            unresolvable case (single-branch projects, non-experiment
+            runs, mocked kanban clients in tests).
+        """
+        load_state = getattr(self.kanban_client, "_load_workspace_state", None)
+        if not callable(load_state):
+            return None
+        try:
+            workspace_state = load_state()
+            if not isinstance(workspace_state, dict):
+                return None
+            project_root = workspace_state.get("project_root")
+            if not isinstance(project_root, str) or not project_root:
+                return None
+            # Marcus convention: worktrees live as siblings to implementation/
+            worktree = Path(project_root).parent / "worktrees" / lease.agent_id
+            if not worktree.exists():
+                return None
+            return worktree
+        except Exception as e:
+            logger.debug(f"Could not resolve worktree path for {lease.task_id}: {e}")
+            return None
+
+    async def _has_unresolved_conflicts(self, worktree: Path) -> bool:
+        """
+        Check whether a worktree has unresolved merge conflicts.
+
+        Runs ``git status --porcelain`` and looks for status codes that
+        indicate unmerged paths (UU, AA, DD, DU, UD, AU, UA). Any
+        subprocess error or non-git worktree returns False — when
+        in doubt, assume no conflict and let the lease expire normally.
+
+        Parameters
+        ----------
+        worktree : Path
+            Worktree directory to inspect.
+
+        Returns
+        -------
+        bool
+            True if at least one unmerged path is present.
+        """
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                "git",
+                "-C",
+                str(worktree),
+                "status",
+                "--porcelain",
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            stdout, _ = await proc.communicate()
+            if proc.returncode != 0:
+                return False
+        except Exception as e:
+            logger.debug(f"git status failed for {worktree}: {e}")
+            return False
+
+        for line in stdout.decode("utf-8", errors="replace").splitlines():
+            # Porcelain format: XY <path>. The XY is the first 2 chars.
+            if len(line) >= 2 and line[:2] in _GIT_UNMERGED_PREFIXES:
+                return True
+        return False
+
+    async def _try_extend_for_merge_conflict(
+        self, lease: AssignmentLease, now: datetime
+    ) -> bool:
+        """
+        Grant a merge-conflict extension if eligible.
+
+        Eligibility:
+          - Lease has not exhausted ``MAX_MERGE_CONFLICT_EXTENSIONS``
+          - Worktree path is resolvable and exists
+          - Worktree has at least one unresolved merge conflict path
+
+        On success, extends the lease by
+        ``MERGE_CONFLICT_EXTENSION_SECONDS`` and increments
+        ``lease.merge_conflict_extensions``. The lease lock is held
+        by the caller (``check_expired_leases``).
+
+        Parameters
+        ----------
+        lease : AssignmentLease
+            The expired lease being considered for recovery.
+        now : datetime
+            Current UTC time (for ``last_renewed``).
+
+        Returns
+        -------
+        bool
+            True if extension granted, False otherwise.
+        """
+        if lease.merge_conflict_extensions >= MAX_MERGE_CONFLICT_EXTENSIONS:
+            return False
+        worktree = self._resolve_worktree_path(lease)
+        if worktree is None:
+            return False
+        if not await self._has_unresolved_conflicts(worktree):
+            return False
+
+        extension = timedelta(seconds=MERGE_CONFLICT_EXTENSION_SECONDS)
+        lease.lease_expires = now + extension
+        lease.last_renewed = now
+        lease.merge_conflict_extensions += 1
+
+        logger.info(
+            f"Granted merge-conflict extension for task {lease.task_id} "
+            f"to agent {lease.agent_id} "
+            f"(extension {lease.merge_conflict_extensions}/"
+            f"{MAX_MERGE_CONFLICT_EXTENSIONS}, "
+            f"new expiry: {lease.lease_expires.isoformat()}, "
+            f"unresolved conflicts in {worktree})"
+        )
+        self.lease_history.append(
+            {
+                "event": "merge_conflict_extension",
+                "task_id": lease.task_id,
+                "agent_id": lease.agent_id,
+                "timestamp": now.isoformat(),
+                "extension_count": lease.merge_conflict_extensions,
+                "new_expiry": lease.lease_expires.isoformat(),
+                "worktree": str(worktree),
+            }
+        )
+        return True
 
     def _find_task(self, task_id: str) -> Optional[Task]:
         """

--- a/src/core/assignment_lease.py
+++ b/src/core/assignment_lease.py
@@ -41,9 +41,15 @@ logger = logging.getLogger(__name__)
 # or forget. Same mechanism handles the mid-rebase case for free.
 MAX_MERGE_CONFLICT_EXTENSIONS = 2  # max grants per lease (=10 min total)
 MERGE_CONFLICT_EXTENSION_SECONDS = 300  # 5 min per grant
+MERGE_CONFLICT_GIT_TIMEOUT_SECONDS = 10.0  # cap git status to bound the lease loop
 
-# Git porcelain status prefixes that indicate unmerged paths. Any of
-# these on a line means the working tree has an unresolved conflict.
+# Git porcelain status prefixes that indicate unmerged paths. Any line
+# whose first two characters match one of these is an unresolved merge:
+#   UU = both modified         (most common — same line edited on both sides)
+#   AA = both added            (same path created independently)
+#   DD = both deleted          (sanity-edge — both branches removed it)
+#   DU/UD = deleted vs modified  (one side removed, other modified)
+#   AU/UA = added vs modified    (one side created, other modified pre-existing)
 # See ``man git-status`` "Output → Short Format" for the full grammar.
 _GIT_UNMERGED_PREFIXES = ("UU", "AA", "DD", "DU", "UD", "AU", "UA")
 
@@ -585,50 +591,72 @@ class AssignmentLeaseManager:
         """
         Check for expired leases that need recovery.
 
-        Before returning a lease as expired, attempts a one-shot
-        merge-conflict extension if the agent's worktree has unresolved
-        git conflicts. Up to ``MAX_MERGE_CONFLICT_EXTENSIONS`` extensions
-        per lease, ``MERGE_CONFLICT_EXTENSION_SECONDS`` each. See the
+        Two-phase to avoid holding ``lease_lock`` during git subprocess
+        I/O (Codex P2 on PR #350). Holding the global lock during
+        per-lease ``git status`` calls would serialize every concurrent
+        ``renew_lease`` and ``touch_lease`` for the duration of the
+        slowest probe, and could cause active agents' renewals to
+        starve and look expired in the next cycle.
+
+        Phase 1 (lock held, no I/O):
+            Snapshot leases that have crossed the grace deadline.
+
+        Phase 2 (lock released, may do I/O):
+            For each candidate, try the merge-conflict extension. The
+            extension helper does a git probe outside the lock and
+            briefly re-acquires the lock only to mutate + persist the
+            lease atomically.
+
+        Before returning a lease as expired, the merge-conflict
+        extension may grant up to ``MAX_MERGE_CONFLICT_EXTENSIONS``
+        extensions of ``MERGE_CONFLICT_EXTENSION_SECONDS`` each when
+        the agent's worktree has unresolved git conflicts. See the
         constants at the top of this module for the rationale.
 
         Returns
         -------
             List of expired leases (considering grace period)
         """
-        expired_leases = []
+        expired_leases: List[AssignmentLease] = []
         now = datetime.now(timezone.utc)
         default_grace_delta = timedelta(minutes=self.grace_period_minutes)
 
+        # Phase 1: collect candidates under lock, no I/O.
+        candidates: List[tuple[AssignmentLease, datetime]] = []
         async with self.lease_lock:
             for task_id, lease in list(self.active_leases.items()):
-                if lease.is_expired:
-                    # Use per-lease adaptive grace if set, else global default
-                    if lease.grace_period_seconds is not None:
-                        grace_delta = timedelta(seconds=lease.grace_period_seconds)
-                    else:
-                        grace_delta = default_grace_delta
-                    # Check if grace period has also expired
-                    grace_deadline = lease.lease_expires + grace_delta
-                    if now > grace_deadline:
-                        # Last-chance check: is the agent stuck on a
-                        # merge conflict? If so, grant an extension.
-                        # dashboard-v73 demonstrated this case: agent
-                        # was actively resolving conflicts when the
-                        # lease expired, work was lost on recovery.
-                        extended = await self._try_extend_for_merge_conflict(lease, now)
-                        if extended:
-                            continue
-                        expired_leases.append(lease)
-                        logger.info(
-                            f"Found expired lease: task {task_id} "
-                            f"(expired: {lease.lease_expires.isoformat()}, "
-                            f"grace ended: {grace_deadline.isoformat()})"
-                        )
-                    else:
-                        logger.debug(
-                            f"Lease expired but in grace period: task {task_id} "
-                            f"(expires fully at: {grace_deadline.isoformat()})"
-                        )
+                if not lease.is_expired:
+                    continue
+                # Use per-lease adaptive grace if set, else global default
+                if lease.grace_period_seconds is not None:
+                    grace_delta = timedelta(seconds=lease.grace_period_seconds)
+                else:
+                    grace_delta = default_grace_delta
+                grace_deadline = lease.lease_expires + grace_delta
+                if now > grace_deadline:
+                    candidates.append((lease, grace_deadline))
+                else:
+                    logger.debug(
+                        f"Lease expired but in grace period: task {task_id} "
+                        f"(expires fully at: {grace_deadline.isoformat()})"
+                    )
+
+        # Phase 2: probe + extend OUTSIDE the lock so concurrent
+        # renew_lease/touch_lease calls aren't blocked on git I/O.
+        # Last-chance check: is the agent stuck on a merge conflict?
+        # dashboard-v73 demonstrated this case — agent was actively
+        # resolving conflicts when the lease expired, work was lost
+        # on recovery.
+        for lease, grace_deadline in candidates:
+            extended = await self._try_extend_for_merge_conflict(lease, now)
+            if extended:
+                continue
+            expired_leases.append(lease)
+            logger.info(
+                f"Found expired lease: task {lease.task_id} "
+                f"(expired: {lease.lease_expires.isoformat()}, "
+                f"grace ended: {grace_deadline.isoformat()})"
+            )
 
         return expired_leases
 
@@ -685,9 +713,11 @@ class AssignmentLeaseManager:
         Check whether a worktree has unresolved merge conflicts.
 
         Runs ``git status --porcelain`` and looks for status codes that
-        indicate unmerged paths (UU, AA, DD, DU, UD, AU, UA). Any
-        subprocess error or non-git worktree returns False — when
-        in doubt, assume no conflict and let the lease expire normally.
+        indicate unmerged paths (UU, AA, DD, DU, UD, AU, UA). Bounded
+        by ``MERGE_CONFLICT_GIT_TIMEOUT_SECONDS`` so a wedged git
+        process cannot stall the lease loop. Any subprocess error,
+        timeout, or non-git worktree returns False — when in doubt,
+        assume no conflict and let the lease expire normally.
 
         Parameters
         ----------
@@ -699,6 +729,7 @@ class AssignmentLeaseManager:
         bool
             True if at least one unmerged path is present.
         """
+        proc: Optional[asyncio.subprocess.Process] = None
         try:
             proc = await asyncio.create_subprocess_exec(
                 "git",
@@ -709,7 +740,24 @@ class AssignmentLeaseManager:
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
             )
-            stdout, _ = await proc.communicate()
+            try:
+                stdout, _ = await asyncio.wait_for(
+                    proc.communicate(),
+                    timeout=MERGE_CONFLICT_GIT_TIMEOUT_SECONDS,
+                )
+            except asyncio.TimeoutError:
+                logger.warning(
+                    f"git status timed out after "
+                    f"{MERGE_CONFLICT_GIT_TIMEOUT_SECONDS}s for {worktree}; "
+                    f"treating as no-conflict"
+                )
+                # Best-effort cleanup; subprocess kill returns immediately
+                try:
+                    proc.kill()
+                    await proc.wait()
+                except ProcessLookupError:
+                    pass
+                return False
             if proc.returncode != 0:
                 return False
         except Exception as e:
@@ -728,15 +776,25 @@ class AssignmentLeaseManager:
         """
         Grant a merge-conflict extension if eligible.
 
-        Eligibility:
-          - Lease has not exhausted ``MAX_MERGE_CONFLICT_EXTENSIONS``
-          - Worktree path is resolvable and exists
-          - Worktree has at least one unresolved merge conflict path
+        Called from ``check_expired_leases`` OUTSIDE the lease lock so
+        the git subprocess probe doesn't serialize concurrent
+        ``renew_lease``/``touch_lease`` calls (Codex P2 on PR #350).
+
+        Phases:
+          1. Eligibility precheck (no lock, no I/O): cap, worktree path
+          2. Git probe (no lock, async subprocess I/O bounded by
+             ``MERGE_CONFLICT_GIT_TIMEOUT_SECONDS``)
+          3. Apply extension under the lock, then persist outside it.
+             The under-lock section re-verifies the lease is still in
+             ``active_leases`` and still under the cap to defend
+             against a race with a successful ``renew_lease``.
 
         On success, extends the lease by
-        ``MERGE_CONFLICT_EXTENSION_SECONDS`` and increments
-        ``lease.merge_conflict_extensions``. The lease lock is held
-        by the caller (``check_expired_leases``).
+        ``MERGE_CONFLICT_EXTENSION_SECONDS``, increments
+        ``lease.merge_conflict_extensions``, and persists the lease so
+        a service restart during the extension window does not reload
+        the old expiry and trigger immediate recovery (Codex P1 on
+        PR #350).
 
         Parameters
         ----------
@@ -750,18 +808,49 @@ class AssignmentLeaseManager:
         bool
             True if extension granted, False otherwise.
         """
+        # Phase 1: cheap eligibility checks (no lock, no I/O).
         if lease.merge_conflict_extensions >= MAX_MERGE_CONFLICT_EXTENSIONS:
             return False
         worktree = self._resolve_worktree_path(lease)
         if worktree is None:
             return False
+
+        # Phase 2: git probe (no lock; bounded by timeout).
         if not await self._has_unresolved_conflicts(worktree):
             return False
 
-        extension = timedelta(seconds=MERGE_CONFLICT_EXTENSION_SECONDS)
-        lease.lease_expires = now + extension
-        lease.last_renewed = now
-        lease.merge_conflict_extensions += 1
+        # Phase 3: apply the extension atomically under the lease lock,
+        # with a defensive re-check against races. A concurrent
+        # successful ``renew_lease`` might have already advanced this
+        # lease while we were probing — in that case skip the
+        # extension and let the lease proceed normally.
+        async with self.lease_lock:
+            if lease.task_id not in self.active_leases:
+                return False
+            if lease.merge_conflict_extensions >= MAX_MERGE_CONFLICT_EXTENSIONS:
+                return False
+
+            extension = timedelta(seconds=MERGE_CONFLICT_EXTENSION_SECONDS)
+            lease.lease_expires = now + extension
+            lease.last_renewed = now
+            lease.merge_conflict_extensions += 1
+
+            self.lease_history.append(
+                {
+                    "event": "merge_conflict_extension",
+                    "task_id": lease.task_id,
+                    "agent_id": lease.agent_id,
+                    "timestamp": now.isoformat(),
+                    "extension_count": lease.merge_conflict_extensions,
+                    "new_expiry": lease.lease_expires.isoformat(),
+                    "worktree": str(worktree),
+                }
+            )
+
+        # Persist OUTSIDE the lock — _persist_lease does I/O against
+        # assignment_persistence and we already hold a consistent
+        # in-memory snapshot of the lease state.
+        await self._persist_lease(lease)
 
         logger.info(
             f"Granted merge-conflict extension for task {lease.task_id} "
@@ -770,17 +859,6 @@ class AssignmentLeaseManager:
             f"{MAX_MERGE_CONFLICT_EXTENSIONS}, "
             f"new expiry: {lease.lease_expires.isoformat()}, "
             f"unresolved conflicts in {worktree})"
-        )
-        self.lease_history.append(
-            {
-                "event": "merge_conflict_extension",
-                "task_id": lease.task_id,
-                "agent_id": lease.agent_id,
-                "timestamp": now.isoformat(),
-                "extension_count": lease.merge_conflict_extensions,
-                "new_expiry": lease.lease_expires.isoformat(),
-                "worktree": str(worktree),
-            }
         )
         return True
 
@@ -998,6 +1076,10 @@ class AssignmentLeaseManager:
             assignment["update_timestamps"] = [
                 ts.isoformat() for ts in lease.update_timestamps
             ]
+            # Persist merge-conflict extension counter so the cap
+            # survives a service restart during the extension window
+            # (Codex P1 on PR #350).
+            assignment["merge_conflict_extensions"] = lease.merge_conflict_extensions
             await self.assignment_persistence.save_assignment(
                 lease.agent_id,
                 lease.task_id,
@@ -1045,6 +1127,13 @@ class AssignmentLeaseManager:
                 renewal_count=assignment.get("renewal_count", 0),
                 progress_percentage=assignment.get("progress_percentage", 0),
                 update_timestamps=update_timestamps,
+                # Restore merge-conflict extension counter so the cap
+                # survives a restart during the extension window
+                # (Codex P1 on PR #350). Defaults to 0 for assignments
+                # written before this field existed.
+                merge_conflict_extensions=assignment.get(
+                    "merge_conflict_extensions", 0
+                ),
             )
 
             self.active_leases[task_id] = lease

--- a/tests/unit/core/test_assignment_lease.py
+++ b/tests/unit/core/test_assignment_lease.py
@@ -4,6 +4,7 @@ Unit tests for the assignment lease system.
 
 import asyncio
 from datetime import datetime, timedelta, timezone
+from pathlib import Path
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
@@ -15,6 +16,8 @@ from src.core.assignment_lease import (
     LeaseStatus,
 )
 from src.core.models import Priority, RecoveryInfo, Task, TaskStatus
+
+pytestmark = pytest.mark.unit
 
 
 class TestAssignmentLease:
@@ -1133,3 +1136,303 @@ class TestExpiredLeaseProgressCapture:
         assert result is None
         assert expired.is_expired  # lease remains expired
         assert expired.progress_percentage == 80  # but progress captured
+
+
+class TestMergeConflictExtension:
+    """
+    Lease grants a one-shot extension when the agent's worktree has
+    unresolved git merge conflicts.
+
+    Regression for dashboard-v73: agent_unicorn_2 was actively
+    resolving merge conflicts when its lease silently expired. The
+    work was discarded and recovery handed the task to a fresh agent
+    that re-did everything (and the same merge conflicts) from
+    scratch. The fix grants up to ``MAX_MERGE_CONFLICT_EXTENSIONS``
+    extensions of ``MERGE_CONFLICT_EXTENSION_SECONDS`` each when the
+    worktree's git porcelain status reports unmerged paths.
+
+    Truth-grounded: the worktree git state IS the source of truth.
+    No new agent API surface, no agent self-declaration, agent
+    cannot lie or forget.
+    """
+
+    @pytest.fixture
+    def mock_kanban_client(self, tmp_path):
+        client = Mock()
+        client.update_task_status = AsyncMock()
+        client.update_task = AsyncMock()
+        # Workspace state points at a fake project_root so the
+        # worktree convention (../worktrees/<agent_id>) lands inside
+        # tmp_path. Tests that need the worktree to "exist" populate
+        # it manually via Path.mkdir.
+        impl_dir = tmp_path / "implementation"
+        impl_dir.mkdir()
+        client._load_workspace_state = Mock(
+            return_value={"project_root": str(impl_dir)}
+        )
+        return client
+
+    @pytest.fixture
+    def mock_persistence(self):
+        persistence = Mock()
+        persistence.save_assignment = AsyncMock()
+        persistence.remove_assignment = AsyncMock()
+        persistence.load_assignments = AsyncMock(return_value={})
+        return persistence
+
+    @pytest.fixture
+    def lease_manager(self, mock_kanban_client, mock_persistence):
+        return AssignmentLeaseManager(
+            mock_kanban_client,
+            mock_persistence,
+            default_lease_hours=4.0,
+            grace_period_minutes=0.001,  # ~0s grace so tests don't wait
+        )
+
+    def _make_expired_lease(
+        self, task_id: str = "task-build", agent_id: str = "agent-001"
+    ) -> AssignmentLease:
+        """Build a lease that is comfortably past its grace period."""
+        now = datetime.now(timezone.utc)
+        return AssignmentLease(
+            task_id=task_id,
+            agent_id=agent_id,
+            assigned_at=now - timedelta(hours=1),
+            lease_expires=now - timedelta(minutes=10),
+            last_renewed=now - timedelta(minutes=15),
+            progress_percentage=75,
+        )
+
+    def _make_worktree_with_conflict(self, kanban_client, agent_id: str) -> None:
+        """Create the worktree dir on disk so _resolve_worktree_path finds it."""
+        impl_dir = Path(kanban_client._load_workspace_state()["project_root"])
+        worktree = impl_dir.parent / "worktrees" / agent_id
+        worktree.mkdir(parents=True, exist_ok=True)
+
+    @pytest.mark.asyncio
+    async def test_extension_granted_when_worktree_has_unmerged_paths(
+        self, lease_manager, mock_kanban_client
+    ):
+        """Worktree with unmerged paths → lease extended, not recovered."""
+        lease = self._make_expired_lease()
+        lease_manager.active_leases[lease.task_id] = lease
+        self._make_worktree_with_conflict(mock_kanban_client, lease.agent_id)
+        original_expiry = lease.lease_expires
+
+        with patch.object(
+            lease_manager,
+            "_has_unresolved_conflicts",
+            new_callable=AsyncMock,
+            return_value=True,
+        ):
+            expired = await lease_manager.check_expired_leases()
+
+        assert expired == []  # not in the recovery list
+        assert lease.merge_conflict_extensions == 1
+        assert lease.lease_expires > original_expiry
+        # Lease is now in the future (extension applied)
+        assert not lease.is_expired
+
+    @pytest.mark.asyncio
+    async def test_extension_not_granted_without_worktree(
+        self, lease_manager, mock_kanban_client
+    ):
+        """No worktree on disk → no extension, lease recovered normally."""
+        lease = self._make_expired_lease()
+        lease_manager.active_leases[lease.task_id] = lease
+        # Note: NOT creating the worktree dir
+
+        expired = await lease_manager.check_expired_leases()
+
+        assert lease in expired
+        assert lease.merge_conflict_extensions == 0
+
+    @pytest.mark.asyncio
+    async def test_extension_not_granted_when_no_conflicts(
+        self, lease_manager, mock_kanban_client
+    ):
+        """Worktree exists but no conflicts → no extension."""
+        lease = self._make_expired_lease()
+        lease_manager.active_leases[lease.task_id] = lease
+        self._make_worktree_with_conflict(mock_kanban_client, lease.agent_id)
+
+        with patch.object(
+            lease_manager,
+            "_has_unresolved_conflicts",
+            new_callable=AsyncMock,
+            return_value=False,
+        ):
+            expired = await lease_manager.check_expired_leases()
+
+        assert lease in expired
+        assert lease.merge_conflict_extensions == 0
+
+    @pytest.mark.asyncio
+    async def test_extension_capped_at_max(self, lease_manager, mock_kanban_client):
+        """After MAX_MERGE_CONFLICT_EXTENSIONS, no further extensions."""
+        from src.core.assignment_lease import MAX_MERGE_CONFLICT_EXTENSIONS
+
+        lease = self._make_expired_lease()
+        lease.merge_conflict_extensions = MAX_MERGE_CONFLICT_EXTENSIONS
+        lease_manager.active_leases[lease.task_id] = lease
+        self._make_worktree_with_conflict(mock_kanban_client, lease.agent_id)
+
+        # Even with conflicts present, the cap stops further extensions
+        with patch.object(
+            lease_manager,
+            "_has_unresolved_conflicts",
+            new_callable=AsyncMock,
+            return_value=True,
+        ):
+            expired = await lease_manager.check_expired_leases()
+
+        assert lease in expired
+        assert lease.merge_conflict_extensions == MAX_MERGE_CONFLICT_EXTENSIONS
+
+    @pytest.mark.asyncio
+    async def test_extension_increments_counter_each_grant(
+        self, lease_manager, mock_kanban_client
+    ):
+        """Each successful extension increments the counter."""
+        lease = self._make_expired_lease()
+        lease_manager.active_leases[lease.task_id] = lease
+        self._make_worktree_with_conflict(mock_kanban_client, lease.agent_id)
+
+        with patch.object(
+            lease_manager,
+            "_has_unresolved_conflicts",
+            new_callable=AsyncMock,
+            return_value=True,
+        ):
+            await lease_manager.check_expired_leases()
+            assert lease.merge_conflict_extensions == 1
+
+            # Force another expiry by rewinding lease_expires
+            lease.lease_expires = datetime.now(timezone.utc) - timedelta(minutes=10)
+            await lease_manager.check_expired_leases()
+            assert lease.merge_conflict_extensions == 2
+
+    @pytest.mark.asyncio
+    async def test_extension_logged_to_lease_history(
+        self, lease_manager, mock_kanban_client
+    ):
+        """Each extension appends a merge_conflict_extension event."""
+        lease = self._make_expired_lease()
+        lease_manager.active_leases[lease.task_id] = lease
+        self._make_worktree_with_conflict(mock_kanban_client, lease.agent_id)
+
+        with patch.object(
+            lease_manager,
+            "_has_unresolved_conflicts",
+            new_callable=AsyncMock,
+            return_value=True,
+        ):
+            await lease_manager.check_expired_leases()
+
+        events = [
+            e
+            for e in lease_manager.lease_history
+            if e.get("event") == "merge_conflict_extension"
+        ]
+        assert len(events) == 1
+        assert events[0]["task_id"] == lease.task_id
+        assert events[0]["agent_id"] == lease.agent_id
+        assert events[0]["extension_count"] == 1
+
+    @pytest.mark.asyncio
+    async def test_resolve_worktree_path_returns_none_without_workspace_state(
+        self, lease_manager, mock_kanban_client
+    ):
+        """No workspace state → _resolve_worktree_path returns None."""
+        mock_kanban_client._load_workspace_state = Mock(return_value=None)
+        lease = self._make_expired_lease()
+        result = lease_manager._resolve_worktree_path(lease)
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_resolve_worktree_path_returns_none_when_dir_missing(
+        self, lease_manager, mock_kanban_client
+    ):
+        """Workspace state present but worktree dir doesn't exist → None."""
+        lease = self._make_expired_lease()
+        # Don't create the worktree dir
+        result = lease_manager._resolve_worktree_path(lease)
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_has_unresolved_conflicts_real_git_clean_worktree(
+        self, lease_manager, tmp_path
+    ):
+        """Real git invocation on a clean worktree returns False."""
+        worktree = tmp_path / "clean"
+        worktree.mkdir()
+        # Initialize a real git repo
+        proc = await asyncio.create_subprocess_exec(
+            "git",
+            "init",
+            "-q",
+            "-b",
+            "main",
+            str(worktree),
+            stdout=asyncio.subprocess.DEVNULL,
+            stderr=asyncio.subprocess.DEVNULL,
+        )
+        await proc.communicate()
+
+        result = await lease_manager._has_unresolved_conflicts(worktree)
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_has_unresolved_conflicts_real_git_with_conflict(
+        self, lease_manager, tmp_path
+    ):
+        """
+        Real git invocation on a worktree with an unmerged path returns True.
+
+        Sets up a minimal git repo with an actual merge conflict by
+        creating two divergent branches that touch the same line and
+        then attempting (and failing) the merge. The resulting
+        porcelain status has a UU line that the helper must detect.
+        """
+        worktree = tmp_path / "conflicted"
+        worktree.mkdir()
+
+        async def run(*args):
+            proc = await asyncio.create_subprocess_exec(
+                "git",
+                "-C",
+                str(worktree),
+                *args,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            await proc.communicate()
+            return proc.returncode
+
+        await run("init", "-q", "-b", "main")
+        await run("config", "user.email", "test@test")
+        await run("config", "user.name", "Test")
+        (worktree / "f.txt").write_text("base\n")
+        await run("add", "f.txt")
+        await run("commit", "-q", "-m", "base")
+        await run("checkout", "-q", "-b", "branch-a")
+        (worktree / "f.txt").write_text("a\n")
+        await run("commit", "-aq", "-m", "a")
+        await run("checkout", "-q", "main")
+        (worktree / "f.txt").write_text("b\n")
+        await run("commit", "-aq", "-m", "b")
+        # This merge will fail with a conflict, leaving UU in status
+        await run("merge", "branch-a", "--no-edit")
+
+        result = await lease_manager._has_unresolved_conflicts(worktree)
+        assert result is True
+
+    @pytest.mark.asyncio
+    async def test_has_unresolved_conflicts_returns_false_on_non_git_dir(
+        self, lease_manager, tmp_path
+    ):
+        """Non-git directory → defensive False, no exception."""
+        worktree = tmp_path / "not_git"
+        worktree.mkdir()
+        result = await lease_manager._has_unresolved_conflicts(worktree)
+        assert result is False

--- a/tests/unit/core/test_assignment_lease.py
+++ b/tests/unit/core/test_assignment_lease.py
@@ -1178,6 +1178,15 @@ class TestMergeConflictExtension:
         persistence.save_assignment = AsyncMock()
         persistence.remove_assignment = AsyncMock()
         persistence.load_assignments = AsyncMock(return_value={})
+        # Default to returning an assignment dict so _persist_lease's
+        # "if assignment:" branch fires when extensions are granted.
+        # Tests that need a different shape override this directly.
+        persistence.get_assignment = AsyncMock(
+            return_value={
+                "task_id": "task-build",
+                "assigned_at": datetime.now(timezone.utc).isoformat(),
+            }
+        )
         return persistence
 
     @pytest.fixture
@@ -1436,3 +1445,167 @@ class TestMergeConflictExtension:
         worktree.mkdir()
         result = await lease_manager._has_unresolved_conflicts(worktree)
         assert result is False
+
+    @pytest.mark.asyncio
+    async def test_extension_persists_lease_for_restart_safety(
+        self, lease_manager, mock_kanban_client, mock_persistence
+    ):
+        """
+        Codex P1 on PR #350: extension must call _persist_lease so a
+        service restart during the 5-min extension window doesn't
+        reload the old expiry and immediately recover the lease.
+        """
+        # Persistence has an existing assignment for this agent so
+        # _persist_lease's "if assignment:" branch fires.
+        mock_persistence.get_assignment = AsyncMock(
+            return_value={
+                "task_id": "task-build",
+                "assigned_at": datetime.now(timezone.utc).isoformat(),
+            }
+        )
+        lease = self._make_expired_lease()
+        lease_manager.active_leases[lease.task_id] = lease
+        self._make_worktree_with_conflict(mock_kanban_client, lease.agent_id)
+
+        with patch.object(
+            lease_manager,
+            "_has_unresolved_conflicts",
+            new_callable=AsyncMock,
+            return_value=True,
+        ):
+            await lease_manager.check_expired_leases()
+
+        # _persist_lease writes via assignment_persistence.save_assignment
+        mock_persistence.save_assignment.assert_called()
+        # The persisted assignment dict must include the new field
+        # so a restart can rehydrate the cap counter.
+        # Check the dict that get_assignment returned was mutated:
+        loaded = await mock_persistence.get_assignment(lease.agent_id)
+        assert loaded["merge_conflict_extensions"] == 1
+        assert "lease_expires" in loaded
+
+    @pytest.mark.asyncio
+    async def test_extension_does_not_hold_lock_during_git_probe(
+        self, lease_manager, mock_kanban_client
+    ):
+        """
+        Codex P2 on PR #350: git subprocess must not run while the
+        lease lock is held, otherwise concurrent renew_lease calls
+        starve.
+
+        The test forces _has_unresolved_conflicts to acquire the
+        lease_lock itself. If check_expired_leases were holding the
+        lock during the probe, this would deadlock. Under the fix
+        (probe outside lock, brief reacquire for mutation), the
+        probe sees the lock as available and the test completes.
+        """
+        lease = self._make_expired_lease()
+        lease_manager.active_leases[lease.task_id] = lease
+        self._make_worktree_with_conflict(mock_kanban_client, lease.agent_id)
+
+        async def probe_acquires_lock(_worktree):
+            # If check_expired_leases is holding lease_lock, this hangs
+            async with lease_manager.lease_lock:
+                return True
+
+        with patch.object(
+            lease_manager,
+            "_has_unresolved_conflicts",
+            side_effect=probe_acquires_lock,
+        ):
+            # Bound the test so a regression manifests as a timeout
+            # rather than an indefinite hang
+            result = await asyncio.wait_for(
+                lease_manager.check_expired_leases(), timeout=5.0
+            )
+
+        assert result == []  # extension was granted
+        assert lease.merge_conflict_extensions == 1
+
+    @pytest.mark.asyncio
+    async def test_has_unresolved_conflicts_times_out_on_wedged_git(
+        self, lease_manager, tmp_path, monkeypatch
+    ):
+        """
+        Subprocess timeout (human review on PR #350): a wedged git
+        process must not stall the lease loop indefinitely. The
+        helper bounds git status with MERGE_CONFLICT_GIT_TIMEOUT_SECONDS
+        and returns False on timeout.
+        """
+        from src.core import assignment_lease as al_mod
+
+        # Drop the timeout to a sub-second value for the test
+        monkeypatch.setattr(al_mod, "MERGE_CONFLICT_GIT_TIMEOUT_SECONDS", 0.1)
+
+        worktree = tmp_path / "wedge"
+        worktree.mkdir()
+
+        # Patch create_subprocess_exec to return a process that
+        # never completes communicate() — simulates a wedged git.
+        class _HangingProcess:
+            def __init__(self):
+                self.returncode = None
+
+            async def communicate(self):
+                await asyncio.sleep(60)  # > timeout
+                return b"", b""
+
+            def kill(self):
+                pass
+
+            async def wait(self):
+                return 0
+
+        async def fake_create(*args, **kwargs):
+            return _HangingProcess()
+
+        monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_create)
+
+        # Should return False quickly, not hang
+        result = await asyncio.wait_for(
+            lease_manager._has_unresolved_conflicts(worktree), timeout=2.0
+        )
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_load_active_leases_restores_merge_conflict_extensions(
+        self, lease_manager, mock_persistence
+    ):
+        """Codex P1 on PR #350: cap counter survives restart via persistence."""
+        # Persistence returns an assignment with the new field set
+        mock_persistence.load_assignments = AsyncMock(
+            return_value={
+                "agent-001": {
+                    "task_id": "task-build",
+                    "assigned_at": datetime.now(timezone.utc).isoformat(),
+                    "lease_expires": datetime.now(timezone.utc).isoformat(),
+                    "lease_renewed_at": datetime.now(timezone.utc).isoformat(),
+                    "merge_conflict_extensions": 2,
+                }
+            }
+        )
+
+        await lease_manager.load_active_leases()
+        loaded = lease_manager.active_leases["task-build"]
+        assert loaded.merge_conflict_extensions == 2
+
+    @pytest.mark.asyncio
+    async def test_load_active_leases_defaults_extensions_to_zero_for_legacy(
+        self, lease_manager, mock_persistence
+    ):
+        """Older persistence rows without the field must default to 0."""
+        mock_persistence.load_assignments = AsyncMock(
+            return_value={
+                "agent-001": {
+                    "task_id": "task-build",
+                    "assigned_at": datetime.now(timezone.utc).isoformat(),
+                    "lease_expires": datetime.now(timezone.utc).isoformat(),
+                    "lease_renewed_at": datetime.now(timezone.utc).isoformat(),
+                    # NOTE: no merge_conflict_extensions key
+                }
+            }
+        )
+
+        await lease_manager.load_active_leases()
+        loaded = lease_manager.active_leases["task-build"]
+        assert loaded.merge_conflict_extensions == 0


### PR DESCRIPTION
## Summary

Dashboard-v73 demonstrated that an agent's lease can silently expire while the agent is actively resolving merge conflicts. ``agent_unicorn_2`` was 75% through Build, hit a merge conflict, went silent during conflict resolution, and the lease expired at 22:42:10 — recovery handed the task to ``agent_unicorn_1`` which had to redo everything *including the same merge conflicts* ``agent_unicorn_2`` had been working on.

## Fix

In ``check_expired_leases``, before adding a lease to the recovery list, inspect the agent's worktree via ``git status --porcelain`` and look for unmerged paths (UU, AA, DD, DU, UD, AU, UA). If any are present, grant a one-shot extension of 5 minutes. Bounded by ``MAX_MERGE_CONFLICT_EXTENSIONS = 2`` (10 min total) so a permanently-stuck agent cannot hold the lease forever.

## Why this design

**Truth-grounded:** the worktree git state IS the source of truth. Zero new agent API surface, no agent self-declaration, agent cannot lie or forget to declare. Same mechanism handles mid-rebase for free.

**Single-branch projects unaffected:** ``_resolve_worktree_path`` returns ``None`` when the worktree directory doesn't exist on disk, so the extension never fires for non-worktree assignments.

**Defensive:** any failure (unresolvable workspace state, mocked clients in tests, non-git directories, subprocess errors) returns ``False`` from ``_has_unresolved_conflicts`` and the lease proceeds to normal recovery.

## Implementation

- ``src/core/assignment_lease.py``:
  - New constants ``MAX_MERGE_CONFLICT_EXTENSIONS=2`` and ``MERGE_CONFLICT_EXTENSION_SECONDS=300``
  - New ``AssignmentLease.merge_conflict_extensions`` field
  - New ``_resolve_worktree_path(lease)`` — derives worktree path from kanban workspace state via Marcus convention
  - New ``_has_unresolved_conflicts(worktree)`` — async git subprocess parsing porcelain status
  - New ``_try_extend_for_merge_conflict(lease, now)`` — eligibility + extension + history logging
  - Hook in ``check_expired_leases`` after grace check, before recovery list append

## Test housekeeping

``tests/unit/core/test_assignment_lease.py`` was missing ``pytestmark = pytest.mark.unit``, so its 32 existing tests had been silently excluded from the ``pytest -m unit`` baseline (per ``test_marker_workflow.md``). Added the marker — the file now contributes all of its tests to CI, including the 11 new merge-conflict regression tests below.

## Tests (TDD, 11 new in ``TestMergeConflictExtension``)

- ``test_extension_granted_when_worktree_has_unmerged_paths``
- ``test_extension_not_granted_without_worktree``
- ``test_extension_not_granted_when_no_conflicts``
- ``test_extension_capped_at_max``
- ``test_extension_increments_counter_each_grant``
- ``test_extension_logged_to_lease_history``
- ``test_resolve_worktree_path_returns_none_without_workspace_state``
- ``test_resolve_worktree_path_returns_none_when_dir_missing``
- ``test_has_unresolved_conflicts_real_git_clean_worktree`` — **real ``git init`` + porcelain status**
- ``test_has_unresolved_conflicts_real_git_with_conflict`` — **real ``git init`` + branch + manual merge that produces a UU line**
- ``test_has_unresolved_conflicts_returns_false_on_non_git_dir``

The two real-git tests use ``asyncio.create_subprocess_exec`` to actually spawn ``git`` in a ``tmp_path`` and verify the parser detects (or doesn't detect) unmerged paths against real porcelain output, not a mock.

## Test plan

- [x] ``black`` + ``mypy`` clean
- [x] ``pytest -m unit`` → **563 passed, 0 regressions** (was 520; +43 from wiring the lease file into the unit marker collection, +11 net-new tests)
- [ ] dashboard-v74 against post-merge develop — confirm an agent stuck in a merge conflict gets at least one extension before recovery fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)