### PR TITLE
fix(product_smoke): switch runner from exec to shell — kill v73 vacuous pass

### DIFF
--- a/src/integrations/product_smoke.py
+++ b/src/integrations/product_smoke.py
@@ -100,6 +100,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
+import signal
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -317,6 +318,11 @@ async def _run_one_shot(
         stderr=asyncio.subprocess.PIPE,
         cwd=str(cwd),
         env=_build_subprocess_env(),
+        # New session/process group so _kill_process can reap the
+        # entire descendant tree, not just the shell PID. See
+        # _kill_process docstring for the rationale (Codex P1 on
+        # PR #352).
+        start_new_session=True,
     )
 
     try:
@@ -355,22 +361,67 @@ async def _run_one_shot(
 
 
 async def _kill_process(proc: asyncio.subprocess.Process) -> None:
-    """Kill a subprocess with SIGTERM→SIGKILL escalation.
+    """Kill a subprocess and its entire descendant tree.
+
+    Marcus runs commands via ``create_subprocess_shell`` with
+    ``start_new_session=True``, which makes the spawned ``/bin/sh``
+    the leader of its own process group. All descendants (the actual
+    server, any helper processes the shell spawned, etc.) inherit
+    that PGID. Sending the kill signal to the entire process group
+    instead of just ``proc.pid`` ensures children are reaped too.
+
+    Why this matters
+    ----------------
+    Codex P1 on PR #352: with ``create_subprocess_shell``, a chain
+    like ``"sleep 60 && echo done"`` keeps the shell as parent and
+    the sleep as a child. Sending ``proc.terminate()`` only signals
+    the shell, so the child sleep leaks. Empirically reproduced on
+    macOS — spawning ``sh -c "sleep 30 && echo done"`` then calling
+    ``proc.terminate()`` left the sleep process running, holding
+    its PID. For server modes (``uvicorn``, ``npm run dev``) this
+    means the port stays bound and the next verification attempt
+    can't bind it — flaky and violates the "always killed before
+    return" contract.
+
+    The fix is the canonical "kill the whole process group" pattern:
+    use ``os.killpg(os.getpgid(proc.pid), signal)`` which signals
+    every process in the group at once.
 
     Parameters
     ----------
     proc : asyncio.subprocess.Process
-        Process to terminate. No-op if already dead.
+        Shell process spawned with ``start_new_session=True``. The
+        function signals the entire process group, not just this
+        single PID. No-op if the group is already gone.
     """
+    pid = proc.pid
     try:
-        proc.terminate()
+        pgid = os.getpgid(pid)
+    except ProcessLookupError:
+        # Process already gone; nothing to do.
+        return
+
+    # SIGTERM the entire group, then wait for the leader to exit.
+    try:
+        os.killpg(pgid, signal.SIGTERM)
+    except ProcessLookupError:
+        return
+
+    try:
         await asyncio.wait_for(proc.wait(), timeout=KILL_GRACE_PERIOD_SECONDS)
-    except (asyncio.TimeoutError, ProcessLookupError):
-        try:
-            proc.kill()
-            await proc.wait()
-        except ProcessLookupError:
-            pass
+        return
+    except asyncio.TimeoutError:
+        pass
+
+    # Grace expired; SIGKILL the entire group.
+    try:
+        os.killpg(pgid, signal.SIGKILL)
+    except ProcessLookupError:
+        return
+    try:
+        await proc.wait()
+    except ProcessLookupError:
+        pass
 
 
 async def _run_probe(probe_command: str, cwd: Path) -> tuple[int, str, str]:
@@ -404,6 +455,8 @@ async def _run_probe(probe_command: str, cwd: Path) -> tuple[int, str, str]:
         stderr=asyncio.subprocess.PIPE,
         cwd=str(cwd),
         env=_build_subprocess_env(),
+        # See _kill_process for rationale (Codex P1 on PR #352).
+        start_new_session=True,
     )
 
     try:
@@ -481,6 +534,14 @@ async def _run_server_with_probe(
         stderr=asyncio.subprocess.PIPE,
         cwd=str(cwd),
         env=_build_subprocess_env(),
+        # CRITICAL for server mode: the shell is the leader of a new
+        # process group so _kill_process can SIGTERM/SIGKILL the
+        # entire descendant tree (uvicorn workers, npm-run-dev's
+        # node child, etc.) at teardown. Without this, killing the
+        # shell leaks the actual server, the port stays bound, and
+        # subsequent verifications fail to bind it. Codex P1 on
+        # PR #352, empirically reproduced on macOS.
+        start_new_session=True,
     )
 
     # Poll the readiness probe. The server runs in the background;

--- a/src/integrations/product_smoke.py
+++ b/src/integrations/product_smoke.py
@@ -100,7 +100,6 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
-import shlex
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -154,8 +153,9 @@ class VerificationStep:
         or ``"missing_start_command"``.
     command : str
         The command as it was declared by the agent. Stored as a string
-        (not argv) because agents declare it as a shell-style string and
-        we run it through ``shlex.split`` at execution time.
+        (not argv) because agents declare it as a shell command string
+        and we run it through ``/bin/sh -c`` at execution time via
+        ``asyncio.create_subprocess_shell``.
     exit_code : Optional[int]
         Process return code. ``None`` if the process was killed by
         timeout or never executed.
@@ -263,12 +263,29 @@ async def _run_one_shot(
     Mode 1 of the verification contract. The command must exit 0
     within ``timeout_seconds`` to succeed.
 
+    Execution model: the command string is passed verbatim to
+    ``asyncio.create_subprocess_shell``, which runs it through
+    ``/bin/sh -c``. This means shell operators (``&&``, ``||``,
+    ``|``, ``$(...)``, ``cd``, env variable expansion) are
+    interpreted normally — agents can declare commands the same
+    way they typed them in their terminal.
+
+    Why shell, not exec
+    -------------------
+    Marcus previously used ``shlex.split`` + ``create_subprocess_exec``,
+    which silently broke shell semantics. ``cd /tmp && npm test``
+    parsed to ``['cd', '/tmp', '&&', 'npm', 'test']`` and ran the
+    real ``/usr/bin/cd`` POSIX-conformance binary on macOS, which
+    exits 0 for any args. Result: a vacuous PASS at the smoke gate
+    even though the second half of the chain never ran. dashboard-v73
+    was a v71-class false pass through this exact path. See task
+    #125 for the full post-mortem.
+
     Parameters
     ----------
     command : str
-        Shell-style command string declared by the agent (e.g.
-        ``"npm run build"``). Parsed via ``shlex.split`` to argv form
-        before invocation, so no shell interpretation happens.
+        Shell command string declared by the agent (e.g.
+        ``"npm run build"`` or ``"npm run build && npm test"``).
     cwd : Path
         Working directory for the subprocess.
     timeout_seconds : float
@@ -283,47 +300,24 @@ async def _run_one_shot(
     """
     start_time = time.monotonic()
 
-    try:
-        argv = shlex.split(command)
-    except ValueError as exc:
+    if not command or not command.strip():
         return VerificationStep(
             name="start_command",
             command=command,
             exit_code=None,
             stdout="",
-            stderr=f"Could not parse command as shell-style string: {exc}",
-            duration_seconds=0.0,
-            success=False,
-        )
-    if not argv:
-        return VerificationStep(
-            name="start_command",
-            command=command,
-            exit_code=None,
-            stdout="",
-            stderr="start_command parsed to empty argv",
+            stderr="start_command was empty or whitespace-only",
             duration_seconds=0.0,
             success=False,
         )
 
-    try:
-        proc = await asyncio.create_subprocess_exec(
-            *argv,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
-            cwd=str(cwd),
-            env=_build_subprocess_env(),
-        )
-    except FileNotFoundError as exc:
-        return VerificationStep(
-            name="start_command",
-            command=command,
-            exit_code=None,
-            stdout="",
-            stderr=f"Command not found: {argv[0]!r} ({exc})",
-            duration_seconds=time.monotonic() - start_time,
-            success=False,
-        )
+    proc = await asyncio.create_subprocess_shell(
+        command,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+        cwd=str(cwd),
+        env=_build_subprocess_env(),
+    )
 
     try:
         stdout_bytes, stderr_bytes = await asyncio.wait_for(
@@ -382,10 +376,16 @@ async def _kill_process(proc: asyncio.subprocess.Process) -> None:
 async def _run_probe(probe_command: str, cwd: Path) -> tuple[int, str, str]:
     """Run a single readiness probe invocation.
 
+    Like ``_run_one_shot``, this uses ``create_subprocess_shell`` so
+    probe commands can use shell features (``curl ... | grep``,
+    ``test -f marker && curl ...``, etc.). See ``_run_one_shot`` for
+    the rationale.
+
     Parameters
     ----------
     probe_command : str
-        Shell-style probe command (e.g. ``"curl -f http://localhost:8000/health"``).
+        Shell command string for the readiness probe (e.g.
+        ``"curl -f http://localhost:8000/health"``).
     cwd : Path
         Working directory for the probe.
 
@@ -393,25 +393,18 @@ async def _run_probe(probe_command: str, cwd: Path) -> tuple[int, str, str]:
     -------
     tuple[int, str, str]
         ``(exit_code, stdout_tail, stderr_tail)``. Exit code -1 on
-        parse/launch failure, -2 on probe timeout.
+        empty/whitespace probe, -2 on probe timeout.
     """
-    try:
-        argv = shlex.split(probe_command)
-    except ValueError:
-        return -1, "", f"could not parse probe: {probe_command!r}"
-    if not argv:
+    if not probe_command or not probe_command.strip():
         return -1, "", "empty probe command"
 
-    try:
-        proc = await asyncio.create_subprocess_exec(
-            *argv,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
-            cwd=str(cwd),
-            env=_build_subprocess_env(),
-        )
-    except FileNotFoundError as exc:
-        return -1, "", f"probe binary not found: {argv[0]!r} ({exc})"
+    proc = await asyncio.create_subprocess_shell(
+        probe_command,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+        cwd=str(cwd),
+        env=_build_subprocess_env(),
+    )
 
     try:
         stdout_bytes, stderr_bytes = await asyncio.wait_for(
@@ -447,11 +440,14 @@ async def _run_server_with_probe(
     Parameters
     ----------
     start_command : str
-        Shell-style command that starts the long-running process
-        (e.g. ``"uvicorn main:app --port 8000"``).
+        Shell command string that starts the long-running process
+        (e.g. ``"uvicorn main:app --port 8000"``). Executed via
+        ``/bin/sh -c`` so shell features (operators, env expansion,
+        cd) work normally.
     readiness_probe : str
-        Shell-style probe command polled for readiness (e.g.
-        ``"curl -f http://localhost:8000/health"``).
+        Shell command string polled for readiness (e.g.
+        ``"curl -f http://localhost:8000/health"``). Same shell
+        execution as ``start_command``.
     cwd : Path
         Working directory for both the server and the probe.
     readiness_timeout_seconds : float
@@ -466,53 +462,26 @@ async def _run_server_with_probe(
     """
     server_start_time = time.monotonic()
 
-    try:
-        argv = shlex.split(start_command)
-    except ValueError as exc:
+    if not start_command or not start_command.strip():
         return [
             VerificationStep(
                 name="start_command",
                 command=start_command,
                 exit_code=None,
                 stdout="",
-                stderr=f"Could not parse start_command: {exc}",
-                duration_seconds=0.0,
-                success=False,
-            )
-        ]
-    if not argv:
-        return [
-            VerificationStep(
-                name="start_command",
-                command=start_command,
-                exit_code=None,
-                stdout="",
-                stderr="start_command parsed to empty argv",
+                stderr="start_command was empty or whitespace-only",
                 duration_seconds=0.0,
                 success=False,
             )
         ]
 
-    try:
-        proc = await asyncio.create_subprocess_exec(
-            *argv,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
-            cwd=str(cwd),
-            env=_build_subprocess_env(),
-        )
-    except FileNotFoundError as exc:
-        return [
-            VerificationStep(
-                name="start_command",
-                command=start_command,
-                exit_code=None,
-                stdout="",
-                stderr=f"Command not found: {argv[0]!r} ({exc})",
-                duration_seconds=time.monotonic() - server_start_time,
-                success=False,
-            )
-        ]
+    proc = await asyncio.create_subprocess_shell(
+        start_command,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+        cwd=str(cwd),
+        env=_build_subprocess_env(),
+    )
 
     # Poll the readiness probe. The server runs in the background;
     # we poll once per second until either:

--- a/tests/unit/integrations/test_product_smoke.py
+++ b/tests/unit/integrations/test_product_smoke.py
@@ -19,6 +19,9 @@ crashes) rather than actually spawning shells.
 
 from __future__ import annotations
 
+import asyncio
+import os
+import signal
 from pathlib import Path
 from unittest.mock import AsyncMock, patch
 
@@ -577,6 +580,101 @@ class TestRunOneShotRealShell:
         )
         assert step.success is True
         assert "nested" in step.stdout
+
+
+class TestKillProcessReapsDescendantTree:
+    """
+    ``_kill_process`` must reap the entire descendant tree of the
+    spawned shell, not just the shell PID.
+
+    Codex P1 on PR #352 caught this. Under
+    ``create_subprocess_shell`` with shell chains like
+    ``"sleep 60 && echo done"``, the shell stays as parent and the
+    sleep is a child. Naive ``proc.terminate()`` only signals the
+    shell, leaving the sleep alive — port stays bound, server keeps
+    running, subsequent verifications fail. The fix is
+    ``start_new_session=True`` + ``os.killpg`` to signal the entire
+    process group at once.
+
+    Empirically reproduced and verified on macOS during the PR #352
+    review cycle.
+    """
+
+    @pytest.mark.asyncio
+    async def test_chain_descendant_killed_by_runner_timeout(
+        self, tmp_path: Path
+    ) -> None:
+        """
+        REGRESSION: a chained command's child process is killed by
+        the one-shot timeout path.
+
+        Spawns ``sleep 60 && echo done`` via ``_run_one_shot`` with
+        a 1-second timeout. After the timeout fires and
+        ``_kill_process`` runs, asserts that the original sleep
+        child is gone (not leaked).
+        """
+        import psutil
+
+        from src.integrations.product_smoke import _run_one_shot
+
+        # We need to capture the descendant PIDs BEFORE the timeout
+        # fires. Easiest way: spawn a task that polls psutil for the
+        # children, then await the runner.
+        captured_pids: list[int] = []
+
+        async def capture_children_after_spawn() -> None:
+            # Wait for the process to actually start
+            await asyncio.sleep(0.4)
+            # Find the sleep process by walking from the test pid
+            me = psutil.Process(os.getpid())
+            for desc in me.children(recursive=True):
+                try:
+                    cmd = " ".join(desc.cmdline())
+                    if "sleep 60" in cmd:
+                        captured_pids.append(desc.pid)
+                except (psutil.NoSuchProcess, psutil.AccessDenied):
+                    pass
+
+        capture_task = asyncio.create_task(capture_children_after_spawn())
+        step = await _run_one_shot(
+            command="sleep 60 && echo done",
+            cwd=tmp_path,
+            timeout_seconds=1.0,
+        )
+        await capture_task
+
+        assert step.success is False
+        assert "Timed out" in step.stderr
+        assert captured_pids, (
+            "Test setup error: did not capture any sleep PID before "
+            "timeout fired. Increase the spawn-detect delay."
+        )
+
+        # Wait briefly for OS to clean up
+        await asyncio.sleep(0.3)
+
+        # Every captured PID must now be dead (or at least not running)
+        leaked = []
+        for pid in captured_pids:
+            try:
+                p = psutil.Process(pid)
+                if p.is_running() and p.status() != psutil.STATUS_ZOMBIE:
+                    leaked.append(pid)
+            except psutil.NoSuchProcess:
+                pass
+
+        # Cleanup any leaks before failing so we don't pollute the
+        # process table on regression
+        for pid in leaked:
+            try:
+                os.kill(pid, signal.SIGKILL)
+            except ProcessLookupError:
+                pass
+
+        assert not leaked, (
+            f"Codex P1 regression: descendant sleep PIDs {leaked} "
+            f"survived _kill_process. The runner is leaking children."
+        )
 
 
 class TestRunProbeRealShell:

--- a/tests/unit/integrations/test_product_smoke.py
+++ b/tests/unit/integrations/test_product_smoke.py
@@ -385,3 +385,225 @@ class TestResultSerialization:
         d = result.to_dict()
         # Serialized stderr tail is limited to 1024 chars
         assert len(d["steps"][0]["stderr_tail"]) <= 1024
+
+
+# ---------------------------------------------------------------------------
+# Real-shell execution regression tests (#125)
+# ---------------------------------------------------------------------------
+
+
+class TestRunOneShotRealShell:
+    """
+    ``_run_one_shot`` runs the agent's command through ``/bin/sh -c``,
+    not through ``shlex.split`` + ``create_subprocess_exec``.
+
+    Regression for the dashboard-v73 vacuous-pass class. Pre-#125 the
+    runner used exec, and ``cd /tmp && true`` parsed to
+    ``['cd', '/tmp', '&&', 'true']``. On macOS, ``/usr/bin/cd`` is a
+    real POSIX-conformance binary that returns exit 0 for any args,
+    so the smoke gate silently false-passed. v73's
+    ``cd worktrees/agent_unicorn_1 && npm test`` was reported as
+    PASSED in 0.0s and we believed it; vitest never ran through
+    Marcus.
+
+    These tests use real subprocess invocations against shell
+    builtins so they catch any future regression to exec semantics.
+    """
+
+    @pytest.mark.asyncio
+    async def test_shell_chain_executes_both_commands(self, tmp_path: Path) -> None:
+        """Shell chain with && must run BOTH halves and reflect their result."""
+        from src.integrations.product_smoke import _run_one_shot
+
+        marker = tmp_path / "marker.txt"
+        step = await _run_one_shot(
+            command=f"cd {tmp_path} && touch marker.txt",
+            cwd=tmp_path,
+            timeout_seconds=10,
+        )
+
+        assert step.success is True
+        assert step.exit_code == 0
+        assert marker.exists(), (
+            "Shell chain second-half (touch) must have executed. If "
+            "this fails, the runner has regressed to exec semantics "
+            "and the && was treated as a literal argument."
+        )
+
+    @pytest.mark.asyncio
+    async def test_shell_chain_short_circuits_on_first_failure(
+        self, tmp_path: Path
+    ) -> None:
+        """Shell && must short-circuit: first failure prevents second from running."""
+        from src.integrations.product_smoke import _run_one_shot
+
+        marker = tmp_path / "should_not_exist.txt"
+        step = await _run_one_shot(
+            command=f"false && touch {marker}",
+            cwd=tmp_path,
+            timeout_seconds=10,
+        )
+
+        assert step.success is False
+        assert step.exit_code != 0
+        assert not marker.exists(), (
+            "Shell && must short-circuit. If the marker exists, the "
+            "second command ran despite the first failing — runner "
+            "has regressed."
+        )
+
+    @pytest.mark.asyncio
+    async def test_v73_vacuous_pass_mode_is_dead(self, tmp_path: Path) -> None:
+        """
+        REGRESSION for dashboard-v73 specifically.
+
+        v73 declared start_command='cd worktrees/agent_unicorn_1 && npm test'.
+        Under exec semantics, this ran /usr/bin/cd with literal args
+        and returned exit 0 in 0ms — vitest never ran. Under shell
+        semantics, this ACTUALLY chdirs and runs npm test, so a
+        broken target would actually fail.
+
+        Test it with a chain that SHOULD fail under shell semantics
+        but DID pass under exec: cd to a nonexistent path, then run
+        a command that would have succeeded. Under shell, cd fails
+        and the chain short-circuits → exit non-zero → success=False.
+        Under exec, /usr/bin/cd swallows the bad path and exit 0 →
+        success=True (the bug). Asserting failure here pins the fix.
+        """
+        from src.integrations.product_smoke import _run_one_shot
+
+        nonexistent = tmp_path / "definitely_does_not_exist"
+        step = await _run_one_shot(
+            command=f"cd {nonexistent} && true",
+            cwd=tmp_path,
+            timeout_seconds=10,
+        )
+
+        assert step.success is False, (
+            "v73 regression: cd to nonexistent path must FAIL under "
+            "shell semantics. If this passes, /usr/bin/cd is "
+            "swallowing the bad path and the runner has regressed "
+            "to exec semantics."
+        )
+        assert step.exit_code != 0
+
+    @pytest.mark.asyncio
+    async def test_simple_single_binary_still_works(self, tmp_path: Path) -> None:
+        """Plain single-binary commands (the common case) must still work."""
+        from src.integrations.product_smoke import _run_one_shot
+
+        step = await _run_one_shot(
+            command="true",
+            cwd=tmp_path,
+            timeout_seconds=10,
+        )
+        assert step.success is True
+        assert step.exit_code == 0
+
+    @pytest.mark.asyncio
+    async def test_command_with_args_still_works(self, tmp_path: Path) -> None:
+        """Single-binary commands with args must still work."""
+        from src.integrations.product_smoke import _run_one_shot
+
+        step = await _run_one_shot(
+            command="echo hello world",
+            cwd=tmp_path,
+            timeout_seconds=10,
+        )
+        assert step.success is True
+        assert "hello world" in step.stdout
+
+    @pytest.mark.asyncio
+    async def test_failing_binary_reports_nonzero_exit(self, tmp_path: Path) -> None:
+        """Single-binary failures must propagate exit code."""
+        from src.integrations.product_smoke import _run_one_shot
+
+        step = await _run_one_shot(
+            command="false",
+            cwd=tmp_path,
+            timeout_seconds=10,
+        )
+        assert step.success is False
+        assert step.exit_code != 0
+
+    @pytest.mark.asyncio
+    async def test_empty_command_rejected(self, tmp_path: Path) -> None:
+        """Empty/whitespace command is rejected without subprocess."""
+        from src.integrations.product_smoke import _run_one_shot
+
+        step = await _run_one_shot(
+            command="   \t  ",
+            cwd=tmp_path,
+            timeout_seconds=10,
+        )
+        assert step.success is False
+        assert "empty" in step.stderr.lower()
+
+    @pytest.mark.asyncio
+    async def test_pipe_works(self, tmp_path: Path) -> None:
+        """Shell pipes (|) must work — used in many real-world probes."""
+        from src.integrations.product_smoke import _run_one_shot
+
+        step = await _run_one_shot(
+            command="echo abc | grep abc",
+            cwd=tmp_path,
+            timeout_seconds=10,
+        )
+        assert step.success is True
+        assert step.exit_code == 0
+
+    @pytest.mark.asyncio
+    async def test_or_operator_works(self, tmp_path: Path) -> None:
+        """Shell || must work — common in probe-with-fallback patterns."""
+        from src.integrations.product_smoke import _run_one_shot
+
+        step = await _run_one_shot(
+            command="false || true",
+            cwd=tmp_path,
+            timeout_seconds=10,
+        )
+        assert step.success is True
+        assert step.exit_code == 0
+
+    @pytest.mark.asyncio
+    async def test_subshell_substitution_works(self, tmp_path: Path) -> None:
+        """$(...) command substitution must work."""
+        from src.integrations.product_smoke import _run_one_shot
+
+        step = await _run_one_shot(
+            command="echo $(echo nested)",
+            cwd=tmp_path,
+            timeout_seconds=10,
+        )
+        assert step.success is True
+        assert "nested" in step.stdout
+
+
+class TestRunProbeRealShell:
+    """``_run_probe`` uses the same shell execution model as one-shot."""
+
+    @pytest.mark.asyncio
+    async def test_probe_supports_shell_pipes(self, tmp_path: Path) -> None:
+        """Probe commands must support the same shell features as start_command."""
+        from src.integrations.product_smoke import _run_probe
+
+        exit_code, stdout, _ = await _run_probe("echo ready | grep ready", tmp_path)
+        assert exit_code == 0
+        assert "ready" in stdout
+
+    @pytest.mark.asyncio
+    async def test_probe_failure_propagates(self, tmp_path: Path) -> None:
+        """Failed probe must return non-zero."""
+        from src.integrations.product_smoke import _run_probe
+
+        exit_code, _, _ = await _run_probe("false", tmp_path)
+        assert exit_code != 0
+
+    @pytest.mark.asyncio
+    async def test_empty_probe_rejected(self, tmp_path: Path) -> None:
+        """Empty/whitespace probe is rejected without subprocess."""
+        from src.integrations.product_smoke import _run_probe
+
+        exit_code, _, stderr = await _run_probe("   ", tmp_path)
+        assert exit_code == -1
+        assert "empty" in stderr.lower()


### PR DESCRIPTION
## Summary

**dashboard-v73 was a v71-class smoke gate FALSE PASS, not a real verification.** This PR fixes the underlying runner bug.

## The bug

``agent_unicorn_1`` declared ``start_command='cd worktrees/agent_unicorn_1 && npm test'`` for the integration verification task. The pre-#125 runner used:

```python
argv = shlex.split(command)
proc = await asyncio.create_subprocess_exec(*argv, ...)
```

``shlex.split('cd /tmp && npm test')`` parses to ``['cd', '/tmp', '&&', 'npm', 'test']`` — ``&&`` becomes a literal argument because exec doesn't interpret shell operators.

**On macOS this manifests in the worst way: ``/usr/bin/cd`` is a real POSIX-conformance binary** that returns exit 0 unconditionally for any args. So Marcus invoked ``/usr/bin/cd`` with five literal arguments, got back exit 0 in 0ms, and logged ``"verify_deliverable PASSED in 0.0s"``. The vitest invocation never ran through Marcus.

The ``"tests passed in 919ms"`` line in v73's ``verification_results.json`` was the **agent's own claim** from running tests manually in their terminal, **not Marcus's verification**.

This means **#347 (agent-declared start_command) has been silently broken since it shipped**: any declaration that begins with ``cd`` or contains shell metacharacters vacuously passes. The whole point of #347 was to catch v71. It hasn't been catching v71.

## Fix

Switch ``_run_one_shot``, ``_run_probe``, and the start path of ``_run_server_with_probe`` from ``create_subprocess_exec`` to ``create_subprocess_shell``. The command string is now passed verbatim to ``/bin/sh -c``, so shell operators (``&&``, ``||``, ``|``, ``$(...)``, ``cd`` builtin, env variable expansion) work normally — agents can declare commands the same way they typed them in their terminal.

## Threat model

Unchanged: agents already run arbitrary code via tests under ``--dangerously-skip-permissions``, so shell metacharacters add no new attack surface.

## Tests (TDD, 13 new total)

**``TestRunOneShotRealShell``** (10 tests, real subprocess invocations against shell builtins):

- ``test_shell_chain_executes_both_commands`` — ``cd && touch`` actually creates the file in the cwd
- ``test_shell_chain_short_circuits_on_first_failure`` — ``false && touch`` does NOT create the file (short-circuits)
- **``test_v73_vacuous_pass_mode_is_dead``** — direct regression: ``cd /nonexistent && true`` MUST fail under shell semantics. Under exec, ``/usr/bin/cd`` would swallow the bad path and the test would pass. Asserting failure here pins the fix.
- ``test_simple_single_binary_still_works``
- ``test_command_with_args_still_works``
- ``test_failing_binary_reports_nonzero_exit``
- ``test_empty_command_rejected``
- ``test_pipe_works``
- ``test_or_operator_works``
- ``test_subshell_substitution_works``

**``TestRunProbeRealShell``** (3 tests):

- ``test_probe_supports_shell_pipes``
- ``test_probe_failure_propagates``
- ``test_empty_probe_rejected``

The existing 14 tests in ``test_product_smoke.py`` all still pass — they mock at the ``_run_one_shot``/``_run_server_with_probe`` level so the underlying subprocess swap is invisible.

## Test plan

- [x] ``black`` + ``mypy`` clean
- [x] ``pytest -m unit`` → **581 passed, 0 regressions** (was 568; +13 net new)
- [x] v73 regression test reproduces the failure mode and proves the fix
- [ ] dashboard-v74 against post-merge develop — confirm the smoke gate actually catches v71-class build failures

## Follow-up

PR #351's prompt change ("declare a single command, no chains") becomes overly conservative once this lands. Either rebase #351 to broaden the prompt (re-allow chains) or merge #351 as-is and follow up. The conservative prompt is never wrong, just narrower than necessary now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)