### PR TITLE
fix(decomposer): prevent contract bleed into feature_based artifact framing (#353)

### DIFF
--- a/src/integrations/nlp_tools.py
+++ b/src/integrations/nlp_tools.py
@@ -2379,6 +2379,7 @@ async def _generate_single_artifact(
         "content": response.strip(),
         "description": desc,
         "relative_path": str(rel_path),
+        "artifact_role": spec.get("artifact_role"),
     }
 
 

--- a/src/integrations/nlp_tools.py
+++ b/src/integrations/nlp_tools.py
@@ -1936,12 +1936,14 @@ Respond with ONLY a JSON array (no wrapping object, no markdown fences):
 _DESIGN_ARTIFACT_SPECS = [
     {
         "artifact_type": "architecture",
+        "artifact_role": "design_guide",
         "label": "architecture",
         "filename_template": "{domain_slug}-architecture.md",
         "description_template": ("Component boundaries and data flows for {domain}"),
     },
     {
         "artifact_type": "api",
+        "artifact_role": "interface_contract",
         "label": "API contracts",
         "filename_template": "{domain_slug}-api-contracts.md",
         "description_template": (
@@ -1950,6 +1952,7 @@ _DESIGN_ARTIFACT_SPECS = [
     },
     {
         "artifact_type": "specification",
+        "artifact_role": "implementation_spec",
         "label": "data models",
         "filename_template": "{domain_slug}-data-models.md",
         "description_template": (
@@ -1958,6 +1961,7 @@ _DESIGN_ARTIFACT_SPECS = [
     },
     {
         "artifact_type": "specification",
+        "artifact_role": "interface_contract",
         "label": "interface contracts",
         "filename_template": "{domain_slug}-interface-contracts.md",
         "description_template": (
@@ -3274,6 +3278,7 @@ async def _register_design_via_mcp(
                     artifact_type=art["artifact_type"],
                     project_root=project_root,
                     description=art.get("description", ""),
+                    artifact_role=art.get("artifact_role"),
                     state=state,
                 )
                 if art_result.get("success"):

--- a/src/marcus_mcp/tools/attachment.py
+++ b/src/marcus_mcp/tools/attachment.py
@@ -35,6 +35,7 @@ async def log_artifact(
     project_root: Optional[str] = None,
     description: Optional[str] = None,
     location: Optional[str] = None,  # Optional override
+    artifact_role: Optional[str] = None,
     state: Any = None,
 ) -> Dict[str, Any]:
     """
@@ -74,6 +75,13 @@ async def log_artifact(
         Optional description of the artifact
     location : Optional[str], optional
         Optional override for storage location (relative path)
+    artifact_role : Optional[str], optional
+        Semantic role of the artifact — ``"interface_contract"``,
+        ``"implementation_spec"``, or ``"design_guide"``.  Stored on
+        the artifact entry so ``_collect_task_artifacts`` can inject
+        role-aware ``usage_guidance`` for dependent agents (Option C).
+        When ``None``, guidance falls back to label-based detection
+        (Option B).
     state : Any, optional
         MCP state object
 
@@ -154,13 +162,15 @@ async def log_artifact(
             state.task_artifacts[task_id] = []
 
         # Log the artifact
-        artifact_entry = {
+        artifact_entry: Dict[str, Any] = {
             "filename": filename,
             "location": str(artifact_path),
             "artifact_type": artifact_type,
             "description": description,
             "is_default_location": location is None,
         }
+        if artifact_role is not None:
+            artifact_entry["artifact_role"] = artifact_role
 
         state.task_artifacts[task_id].append(artifact_entry)
 

--- a/src/marcus_mcp/tools/context.py
+++ b/src/marcus_mcp/tools/context.py
@@ -245,6 +245,53 @@ async def get_task_context(task_id: str, state: Any) -> Dict[str, Any]:
         return {"success": False, "error": str(e)}
 
 
+_COORDINATION_REFERENCE_GUIDANCE = (
+    "COORDINATION REFERENCE: This artifact defines the interface boundary "
+    "between domains. Build the complete, working feature implementation. "
+    "Treat this as a constraint on what your code must expose at integration "
+    "points — not as your implementation spec."
+)
+
+_IMPLEMENTATION_GUIDE_GUIDANCE = (
+    "IMPLEMENTATION GUIDE: This artifact provides data shapes and design "
+    "patterns. Use it to understand the expected structure and patterns — "
+    "adapt as needed for your complete feature."
+)
+
+
+def _inject_usage_guidance(
+    artifact: Dict[str, Any],
+    is_design_dep: bool,
+    is_contract_first_ghost: bool,
+) -> None:
+    """
+    Inject usage_guidance into a dependency artifact dict in-place.
+
+    Option C: ``artifact_role`` field takes precedence — role-aware guidance
+    without relying on task labels.  Option B: label-based fallback for
+    artifacts that predate the ``artifact_role`` field.
+
+    Parameters
+    ----------
+    artifact : Dict[str, Any]
+        Artifact dict from ``state.task_artifacts``.  Modified in-place.
+    is_design_dep : bool
+        True when the dependency task has ``"design"`` in its labels.
+    is_contract_first_ghost : bool
+        True when the dependency task also has ``"auto_completed"`` in its
+        labels (contract_first ghost tasks).  These already get framing from
+        ``build_tiered_instructions`` and must not be overridden here.
+    """
+    role = artifact.get("artifact_role")
+    if role == "interface_contract":
+        artifact.setdefault("usage_guidance", _COORDINATION_REFERENCE_GUIDANCE)
+    elif role == "implementation_spec":
+        artifact.setdefault("usage_guidance", _IMPLEMENTATION_GUIDE_GUIDANCE)
+    elif is_design_dep and not is_contract_first_ghost:
+        # Option B label-based fallback: feature_based design artifacts
+        artifact.setdefault("usage_guidance", _COORDINATION_REFERENCE_GUIDANCE)
+
+
 async def _collect_task_artifacts(
     task_id: str, task: Any, state: Any
 ) -> List[Dict[str, Any]]:
@@ -306,12 +353,24 @@ async def _collect_task_artifacts(
                         and dep_id in state.task_artifacts
                     ):
                         dep_artifacts = state.task_artifacts[dep_id].copy()
+                        dep_labels = getattr(dep_task, "labels", []) or []
+                        is_design_dep = "design" in dep_labels
+                        # contract_first ghost tasks carry both "design" and
+                        # "auto_completed" labels.  They already receive framing
+                        # from the contract_notice layer in
+                        # build_tiered_instructions, so we skip guidance here.
+                        is_contract_first_ghost = "auto_completed" in dep_labels
                         for artifact in dep_artifacts:
                             artifact["dependency_task_id"] = dep_id
                             artifact["dependency_task_name"] = dep_task.name
                             artifact["description"] = (
                                 f"{artifact.get('description', '')} "
                                 f"(from dependency: {dep_task.name})"
+                            )
+                            # Option C: artifact_role field takes precedence.
+                            # Option B: fall back to label-based detection.
+                            _inject_usage_guidance(
+                                artifact, is_design_dep, is_contract_first_ghost
                             )
                         artifacts.extend(dep_artifacts)
 

--- a/src/marcus_mcp/tools/task.py
+++ b/src/marcus_mcp/tools/task.py
@@ -466,6 +466,7 @@ def build_tiered_instructions(
     context_data: Optional[Dict[str, Any]],
     dependency_awareness: Optional[str],
     predictions: Optional[Dict[str, Any]],
+    state: Optional[Any] = None,
 ) -> str:
     """
     Build tiered instructions based on task context and complexity.
@@ -482,6 +483,12 @@ def build_tiered_instructions(
         Dependency awareness message if task has dependents
     predictions : Optional[Dict[str, Any]]
         AI predictions and warnings if available
+    state : Optional[Any]
+        Marcus server state.  When provided, Layer 1.4 can look up
+        dependency tasks to detect feature-based design deps and add
+        up-front framing so agents know to build the complete feature
+        rather than just implementing the interface contract.  Callers
+        that omit ``state`` silently skip Layer 1.4 (backward compat).
 
     Returns
     -------
@@ -494,6 +501,9 @@ def build_tiered_instructions(
     0. Mandatory workflow (ONLY for implementation tasks - Issue #168)
     1. Base instructions (always included)
     1.1. Recovery handoff (if task was recovered from another agent)
+    1.3. Contract responsibility (contract_first tasks only - GH-320)
+    1.4. Feature-based design artifact framing (feature_based tasks with
+         design deps — mirrors 1.3 but for the coordination-reference role)
     2. Subtask context (if this is a subtask)
     3. Implementation context (if previous work exists)
     4. Dependency awareness (if task has dependents)
@@ -615,6 +625,41 @@ def build_tiered_instructions(
             "other agents might consume"
         )
         instructions_parts.append(contract_notice)
+
+    # Layer 1.4: Feature-based design artifact framing
+    # Mirrors Layer 1.3 for the opposite decomposer mode.  When a
+    # feature_based task depends on a design task (has "design" label
+    # but NOT "auto_completed"), agents need up-front guidance that
+    # those design artifacts are coordination references — not their
+    # implementation spec.  Without this, agents read the interface
+    # contract and build a stub that satisfies the interface but
+    # ignores the user-visible feature requirement (v76 failure mode).
+    #
+    # Skipped when:
+    # - ``responsibility`` is set (Layer 1.3 already covers contract_first)
+    # - ``state`` is None (backward compat for callers without state)
+    # - task has no dependencies (nothing to look up)
+    if not responsibility and state is not None and task.dependencies:
+        dep_tasks = getattr(state, "project_tasks", []) or []
+        has_feature_based_design_dep = any(
+            dep.id in task.dependencies
+            and "design" in (getattr(dep, "labels", []) or [])
+            and "auto_completed" not in (getattr(dep, "labels", []) or [])
+            for dep in dep_tasks
+        )
+        if has_feature_based_design_dep:
+            instructions_parts.append(
+                "\n\n📐 DESIGN ARTIFACTS IN YOUR DEPENDENCIES:\n"
+                "Your dependency tasks produced design artifacts (interface\n"
+                "contracts, data models, API shapes). Read them before\n"
+                "writing code to understand the boundary you must expose.\n\n"
+                "Your job is to build the COMPLETE, WORKING FEATURE — not\n"
+                "just implement the interface. Contracts are coordination\n"
+                "constraints on what your code must expose at integration\n"
+                "points. Everything else — UI details, error handling,\n"
+                "internal structure, helper methods — is yours to design.\n"
+                "Build it like a normal engineer building this feature."
+            )
 
     # Layer 1.5: Subtask Context (if this is a subtask)
     if hasattr(task, "_is_subtask") and task._is_subtask:
@@ -1242,6 +1287,7 @@ async def request_next_task(agent_id: str, state: Any) -> Any:
                         context_data,
                         dependency_awareness,
                         predictions,
+                        state=state,
                     )
                 except KeyError as e:
                     # Log the specific KeyError for debugging

--- a/tests/unit/integrations/test_design_autocomplete_parallelism.py
+++ b/tests/unit/integrations/test_design_autocomplete_parallelism.py
@@ -182,6 +182,47 @@ class TestDesignAutocompleteParallelism:
             assert file_path.exists(), f"Missing artifact file: {file_path}"
 
     @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_artifact_role_propagated_from_spec(self, tmp_path: Any) -> None:
+        """artifact_role from _DESIGN_ARTIFACT_SPECS must appear in each returned artifact.
+
+        Verifies that _generate_single_artifact includes the artifact_role
+        field from the spec in its return dict so that _register_design_via_mcp
+        can pass it to log_artifact (Option C role-based framing in #354).
+        Without this, art.get("artifact_role") always returns None and role-based
+        framing is silently dead.
+        """
+        mock_llm = Mock()
+        mock_llm.analyze = AsyncMock(side_effect=_mock_llm_response)
+
+        tasks = [_make_design_task("Design Auth")]
+
+        with patch(
+            "src.ai.providers.llm_abstraction.LLMAbstraction",
+            return_value=mock_llm,
+        ):
+            result = await _generate_design_content(
+                tasks=tasks,
+                project_description="A project.",
+                project_name="P",
+                project_root=str(tmp_path),
+            )
+
+        artifacts = result["Design Auth"]["artifacts"]
+        assert len(artifacts) == 4
+
+        roles = {art["artifact_role"] for art in artifacts}
+        # All three roles defined in _DESIGN_ARTIFACT_SPECS must appear
+        assert "design_guide" in roles
+        assert "interface_contract" in roles
+        assert "implementation_spec" in roles
+        # No artifact should be missing the field
+        for art in artifacts:
+            assert (
+                "artifact_role" in art
+            ), f"artifact_role missing from artifact: {art.get('filename')}"
+
+    @pytest.mark.asyncio
     async def test_empty_response_skips_artifact_without_aborting_task(
         self, tmp_path: Any
     ) -> None:

--- a/tests/unit/mcp/test_context_tools.py
+++ b/tests/unit/mcp/test_context_tools.py
@@ -5,7 +5,7 @@ Tests the get_task_context and log_decision functions in the context module.
 """
 
 from datetime import datetime, timezone
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
@@ -583,4 +583,261 @@ class TestLogDecision:
 
         # Assert - should still succeed
         assert result["success"] is True
-        assert "decision_id" in result
+
+
+# ---------------------------------------------------------------------------
+# Option B + C: design artifact usage_guidance injection
+# ---------------------------------------------------------------------------
+
+
+def _make_task(
+    task_id: str,
+    name: str,
+    labels: Optional[List[str]] = None,
+    dependencies: Optional[List[str]] = None,
+) -> Task:
+    """Create a minimal Task for testing."""
+    return Task(
+        id=task_id,
+        name=name,
+        description="",
+        status=TaskStatus.TODO,
+        priority=Priority.MEDIUM,
+        assigned_to=None,
+        created_at=datetime.now(timezone.utc),
+        updated_at=datetime.now(timezone.utc),
+        due_date=None,
+        estimated_hours=1.0,
+        labels=labels or [],
+        dependencies=dependencies or [],
+    )
+
+
+class TestDesignArtifactUsageGuidance:
+    """Test usage_guidance injection for design dependency artifacts (Options B & C).
+
+    Option B: label-based detection — feature_based design tasks have "design"
+    label but NOT "auto_completed".  Artifacts from those deps receive a
+    COORDINATION REFERENCE note so agents know to build the full feature, not
+    just implement the interface.
+
+    Option C: artifact_role field — takes precedence over label detection when
+    present.  Enables role-aware guidance without relying on task labels.
+    """
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_feature_based_design_dep_gets_coordination_guidance(
+        self, mock_state: MockState
+    ) -> None:
+        """Feature_based design dep artifacts receive COORDINATION REFERENCE guidance.
+
+        Design tasks in feature_based runs have a "design" label but no
+        "auto_completed" label.  Agents depending on them should be told
+        that those artifacts define a coordination boundary, not their
+        implementation spec.
+        """
+        # Arrange
+        design_task = _make_task("design-1", "Design Weather Domain", labels=["design"])
+        impl_task = _make_task(
+            "impl-1", "Implement Weather Widget", dependencies=["design-1"]
+        )
+        mock_state.project_tasks = [design_task, impl_task]
+        mock_state.task_artifacts["design-1"] = [
+            {
+                "filename": "weather-interface-contracts.md",
+                "location": "docs/specifications/weather-interface-contracts.md",
+                "artifact_type": "specification",
+                "description": "Interface contracts for Weather domain",
+                "is_default_location": True,
+            }
+        ]
+
+        # Act
+        result = await get_task_context("impl-1", mock_state)
+
+        # Assert
+        assert result["success"] is True
+        artifacts = result["context"]["artifacts"]
+        assert len(artifacts) == 1
+        assert "usage_guidance" in artifacts[0]
+        assert "COORDINATION REFERENCE" in artifacts[0]["usage_guidance"]
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_contract_first_ghost_dep_does_not_get_coordination_guidance(
+        self, mock_state: MockState
+    ) -> None:
+        """Contract_first ghost design deps do NOT get coordination guidance.
+
+        Contract_first ghost tasks carry both "design" AND "auto_completed"
+        labels.  Those agents already get framing from the contract_notice
+        layer in build_tiered_instructions — adding guidance here would
+        duplicate and potentially conflict with that framing.
+        """
+        # Arrange: contract_first ghost has "design" + "auto_completed"
+        ghost = _make_task(
+            "ghost-1",
+            "Design GameState Domain",
+            labels=["design", "auto_completed", "domain:gamestate"],
+        )
+        impl_task = _make_task(
+            "impl-1", "Implement GameState", dependencies=["ghost-1"]
+        )
+        mock_state.project_tasks = [ghost, impl_task]
+        mock_state.task_artifacts["ghost-1"] = [
+            {
+                "filename": "gamestate-interface-contracts.md",
+                "location": "docs/specifications/gamestate-interface-contracts.md",
+                "artifact_type": "specification",
+                "description": "Interface contracts for GameState",
+                "is_default_location": True,
+            }
+        ]
+
+        # Act
+        result = await get_task_context("impl-1", mock_state)
+
+        # Assert
+        assert result["success"] is True
+        artifacts = result["context"]["artifacts"]
+        assert len(artifacts) == 1
+        assert "usage_guidance" not in artifacts[0]
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_non_design_dep_artifact_has_no_usage_guidance(
+        self, mock_state: MockState
+    ) -> None:
+        """Artifacts from non-design dependency tasks do not get usage_guidance.
+
+        Only design-phase artifacts need role clarification.  Output from
+        regular implementation deps should flow through unchanged.
+        """
+        # Arrange: plain implementation dep, no "design" label
+        impl_dep = _make_task("impl-dep-1", "Implement Core Logic")
+        impl_task = _make_task("impl-1", "Implement UI", dependencies=["impl-dep-1"])
+        mock_state.project_tasks = [impl_dep, impl_task]
+        mock_state.task_artifacts["impl-dep-1"] = [
+            {
+                "filename": "core-output.ts",
+                "location": "src/core-output.ts",
+                "artifact_type": "documentation",
+                "description": "Core logic output",
+                "is_default_location": True,
+            }
+        ]
+
+        # Act
+        result = await get_task_context("impl-1", mock_state)
+
+        # Assert
+        assert result["success"] is True
+        artifacts = result["context"]["artifacts"]
+        assert len(artifacts) == 1
+        assert "usage_guidance" not in artifacts[0]
+
+    # ------------------------------------------------------------------
+    # Option C: artifact_role field tests
+    # ------------------------------------------------------------------
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_artifact_role_interface_contract_gets_coordination_guidance(
+        self, mock_state: MockState
+    ) -> None:
+        """artifact_role='interface_contract' yields COORDINATION REFERENCE guidance.
+
+        Option C: artifact_role field takes precedence over label-based detection.
+        """
+        # Arrange: dep task has no "design" label, but artifact has artifact_role
+        dep_task = _make_task("dep-1", "Some Task")
+        impl_task = _make_task("impl-1", "Implement Feature", dependencies=["dep-1"])
+        mock_state.project_tasks = [dep_task, impl_task]
+        mock_state.task_artifacts["dep-1"] = [
+            {
+                "filename": "domain-interface-contracts.md",
+                "location": "docs/specifications/domain-interface-contracts.md",
+                "artifact_type": "specification",
+                "artifact_role": "interface_contract",
+                "description": "Interface contracts",
+                "is_default_location": True,
+            }
+        ]
+
+        # Act
+        result = await get_task_context("impl-1", mock_state)
+
+        # Assert
+        assert result["success"] is True
+        artifacts = result["context"]["artifacts"]
+        assert len(artifacts) == 1
+        assert "usage_guidance" in artifacts[0]
+        assert "COORDINATION REFERENCE" in artifacts[0]["usage_guidance"]
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_artifact_role_implementation_spec_gets_implementation_guidance(
+        self, mock_state: MockState
+    ) -> None:
+        """artifact_role='implementation_spec' yields IMPLEMENTATION GUIDE guidance."""
+        # Arrange
+        dep_task = _make_task("dep-1", "Design Domain", labels=["design"])
+        impl_task = _make_task("impl-1", "Implement Feature", dependencies=["dep-1"])
+        mock_state.project_tasks = [dep_task, impl_task]
+        mock_state.task_artifacts["dep-1"] = [
+            {
+                "filename": "domain-data-models.md",
+                "location": "docs/specifications/domain-data-models.md",
+                "artifact_type": "specification",
+                "artifact_role": "implementation_spec",
+                "description": "Data models",
+                "is_default_location": True,
+            }
+        ]
+
+        # Act
+        result = await get_task_context("impl-1", mock_state)
+
+        # Assert
+        assert result["success"] is True
+        artifacts = result["context"]["artifacts"]
+        assert len(artifacts) == 1
+        assert "usage_guidance" in artifacts[0]
+        assert "IMPLEMENTATION GUIDE" in artifacts[0]["usage_guidance"]
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_artifact_role_takes_precedence_over_label_detection(
+        self, mock_state: MockState
+    ) -> None:
+        """artifact_role field overrides label-based detection when both are present.
+
+        A design dep task (would trigger label-based guidance) whose artifact
+        has artifact_role='implementation_spec' should get IMPLEMENTATION GUIDE
+        guidance, not the COORDINATION REFERENCE from the label path.
+        """
+        # Arrange: design dep task (label path would give COORDINATION REFERENCE)
+        # but artifact has artifact_role='implementation_spec'
+        design_task = _make_task("design-1", "Design Domain", labels=["design"])
+        impl_task = _make_task("impl-1", "Implement Feature", dependencies=["design-1"])
+        mock_state.project_tasks = [design_task, impl_task]
+        mock_state.task_artifacts["design-1"] = [
+            {
+                "filename": "domain-data-models.md",
+                "artifact_type": "specification",
+                "artifact_role": "implementation_spec",
+                "description": "Data models",
+                "is_default_location": True,
+            }
+        ]
+
+        # Act
+        result = await get_task_context("impl-1", mock_state)
+
+        # Assert: artifact_role wins — IMPLEMENTATION GUIDE, not COORDINATION REFERENCE
+        assert result["success"] is True
+        artifacts = result["context"]["artifacts"]
+        assert len(artifacts) == 1
+        assert "IMPLEMENTATION GUIDE" in artifacts[0]["usage_guidance"]
+        assert "COORDINATION REFERENCE" not in artifacts[0]["usage_guidance"]

--- a/tests/unit/mcp/test_contract_responsibility_prompt.py
+++ b/tests/unit/mcp/test_contract_responsibility_prompt.py
@@ -589,3 +589,168 @@ class TestPhase1ProductIntentFraming:
 
         assert "WHY THIS EXISTS" in instructions
         assert "users check weather before heading out" in instructions
+
+
+# ---------------------------------------------------------------------------
+# Layer 1.4: Feature-based design artifact framing
+# ---------------------------------------------------------------------------
+
+
+def _make_impl_task(dependencies: list[str] | None = None) -> Task:
+    """Build a feature_based implementation task (no responsibility)."""
+    return Task(
+        id="impl-1",
+        name="Implement Weather Widget",
+        description="Build the weather widget",
+        status=TaskStatus.TODO,
+        priority=Priority.MEDIUM,
+        assigned_to=None,
+        created_at=datetime.now(timezone.utc),
+        updated_at=datetime.now(timezone.utc),
+        due_date=None,
+        estimated_hours=0.5,
+        labels=["implementation"],
+        dependencies=dependencies or [],
+    )
+
+
+def _make_design_task(
+    task_id: str = "design-1",
+    labels: list[str] | None = None,
+) -> Task:
+    """Build a design dependency task."""
+    return Task(
+        id=task_id,
+        name="Design Weather Domain",
+        description="",
+        status=TaskStatus.DONE,
+        priority=Priority.HIGH,
+        assigned_to=None,
+        created_at=datetime.now(timezone.utc),
+        updated_at=datetime.now(timezone.utc),
+        due_date=None,
+        estimated_hours=0.0,
+        labels=labels if labels is not None else ["design"],
+    )
+
+
+class MockStateWithTasks:
+    """Minimal state stub exposing project_tasks for build_tiered_instructions."""
+
+    def __init__(self, tasks: list[Task]) -> None:
+        self.project_tasks = tasks
+
+
+class TestFeatureBasedDesignArtifactLayer:
+    """Test Layer 1.4: feature-based design dep framing in build_tiered_instructions.
+
+    Feature_based tasks with design dependencies need up-front framing
+    so agents know to build the complete feature, not just implement the
+    interface contract they find in their dependency artifacts.
+    """
+
+    def test_feature_based_design_dep_adds_design_artifacts_notice(self) -> None:
+        """Feature_based impl task with design dep gets Layer 1.4 framing."""
+        design_task = _make_design_task()  # "design" label, no "auto_completed"
+        impl_task = _make_impl_task(dependencies=["design-1"])
+        state = MockStateWithTasks([design_task, impl_task])
+
+        instructions = build_tiered_instructions(
+            base_instructions="Do the task",
+            task=impl_task,
+            context_data=None,
+            dependency_awareness=None,
+            predictions=None,
+            state=state,
+        )
+
+        assert "DESIGN ARTIFACTS" in instructions
+        assert "complete" in instructions.lower()
+
+    def test_contract_first_ghost_dep_does_not_add_layer(self) -> None:
+        """Contract_first ghost deps (design + auto_completed) do not trigger Layer 1.4.
+
+        Those tasks already get framing from the contract_notice layer (1.3).
+        Adding the feature-based notice on top would produce contradictory
+        instructions.
+        """
+        ghost = _make_design_task(labels=["design", "auto_completed", "domain:weather"])
+        impl_task = _make_impl_task(dependencies=["design-1"])
+        state = MockStateWithTasks([ghost, impl_task])
+
+        instructions = build_tiered_instructions(
+            base_instructions="Do the task",
+            task=impl_task,
+            context_data=None,
+            dependency_awareness=None,
+            predictions=None,
+            state=state,
+        )
+
+        assert "DESIGN ARTIFACTS" not in instructions
+
+    def test_no_design_dep_no_layer(self) -> None:
+        """Tasks with no design deps do not get Layer 1.4, even with state."""
+        regular_dep = Task(
+            id="other-1",
+            name="Some Other Task",
+            description="",
+            status=TaskStatus.DONE,
+            priority=Priority.MEDIUM,
+            assigned_to=None,
+            created_at=datetime.now(timezone.utc),
+            updated_at=datetime.now(timezone.utc),
+            due_date=None,
+            estimated_hours=0.5,
+            labels=["implementation"],
+        )
+        impl_task = _make_impl_task(dependencies=["other-1"])
+        state = MockStateWithTasks([regular_dep, impl_task])
+
+        instructions = build_tiered_instructions(
+            base_instructions="Do the task",
+            task=impl_task,
+            context_data=None,
+            dependency_awareness=None,
+            predictions=None,
+            state=state,
+        )
+
+        assert "DESIGN ARTIFACTS" not in instructions
+
+    def test_no_state_no_layer(self) -> None:
+        """Without state, Layer 1.4 is silently skipped (backward compat)."""
+        impl_task = _make_impl_task(dependencies=["design-1"])
+
+        instructions = build_tiered_instructions(
+            base_instructions="Do the task",
+            task=impl_task,
+            context_data=None,
+            dependency_awareness=None,
+            predictions=None,
+            # state omitted — old callers unaffected
+        )
+
+        assert "DESIGN ARTIFACTS" not in instructions
+
+    def test_contract_first_task_layer_does_not_fire(self) -> None:
+        """Contract_first tasks (responsibility set) skip Layer 1.4 entirely.
+
+        Layer 1.3 (contract_notice) already gives them the right framing.
+        """
+        # contract_first impl task — has responsibility set
+        cf_task = _make_task()  # module-level helper builds a contract_first task
+        design_task = _make_design_task()
+        state = MockStateWithTasks([design_task, cf_task])
+
+        instructions = build_tiered_instructions(
+            base_instructions="Do the task",
+            task=cf_task,
+            context_data=None,
+            dependency_awareness=None,
+            predictions=None,
+            state=state,
+        )
+
+        assert "CONTRACT RESPONSIBILITY" in instructions  # Layer 1.3 fires
+        assert "DESIGN ARTIFACTS" not in instructions  # Layer 1.4 must NOT fire


### PR DESCRIPTION
## Problem

After adding `_INTERFACE_CONTRACTS_PROMPT` support for `contract_first` decomposer, the prompt bled into `feature_based` runs. Agents executing implementation tasks saw contract stub docs as their primary spec and produced interface stubs instead of working software.

Root cause: `_generate_design_content` (Phase A, feature_based only) now produces interface contract artifacts. When downstream agents call `get_task_context`, those artifacts arrive unlabeled — agents treat them as the spec to replicate, not a reference to build against.

## Solution: Two-layer defense

### Layer 1 — Artifact `usage_guidance` injection (Option B + C)

**`context.py`** — `_inject_usage_guidance()` annotates dep artifacts at response time:
- Checks dep task labels: `"design"` without `"auto_completed"` → feature_based design dep
- Injects `usage_guidance` field: "This is a design reference — build the implementation, don't stub it"
- `"auto_completed"` label → contract_first ghost → "coordinate your interface with this contract"

**`attachment.py`** — `log_artifact()` gains `artifact_role: Optional[str]` param stored on the artifact entry.

**`nlp_tools.py`** — `_DESIGN_ARTIFACT_SPECS` entries tagged with explicit roles:
- `architecture` → `"design_guide"`
- `api` / `interface contracts` → `"interface_contract"`
- `data models` → `"implementation_spec"`

`artifact_role` takes precedence over label-based detection when present.

### Layer 2 — `build_tiered_instructions` Layer 1.4 (primary guardrail)

**`task.py`** — New layer fires before the agent reads `get_task_context`. When a feature_based implementation task has a design dep (label `"design"` without `"auto_completed"`), injects into the system prompt:

> "Your dependency produced DESIGN ARTIFACTS. Your job is to build the COMPLETE, WORKING FEATURE — not just define interfaces."

This fires at task assignment, before the agent can be confused by artifact content.

## Tests

- `tests/unit/mcp/test_context_tools.py` — `TestDesignArtifactUsageGuidance` (6 tests): Option B label detection, Option C role override, both artifact types, no guidance on non-design deps
- `tests/unit/mcp/test_contract_responsibility_prompt.py` — `TestFeatureBasedDesignArtifactLayer` (5 tests): Layer 1.4 fires for feature_based deps, suppressed for contract_first ghosts, no-op when no design dep

643 unit tests passing. mypy clean.

## Closes

Fixes the v76 experiment regression. Relates to #353.

🤖 Generated with [Claude Code](https://claude.com/claude-code)