### PR TITLE
fix(#388): project-scoped agent registration

### DIFF
--- a/src/marcus_mcp/handlers.py
+++ b/src/marcus_mcp/handlers.py
@@ -152,8 +152,16 @@ def get_tool_definitions(role: str = "agent") -> List[types.Tool]:
                         "description": "List of agent's skills",
                         "default": [],
                     },
+                    "project_id": {
+                        "type": "string",
+                        "description": (
+                            "Project this agent is working on (required). "
+                            "Scopes task assignment to prevent cross-experiment "
+                            "task theft (GH-388)."
+                        ),
+                    },
                 },
-                "required": ["agent_id", "name", "role"],
+                "required": ["agent_id", "name", "role", "project_id"],
             },
         ),
         types.Tool(
@@ -1076,6 +1084,7 @@ async def handle_tool_call(
                     role=role,
                     skills=arguments.get("skills", []),
                     state=state,
+                    project_id=arguments.get("project_id", ""),
                 )
 
         elif name == "get_agent_status":

--- a/src/marcus_mcp/tools/agent.py
+++ b/src/marcus_mcp/tools/agent.py
@@ -63,6 +63,18 @@ async def register_agent(
         )
 
         # Create worker status with correct field names
+        # Validate project_id before any state mutation (P2: keeps
+        # registration atomic — no ghost entries on rejected calls).
+        # Agents are ephemeral — one project, then terminated (GH-389).
+        if not project_id:
+            return {
+                "success": False,
+                "error": (
+                    "project_id is required. Agents are ephemeral and must "
+                    "register with the project they are working on."
+                ),
+            }
+
         status = WorkerStatus(
             worker_id=agent_id,
             name=name,
@@ -86,18 +98,7 @@ async def register_agent(
 
         state.agent_status[agent_id] = status
 
-        # Store project scope for this agent (GH-388: prevents cross-project
-        # task theft when multiple experiments run concurrently).
-        # Agents are ephemeral — one project, then terminated (GH-389).
-        # project_id is required; registration without one is rejected.
-        if not project_id:
-            return {
-                "success": False,
-                "error": (
-                    "project_id is required. Agents are ephemeral and must "
-                    "register with the project they are working on."
-                ),
-            }
+        # Store project scope (GH-388: prevents cross-project task theft).
         if not hasattr(state, "agent_project_map"):
             state.agent_project_map = {}
         state.agent_project_map[agent_id] = project_id


### PR DESCRIPTION
## Summary

- `register_agent` now requires `project_id`; missing → rejected with clear error message
- `agent_project_map: Dict[str, str]` added to server state; maps `agent_id → project_id`
- `_scope_tasks_to_project()` filters `request_next_task` candidates to the agent's registered project only; raises `ValueError` on empty `project_id` (fail loud — misconfiguration, not runtime condition)
- Legacy tasks with `task.project_id = None` pass through (backwards compat with pre-GH-388 board state)

## Why

Sequential experiments were cross-contaminating: agents from experiment N+1 were stealing tasks from experiment N because `kanban_client.project_id` is server-wide and gets overwritten on each `create_project` call. Agents are ephemeral — they should only ever see tasks from the project they registered for.

## Test plan

- [ ] `pytest -m unit tests/unit/marcus_mcp/test_project_scoped_registration.py` — 14 tests covering registration, scoping, and ValueError on misconfiguration
- [ ] Verified live against running Marcus server: agent without `project_id` rejected at registration, agent with valid `project_id` scoped correctly

## Notes

- GH-389 (agent termination at project completion) deferred — same-named agents across sequential experiments still overwrite the map entry on re-registration. Acceptable for now; runner uses unique session names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)