### PR TITLE
fix(integration): require start_command to exercise build pipeline

### DIFF
--- a/src/integrations/integration_verification.py
+++ b/src/integrations/integration_verification.py
@@ -523,8 +523,19 @@ The deliverable is the running product, not the green test bar. \
 Your declared command must be one that would FAIL if the \
 deliverable cannot actually be built and launched in a fresh \
 checkout. If your stack has both a build step and a test step, \
-declare the build (or chain both: build first, then tests). \
-Marcus accepts shell chains, so combining steps is fine.
+declare the BUILD command — the build is the gate that catches \
+missing entry points and broken bundlers; the test suite is not.
+
+   **Declare a SINGLE command, not a shell chain.** Marcus runs \
+``start_command`` as a single subprocess invocation, not a shell \
+script. Shell operators (``&&``, ``||``, ``|``, ``$(...)``, \
+``cd``, environment variable expansion) are NOT interpreted — \
+they will be passed as literal arguments and produce confusing \
+failures. If you genuinely need to combine steps (e.g. build then \
+test, or chdir then run), commit a small wrapper script to your \
+worktree (e.g. ``./scripts/verify.sh``) and declare \
+``start_command="./scripts/verify.sh"``. The wrapper is plain \
+shell and can do whatever you need.
 
    **What if there's no meaningful start_command?** There \
 always is. Some examples by stack:
@@ -534,9 +545,15 @@ always is. Some examples by stack:
    - **Library with no entry point**: \
 ``start_command="python -c 'import mypackage'"`` (import smoke)
    - **Pure documentation project**: \
-``start_command="test -d docs && test -f README.md"``
+``start_command="test -f README.md"``
    - **Data pipeline with no server**: \
 ``start_command="python -m mypipeline --dry-run"``
+   - **Two checks needed**: write a wrapper script (e.g. \
+``./scripts/verify.sh``) that runs both, commit it to the \
+worktree, and declare \
+``start_command="./scripts/verify.sh"``. Marcus runs the \
+wrapper as a single subprocess; the wrapper is plain shell \
+and can chain whatever you need.
 
    If you genuinely cannot think of a smoke command, that is a \
 signal you don't have a clear definition of "done" for this \

--- a/src/integrations/integration_verification.py
+++ b/src/integrations/integration_verification.py
@@ -514,6 +514,18 @@ with ``CI=true`` set in the environment — if your command needs \
 interactive prompts it will fail in Marcus's subprocess. Use \
 non-interactive flags where needed.
 
+   **REQUIRED: ``start_command`` must exercise the build \
+pipeline that produces the deliverable, not merely the test \
+suite.** A passing test suite does not prove the product builds \
+and starts — tests can pass against stubbed entry points, missing \
+templates, broken bundlers, or unsatisfied native dependencies. \
+The deliverable is the running product, not the green test bar. \
+Your declared command must be one that would FAIL if the \
+deliverable cannot actually be built and launched in a fresh \
+checkout. If your stack has both a build step and a test step, \
+declare the build (or chain both: build first, then tests). \
+Marcus accepts shell chains, so combining steps is fine.
+
    **What if there's no meaningful start_command?** There \
 always is. Some examples by stack:
 

--- a/tests/unit/integrations/test_integration_verification.py
+++ b/tests/unit/integrations/test_integration_verification.py
@@ -14,6 +14,8 @@ import pytest
 from src.core.models import Priority, Task, TaskStatus
 from src.integrations.nlp_task_utils import TaskType
 
+pytestmark = pytest.mark.unit
+
 
 def create_test_task(
     task_id: str,
@@ -891,3 +893,119 @@ class TestIntegrationTaskFunctionalRequirements:
         assert any("Tests run" in c for c in integration_task.acceptance_criteria)
         # No requirement-specific criteria
         assert not any("Display" in c for c in integration_task.acceptance_criteria)
+
+
+class TestStartCommandBuildPipelineRequirement:
+    """
+    Integration verification prompt must require the agent's declared
+    start_command to exercise the build pipeline, not merely the test
+    suite.
+
+    Regression for dashboard-v73: agent_unicorn_1 declared
+    ``start_command='cd worktrees/agent_unicorn_1 && npm test'`` for
+    the integration verification task. The smoke gate ran vitest in
+    the worktree and it passed in <1s — but vitest never invokes the
+    build pipeline. Had the React app been missing public/index.html
+    (the v71 failure shape), npm test would still pass while
+    npm run build would fail. The prompt now teaches the agent that
+    a passing test suite does not prove the deliverable can be built
+    and started, and requires start_command to exercise the build
+    pipeline (chain build + test if both apply).
+
+    Tool-agnostic by design: the prompt names the *contract* (must
+    exercise the build pipeline) without naming any specific tool.
+    Marcus stays platform-agnostic; the agent picks the right
+    command for their stack.
+    """
+
+    def test_prompt_requires_start_command_to_exercise_build_pipeline(self) -> None:
+        from src.integrations.integration_verification import (
+            IntegrationTaskGenerator,
+        )
+
+        prompt = IntegrationTaskGenerator._generate_integration_description(
+            project_name="dashboard-v74"
+        )
+
+        # The contract must appear verbatim — this is the v73-class fix
+        assert "exercise the build pipeline" in prompt
+
+    def test_prompt_explains_why_test_suite_is_not_enough(self) -> None:
+        """
+        The prompt must explain WHY a passing test suite isn't
+        sufficient evidence the deliverable works. Without the
+        explanation the agent will rationalize that "tests pass =
+        product works" and re-fall into v73.
+        """
+        from src.integrations.integration_verification import (
+            IntegrationTaskGenerator,
+        )
+
+        prompt = IntegrationTaskGenerator._generate_integration_description(
+            project_name="dashboard-v74"
+        )
+
+        # Must address the "tests pass therefore product works" fallacy
+        assert "test suite does not prove" in prompt
+
+    def test_prompt_is_tool_agnostic(self) -> None:
+        """
+        The contract sentence must not pin any specific stack. Tool
+        names (npm, vite, tsc, pip, cargo, go, mvn, etc.) may appear
+        in worked examples elsewhere in the prompt, but the contract
+        sentence itself must describe the requirement abstractly.
+        Marcus is a coordination layer for ALL agent work, not just
+        software dev — stack-specific contract language regresses
+        toward the "software bias" failure mode that pre-#347 had.
+        """
+        from src.integrations.integration_verification import (
+            IntegrationTaskGenerator,
+        )
+
+        prompt = IntegrationTaskGenerator._generate_integration_description(
+            project_name="dashboard-v74"
+        )
+
+        # Find the "must exercise the build pipeline" sentence and
+        # verify the SENTENCE itself contains no stack-specific tokens.
+        # Locate the contract sentence
+        idx = prompt.find("must exercise the build pipeline")
+        assert idx >= 0
+        # Take a window of ~400 chars around the contract sentence
+        # to sanity-check the surrounding language
+        window = prompt[idx : idx + 400].lower()
+        # The contract sentence should be tool-agnostic — none of
+        # these stack names should appear in the window
+        forbidden_in_contract = [
+            " npm ",
+            " vite ",
+            " tsc ",
+            " pip ",
+            " cargo ",
+            " maven ",
+            " gradle ",
+            " webpack ",
+        ]
+        for tok in forbidden_in_contract:
+            assert tok not in window, (
+                f"Build-pipeline contract sentence must be "
+                f"tool-agnostic; found {tok!r} in:\n\n{window}"
+            )
+
+    def test_prompt_allows_chaining_build_and_tests(self) -> None:
+        """
+        The prompt must explicitly tell agents that chaining build
+        and tests is acceptable — otherwise an agent with both a
+        build step and a test step might pick only one and re-fall
+        into the v73 trap.
+        """
+        from src.integrations.integration_verification import (
+            IntegrationTaskGenerator,
+        )
+
+        prompt = IntegrationTaskGenerator._generate_integration_description(
+            project_name="dashboard-v74"
+        )
+
+        # Must mention chaining as an option
+        assert "chain" in prompt.lower()

--- a/tests/unit/integrations/test_integration_verification.py
+++ b/tests/unit/integrations/test_integration_verification.py
@@ -992,12 +992,20 @@ class TestStartCommandBuildPipelineRequirement:
                 f"tool-agnostic; found {tok!r} in:\n\n{window}"
             )
 
-    def test_prompt_allows_chaining_build_and_tests(self) -> None:
+    def test_prompt_forbids_shell_chains_in_start_command(self) -> None:
         """
-        The prompt must explicitly tell agents that chaining build
-        and tests is acceptable — otherwise an agent with both a
-        build step and a test step might pick only one and re-fall
-        into the v73 trap.
+        The prompt must explicitly tell agents that start_command is
+        a single subprocess invocation, not a shell script.
+
+        Codex P1 on PR #351: Marcus's product_smoke runner uses
+        asyncio.create_subprocess_exec(*shlex.split(...)), which does
+        NOT interpret shell operators. && / || / | / cd / $(...) are
+        passed as literal arguments and produce confusing failures
+        (or worse, vacuous passes — on macOS /usr/bin/cd is a real
+        no-op binary that returns exit 0 for any args, so
+        `cd ... && X` silently false-passes the smoke gate). Until
+        the runner is fixed (#125), the prompt must steer agents
+        away from shell chains and toward a single binary invocation.
         """
         from src.integrations.integration_verification import (
             IntegrationTaskGenerator,
@@ -1007,5 +1015,56 @@ class TestStartCommandBuildPipelineRequirement:
             project_name="dashboard-v74"
         )
 
-        # Must mention chaining as an option
-        assert "chain" in prompt.lower()
+        prompt_lower = prompt.lower()
+        # Must explicitly state that start_command is a single command
+        assert "single command" in prompt_lower or "single subprocess" in prompt_lower
+        # Must call out shell operators by name so the agent
+        # recognizes the trap
+        assert "&&" in prompt
+        # Must offer the wrapper-script escape hatch for cases that
+        # genuinely need to combine steps
+        assert "wrapper" in prompt_lower
+
+    def test_prompt_examples_contain_no_shell_chains(self) -> None:
+        """
+        All ``start_command`` example strings in the prompt must be
+        single-command invocations. Pre-existing examples used shell
+        chains (``test -d docs && test -f README.md``) which would
+        not work under Marcus's exec-based runner. The fix is to
+        replace them with single binary invocations and steer
+        chained needs toward wrapper scripts.
+
+        Detection strategy: find every quoted ``start_command="..."``
+        substring in the prompt and assert none contain ``&&``.
+        """
+        import re
+
+        from src.integrations.integration_verification import (
+            IntegrationTaskGenerator,
+        )
+
+        prompt = IntegrationTaskGenerator._generate_integration_description(
+            project_name="dashboard-v74"
+        )
+
+        # Find every start_command="..." example string
+        examples = re.findall(r'start_command="([^"]*)"', prompt)
+        assert examples, "Prompt should still have start_command examples"
+        for example in examples:
+            assert "&&" not in example, (
+                f"start_command example contains a shell chain that "
+                f"will not work under Marcus's exec-based runner: "
+                f"{example!r}. Replace with a single command or a "
+                f"wrapper script."
+            )
+            assert "||" not in example
+            # `cd` as the first token is the v73 vacuous-pass trap
+            # on macOS where /usr/bin/cd exists as a no-op stub
+            tokens = example.split()
+            if tokens:
+                assert tokens[0] != "cd", (
+                    f"start_command example begins with 'cd' which is "
+                    f"a vacuous-pass trap on macOS (/usr/bin/cd returns "
+                    f"exit 0 for any args). Use the worktree's actual "
+                    f"build command instead."
+                )


### PR DESCRIPTION
## Summary

Fixes the dashboard-v73 failure shape where an agent declares a narrow ``start_command`` (e.g. running only the test suite) for the integration verification task, leaving v71-class build failures undetectable.

``agent_unicorn_1`` declared ``start_command='cd worktrees/agent_unicorn_1 && npm test'`` — the smoke gate ran vitest in the worktree and it passed in <1s, but vitest never invokes the build pipeline. Had the React app been missing ``public/index.html`` (the v71 failure shape), ``npm test`` would still pass while ``npm run build`` would fail.

## Fix

Added an explicit contract sentence to the integration verifier prompt under "Choosing the right values":

> **REQUIRED: ``start_command`` must exercise the build pipeline that produces the deliverable, not merely the test suite.** A passing test suite does not prove the product builds and starts — tests can pass against stubbed entry points, missing templates, broken bundlers, or unsatisfied native dependencies. The deliverable is the running product, not the green test bar. Your declared command must be one that would FAIL if the deliverable cannot actually be built and launched in a fresh checkout. If your stack has both a build step and a test step, declare the build (or chain both: build first, then tests). Marcus accepts shell chains, so combining steps is fine.

## Tool-agnostic by design

The contract sentence names the requirement abstractly without naming any specific stack. No npm/vite/tsc/pip/cargo/maven/gradle/webpack tokens appear in the contract language. Tool names may appear in worked examples elsewhere in the prompt for concreteness, but the contract sentence itself stays stack-neutral. Marcus is a coordination layer for ALL agent work, not just software dev — stack-specific contract language regresses toward the "software bias" failure mode that pre-#347 had.

## Test housekeeping

``tests/unit/integrations/test_integration_verification.py`` was missing ``pytestmark = pytest.mark.unit``, so its 45 existing tests had been silently excluded from ``pytest -m unit`` (per memory feedback ``test_marker_workflow.md``). Added the marker — the file now contributes all of its tests to CI. Same retroactive CI win as PR #350 for the lease test file.

## Tests (TDD, 4 new in ``TestStartCommandBuildPipelineRequirement``)

- ``test_prompt_requires_start_command_to_exercise_build_pipeline`` — asserts the contract sentence appears verbatim
- ``test_prompt_explains_why_test_suite_is_not_enough`` — asserts the prompt addresses the "tests pass therefore product works" fallacy so the agent can't rationalize around the requirement
- ``test_prompt_is_tool_agnostic`` — takes a 400-char window around the contract sentence and asserts no stack-specific tokens (``npm``, ``vite``, ``tsc``, ``pip``, ``cargo``, ``maven``, ``gradle``, ``webpack``) appear in the contract language itself
- ``test_prompt_allows_chaining_build_and_tests`` — asserts the prompt explicitly names chaining as an option, otherwise an agent with both a build and test step might pick only one and re-fall into the v73 trap

## Test plan

- [x] ``black`` + ``mypy`` clean
- [x] ``pytest -m unit`` → **617 passed, 0 regressions** (was 568; +49 from wiring the integration_verification test file into the unit marker collection, +4 net-new build-pipeline tests)
- [ ] dashboard-v74 against post-merge develop — confirm agents declare a build-pipeline command and the smoke gate catches v71-class failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)