### PR TITLE
fix: 0.3.4.post2 — scope git guard to artifact roots; hard-reject smoke gate on missing workspace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable changes to Marcus will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.4.post2] - 2026-04-17
+
+**Patch release — Codex P2 guardrail scope fixes.**
+
+### Fixed
+- **`log_artifact` guard too broad (P2-1)** — the git-tracked-file guard
+  introduced in `0.3.4.post1` blocked *all* tracked files, including legitimate
+  artifact outputs under `docs/` and `tmp/` that were committed in a previous
+  run. Iterative artifact refreshes must be allowed. Guard is now scoped to
+  paths whose first component is NOT in `{"docs", "tmp"}` — files under those
+  artifact output roots skip the check entirely. Source roots (`src/`, `lib/`,
+  etc.) are still protected.
+- **Smoke gate fail-open on missing workspace state (P2-2)** — `_run_product_smoke_gate`
+  previously returned `None` (the "verification passed" sentinel) in three
+  infrastructure-failure paths: workspace state load error, `project_root` absent
+  from state, and `project_root` not a directory on disk. Integration tasks could
+  therefore slip through unverified on misconfigured environments. All three paths
+  now return a `smoke_gate_unavailable` rejection dict so the gate is always a
+  hard stop when it cannot initialise.
+
 ## [0.3.4.post1] - 2026-04-17
 
 **Patch release — dashboard-v82 post-mortem fixes.**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "marcus-ai"
-version = "0.3.4.post1"
+version = "0.3.4.post2"
 description = "Multi-Agent Resource Coordination and Understanding System"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/marcus_mcp/tools/attachment.py
+++ b/src/marcus_mcp/tools/attachment.py
@@ -149,6 +149,29 @@ async def log_artifact(
         # Create full path using project_root instead of Path.cwd()
         full_path = project_root_path / artifact_path
 
+        # Normalise away any ".." traversal segments so the artifact-root
+        # bypass check cannot be subverted via paths like
+        # "docs/../src/theme.css".  strict=False because the target file
+        # may not exist yet.
+        try:
+            _resolved_root = project_root_path.resolve()
+            _resolved_full = full_path.resolve()
+            _normalized_relative = _resolved_full.relative_to(_resolved_root)
+        except ValueError:
+            # Path resolves outside project root — reject unconditionally.
+            return {
+                "success": False,
+                "error": (
+                    f"Location resolves outside project root: {artifact_path}. "
+                    "Use a path that stays within the project directory."
+                ),
+                "data": {"task_id": task_id, "filename": filename},
+            }
+        # Use the canonicalised paths for all downstream operations so
+        # that filesystem writes and the git check target the same file.
+        artifact_path = _normalized_relative
+        full_path = _resolved_full
+
         # Guard: refuse to overwrite git-tracked source files.
         # log_artifact's contract is to persist artifacts (docs, reports,
         # design outputs) — not to overwrite source code managed by git.
@@ -163,6 +186,8 @@ async def log_artifact(
         # be tracked — a previous run committed them — and iterative
         # artifact refreshes must be allowed. Paths under src/, lib/, or
         # any other root are not artifact outputs and are guarded.
+        # NOTE: artifact_path is already normalised above — parts[0] reflects
+        # the true root even when the caller supplied ".." segments.
         _artifact_output_roots = {"docs", "tmp"}
         _in_artifact_dir = (
             len(artifact_path.parts) > 0

--- a/src/marcus_mcp/tools/attachment.py
+++ b/src/marcus_mcp/tools/attachment.py
@@ -157,31 +157,45 @@ async def log_artifact(
         # (commit d44dd5a). ``git ls-files --error-unmatch`` exits 0 only
         # when the path is tracked; non-zero means untracked or outside
         # the repo — both safe to write.
-        try:
-            git_result = subprocess.run(
-                [
-                    "git",
-                    "-C",
-                    str(project_root_path),
-                    "ls-files",
-                    "--error-unmatch",
-                    str(full_path),
-                ],
-                capture_output=True,
-            )
-            if git_result.returncode == 0:
-                return {
-                    "success": False,
-                    "error": (
-                        f"Refusing to overwrite git-tracked file: {artifact_path}. "
-                        "log_artifact is for documentation artifacts, not source "
-                        "files. Use a docs/ or tmp/ path for this artifact."
-                    ),
-                    "data": {"task_id": task_id, "filename": filename},
-                }
-        except FileNotFoundError:
-            # git not available in this environment — skip the guard.
-            logger.debug("git not found; skipping tracked-file guard for %s", full_path)
+        #
+        # Scope: only enforce for paths outside the known artifact output
+        # roots (docs/ and tmp/). Files under those roots may legitimately
+        # be tracked — a previous run committed them — and iterative
+        # artifact refreshes must be allowed. Paths under src/, lib/, or
+        # any other root are not artifact outputs and are guarded.
+        _artifact_output_roots = {"docs", "tmp"}
+        _in_artifact_dir = (
+            len(artifact_path.parts) > 0
+            and artifact_path.parts[0] in _artifact_output_roots
+        )
+        if not _in_artifact_dir:
+            try:
+                git_result = subprocess.run(
+                    [
+                        "git",
+                        "-C",
+                        str(project_root_path),
+                        "ls-files",
+                        "--error-unmatch",
+                        str(full_path),
+                    ],
+                    capture_output=True,
+                )
+                if git_result.returncode == 0:
+                    return {
+                        "success": False,
+                        "error": (
+                            f"Refusing to overwrite git-tracked file: {artifact_path}. "
+                            "log_artifact is for documentation artifacts, not source "
+                            "files. Use a docs/ or tmp/ path for this artifact."
+                        ),
+                        "data": {"task_id": task_id, "filename": filename},
+                    }
+            except FileNotFoundError:
+                # git not available in this environment — skip the guard.
+                logger.debug(
+                    "git not found; skipping tracked-file guard for %s", full_path
+                )
 
         # Ensure directory exists
         full_path.parent.mkdir(parents=True, exist_ok=True)

--- a/src/marcus_mcp/tools/task.py
+++ b/src/marcus_mcp/tools/task.py
@@ -283,6 +283,32 @@ async def _run_product_smoke_gate(
     # This is the same source of truth used by
     # ``_merge_agent_branch_to_main`` so the smoke gate sees the
     # same project root that the agent's git operations target.
+    # Helper: build a rejection dict for smoke-gate infrastructure failures.
+    # Integration tasks MUST be verifiable — "cannot run the gate" is a
+    # hard rejection, not a pass.  The caller's log-and-continue except
+    # clause is intentionally reserved for exceptions (programmer errors in
+    # the verification system), not for resolvable configuration failures
+    # such as a missing or misconfigured workspace state.
+    def _gate_unavailable(reason: str) -> Dict[str, Any]:
+        return {
+            "success": False,
+            "status": "smoke_verification_failed",
+            "error": "smoke_gate_unavailable",
+            "agent_id": agent_id,
+            "task_id": task.id,
+            "failure_summary": reason,
+            "blocker": (
+                f"Marcus could not run the product smoke gate: {reason}. "
+                "Ensure the experiment runner has written workspace state "
+                "with a valid project_root before the integration task runs."
+            ),
+            "message": (
+                f"Marcus rejected this integration-task completion because "
+                f"the smoke gate could not be initialised: {reason}. "
+                "Fix the workspace state and re-report completion."
+            ),
+        }
+
     project_root: Optional[str] = None
     if hasattr(state, "kanban_client") and state.kanban_client:
         try:
@@ -292,24 +318,24 @@ async def _run_product_smoke_gate(
         except Exception as ws_err:
             logger.warning(
                 f"PRODUCT SMOKE GATE: Failed to load workspace state "
-                f"for {task.id}: {ws_err}. Skipping smoke verification."
+                f"for {task.id}: {ws_err}. Rejecting completion."
             )
-            return None
+            return _gate_unavailable(f"workspace state load failed: {ws_err}")
 
     if not project_root:
         logger.warning(
             f"PRODUCT SMOKE GATE: No project_root resolved for "
-            f"{task.id}. Skipping smoke verification."
+            f"{task.id}. Rejecting completion."
         )
-        return None
+        return _gate_unavailable("project_root not found in workspace state")
 
     project_root_path = _Path(project_root)
     if not project_root_path.is_dir():
         logger.warning(
             f"PRODUCT SMOKE GATE: project_root {project_root!r} is "
-            f"not a directory. Skipping smoke verification for {task.id}."
+            f"not a directory. Rejecting completion for {task.id}."
         )
-        return None
+        return _gate_unavailable(f"project_root {project_root!r} is not a directory")
 
     logger.info(
         f"PRODUCT SMOKE GATE: Running deliverable verification for "

--- a/tests/unit/marcus_mcp/test_integration_smoke_gate.py
+++ b/tests/unit/marcus_mcp/test_integration_smoke_gate.py
@@ -311,8 +311,8 @@ class TestProductSmokeGate:
         assert call_kwargs["readiness_probe"] == "curl -f http://localhost:8000/health"
 
     @pytest.mark.asyncio
-    async def test_gate_skips_when_no_workspace_state(self) -> None:
-        """No project_root → gate skips with None, no crash."""
+    async def test_gate_rejects_when_no_workspace_state(self) -> None:
+        """No project_root → gate rejects completion (P2-2 fix: was None/pass)."""
         task = _make_integration_task()
         state = _make_state(task)
         state.kanban_client._load_workspace_state = Mock(return_value=None)
@@ -324,7 +324,12 @@ class TestProductSmokeGate:
             start_command="npm run build",
             readiness_probe=None,
         )
-        assert response is None
+        assert (
+            response is not None
+        ), "P2-2 fix: missing workspace state must be a hard rejection, not None"
+        assert response["success"] is False
+        assert response["error"] == "smoke_gate_unavailable"
+        assert "project_root not found" in response["failure_summary"]
 
 
 class TestReportTaskProgressIntegration:

--- a/tests/unit/mcp/test_log_artifact_guardrail.py
+++ b/tests/unit/mcp/test_log_artifact_guardrail.py
@@ -7,9 +7,10 @@ dashboard-v82 post-mortem: Agent 1 overwrote theme.css and design-tokens.json
 via log_artifact and had to restore from git (commit d44dd5a).
 
 Tests:
-- tracked file → rejected with clear error message
+- tracked source file (src/) → rejected
+- tracked artifact file (docs/, tmp/) → allowed (iterative refresh)
 - untracked file → write proceeds normally
-- git not available → write proceeds (fail-open so non-git projects work)
+- git not available on non-artifact path → write proceeds (fail-open)
 """
 
 import subprocess
@@ -134,10 +135,11 @@ class TestLogArtifactGitGuard:
         self, project_root: Path, state: _MockState
     ) -> None:
         """
-        Verify log_artifact proceeds when git is not installed.
+        Verify log_artifact proceeds when git is not installed (non-artifact path).
 
         The guard must be fail-open: non-git projects and CI environments
-        without git should not be blocked from writing artifacts.
+        without git should not be blocked from writing artifacts, even when
+        the target is outside the standard artifact directories.
         """
         with (
             patch(
@@ -155,10 +157,112 @@ class TestLogArtifactGitGuard:
                 content="# API",
                 artifact_type="api",
                 project_root=str(project_root),
+                # Use a non-artifact path so the guard actually runs
+                location="reports/api-spec.md",
                 state=state,
             )
 
         assert result["success"] is True
+
+    @pytest.mark.asyncio
+    async def test_allows_tracked_file_under_docs(
+        self, project_root: Path, state: _MockState
+    ) -> None:
+        """
+        Verify tracked files under docs/ are allowed (iterative artifact refresh).
+
+        Codex P2: the original guard blocked ALL tracked files, including
+        legitimate artifact files under docs/ committed in a previous run.
+        Iterative refreshes must succeed; the guard only protects source roots.
+        """
+        tracked_result = Mock(spec=subprocess.CompletedProcess)
+        tracked_result.returncode = 0  # would be "tracked" if git ran
+
+        with (
+            patch(
+                "src.marcus_mcp.tools.attachment.subprocess.run",
+                return_value=tracked_result,
+            ) as mock_git,
+            patch(
+                "src.marcus_mcp.tools.attachment._persist_artifact_to_history",
+                new_callable=AsyncMock,
+            ),
+        ):
+            result = await log_artifact(
+                task_id="task-5",
+                filename="design-spec.md",
+                content="# Updated Design",
+                artifact_type="design",
+                project_root=str(project_root),
+                # Default location → docs/design/design-spec.md
+                state=state,
+            )
+
+        assert result["success"] is True, "Tracked docs/ file must be refreshable"
+        # Guard must not have run git for a docs/ path
+        mock_git.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_allows_tracked_file_under_tmp(
+        self, project_root: Path, state: _MockState
+    ) -> None:
+        """
+        Verify tracked files under tmp/ are allowed (artifact output root).
+        """
+        tracked_result = Mock(spec=subprocess.CompletedProcess)
+        tracked_result.returncode = 0
+
+        with (
+            patch(
+                "src.marcus_mcp.tools.attachment.subprocess.run",
+                return_value=tracked_result,
+            ) as mock_git,
+            patch(
+                "src.marcus_mcp.tools.attachment._persist_artifact_to_history",
+                new_callable=AsyncMock,
+            ),
+        ):
+            result = await log_artifact(
+                task_id="task-6",
+                filename="scratch.json",
+                content="{}",
+                artifact_type="temporary",
+                project_root=str(project_root),
+                state=state,
+            )
+
+        assert result["success"] is True
+        mock_git.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_still_blocks_tracked_source_file(
+        self, project_root: Path, state: _MockState
+    ) -> None:
+        """
+        Verify the guard still blocks tracked files outside artifact roots.
+
+        A file under src/ is not an artifact output — if it's tracked, the
+        guard must reject the write regardless of the P2 scoping fix.
+        """
+        tracked_result = Mock(spec=subprocess.CompletedProcess)
+        tracked_result.returncode = 0
+
+        with patch(
+            "src.marcus_mcp.tools.attachment.subprocess.run",
+            return_value=tracked_result,
+        ):
+            result = await log_artifact(
+                task_id="task-7",
+                filename="theme.css",
+                content="body {}",
+                artifact_type="design",
+                project_root=str(project_root),
+                location="src/widgets/theme.css",
+                state=state,
+            )
+
+        assert result["success"] is False
+        assert "git-tracked" in result["error"]
 
     @pytest.mark.asyncio
     async def test_error_message_names_the_path(

--- a/tests/unit/mcp/test_log_artifact_guardrail.py
+++ b/tests/unit/mcp/test_log_artifact_guardrail.py
@@ -295,3 +295,68 @@ class TestLogArtifactGitGuard:
         assert (
             "design-tokens.json" in result["error"] or "src/styles" in result["error"]
         )
+
+    @pytest.mark.asyncio
+    async def test_rejects_path_traversal_bypassing_artifact_root(
+        self, project_root: Path, state: _MockState
+    ) -> None:
+        """
+        Verify that "docs/../src/theme.css" is treated as a src/ path, not docs/.
+
+        Codex P1: the artifact-root bypass checked artifact_path.parts[0] on
+        the raw string, so "docs/../src/theme.css" appeared to start with
+        "docs" and skipped the git guard — even though it resolves to
+        src/theme.css. After the fix, the path is normalised before the check.
+        A git-tracked file at the resolved src/ location must still be blocked.
+        """
+        tracked_result = Mock(spec=subprocess.CompletedProcess)
+        tracked_result.returncode = 0  # git says: tracked
+
+        with patch(
+            "src.marcus_mcp.tools.attachment.subprocess.run",
+            return_value=tracked_result,
+        ):
+            result = await log_artifact(
+                task_id="task-traversal",
+                filename="theme.css",
+                content="body {}",
+                artifact_type="design",
+                project_root=str(project_root),
+                # Traversal: looks like docs/ root but resolves to src/
+                location="docs/../src/widgets/theme.css",
+                state=state,
+            )
+
+        assert (
+            result["success"] is False
+        ), "Traversal via docs/../src/ must not bypass the git guard"
+        # Should be blocked by git guard (not by the path-escape check)
+        assert "git-tracked" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_rejects_path_escaping_project_root(
+        self, project_root: Path, state: _MockState
+    ) -> None:
+        """
+        Verify that a location resolving outside project_root is rejected.
+
+        A path like "../../etc/passwd" escapes the project root entirely.
+        The normalisation step must catch this and return an error before
+        any filesystem or git operations occur.
+        """
+        with patch(
+            "src.marcus_mcp.tools.attachment.subprocess.run",
+        ) as mock_git:
+            result = await log_artifact(
+                task_id="task-escape",
+                filename="passwd",
+                content="root:x:0:0",
+                artifact_type="design",
+                project_root=str(project_root),
+                location="../../etc/passwd",
+                state=state,
+            )
+
+        assert result["success"] is False
+        assert "outside project root" in result["error"]
+        mock_git.assert_not_called()

--- a/tests/unit/mcp/test_smoke_gate_unavailable.py
+++ b/tests/unit/mcp/test_smoke_gate_unavailable.py
@@ -1,0 +1,232 @@
+"""
+Unit tests for _run_product_smoke_gate infrastructure-failure rejections (P2-2 fix).
+
+Codex P2-2 post-mortem: _run_product_smoke_gate previously returned None
+(pass) in three error paths where the smoke gate could not be initialised:
+  1. workspace state load raised an exception
+  2. project_root not present in workspace state
+  3. project_root path is not a directory
+
+None is the "verification passed" sentinel; these cases should be hard
+rejections so that integration tasks cannot slip through on misconfigured
+environments.
+
+Tests:
+- workspace state load failure  → smoke_gate_unavailable rejection
+- project_root missing from state → smoke_gate_unavailable rejection
+- project_root not a directory   → smoke_gate_unavailable rejection
+- valid project_root + passing verify_deliverable → returns None (pass)
+"""
+
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+# ---------------------------------------------------------------------------
+# Import the private function under test.
+# We reach into the module to grab the private coroutine directly.
+# ---------------------------------------------------------------------------
+from src.marcus_mcp.tools.task import _run_product_smoke_gate  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Minimal stubs
+# ---------------------------------------------------------------------------
+
+
+def _make_task(task_id: str = "task-42") -> Any:
+    """Return a minimal Task-like stub."""
+    task = Mock()
+    task.id = task_id
+    return task
+
+
+def _make_state(ws_state: Any = None, ws_raises: Any = None) -> Any:
+    """Return a minimal state stub with a mock kanban_client.
+
+    Parameters
+    ----------
+    ws_state : Any
+        Dict returned by `_load_workspace_state()`, or None.
+    ws_raises : Any
+        If set, `_load_workspace_state()` raises this exception instead.
+    """
+    state = Mock()
+    kanban = Mock()
+    if ws_raises is not None:
+        kanban._load_workspace_state = Mock(side_effect=ws_raises)
+    else:
+        kanban._load_workspace_state = Mock(return_value=ws_state)
+    state.kanban_client = kanban
+    return state
+
+
+def _make_verify_result(success: bool) -> Any:
+    """Return a minimal VerifyResult-like stub."""
+    result = Mock()
+    result.success = success
+    result.steps = []
+    result.failure_summary = "command exited non-zero"
+    result.blocker_message = "Fix the command."
+    result.to_dict = Mock(return_value={})
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Tests: _gate_unavailable paths
+# ---------------------------------------------------------------------------
+
+
+class TestSmokeGateUnavailable:
+    """Tests for the P2-2 hard-rejection paths in _run_product_smoke_gate."""
+
+    @pytest.mark.asyncio
+    async def test_rejects_when_workspace_state_load_raises(self) -> None:
+        """
+        Verify a rejection dict is returned when workspace state load fails.
+
+        Previously this path returned None (pass). After the P2-2 fix it
+        must return a rejection with error='smoke_gate_unavailable'.
+        """
+        task = _make_task("task-ws-err")
+        state = _make_state(ws_raises=RuntimeError("db unavailable"))
+
+        result = await _run_product_smoke_gate(
+            task=task,
+            agent_id="agent-1",
+            state=state,
+            start_command="npm start",
+            readiness_probe=None,
+        )
+
+        assert result is not None, "Must not return None (pass) on ws load failure"
+        assert result["success"] is False
+        assert result["error"] == "smoke_gate_unavailable"
+        assert result["status"] == "smoke_verification_failed"
+        assert "workspace state load failed" in result["failure_summary"]
+        assert result["task_id"] == "task-ws-err"
+
+    @pytest.mark.asyncio
+    async def test_rejects_when_project_root_missing(self) -> None:
+        """
+        Verify a rejection dict is returned when project_root is absent.
+
+        workspace state loads successfully but contains no project_root key.
+        Previously returned None; now must reject.
+        """
+        task = _make_task("task-no-root")
+        state = _make_state(ws_state={"other_key": "value"})
+
+        result = await _run_product_smoke_gate(
+            task=task,
+            agent_id="agent-2",
+            state=state,
+            start_command="python -m app",
+            readiness_probe=None,
+        )
+
+        assert result is not None, "Must not return None when project_root absent"
+        assert result["success"] is False
+        assert result["error"] == "smoke_gate_unavailable"
+        assert "project_root not found" in result["failure_summary"]
+
+    @pytest.mark.asyncio
+    async def test_rejects_when_project_root_not_a_directory(
+        self, tmp_path: Path
+    ) -> None:
+        """
+        Verify a rejection dict is returned when project_root is not a directory.
+
+        project_root in workspace state points to a non-existent path.
+        Previously returned None; now must reject.
+        """
+        task = _make_task("task-bad-dir")
+        nonexistent = str(tmp_path / "does_not_exist")
+        state = _make_state(ws_state={"project_root": nonexistent})
+
+        result = await _run_product_smoke_gate(
+            task=task,
+            agent_id="agent-3",
+            state=state,
+            start_command="cargo run",
+            readiness_probe=None,
+        )
+
+        assert result is not None, "Must not return None when project_root not a dir"
+        assert result["success"] is False
+        assert result["error"] == "smoke_gate_unavailable"
+        assert "not a directory" in result["failure_summary"]
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_verification_passes(self, tmp_path: Path) -> None:
+        """
+        Verify the function returns None (pass sentinel) on successful verification.
+
+        This is the golden-path test: valid project_root + passing
+        verify_deliverable → None.
+        """
+        task = _make_task("task-ok")
+        state = _make_state(ws_state={"project_root": str(tmp_path)})
+        passing_result = _make_verify_result(success=True)
+
+        with patch(
+            "src.integrations.product_smoke.verify_deliverable",
+            new_callable=AsyncMock,
+            return_value=passing_result,
+        ):
+            result = await _run_product_smoke_gate(
+                task=task,
+                agent_id="agent-4",
+                state=state,
+                start_command="echo ok",
+                readiness_probe=None,
+            )
+
+        assert result is None, "Passing verification must return None"
+
+    @pytest.mark.asyncio
+    async def test_rejection_includes_task_and_agent_ids(self) -> None:
+        """
+        Verify task_id and agent_id appear in the rejection payload.
+
+        Agents need these fields to correlate the rejection with their work.
+        """
+        task = _make_task("task-id-check")
+        state = _make_state(ws_state={})  # no project_root
+
+        result = await _run_product_smoke_gate(
+            task=task,
+            agent_id="agent-id-check",
+            state=state,
+            start_command="yarn dev",
+            readiness_probe=None,
+        )
+
+        assert result is not None
+        assert result["task_id"] == "task-id-check"
+        assert result["agent_id"] == "agent-id-check"
+
+    @pytest.mark.asyncio
+    async def test_rejection_blocker_mentions_workspace_state(self) -> None:
+        """
+        Verify the blocker message guides the agent toward the root cause.
+
+        The message must mention 'workspace state' so the agent (or the
+        experiment runner) knows where to look.
+        """
+        task = _make_task("task-blocker-msg")
+        state = _make_state(ws_state=None)  # _load_workspace_state returns None
+
+        result = await _run_product_smoke_gate(
+            task=task,
+            agent_id="agent-5",
+            state=state,
+            start_command="make serve",
+            readiness_probe=None,
+        )
+
+        assert result is not None
+        assert "workspace state" in result["blocker"].lower()


### PR DESCRIPTION
## Summary

- **P2-1 (`attachment.py`)**: git-tracked-file guard introduced in 0.3.4.post1 was too broad — it blocked tracked files under `docs/` and `tmp/`, breaking iterative artifact refreshes (files committed in a previous run). Guard is now scoped to paths whose first component is NOT in `{"docs", "tmp"}`. Source paths (`src/`, `lib/`, etc.) remain fully guarded.
- **P2-2 (`task.py`)**: `_run_product_smoke_gate` returned `None` (the "passed" sentinel) in three infrastructure-failure paths — workspace state load error, `project_root` absent, `project_root` not a directory. All three now return a `smoke_gate_unavailable` rejection dict so integration tasks cannot silently bypass verification.
- Version bumped to `0.3.4.post2`; CHANGELOG updated.

## Test plan

- [ ] `pytest -m unit --no-cov` passes (706 passed, 1 skipped — confirmed locally)
- [ ] `test_log_artifact_guardrail.py` — 4 new P2-1 regression cases (tracked docs/ allowed, tracked tmp/ allowed, git not called for artifact roots, src/ still blocked)
- [ ] `test_smoke_gate_unavailable.py` — 6 new P2-2 tests (ws load failure → reject, project_root absent → reject, path not dir → reject, golden path → None, IDs in payload, blocker message)
- [ ] `test_integration_smoke_gate.py::test_gate_rejects_when_no_workspace_state` updated from `assert response is None` → assert rejection dict
- [ ] All pre-commit hooks pass (mypy, black, isort, flake8, bandit, detect-secrets)

🤖 Generated with [Claude Code](https://claude.com/claude-code)