### PR TITLE
fix(#388): atomic registration + wire project_id through stdio handler

### DIFF
--- a/src/marcus_mcp/handlers.py
+++ b/src/marcus_mcp/handlers.py
@@ -152,8 +152,16 @@ def get_tool_definitions(role: str = "agent") -> List[types.Tool]:
                         "description": "List of agent's skills",
                         "default": [],
                     },
+                    "project_id": {
+                        "type": "string",
+                        "description": (
+                            "Project this agent is working on (required). "
+                            "Scopes task assignment to prevent cross-experiment "
+                            "task theft (GH-388)."
+                        ),
+                    },
                 },
-                "required": ["agent_id", "name", "role"],
+                "required": ["agent_id", "name", "role", "project_id"],
             },
         ),
         types.Tool(
@@ -1076,6 +1084,7 @@ async def handle_tool_call(
                     role=role,
                     skills=arguments.get("skills", []),
                     state=state,
+                    project_id=arguments.get("project_id", ""),
                 )
 
         elif name == "get_agent_status":

--- a/src/marcus_mcp/tools/agent.py
+++ b/src/marcus_mcp/tools/agent.py
@@ -63,6 +63,18 @@ async def register_agent(
         )
 
         # Create worker status with correct field names
+        # Validate project_id before any state mutation (P2: keeps
+        # registration atomic — no ghost entries on rejected calls).
+        # Agents are ephemeral — one project, then terminated (GH-389).
+        if not project_id:
+            return {
+                "success": False,
+                "error": (
+                    "project_id is required. Agents are ephemeral and must "
+                    "register with the project they are working on."
+                ),
+            }
+
         status = WorkerStatus(
             worker_id=agent_id,
             name=name,
@@ -86,18 +98,7 @@ async def register_agent(
 
         state.agent_status[agent_id] = status
 
-        # Store project scope for this agent (GH-388: prevents cross-project
-        # task theft when multiple experiments run concurrently).
-        # Agents are ephemeral — one project, then terminated (GH-389).
-        # project_id is required; registration without one is rejected.
-        if not project_id:
-            return {
-                "success": False,
-                "error": (
-                    "project_id is required. Agents are ephemeral and must "
-                    "register with the project they are working on."
-                ),
-            }
+        # Store project scope (GH-388: prevents cross-project task theft).
         if not hasattr(state, "agent_project_map"):
             state.agent_project_map = {}
         state.agent_project_map[agent_id] = project_id


### PR DESCRIPTION
## Summary

Follow-up to #390 addressing two Codex review findings.

**P2 — ghost state on rejected registration** (`agent.py`):
`state.agent_status[agent_id]` was written before the `project_id` guard, leaving a stale `WorkerStatus` entry in server state whenever registration was rejected. Moved the `project_id` validation to the top of the try block — registration is now atomic (nothing written on failure).

**P1 — stdio call path never forwarded project_id** (`handlers.py`):
The `register_agent` dispatch in the handlers extracted `agent_id/name/role/skills` but not `project_id`. Every registration via the stdio tool path returned `success=False`, silently blocking all non-runner agent startups. Fixed by:
- Extracting `project_id` from arguments and forwarding to `register_agent()`
- Declaring `project_id` in the tool's `inputSchema` properties
- Adding `project_id` to the schema's `required` list

## Test plan

- [ ] `pytest -m unit tests/unit/marcus_mcp/test_project_scoped_registration.py` — 14 tests, all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)