### PR TITLE
feat(#355): pre-fork synthesis, planning observability, integration doc-code verification

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,3 +1,9 @@
+SESSION_START:
+  - At session start, read ~/.simon/memory-bank/activeContext.md for current focus and recent state.
+  - Also read ~/.simon/memory-bank/progress.md for what shipped / what's left / critical reminders.
+  - Optionally read the other four files in ~/.simon/memory-bank/ (projectbrief, productContext, techContext, systemPatterns) when you need project-wide context — they change rarely.
+  - When the user says "update simon memory bank", review the recent conversation and rewrite activeContext.md + progress.md to match the new state. Leave the other four files alone unless the stack or patterns actually changed.
+
 FILE_MANAGEMENT:
   - Don't ever version files...just change the original file.  No "_fixed", "_v2", "_patched", etc.
   - When modifying files, always overwrite the original file. Never create new versions with suffixes like _fixed, _v2, _new, _updated, _patched, or similar naming patterns.
@@ -260,3 +266,40 @@ FILE_MANAGEMENT:
     When the user mentions "Kaia", "Dr. Chen", "ask Kaia", "what would Kaia think",
     or wants architectural advice, mentorship, or a second opinion, invoke the /kaia skill.
     Modes: /kaia <question>, /kaia --review, /kaia --research <topic>, /kaia --reflect, /kaia --chat
+
+  MULTIAGENCY_PROCLAMATION:
+    Marcus is a board-mediated, blackboard-architecture Multi-Agent System.
+    The kanban board is the shared environment. Marcus manages that environment.
+    Agents operate within it independently.
+
+    THE THREE AGENT INVARIANTS — never violate these:
+    1. Agents self-select work. Agents pull tasks via request_next_task. Marcus
+       never pushes work, never assigns without request, never forces a specific
+       agent onto a specific task.
+    2. Agents make all implementation decisions. Marcus says WHAT to build and
+       WHY it matters. Marcus never says HOW — no library choices, no patterns,
+       no internal code structure. Two agents given the same task must be able
+       to produce legitimately different implementations.
+    3. Agents communicate exclusively through the board. No agent-to-agent
+       direct communication. No Marcus-to-agent push outside task assignment.
+       The board is the only channel.
+
+    WHAT MARCUS CAN DO (coordination, not control):
+    - Structure the task graph (DAG) — environment design
+    - Synthesize shared foundation pre-fork tasks before agents spawn
+    - Provide artifacts (design docs, contracts, scope annotations) as board state
+    - Make setup-time LLM calls (domain discovery, contract generation, decomposition)
+    - Observe, measure, and log coordination quality
+
+    THE BRIGHT LINE TEST — apply to every new feature:
+    "Could an agent, given the same board state, choose to do something
+    meaningfully different from what Marcus suggests?"
+    YES = coordination. Build it.
+    NO  = control. Stop.
+
+    RESEARCH CLAIM:
+    Marcus is a legitimate MAS with: autonomous task selection, independent
+    parallel execution, emergent coordination through shared board state,
+    measurable contribution distribution, and fully observable board-mediated
+    communication. Honest limitation: agents are reactive within a task, not
+    continuously goal-pursuing across tasks (not a BDI architecture).

--- a/checklist.md
+++ b/checklist.md
@@ -9,8 +9,11 @@
 - [ ] [Refactor] Extract KanbanWorkflowMixin to eliminate workflow duplication across providers (#251) 🟡
 - [ ] [Refactor] Validator should evaluate evidence, not truncated source code (#270) 🟡
 - [ ] [Enhancement] Add Integration Verification phase after implementation tasks complete (#271) 🔴
+- [ ] [Feature] Cato Living Architecture Diagram — real-time IDEA flow with drill-down and GIF export (#378) 🟡
+- [ ] [Enhancement] Spread-first task assignment for independent tasks (#379) 🔴
 
 ## Bug Fixes
 
 - [ ] [Bug] Validation cannot access acceptance criteria stored as Planka checklists (#189)
 - [ ] [Performance] Project filtering loads all 6,970 tasks instead of project subset (#192)
+- [ ] [Bug] feature_based agents receive contract docs as primary spec, produce stubs instead of implementations (#353) 🔴

--- a/src/integrations/integration_verification.py
+++ b/src/integrations/integration_verification.py
@@ -338,6 +338,18 @@ Fabricating output is worse than reporting a failure.
      JSON, missing backends, broken imports)
    - Verify that components built by different agents connect
    - Record each curl command and its full response
+   - **Check Content-Type on every external dependency error path**: \
+For each dependency documented as out-of-scope or unavailable (missing \
+backend, external API, third-party service), make a real HTTP request to \
+the missing endpoint — do NOT rely on mocked tests. Verify: (a) the \
+response Content-Type header is what the consumer expects (e.g., \
+`application/json` for JSON APIs — a 200 response with \
+`Content-Type: text/html` will silently corrupt any JSON parser that \
+calls `.json()` on it), and (b) the UI renders the correct error state \
+rather than a parse exception. SPA frameworks (Vite, Next.js, CRA) \
+serve `index.html` with status 200 for unmatched API routes in \
+development — this is the most common source of "Unexpected token '<'" \
+JSON parse errors that pass all mocked tests.
 
 8. **Check for Missing Components**:
    - Is the app entry point wired up? (e.g., does App.jsx import
@@ -348,6 +360,24 @@ Fabricating output is worse than reporting a failure.
    - Does the design spec describe components that have no code?
    - Are there duplicate/conflicting implementations that need
      consolidation?
+   - **Composition verification — real component instantiation**: \
+For every component type, widget, view, or route listed in the design \
+spec or task list, read the container or layout file that is supposed \
+to render it. Verify the container instantiates the REAL component, not \
+a placeholder div, TODO comment, or hardcoded stub. A placeholder \
+passes all unit tests but ships a broken product. Check the actual JSX \
+/ template / handler — `<WeatherWidget />` is not the same as \
+`<div>Weather goes here</div>`.
+   - **Dead enum and union type variants** — \
+For each state machine, enum, or union type defined in the codebase \
+(e.g. a WidgetState type with LOADING | READY | ERROR | STALE variants, \
+a status enum, an event discriminated union): list every variant and \
+confirm each is reachable — some code path calls or emits it at \
+runtime. A variant that is typed, styled, or tested but never set by \
+any production code path is an unreachable dead variant. It misleads \
+developers, generates dead branches in rendering logic, and will never \
+be exercised by real users. Either implement the logic that sets it or \
+remove it and all its dead branches from the type system.
 
    **Doc-Code Consistency** (prevents specification theater — agents \
 documenting what a spec says without verifying what actually exists):

--- a/src/integrations/integration_verification.py
+++ b/src/integrations/integration_verification.py
@@ -349,6 +349,27 @@ Fabricating output is worse than reporting a failure.
    - Are there duplicate/conflicting implementations that need
      consolidation?
 
+   **Doc-Code Consistency** (prevents specification theater — agents \
+documenting what a spec says without verifying what actually exists):
+
+   - **Configuration values**: List every configuration key, environment \
+variable, or named setting that appears in any documentation file (README, \
+setup guides, `.env.example`, config templates). For each one, search the \
+source tree to confirm it is actually consumed — the name appears in \
+source code that reads or references it. If documented but never used in \
+source, it is a phantom — either remove it from docs or add the missing \
+source wiring. Project-appropriate search patterns vary (env vars: \
+`import.meta.env.VAR`, `os.environ["VAR"]`, `process.env.VAR`; config \
+keys: the literal key name in config-loading code; etc.).
+   - **Documented interfaces and entry points**: For every interface, \
+command, function, or entry point described in setup guides or README, \
+confirm the corresponding implementation exists in source. Project type \
+determines what this means: for a web service, every documented endpoint \
+should have an implementation; for a CLI, every documented command; for a \
+library, every documented public function; for a data pipeline, every \
+documented stage or transform. If a documented interface has no \
+implementation, either add it or remove the documentation.
+
 9. **Verify ALL Interface Boundaries (cross-agent AND intra-agent)**:
    This is the most critical step. A boundary is any place where \
 one chunk of code produces data that another chunk of code consumes — \

--- a/src/integrations/nlp_tools.py
+++ b/src/integrations/nlp_tools.py
@@ -961,6 +961,13 @@ class NaturalLanguageProjectCreator(NaturalLanguageTaskCreator):
         """
         try:
             _planning_started_at = datetime.now(timezone.utc)
+            # Initialise deferred-write state so the except block can write
+            # a failure outcome if project creation fails after planning ends.
+            _planning_id: str | None = None
+            _planning_persistence: object | None = None
+            _planning_outcome_key: str | None = None
+            _planning_outcome: dict[str, object] | None = None
+            _planning_hours_val: float = 0.0
             log_agent_event(
                 "planning_start",
                 {
@@ -1223,7 +1230,7 @@ class NaturalLanguageProjectCreator(NaturalLanguageTaskCreator):
 
                     _marcus_root = Path(__file__).parent.parent.parent
                     _db_path = _marcus_root / "data" / "marcus.db"
-                    _persistence = SQLitePersistence(db_path=_db_path)
+                    _planning_persistence = SQLitePersistence(db_path=_db_path)
 
                     _planning_id = f"planning_{_uuid_mod.uuid4().hex[:12]}"
                     _planning_start_iso = _planning_started_at.isoformat()
@@ -1231,47 +1238,45 @@ class NaturalLanguageProjectCreator(NaturalLanguageTaskCreator):
                     _planning_hours = (
                         _planning_ended_at - _planning_started_at
                     ).total_seconds() / 3600
+                    _planning_hours_val = _planning_hours
 
-                    await _persistence.store(
+                    # Stage metadata write — executed after full success below.
+                    _planning_metadata = {
+                        "task_id": _planning_id,
+                        "name": f"Marcus Planning: {project_name}",
+                        "description": (
+                            "LLM synthesis, task decomposition, and board "
+                            "setup before agents begin parallel work."
+                        ),
+                        "priority": "high",
+                        "estimated_hours": 0.0,
+                        "labels": ["planning", "coordination"],
+                        "dependencies": [],
+                        "project_id": self.active_project_id,
+                        "created_at": _planning_start_iso,
+                    }
+                    _planning_outcome_key = f"{_planning_id}_Marcus_{_planning_end_iso}"
+                    _planning_outcome = {
+                        "task_id": _planning_id,
+                        "agent_id": "Marcus",
+                        "task_name": f"Marcus Planning: {project_name}",
+                        "estimated_hours": 0.0,
+                        "actual_hours": _planning_hours,
+                        # success/blockers filled in after full method completes
+                        "started_at": _planning_start_iso,
+                        "completed_at": _planning_end_iso,
+                    }
+                    # task_metadata is written now (it is independent of
+                    # success/failure); task_outcomes is written after the
+                    # full method completes so success reflects the real result.
+                    await _planning_persistence.store(
                         "task_metadata",
                         _planning_id,
-                        {
-                            "task_id": _planning_id,
-                            "name": f"Marcus Planning: {project_name}",
-                            "description": (
-                                "LLM synthesis, task decomposition, and board "
-                                "setup before agents begin parallel work."
-                            ),
-                            "priority": "high",
-                            "estimated_hours": 0.0,
-                            "labels": ["planning", "coordination"],
-                            "dependencies": [],
-                            "project_id": self.active_project_id,
-                            "created_at": _planning_start_iso,
-                        },
-                    )
-                    await _persistence.store(
-                        "task_outcomes",
-                        f"{_planning_id}_Marcus_{_planning_end_iso}",
-                        {
-                            "task_id": _planning_id,
-                            "agent_id": "Marcus",
-                            "task_name": f"Marcus Planning: {project_name}",
-                            "estimated_hours": 0.0,
-                            "actual_hours": _planning_hours,
-                            "success": True,
-                            "blockers": [],
-                            "started_at": _planning_start_iso,
-                            "completed_at": _planning_end_iso,
-                        },
-                    )
-                    logger.info(
-                        f"[planning_observability] Persisted planning bar "
-                        f"({_planning_hours * 60:.1f} min) to marcus.db"
+                        _planning_metadata,
                     )
                 except Exception as _plan_err:
                     logger.warning(
-                        f"Failed to persist planning phase metadata: {_plan_err}"
+                        f"Failed to stage planning phase metadata: {_plan_err}"
                     )
 
                 # NOW create About task AFTER decomposition with real task IDs
@@ -1465,6 +1470,32 @@ class NaturalLanguageProjectCreator(NaturalLanguageTaskCreator):
 
             logger.info(f"Successfully created project with {len(created_tasks)} tasks")
 
+            # Deferred planning-phase outcome write: project creation fully
+            # succeeded, so record success=True. Writing here (not mid-method)
+            # ensures the outcome reflects the real overall result (Codex P2).
+            if (
+                _planning_id is not None
+                and _planning_persistence is not None
+                and _planning_outcome_key is not None
+                and _planning_outcome is not None
+            ):
+                try:
+                    _planning_outcome["success"] = True
+                    _planning_outcome["blockers"] = []
+                    await _planning_persistence.store(  # type: ignore[attr-defined]
+                        "task_outcomes",
+                        _planning_outcome_key,
+                        _planning_outcome,
+                    )
+                    logger.info(
+                        f"[planning_observability] Persisted planning bar "
+                        f"({_planning_hours_val * 60:.1f} min) to marcus.db"
+                    )
+                except Exception as _plan_write_err:
+                    logger.warning(
+                        f"Failed to persist planning outcome: {_plan_write_err}"
+                    )
+
             # Phase A+B (background): Generate design artifacts,
             # register via MCP, mark design tasks DONE, generate
             # scaffold. Runs AFTER response is returned so Claude
@@ -1526,6 +1557,29 @@ class NaturalLanguageProjectCreator(NaturalLanguageTaskCreator):
             return result
 
         except Exception as e:
+            # Planning phase completed but project creation failed downstream.
+            # Write task_outcomes with success=False so Cato shows the real
+            # outcome instead of a ghost "success" bar (Codex P2 fix).
+            if (
+                _planning_id is not None
+                and _planning_persistence is not None
+                and _planning_outcome_key is not None
+                and _planning_outcome is not None
+            ):
+                try:
+                    _planning_outcome["success"] = False
+                    _planning_outcome["blockers"] = [str(e)]
+                    await _planning_persistence.store(  # type: ignore[attr-defined]
+                        "task_outcomes",
+                        _planning_outcome_key,
+                        _planning_outcome,
+                    )
+                except Exception as _plan_fail_err:
+                    logger.warning(
+                        f"Failed to persist failed planning outcome: "
+                        f"{_plan_fail_err}"
+                    )
+
             from src.core.error_framework import MarcusBaseError
             from src.core.error_responses import handle_mcp_tool_error
 

--- a/src/integrations/nlp_tools.py
+++ b/src/integrations/nlp_tools.py
@@ -34,6 +34,7 @@ from src.integrations.enhanced_task_classifier import (  # noqa: E402
 # Import refactored base classes and utilities
 from src.integrations.nlp_base import NaturalLanguageTaskCreator  # noqa: E402
 from src.integrations.nlp_task_utils import TaskType  # noqa: E402
+from src.logging.agent_events import log_agent_event  # noqa: E402
 from src.modes.adaptive.basic_adaptive import BasicAdaptiveMode  # noqa: E402
 
 logger = logging.getLogger(__name__)
@@ -256,6 +257,12 @@ class NaturalLanguageProjectCreator(NaturalLanguageTaskCreator):
                 "contract_first and is not getting it)"
             )
 
+        # Pre-fork synthesis (GH-355): detect shared foundation needs
+        # before domain tasks are created.  Feature-based path runs on
+        # PRD text only (lower fidelity than contract_first).
+        # Conservative: returns [] on LLM failure — never blocks creation.
+        foundation_tasks = await self._synthesize_shared_foundation(description)
+
         # Feature-based decomposition path (default + fallback target)  # noqa: E501
         prd_result = await self.prd_parser.parse_prd_to_tasks(description, constraints)
 
@@ -299,7 +306,20 @@ class NaturalLanguageProjectCreator(NaturalLanguageTaskCreator):
         else:
             logger.info("No dependencies returned from PRD parser")
 
-        return prd_result.tasks
+        # Wire domain tasks to depend on pre-fork foundation tasks (GH-355).
+        # Foundation tasks must complete before any domain-specific work
+        # begins — this is the board-state guarantee for visual/structural
+        # coherence across parallel agents.
+        domain_tasks = prd_result.tasks
+        if foundation_tasks:
+            foundation_ids = [t.id for t in foundation_tasks]
+            for task in domain_tasks:
+                for fid in foundation_ids:
+                    if fid not in task.dependencies:
+                        task.dependencies.append(fid)
+            return foundation_tasks + domain_tasks
+
+        return domain_tasks
 
     async def _try_contract_first_decomposition(
         self,
@@ -506,6 +526,14 @@ class NaturalLanguageProjectCreator(NaturalLanguageTaskCreator):
             )
             return None
 
+        # Pre-fork synthesis (GH-355): detect shared foundation using
+        # domain contracts.  Higher fidelity than feature_based because
+        # the full contract set is available here.  Conservative:
+        # returns [] on LLM failure so the pipeline never stalls.
+        foundation_tasks = await self._synthesize_shared_foundation(
+            description, domains=usable_contracts
+        )
+
         try:
             tasks = await self.prd_parser.decompose_by_contract(
                 prd_analysis=prd_analysis,
@@ -694,6 +722,17 @@ class NaturalLanguageProjectCreator(NaturalLanguageTaskCreator):
         # ``_remap_dependencies`` converts the slug IDs to real UUIDs
         # and persists them to the kanban.
 
+        # Wire impl tasks to depend on pre-fork foundation tasks (GH-355).
+        # Foundation tasks are TODO and must complete before domain agents
+        # begin.  Ghost tasks (DONE) are excluded — they represent design
+        # work that already happened and need not wait for foundation.
+        if foundation_tasks:
+            foundation_ids = [t.id for t in foundation_tasks]
+            for task in tasks:
+                for fid in foundation_ids:
+                    if fid not in task.dependencies:
+                        task.dependencies.append(fid)
+
         # Stash the rekeyed design content on the creator instance.
         # The background design phase scheduler at the end of
         # ``create_tasks_from_description`` reads this attribute via
@@ -711,13 +750,203 @@ class NaturalLanguageProjectCreator(NaturalLanguageTaskCreator):
         logger.info(
             f"[decomposer] contract_first: synthesized "
             f"{len(ghost_tasks)} design ghost(s) for "
-            f"{len(usable_contracts)} domain(s); contract content "
-            f"stashed for background Phase B"
+            f"{len(usable_contracts)} domain(s); "
+            f"{len(foundation_tasks)} foundation task(s) pre-fork; "
+            f"contract content stashed for background Phase B"
         )
 
-        # Design ghosts come first so the integration task's
-        # dependency walk picks them up alongside impl tasks.
-        return ghost_tasks + tasks
+        # Design ghosts come first so the integration task's dependency
+        # walk picks them up alongside impl tasks.  Foundation tasks
+        # follow ghosts; impl tasks come last.
+        return ghost_tasks + foundation_tasks + tasks
+
+    async def _synthesize_shared_foundation(
+        self,
+        description: str,
+        domains: Optional[Dict[str, Any]] = None,
+    ) -> List[Task]:
+        """
+        Detect shared foundation needs before parallel agents spawn (GH-355).
+
+        Makes a single LLM call to analyse whether parallel development
+        agents need any shared foundation built before starting domain-
+        specific work.  Three synthesis targets are checked:
+
+        - **Design System**: shared visual tokens (colors, typography,
+          spacing, themes) — needed when multiple UI features must look
+          visually consistent.
+        - **Shared Components**: reusable UI or logic components (Card,
+          Button, API client) — needed when ≥2 domains use the same
+          component.
+        - **Tech Foundation**: shared configuration (TypeScript config,
+          routing setup, test harness) — needed when agents would
+          duplicate this setup independently.
+
+        This method is **conservative**: it returns an empty list on any
+        LLM or parse failure so project creation is never blocked.
+
+        Parameters
+        ----------
+        description : str
+            Project description (PRD text). Used as the primary input.
+        domains : Optional[Dict[str, Any]], optional
+            Domain contracts from contract-first decomposition.  When
+            provided, the prompt gains higher-fidelity context about
+            what each domain builds.  ``None`` for the feature-based
+            path (lower-fidelity, PRD text only).
+
+        Returns
+        -------
+        List[Task]
+            Pre-fork foundation tasks (status TODO, priority HIGH,
+            labels ``["foundation", "pre-fork"]``).  Empty list when no
+            shared foundation is needed or when the LLM call fails.
+
+        Notes
+        -----
+        GH-355 : Pre-fork synthesis — shared foundation tasks before
+        parallel agents start.
+        """
+        import uuid as _uuid
+
+        class _Ctx:
+            max_tokens = 1024
+
+        # Appended to every synthesized description so foundation tasks
+        # carry the same Marcus workflow reminder as any implementation
+        # task — agents must call log_artifact so downstream agents can
+        # discover the output via get_task_context.  This is not HOW
+        # guidance; it is standard Marcus workflow that applies to all
+        # tasks that produce artifacts consumed by other tasks.
+        _WORKFLOW_REMINDER = (
+            " Call log_artifact for every file you produce so that "
+            "downstream agents can discover your output via "
+            "get_task_context."
+        )
+
+        # Build optional domain-contract section for higher-fidelity
+        # contract_first synthesis.  Feature-based path omits this.
+        domain_section = ""
+        if domains:
+            lines: List[str] = []
+            for domain_name, payload in domains.items():
+                artifacts = (
+                    payload.get("artifacts", []) if isinstance(payload, dict) else []
+                )
+                preview = ""
+                if artifacts:
+                    raw_content = artifacts[0].get("content", "")
+                    preview = str(raw_content)[:300].strip()
+                lines.append(f"Domain '{domain_name}':\n{preview}")
+            domain_section = (
+                "\n\nDomain Contracts (for higher-fidelity analysis):\n"
+                + "\n---\n".join(lines)
+            )
+
+        prompt = (
+            "You are analysing a software project to determine whether "
+            "parallel development agents need a shared foundation before "
+            "their independent work begins.\n\n"
+            f"PRD Description:\n{description}"
+            f"{domain_section}\n\n"
+            "Analyse whether parallel agents working on this project need "
+            "ANY of these shared foundations BEFORE starting domain-specific "
+            "work:\n\n"
+            "1. Design System: shared visual tokens (colors, typography, "
+            "spacing, themes) — needed when multiple UI features must look "
+            "visually consistent.\n"
+            "2. Shared Components: reusable UI or logic components (Card, "
+            "Button, API client) — needed when ≥2 domains will use the "
+            "same component.\n"
+            "3. Tech Foundation: shared configuration (TypeScript config, "
+            "routing, test harness) — needed when agents would duplicate "
+            "this setup independently.\n\n"
+            "Be CONSERVATIVE. Return foundation tasks ONLY when agents "
+            "would DEFINITELY produce incompatible implementations without "
+            "them.  When uncertain, return an empty list.\n\n"
+            "Return ONLY valid JSON with this exact structure:\n"
+            '{"foundation_tasks": ['
+            '{"name": "<plain task name, e.g. Design System Setup or '
+            'Shared Widget Components — no category prefix>", '
+            '"description": "<what to build and why parallel agents '
+            'need it done first>", '
+            '"estimated_hours": <positive number>}'
+            "]}\n\n"
+            'If no shared foundation is needed: {"foundation_tasks": []}'
+        )
+
+        try:
+            raw = await self.prd_parser.llm_client.analyze(
+                prompt=prompt, context=_Ctx()
+            )
+        except Exception as exc:
+            logger.warning(
+                f"[pre-fork synthesis] LLM call failed ({exc}); "
+                "no foundation tasks injected"
+            )
+            return []
+
+        try:
+            from src.utils.json_parser import parse_ai_json_response
+
+            # parse_ai_json_response raises ValueError when the LLM
+            # output is not a JSON object — caught by the except below.
+            parsed = parse_ai_json_response(raw)
+            raw_tasks = parsed.get("foundation_tasks")
+            if not isinstance(raw_tasks, list) or not raw_tasks:
+                return []
+        except Exception as exc:
+            logger.warning(
+                f"[pre-fork synthesis] JSON parse failed ({exc}); "
+                "no foundation tasks injected"
+            )
+            return []
+
+        now = datetime.now(timezone.utc)
+        foundation_tasks: List[Task] = []
+        for item in raw_tasks:
+            if not isinstance(item, dict):
+                continue
+            name = str(item.get("name", "Shared Foundation"))
+            desc = str(item.get("description", "Shared foundation setup.")).rstrip(".")
+            desc = desc + "." + _WORKFLOW_REMINDER
+            try:
+                hours = float(item.get("estimated_hours", 2.0))
+            except (TypeError, ValueError):
+                hours = 2.0
+            if hours <= 0:
+                hours = 2.0
+
+            task = Task(
+                id=f"foundation_{_uuid.uuid4().hex[:12]}",
+                name=name,
+                description=desc,
+                status=TaskStatus.TODO,
+                priority=Priority.HIGH,
+                assigned_to=None,
+                created_at=now,
+                updated_at=now,
+                due_date=None,
+                estimated_hours=hours,
+                dependencies=[],
+                # Foundation tasks are real implementation work done
+                # by agents — not Marcus design ghosts.  No "design"
+                # or "foundation" label; source_type is the internal
+                # marker.  "pre-fork" is the only tag so Cato can
+                # optionally surface the pre-domain distinction
+                # without inventing a new task category.
+                labels=["pre-fork"],
+                source_type="pre_fork_synthesis",
+            )
+            foundation_tasks.append(task)
+
+        if foundation_tasks:
+            logger.info(
+                f"[pre-fork synthesis] Injecting {len(foundation_tasks)} "
+                f"foundation task(s): " + ", ".join(t.name for t in foundation_tasks)
+            )
+
+        return foundation_tasks
 
     async def create_project_from_description(
         self,
@@ -731,6 +960,14 @@ class NaturalLanguageProjectCreator(NaturalLanguageTaskCreator):
         Uses the base class implementation for common functionality.
         """
         try:
+            _planning_started_at = datetime.now(timezone.utc)
+            log_agent_event(
+                "planning_start",
+                {
+                    "project_name": project_name,
+                    "description_length": len(description),
+                },
+            )
             logger.info(f"Creating project '{project_name}' from natural language")
             logger.debug(f"Description: {description[:200]}...")
             logger.debug(f"Options: {options}")
@@ -966,6 +1203,76 @@ class NaturalLanguageProjectCreator(NaturalLanguageTaskCreator):
             ):
                 created_tasks = await self.create_tasks_on_board(safe_tasks)
                 logger.info(f"Created {len(created_tasks)} tasks on board")
+                # Planning phase ends: board is populated, agents can now
+                # self-select work.  Log JSONL event (debugging) and persist
+                # to marcus.db so Cato renders a "Marcus Planning" swim lane
+                # bar attributed to "Marcus", spanning setup duration.
+                _planning_ended_at = datetime.now(timezone.utc)
+                log_agent_event(
+                    "planning_end",
+                    {
+                        "project_name": project_name,
+                        "task_count": len(created_tasks),
+                    },
+                )
+                try:
+                    import uuid as _uuid_mod
+                    from pathlib import Path
+
+                    from src.core.persistence import SQLitePersistence
+
+                    _marcus_root = Path(__file__).parent.parent.parent
+                    _db_path = _marcus_root / "data" / "marcus.db"
+                    _persistence = SQLitePersistence(db_path=_db_path)
+
+                    _planning_id = f"planning_{_uuid_mod.uuid4().hex[:12]}"
+                    _planning_start_iso = _planning_started_at.isoformat()
+                    _planning_end_iso = _planning_ended_at.isoformat()
+                    _planning_hours = (
+                        _planning_ended_at - _planning_started_at
+                    ).total_seconds() / 3600
+
+                    await _persistence.store(
+                        "task_metadata",
+                        _planning_id,
+                        {
+                            "task_id": _planning_id,
+                            "name": f"Marcus Planning: {project_name}",
+                            "description": (
+                                "LLM synthesis, task decomposition, and board "
+                                "setup before agents begin parallel work."
+                            ),
+                            "priority": "high",
+                            "estimated_hours": 0.0,
+                            "labels": ["planning", "coordination"],
+                            "dependencies": [],
+                            "project_id": self.active_project_id,
+                            "created_at": _planning_start_iso,
+                        },
+                    )
+                    await _persistence.store(
+                        "task_outcomes",
+                        f"{_planning_id}_Marcus_{_planning_end_iso}",
+                        {
+                            "task_id": _planning_id,
+                            "agent_id": "Marcus",
+                            "task_name": f"Marcus Planning: {project_name}",
+                            "estimated_hours": 0.0,
+                            "actual_hours": _planning_hours,
+                            "success": True,
+                            "blockers": [],
+                            "started_at": _planning_start_iso,
+                            "completed_at": _planning_end_iso,
+                        },
+                    )
+                    logger.info(
+                        f"[planning_observability] Persisted planning bar "
+                        f"({_planning_hours * 60:.1f} min) to marcus.db"
+                    )
+                except Exception as _plan_err:
+                    logger.warning(
+                        f"Failed to persist planning phase metadata: {_plan_err}"
+                    )
 
                 # NOW create About task AFTER decomposition with real task IDs
                 # Map created tasks to original tasks to preserve details

--- a/src/marcus_mcp/tools/context.py
+++ b/src/marcus_mcp/tools/context.py
@@ -398,6 +398,7 @@ async def _collect_task_artifacts(
                             _inject_usage_guidance(
                                 artifact, is_design_dep, is_contract_first_ghost
                             )
+                            artifact.pop("_is_foundation_dep", None)
                         artifacts.extend(dep_artifacts)
 
                     # Kanban attachments from dependency

--- a/src/marcus_mcp/tools/context.py
+++ b/src/marcus_mcp/tools/context.py
@@ -258,6 +258,13 @@ _IMPLEMENTATION_GUIDE_GUIDANCE = (
     "adapt as needed for your complete feature."
 )
 
+_FOUNDATION_USAGE_GUIDANCE = (
+    "SHARED FOUNDATION: This artifact was produced by a shared setup task "
+    "that completed before parallel work began. Use it directly — import it, "
+    "consume its exports, and extend it if needed. Do not recreate or "
+    "duplicate what it already provides."
+)
+
 
 def _inject_usage_guidance(
     artifact: Dict[str, Any],
@@ -267,9 +274,13 @@ def _inject_usage_guidance(
     """
     Inject usage_guidance into a dependency artifact dict in-place.
 
-    Option C: ``artifact_role`` field takes precedence — role-aware guidance
-    without relying on task labels.  Option B: label-based fallback for
-    artifacts that predate the ``artifact_role`` field.
+    Priority (highest to lowest):
+
+    1. ``artifact_role`` field — role-aware guidance (Option C).
+    2. ``_is_foundation_dep`` marker — pre-fork synthesis tasks (GH-355).
+       Set by ``_collect_task_artifacts`` when ``source_type == "pre_fork_synthesis"``.
+    3. ``is_design_dep`` label-based fallback for feature_based design
+       artifacts that predate the ``artifact_role`` field (Option B).
 
     Parameters
     ----------
@@ -287,6 +298,12 @@ def _inject_usage_guidance(
         artifact.setdefault("usage_guidance", _COORDINATION_REFERENCE_GUIDANCE)
     elif role == "implementation_spec":
         artifact.setdefault("usage_guidance", _IMPLEMENTATION_GUIDE_GUIDANCE)
+    elif artifact.get("_is_foundation_dep"):
+        # Pre-fork synthesis artifacts (GH-355): shared setup that
+        # completed before domain work began.  Consumption guidance
+        # delivered here, not in the task description, so Marcus
+        # stays on the coordination side of the bright line.
+        artifact.setdefault("usage_guidance", _FOUNDATION_USAGE_GUIDANCE)
     elif is_design_dep and not is_contract_first_ghost:
         # Option B label-based fallback: feature_based design artifacts
         artifact.setdefault("usage_guidance", _COORDINATION_REFERENCE_GUIDANCE)
@@ -360,6 +377,10 @@ async def _collect_task_artifacts(
                         # from the contract_notice layer in
                         # build_tiered_instructions, so we skip guidance here.
                         is_contract_first_ghost = "auto_completed" in dep_labels
+                        is_foundation_dep = (
+                            getattr(dep_task, "source_type", None)
+                            == "pre_fork_synthesis"
+                        )
                         for artifact in dep_artifacts:
                             artifact["dependency_task_id"] = dep_id
                             artifact["dependency_task_name"] = dep_task.name
@@ -367,6 +388,11 @@ async def _collect_task_artifacts(
                                 f"{artifact.get('description', '')} "
                                 f"(from dependency: {dep_task.name})"
                             )
+                            # Mark foundation artifacts so _inject_usage_guidance
+                            # can apply GH-355 consumption guidance without
+                            # widening the function signature.
+                            if is_foundation_dep:
+                                artifact["_is_foundation_dep"] = True
                             # Option C: artifact_role field takes precedence.
                             # Option B: fall back to label-based detection.
                             _inject_usage_guidance(

--- a/tests/unit/integrations/test_integration_verification.py
+++ b/tests/unit/integrations/test_integration_verification.py
@@ -299,6 +299,90 @@ class TestIntegrationTaskGenerator:
         assert task is not None
         assert "My Dashboard" in task.name
 
+    def test_description_requires_composition_verification(
+        self, all_sample_tasks: list[Task]
+    ) -> None:
+        """Description must instruct agent to verify real component instantiation.
+
+        Catches the v81 composition gap: Agent 1 left placeholder divs in
+        DashboardContainer instead of real component instances.  The
+        integration agent must explicitly check each component type renders
+        a real implementation, not a placeholder div or stub.
+        """
+        from src.integrations.integration_verification import (
+            IntegrationTaskGenerator,
+        )
+
+        task = IntegrationTaskGenerator.create_integration_task(
+            all_sample_tasks, "Dashboard"
+        )
+
+        assert task is not None
+        desc = task.description
+        # Must mention placeholder divs specifically (not just generic "missing")
+        assert (
+            "placeholder" in desc.lower()
+        ), "Description must warn against placeholder divs"
+        # Must require verifying real component instantiation
+        assert (
+            "real component" in desc.lower() or "real implementation" in desc.lower()
+        ), "Description must require verifying real component/implementation, not stubs"
+
+    def test_description_requires_error_path_content_type_check(
+        self, all_sample_tasks: list[Task]
+    ) -> None:
+        """Description must instruct the agent to check Content-Type on error paths.
+
+        Catches the v81 JSON parse error: weather widget called res.json()
+        on Vite's HTML SPA-fallback page (200 + text/html).  The integration
+        agent must verify that out-of-scope dependencies return the correct
+        content-type on the error path, not HTML masquerading as JSON.
+        """
+        from src.integrations.integration_verification import (
+            IntegrationTaskGenerator,
+        )
+
+        task = IntegrationTaskGenerator.create_integration_task(
+            all_sample_tasks, "Dashboard"
+        )
+
+        assert task is not None
+        desc = task.description
+        # Must explicitly mention Content-Type checking (not just "HTML" generically)
+        assert (
+            "content-type" in desc.lower() or "content_type" in desc.lower()
+        ), "Description must require Content-Type verification on error paths"
+
+    def test_description_requires_dead_type_variant_check(
+        self, all_sample_tasks: list[Task]
+    ) -> None:
+        """Description must instruct agent to detect unreachable type variants.
+
+        Catches the v81 STALE ghost-state: a WidgetState variant declared
+        in the type system and styled in WidgetCard but never set by any
+        widget.  Both agents treated it as in-scope without anyone building
+        the transition logic.  The integration agent must enumerate
+        enum/union variants and verify each is reachable at runtime.
+        """
+        from src.integrations.integration_verification import (
+            IntegrationTaskGenerator,
+        )
+
+        task = IntegrationTaskGenerator.create_integration_task(
+            all_sample_tasks, "Dashboard"
+        )
+
+        assert task is not None
+        desc = task.description
+        # Must address dead / unreachable variants specifically
+        assert (
+            "never set" in desc.lower() or "unreachable" in desc.lower()
+        ), "Description must flag variants that are defined but never set at runtime"
+        # Must reference enums or union type variants explicitly
+        assert (
+            "enum" in desc.lower() or "variant" in desc.lower()
+        ), "Description must mention enum/union variant checking by name"
+
     def test_works_with_generic_ai_labels(self) -> None:
         """Test integration task created with generic labels.
 

--- a/tests/unit/integrations/test_integration_verification.py
+++ b/tests/unit/integrations/test_integration_verification.py
@@ -185,6 +185,65 @@ class TestIntegrationTaskGenerator:
         assert "integration_verification.json" in desc
         assert "log_artifact" in desc
 
+    def test_description_includes_config_doc_verification(
+        self, all_sample_tasks: list[Task]
+    ) -> None:
+        """Description instructs agent to cross-check documented config values against source.
+
+        Prevents 'specification theater': agents documenting configuration keys
+        or env vars from a spec without verifying they are actually wired in
+        code. Applies to any project type, not just web apps.
+        """
+        from src.integrations.integration_verification import (
+            IntegrationTaskGenerator,
+        )
+
+        task = IntegrationTaskGenerator.create_integration_task(
+            all_sample_tasks, "Dashboard"
+        )
+
+        assert task is not None
+        desc = task.description
+        # Must mention configuration / env var checking …
+        assert "configuration" in desc.lower() or "env" in desc.lower()
+        # … and include at least one concrete search pattern for common stacks
+        assert any(
+            pattern in desc
+            for pattern in ["import.meta.env", "os.environ", "process.env"]
+        )
+        # … and the concept of phantom / unused values
+        assert "phantom" in desc.lower() or "never used" in desc.lower()
+
+    def test_description_includes_interface_doc_verification(
+        self, all_sample_tasks: list[Task]
+    ) -> None:
+        """Description instructs agent to verify documented interfaces have implementations.
+
+        General language covers all project types: web services (endpoints),
+        CLIs (commands), libraries (functions), data pipelines (stages), etc.
+        Dead documentation should be removed or implemented.
+        """
+        from src.integrations.integration_verification import (
+            IntegrationTaskGenerator,
+        )
+
+        task = IntegrationTaskGenerator.create_integration_task(
+            all_sample_tasks, "Dashboard"
+        )
+
+        assert task is not None
+        desc = task.description
+        # Must mention documentation accuracy in general terms …
+        assert "documented" in desc.lower() or "documentation" in desc.lower()
+        # … with project-type examples that span beyond just web APIs
+        assert "implementation" in desc.lower() or "implement" in desc.lower()
+        # … and cover multiple project type examples
+        assert (
+            "cli" in desc.lower()
+            or "library" in desc.lower()
+            or "pipeline" in desc.lower()
+        )
+
     def test_task_id_format(self, all_sample_tasks: list[Task]) -> None:
         """Test integration task ID starts with correct prefix."""
         from src.integrations.integration_verification import (

--- a/tests/unit/integrations/test_planning_observability.py
+++ b/tests/unit/integrations/test_planning_observability.py
@@ -49,10 +49,15 @@ def _make_creator() -> Any:
     mock_kanban.project_id = "proj-test-1"
     mock_ai_engine = MagicMock()
 
-    creator = NaturalLanguageProjectCreator(
-        kanban_client=mock_kanban,
-        ai_engine=mock_ai_engine,
-    )
+    with (
+        patch("src.integrations.nlp_tools.AdvancedPRDParser"),
+        patch("src.integrations.nlp_tools.BoardAnalyzer"),
+        patch("src.integrations.nlp_tools.ContextDetector"),
+    ):
+        creator = NaturalLanguageProjectCreator(
+            kanban_client=mock_kanban,
+            ai_engine=mock_ai_engine,
+        )
     creator.active_project_id = "proj-test-1"
     return creator
 

--- a/tests/unit/integrations/test_planning_observability.py
+++ b/tests/unit/integrations/test_planning_observability.py
@@ -306,3 +306,113 @@ class TestPlanningObservability:
             f"task_count {captured[0]['task_count']} must be "
             f">= {expected_min_count}"
         )
+
+    async def test_planning_outcome_written_with_success_true_on_success(
+        self,
+    ) -> None:
+        """``task_outcomes`` is persisted with ``success=True`` only after the
+        full ``create_project_from_description`` call completes successfully.
+
+        Writing early (before About-card creation, etc.) would record
+        success even when downstream steps fail, skewing Cato analytics.
+        """
+        from src.integrations.nlp_task_utils import TaskType
+
+        creator = _make_creator()
+        tasks = [_make_task("task-1", "Build Widget")]
+
+        mock_store = AsyncMock()
+        mock_persistence_instance = MagicMock()
+        mock_persistence_instance.store = mock_store
+        mock_persistence_class = MagicMock(return_value=mock_persistence_instance)
+
+        with _patch_heavy_deps(creator, tasks):
+            # classify_tasks / _extract_phases / _estimate_duration are
+            # called after planning ends.  They involve AI-based regex
+            # that breaks with MagicMock task_classifier — stub them so
+            # the function reaches its success return.
+            with (
+                patch.object(
+                    creator,
+                    "classify_tasks",
+                    return_value={TaskType.IMPLEMENTATION: tasks},
+                ),
+                patch.object(creator, "_extract_phases", return_value=[]),
+                patch.object(creator, "_estimate_duration", return_value=1.0),
+                patch.object(creator, "_count_dependencies", return_value=0),
+                patch.object(creator, "_assess_risk_by_count", return_value="low"),
+                patch(
+                    "src.core.persistence.SQLitePersistence",
+                    mock_persistence_class,
+                ),
+            ):
+                result = await creator.create_project_from_description(
+                    "Build a widget", "TestProject"
+                )
+
+        assert (
+            result.get("success") is True
+        ), f"create_project_from_description should succeed: {result}"
+        outcomes_calls = [
+            c
+            for c in mock_store.call_args_list
+            if c.args[0] == "task_outcomes" and c.args[1].startswith("planning_")
+        ]
+        assert len(outcomes_calls) == 1, (
+            f"expected exactly one planning task_outcomes write, "
+            f"got: {[c.args[1] for c in outcomes_calls]}"
+        )
+        assert outcomes_calls[0].args[2]["success"] is True, (
+            "task_outcomes for planning must record success=True on a "
+            f"successful run, got: {outcomes_calls[0].args[2]}"
+        )
+
+    async def test_planning_outcome_written_with_success_false_on_failure(
+        self,
+    ) -> None:
+        """``task_outcomes`` is persisted with ``success=False`` when project
+        creation fails after the planning phase ends (e.g. About-card write
+        failure).
+
+        Without this, a failed run would show a phantom 'success' bar in
+        Cato's Marcus swim lane, skewing the planning-overhead metric.
+        """
+        creator = _make_creator()
+        tasks = [_make_task("task-1", "Build Widget")]
+
+        mock_store = AsyncMock()
+        mock_persistence_instance = MagicMock()
+        mock_persistence_instance.store = mock_store
+        mock_persistence_class = MagicMock(return_value=mock_persistence_instance)
+
+        with _patch_heavy_deps(creator, tasks):
+            # Simulate failure when the About card is written to the board
+            creator.kanban_client.create_task = AsyncMock(
+                side_effect=RuntimeError("board write failed")
+            )
+            with patch(
+                "src.core.persistence.SQLitePersistence", mock_persistence_class
+            ):
+                result = await creator.create_project_from_description(
+                    "Build a widget", "TestProject"
+                )
+
+        # create_project_from_description returns an error dict, not raises
+        assert result.get("success") is False, f"expected error result, got: {result}"
+
+        outcomes_calls = [
+            c
+            for c in mock_store.call_args_list
+            if c.args[0] == "task_outcomes" and c.args[1].startswith("planning_")
+        ]
+        assert len(outcomes_calls) == 1, (
+            f"expected exactly one planning task_outcomes write on failure, "
+            f"got: {[c.args[1] for c in outcomes_calls]}"
+        )
+        assert outcomes_calls[0].args[2]["success"] is False, (
+            "task_outcomes for planning must record success=False when "
+            f"creation fails, got: {outcomes_calls[0].args[2]}"
+        )
+        assert (
+            outcomes_calls[0].args[2].get("blockers")
+        ), "blockers must be non-empty on failure"

--- a/tests/unit/integrations/test_planning_observability.py
+++ b/tests/unit/integrations/test_planning_observability.py
@@ -1,0 +1,308 @@
+"""
+Unit tests for planning phase observability (GH-357).
+
+Verifies that ``create_project_from_description`` on
+``NaturalLanguageProjectCreator`` logs ``planning_start`` and
+``planning_end`` agent events so Cato's swim lanes can show how long
+the Marcus coordination / setup phase takes relative to agent work.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from src.core.models import Priority, Task, TaskStatus
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_task(task_id: str, name: str) -> Task:
+    """Build a minimal Task for use in mocked return values."""
+    now = datetime.now(timezone.utc)
+    return Task(
+        id=task_id,
+        name=name,
+        description="Do the thing",
+        status=TaskStatus.TODO,
+        priority=Priority.MEDIUM,
+        assigned_to=None,
+        created_at=now,
+        updated_at=now,
+        due_date=None,
+        estimated_hours=2.0,
+        dependencies=[],
+    )
+
+
+def _make_creator() -> Any:
+    """Build a ``NaturalLanguageProjectCreator`` with all I/O mocked."""
+    from src.integrations.nlp_tools import NaturalLanguageProjectCreator
+
+    mock_kanban = MagicMock()
+    mock_kanban.auto_setup_project = AsyncMock()
+    mock_kanban.project_id = "proj-test-1"
+    mock_ai_engine = MagicMock()
+
+    creator = NaturalLanguageProjectCreator(
+        kanban_client=mock_kanban,
+        ai_engine=mock_ai_engine,
+    )
+    creator.active_project_id = "proj-test-1"
+    return creator
+
+
+def _make_about_task() -> Task:
+    """Minimal About task returned by ``_create_about_task`` mock."""
+    now = datetime.now(timezone.utc)
+    return Task(
+        id="about-1",
+        name="About: TestProject",
+        description="Project overview",
+        status=TaskStatus.DONE,
+        priority=Priority.LOW,
+        assigned_to=None,
+        created_at=now,
+        updated_at=now,
+        due_date=None,
+        estimated_hours=0.0,
+        dependencies=[],
+        labels=[],
+    )
+
+
+def _mock_kanban_task(task_id: str = "kanban-1") -> MagicMock:
+    """Minimal kanban API response for create_task calls."""
+    m = MagicMock()
+    m.id = task_id
+    return m
+
+
+# ---------------------------------------------------------------------------
+# Shared patch context manager
+# ---------------------------------------------------------------------------
+
+
+def _patch_heavy_deps(creator: Any, domain_tasks: list[Task]) -> Any:
+    """
+    Return a context manager that stubs out all heavy I/O in
+    ``create_project_from_description`` so only planning events are emitted.
+
+    The function uses local imports for several helpers, so we patch them at
+    their source modules (which is where Python caches the name after the
+    first import).
+    """
+    from contextlib import ExitStack
+
+    stack = ExitStack()
+
+    # Internal methods
+    stack.enter_context(
+        patch.object(
+            creator,
+            "process_natural_language",
+            new=AsyncMock(return_value=domain_tasks),
+        )
+    )
+    stack.enter_context(
+        patch.object(
+            creator,
+            "apply_safety_checks",
+            new=AsyncMock(return_value=domain_tasks),
+        )
+    )
+    stack.enter_context(
+        patch.object(
+            creator,
+            "create_tasks_on_board",
+            new=AsyncMock(return_value=domain_tasks),
+        )
+    )
+    stack.enter_context(
+        patch.object(
+            creator,
+            "_create_about_task",
+            return_value=_make_about_task(),
+        )
+    )
+    stack.enter_context(
+        patch.object(
+            creator,
+            "_cleanup_background",
+            new=AsyncMock(),
+        )
+    )
+
+    # About task kanban write
+    creator.kanban_client.create_task = AsyncMock(
+        return_value=_mock_kanban_task("about-kanban-1")
+    )
+
+    # Local imports inside the function — patch at source
+    stack.enter_context(
+        patch(
+            "src.integrations.integration_verification"
+            ".enhance_project_with_integration",
+            return_value=domain_tasks,
+        )
+    )
+    stack.enter_context(
+        patch(
+            "src.integrations.documentation_tasks"
+            ".enhance_project_with_documentation",
+            return_value=domain_tasks,
+        )
+    )
+    # Prevent SQLite writes
+    stack.enter_context(
+        patch("src.core.persistence.SQLitePersistence", new=MagicMock())
+    )
+    # Prevent background design phase
+    stack.enter_context(patch("asyncio.ensure_future", new=MagicMock()))
+
+    return stack
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+class TestPlanningObservability:
+    """``create_project_from_description`` logs planning start/end events."""
+
+    async def test_logs_planning_start_event(self) -> None:
+        """A ``planning_start`` event is logged when project creation begins.
+
+        This lets Cato's swim lanes show the coordination / setup phase
+        duration that currently appears as dead time before any task bar
+        appears on the timeline.
+        """
+        creator = _make_creator()
+        tasks = [_make_task("task-1", "Build Widget")]
+
+        with _patch_heavy_deps(creator, tasks):
+            with patch("src.integrations.nlp_tools.log_agent_event") as mock_log:
+                await creator.create_project_from_description(
+                    "Build a widget", "TestProject"
+                )
+
+        event_types = [c.args[0] for c in mock_log.call_args_list]
+        assert (
+            "planning_start" in event_types
+        ), f"expected planning_start in logged events, got: {event_types}"
+
+    async def test_logs_planning_end_event(self) -> None:
+        """A ``planning_end`` event is logged when task creation completes.
+
+        The span from ``planning_start`` to ``planning_end`` is the
+        coordination overhead visible in Cato swim lanes.
+        """
+        creator = _make_creator()
+        tasks = [_make_task("task-1", "Build Widget")]
+
+        with _patch_heavy_deps(creator, tasks):
+            with patch("src.integrations.nlp_tools.log_agent_event") as mock_log:
+                await creator.create_project_from_description(
+                    "Build a widget", "TestProject"
+                )
+
+        event_types = [c.args[0] for c in mock_log.call_args_list]
+        assert (
+            "planning_end" in event_types
+        ), f"expected planning_end in logged events, got: {event_types}"
+
+    async def test_planning_start_logged_before_planning_end(self) -> None:
+        """``planning_start`` must be logged before ``planning_end``.
+
+        Order matters: Cato computes duration as end − start.
+        """
+        creator = _make_creator()
+        tasks = [_make_task("task-1", "Build Widget")]
+        log_order: list[str] = []
+
+        def _capture(event_type: str, _data: Any) -> None:
+            if event_type in ("planning_start", "planning_end"):
+                log_order.append(event_type)
+
+        with _patch_heavy_deps(creator, tasks):
+            with patch(
+                "src.integrations.nlp_tools.log_agent_event",
+                side_effect=_capture,
+            ):
+                await creator.create_project_from_description(
+                    "Build a widget", "TestProject"
+                )
+
+        assert "planning_start" in log_order, "planning_start not logged"
+        assert "planning_end" in log_order, "planning_end not logged"
+        assert log_order.index("planning_start") < log_order.index(
+            "planning_end"
+        ), f"planning_start must precede planning_end, got order: {log_order}"
+
+    async def test_planning_start_event_includes_project_name(self) -> None:
+        """``planning_start`` payload contains the project name for Cato filtering."""
+        creator = _make_creator()
+        tasks = [_make_task("task-1", "Build Widget")]
+        captured: list[dict[str, Any]] = []
+
+        def _capture(event_type: str, data: Any) -> None:
+            if event_type == "planning_start":
+                captured.append(data)
+
+        with _patch_heavy_deps(creator, tasks):
+            with patch(
+                "src.integrations.nlp_tools.log_agent_event",
+                side_effect=_capture,
+            ):
+                await creator.create_project_from_description(
+                    "Build a widget", "TestProject"
+                )
+
+        assert len(captured) == 1, "exactly one planning_start event expected"
+        assert (
+            captured[0].get("project_name") == "TestProject"
+        ), f"planning_start payload must include project_name, got: {captured[0]}"
+
+    async def test_planning_end_event_includes_task_count(self) -> None:
+        """``planning_end`` payload contains the number of tasks created.
+
+        Cato can use this to display a summary annotation on the planning bar.
+        """
+        creator = _make_creator()
+        tasks = [_make_task(f"task-{i}", f"Task {i}") for i in range(3)]
+        # Capture expected count before the call: the list is mutated
+        # when the About task is appended to created_tasks.
+        expected_min_count = len(tasks)
+        captured: list[dict[str, Any]] = []
+
+        def _capture(event_type: str, data: Any) -> None:
+            if event_type == "planning_end":
+                captured.append(data)
+
+        with _patch_heavy_deps(creator, tasks):
+            with patch(
+                "src.integrations.nlp_tools.log_agent_event",
+                side_effect=_capture,
+            ):
+                await creator.create_project_from_description(
+                    "Build a multi-widget dashboard", "TestProject"
+                )
+
+        assert len(captured) == 1, "exactly one planning_end event expected"
+        assert (
+            "task_count" in captured[0]
+        ), f"planning_end payload must include task_count, got: {captured[0]}"
+        # planning_end fires right after create_tasks_on_board; task_count
+        # reflects work tasks only (About task is added after).
+        assert captured[0]["task_count"] >= expected_min_count, (
+            f"task_count {captured[0]['task_count']} must be "
+            f">= {expected_min_count}"
+        )

--- a/tests/unit/integrations/test_shared_foundation_synthesis.py
+++ b/tests/unit/integrations/test_shared_foundation_synthesis.py
@@ -1,0 +1,456 @@
+"""
+Unit tests for pre-fork shared foundation synthesis (GH-355).
+
+Verifies that ``_synthesize_shared_foundation()`` on
+``NaturalLanguageProjectCreator``:
+
+- Returns an empty list when the LLM detects no shared foundation needs
+  (conservative, no-op path).
+- Returns a list of Task objects when the LLM detects foundation needs.
+- Returns an empty list on LLM failure or JSON parse failure
+  (never crashes the pipeline).
+- Includes domain contract context in the prompt when domains are provided.
+- Produces Task objects with correct fields (status TODO, priority HIGH,
+  labels contain "foundation" and "pre-fork").
+- Feature-based path: foundation tasks are prepended and domain tasks
+  depend on them.
+- Contract-first path: foundation tasks are prepended and domain tasks
+  depend on them.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from typing import Any, Dict, List
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
+
+import pytest
+
+from src.core.models import Priority, Task, TaskStatus
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_creator() -> Any:
+    """Build a ``NaturalLanguageProjectCreator`` with all dependencies mocked.
+
+    Returns
+    -------
+    Any
+        A ``NaturalLanguageProjectCreator`` instance whose ``prd_parser``,
+        ``kanban_client``, and ``ai_engine`` are all mocked, so no real
+        I/O happens.
+    """
+    from src.integrations.nlp_tools import NaturalLanguageProjectCreator
+
+    mock_kanban = MagicMock()
+    mock_ai_engine = MagicMock()
+
+    creator = NaturalLanguageProjectCreator(
+        kanban_client=mock_kanban,
+        ai_engine=mock_ai_engine,
+    )
+
+    # Replace the real LLM client on prd_parser with a mock
+    mock_llm = MagicMock()
+    mock_llm.analyze = AsyncMock()
+    creator.prd_parser.llm_client = mock_llm
+
+    return creator
+
+
+def _make_task(task_id: str, name: str) -> Task:
+    """Build a minimal Task for dependency-wiring tests.
+
+    Parameters
+    ----------
+    task_id : str
+        Task identifier.
+    name : str
+        Task name.
+
+    Returns
+    -------
+    Task
+        Minimal Task with empty dependencies list.
+    """
+    now = datetime.now(timezone.utc)
+    return Task(
+        id=task_id,
+        name=name,
+        description="Do the thing",
+        status=TaskStatus.TODO,
+        priority=Priority.MEDIUM,
+        assigned_to=None,
+        created_at=now,
+        updated_at=now,
+        due_date=None,
+        estimated_hours=4.0,
+        dependencies=[],
+    )
+
+
+# ---------------------------------------------------------------------------
+# _synthesize_shared_foundation — unit tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+class TestSynthesizeSharedFoundation:
+    """Tests for ``NaturalLanguageProjectCreator._synthesize_shared_foundation``."""
+
+    async def test_returns_empty_list_when_llm_says_no_shared_needs(self) -> None:
+        """When LLM returns no foundation tasks, result is an empty list.
+
+        This is the conservative no-op path: the caller's task list is
+        unchanged and no pre-fork tasks are injected.
+        """
+        creator = _make_creator()
+        creator.prd_parser.llm_client.analyze.return_value = json.dumps(
+            {"foundation_tasks": []}
+        )
+
+        result = await creator._synthesize_shared_foundation(
+            "Build a simple weather dashboard."
+        )
+
+        assert result == []
+
+    async def test_returns_tasks_when_shared_needs_detected(self) -> None:
+        """When LLM identifies shared foundation needs, Task objects are returned.
+
+        Three targets are supported: design system, shared components, and
+        tech foundation.  The LLM may return any subset.
+        """
+        creator = _make_creator()
+        creator.prd_parser.llm_client.analyze.return_value = json.dumps(
+            {
+                "foundation_tasks": [
+                    {
+                        "name": "Shared Foundation: Design System",
+                        "description": "Create shared color tokens and typography.",
+                        "estimated_hours": 2.0,
+                    },
+                    {
+                        "name": "Shared Foundation: Shared Components",
+                        "description": "Build Card and Button components.",
+                        "estimated_hours": 3.0,
+                    },
+                ]
+            }
+        )
+
+        result = await creator._synthesize_shared_foundation(
+            "Build a multi-widget dashboard with clock and weather panels."
+        )
+
+        assert len(result) == 2
+        assert all(isinstance(t, Task) for t in result)
+        names = {t.name for t in result}
+        assert "Shared Foundation: Design System" in names
+        assert "Shared Foundation: Shared Components" in names
+
+    async def test_is_conservative_on_llm_failure(self) -> None:
+        """When the LLM call raises, the method returns [] instead of crashing.
+
+        The pre-fork synthesis is a best-effort enhancement. A failure must
+        not prevent project creation.
+        """
+        creator = _make_creator()
+        creator.prd_parser.llm_client.analyze.side_effect = RuntimeError(
+            "LLM unavailable"
+        )
+
+        result = await creator._synthesize_shared_foundation(
+            "Build a weather dashboard."
+        )
+
+        assert result == []
+
+    async def test_is_conservative_on_invalid_json(self) -> None:
+        """When the LLM returns unparseable JSON, the method returns [].
+
+        Malformed LLM output is common — never crash the pipeline.
+        """
+        creator = _make_creator()
+        creator.prd_parser.llm_client.analyze.return_value = (
+            "Sorry, I cannot help with that."
+        )
+
+        result = await creator._synthesize_shared_foundation(
+            "Build a weather dashboard."
+        )
+
+        assert result == []
+
+    async def test_is_conservative_on_missing_foundation_tasks_key(self) -> None:
+        """When the LLM returns JSON without ``foundation_tasks`` key, return [].
+
+        Unexpected but valid JSON should degrade gracefully.
+        """
+        creator = _make_creator()
+        creator.prd_parser.llm_client.analyze.return_value = json.dumps(
+            {"tasks": []}  # wrong key
+        )
+
+        result = await creator._synthesize_shared_foundation(
+            "Build a weather dashboard."
+        )
+
+        assert result == []
+
+    async def test_foundation_tasks_have_correct_structure(self) -> None:
+        """Each returned Task has the expected fields set for a pre-fork task.
+
+        - status: TODO (not yet started)
+        - priority: HIGH (blocking downstream domain tasks)
+        - labels: contains "foundation" and "pre-fork"
+        - assigned_to: None (self-assigned by whichever agent picks it first)
+        - estimated_hours: matches LLM value
+        """
+        creator = _make_creator()
+        creator.prd_parser.llm_client.analyze.return_value = json.dumps(
+            {
+                "foundation_tasks": [
+                    {
+                        "name": "Shared Foundation: Design System",
+                        "description": "Create shared tokens.",
+                        "estimated_hours": 2.5,
+                    }
+                ]
+            }
+        )
+
+        result = await creator._synthesize_shared_foundation("Build a dashboard.")
+
+        assert len(result) == 1
+        task = result[0]
+        assert task.status == TaskStatus.TODO
+        assert task.priority == Priority.HIGH
+        assert task.assigned_to is None
+        # Foundation tasks are real implementation work — not design ghosts.
+        # Only "pre-fork" tag used; source_type is the internal marker.
+        assert "pre-fork" in task.labels
+        assert "design" not in task.labels
+        assert task.estimated_hours == 2.5
+        # Description contains the original text plus the workflow reminder.
+        assert "Create shared tokens" in task.description
+        assert "log_artifact" in task.description
+        # ID must be a non-empty string
+        assert isinstance(task.id, str) and len(task.id) > 0
+
+    async def test_domain_context_included_in_prompt_when_provided(self) -> None:
+        """When domains are provided, the LLM prompt includes domain contract text.
+
+        Contract-first synthesis has higher fidelity than feature-based because
+        domain contracts are available.  This test checks that the prompt the
+        LLM actually receives contains the domain name.
+        """
+        creator = _make_creator()
+        creator.prd_parser.llm_client.analyze.return_value = json.dumps(
+            {"foundation_tasks": []}
+        )
+
+        domains: Dict[str, Any] = {
+            "WeatherDomain": {
+                "artifacts": [
+                    {"content": "interface WeatherService { getTemp(): number }"}
+                ]
+            }
+        }
+
+        await creator._synthesize_shared_foundation(
+            "Build a dashboard.", domains=domains
+        )
+
+        # Verify the LLM was called with a prompt that mentions the domain
+        call_args = creator.prd_parser.llm_client.analyze.call_args
+        prompt_text: str = call_args.kwargs.get("prompt") or call_args.args[0]
+        assert "WeatherDomain" in prompt_text
+
+    async def test_prompt_omits_domain_section_when_no_domains(self) -> None:
+        """When no domains are given (feature_based path), the prompt still works.
+
+        The feature_based path runs on PRD text only (lower fidelity) so the
+        prompt should not contain a domain-contract section.
+        """
+        creator = _make_creator()
+        creator.prd_parser.llm_client.analyze.return_value = json.dumps(
+            {"foundation_tasks": []}
+        )
+
+        await creator._synthesize_shared_foundation(
+            "Build a weather dashboard.", domains=None
+        )
+
+        call_args = creator.prd_parser.llm_client.analyze.call_args
+        prompt_text: str = call_args.kwargs.get("prompt") or call_args.args[0]
+        # Prompt must still contain the PRD description
+        assert "weather dashboard" in prompt_text.lower()
+
+    async def test_foundation_task_missing_estimated_hours_uses_default(self) -> None:
+        """If LLM omits ``estimated_hours``, a sensible default is used.
+
+        Defensive handling for partial LLM responses.
+        """
+        creator = _make_creator()
+        creator.prd_parser.llm_client.analyze.return_value = json.dumps(
+            {
+                "foundation_tasks": [
+                    {
+                        "name": "Shared Foundation: Tech Setup",
+                        "description": "Configure Vite + TypeScript.",
+                        # no estimated_hours key
+                    }
+                ]
+            }
+        )
+
+        result = await creator._synthesize_shared_foundation("Build a dashboard.")
+
+        assert len(result) == 1
+        assert result[0].estimated_hours > 0  # some positive default
+
+
+# ---------------------------------------------------------------------------
+# Feature-based wiring tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+class TestFeatureBasedFoundationWiring:
+    """Foundation tasks are prepended and domain tasks depend on them.
+
+    These tests patch ``_synthesize_shared_foundation`` and
+    ``parse_prd_to_tasks`` so we can verify only the wiring logic in
+    ``process_natural_language`` without running real LLM calls.
+    """
+
+    async def test_foundation_tasks_prepended_before_domain_tasks(self) -> None:
+        """When synthesis returns tasks, they appear first in the task list."""
+        from src.integrations.nlp_tools import NaturalLanguageProjectCreator
+
+        creator = _make_creator()
+
+        now = datetime.now(timezone.utc)
+        foundation_task = _make_task("foundation-1", "Shared Foundation: Design System")
+        foundation_task.labels = ["foundation", "pre-fork"]
+
+        domain_task_a = _make_task("domain-a", "Build WeatherWidget")
+        domain_task_b = _make_task("domain-b", "Build ClockWidget")
+
+        # Stub synthesis
+        async def fake_synthesis(description: str, domains: Any = None) -> List[Task]:
+            return [foundation_task]
+
+        # Stub prd_parser.parse_prd_to_tasks
+        from src.ai.advanced.prd.advanced_parser import TaskGenerationResult
+
+        mock_result = Mock(spec=TaskGenerationResult)
+        mock_result.tasks = [domain_task_a, domain_task_b]
+        mock_result.dependencies = []
+
+        creator._synthesize_shared_foundation = fake_synthesis  # type: ignore[method-assign]
+        creator.prd_parser.parse_prd_to_tasks = AsyncMock(return_value=mock_result)
+
+        # Stub board_analyzer and context_detector to avoid real I/O
+        creator.board_analyzer.analyze_board = AsyncMock()
+        from unittest.mock import MagicMock
+
+        mock_ctx = MagicMock()
+        from src.detection.context_detector import MarcusMode
+
+        mock_ctx.recommended_mode = MarcusMode.CREATOR
+        creator.context_detector.detect_optimal_mode = AsyncMock(return_value=mock_ctx)
+
+        tasks = await creator.process_natural_language(
+            "Build a dashboard", project_name="Test"
+        )
+
+        assert tasks[0].id == "foundation-1"
+        assert tasks[1].id == "domain-a"
+        assert tasks[2].id == "domain-b"
+
+    async def test_domain_tasks_depend_on_foundation_tasks(self) -> None:
+        """When foundation tasks exist, all domain tasks list them as dependencies."""
+        from src.integrations.nlp_tools import NaturalLanguageProjectCreator
+
+        creator = _make_creator()
+
+        foundation_task = _make_task("foundation-1", "Shared Foundation: Design System")
+        foundation_task.labels = ["foundation", "pre-fork"]
+
+        domain_task_a = _make_task("domain-a", "Build WeatherWidget")
+        domain_task_b = _make_task("domain-b", "Build ClockWidget")
+
+        async def fake_synthesis(description: str, domains: Any = None) -> List[Task]:
+            return [foundation_task]
+
+        from src.ai.advanced.prd.advanced_parser import TaskGenerationResult
+
+        mock_result = Mock(spec=TaskGenerationResult)
+        mock_result.tasks = [domain_task_a, domain_task_b]
+        mock_result.dependencies = []
+
+        creator._synthesize_shared_foundation = fake_synthesis  # type: ignore[method-assign]
+        creator.prd_parser.parse_prd_to_tasks = AsyncMock(return_value=mock_result)
+
+        creator.board_analyzer.analyze_board = AsyncMock()
+        mock_ctx = MagicMock()
+        from src.detection.context_detector import MarcusMode
+
+        mock_ctx.recommended_mode = MarcusMode.CREATOR
+        creator.context_detector.detect_optimal_mode = AsyncMock(return_value=mock_ctx)
+
+        tasks = await creator.process_natural_language(
+            "Build a dashboard", project_name="Test"
+        )
+
+        # domain tasks must have foundation-1 as a dependency
+        domain_tasks = [t for t in tasks if t.id != "foundation-1"]
+        for dt in domain_tasks:
+            assert (
+                "foundation-1" in dt.dependencies
+            ), f"Task '{dt.name}' missing dependency on foundation-1"
+
+    async def test_no_foundation_tasks_leaves_domain_tasks_unchanged(self) -> None:
+        """When synthesis returns [], domain tasks have no injected dependencies."""
+        from src.integrations.nlp_tools import NaturalLanguageProjectCreator
+
+        creator = _make_creator()
+
+        domain_task_a = _make_task("domain-a", "Build WeatherWidget")
+        domain_task_b = _make_task("domain-b", "Build ClockWidget")
+
+        async def fake_synthesis(description: str, domains: Any = None) -> List[Task]:
+            return []
+
+        from src.ai.advanced.prd.advanced_parser import TaskGenerationResult
+
+        mock_result = Mock(spec=TaskGenerationResult)
+        mock_result.tasks = [domain_task_a, domain_task_b]
+        mock_result.dependencies = []
+
+        creator._synthesize_shared_foundation = fake_synthesis  # type: ignore[method-assign]
+        creator.prd_parser.parse_prd_to_tasks = AsyncMock(return_value=mock_result)
+
+        creator.board_analyzer.analyze_board = AsyncMock()
+        mock_ctx = MagicMock()
+        from src.detection.context_detector import MarcusMode
+
+        mock_ctx.recommended_mode = MarcusMode.CREATOR
+        creator.context_detector.detect_optimal_mode = AsyncMock(return_value=mock_ctx)
+
+        tasks = await creator.process_natural_language(
+            "Build a dashboard", project_name="Test"
+        )
+
+        # No foundation injected — task list unchanged, dependencies empty
+        assert len(tasks) == 2
+        for t in tasks:
+            assert t.dependencies == []


### PR DESCRIPTION
## Summary

- **Pre-fork synthesis** (`_synthesize_shared_foundation`): LLM call before any agent begins work, producing foundation tasks with `source_type="pre_fork_synthesis"` and `["pre-fork"]` label. Includes `_WORKFLOW_REMINDER` so consuming agents know to call `log_artifact` with their output.
- **Planning phase observability** for Cato swim lanes: `planning_start`/`planning_end` logged to JSONL (debugging) and persisted to SQLite `task_metadata` + `task_outcomes` with `agent_id="Marcus"`. Cato will render a "Marcus Planning" bar on the timeline showing coordination overhead before agent work begins.
- **`_inject_usage_guidance` (Option D, GH-355)**: Detects `source_type == "pre_fork_synthesis"` dependencies in `context.py` and delivers `_FOUNDATION_USAGE_GUIDANCE` via the artifact system (not task description), consistent with how coordination/implementation artifacts are delivered.
- **Broader integration task doc-code verification**: Checklist now covers CLI commands, library functions, pipeline stages, and web services — not just API endpoints. Configuration section checks env var usage patterns across languages.

## Issues

Closes #355 (pre-fork synthesis)
References #357 (planning observability)
References #379 (foundation task availability — filed, not yet implemented)

## Test plan

- [ ] `pytest -m unit tests/unit/integrations/test_shared_foundation_synthesis.py` — 12 new tests for `_synthesize_shared_foundation`
- [ ] `pytest -m unit tests/unit/integrations/test_planning_observability.py` — 5 new tests for planning_start/planning_end events
- [ ] `pytest -m unit tests/unit/integrations/test_integration_verification.py` — updated doc-code verification assertions (general, not API-specific)
- [ ] `pytest -m unit` — full unit suite (651 tests, all green)
- [ ] Run v80 experiment: Cato swim lanes should show a "Marcus Planning" bar before agent task bars

🤖 Generated with [Claude Code](https://claude.com/claude-code)