### PR TITLE
fix(#394): inject last_progress_message into recovery handoff note

### DIFF
--- a/src/core/assignment_lease.py
+++ b/src/core/assignment_lease.py
@@ -970,7 +970,22 @@ class AssignmentLeaseManager:
                     f"{lease.progress_percentage}%\n"
                     f"4. **Continue from where they left off** - "
                     f"don't restart from scratch\n\n"
-                    f"**Recovery Context:**\n"
+                    + (
+                        f"**Previous agent's last progress note:**\n"
+                        f"> {lease.last_progress_message}\n\n"
+                        f"Use this note to understand what was built and "
+                        f"what remains. Wire any completed components "
+                        f"into the entry point if they are not yet "
+                        f"reachable.\n\n"
+                        if lease.last_progress_message
+                        else f"**Previous agent left no progress notes.**\n"
+                        f"Check `git log {previous_branch}` and `git "
+                        f"diff main {previous_branch}` to discover what "
+                        f"was committed. Do NOT re-implement files that "
+                        f"already exist on the branch — read them "
+                        f"first.\n\n"
+                    )
+                    + f"**Recovery Context:**\n"
                     f"- Previous agent: {lease.agent_id}\n"
                     f"- Previous branch: {previous_branch}\n"
                     f"- Time they spent: "

--- a/src/core/assignment_lease.py
+++ b/src/core/assignment_lease.py
@@ -971,13 +971,16 @@ class AssignmentLeaseManager:
                     f"4. **Continue from where they left off** - "
                     f"don't restart from scratch\n\n"
                     + (
-                        f"**Previous agent's last progress note:**\n"
-                        f"> {lease.last_progress_message}\n\n"
-                        f"Use this note to understand what was built and "
-                        f"what remains. Wire any completed components "
-                        f"into the entry point if they are not yet "
-                        f"reachable.\n\n"
-                        if lease.last_progress_message
+                        "**Previous agent's last progress note:**\n"
+                        + "\n".join(
+                            f"> {line}"
+                            for line in lease.last_progress_message.strip().splitlines()
+                        )
+                        + "\n\nUse this note to understand what was built"
+                        " and what remains. Wire any completed components"
+                        " into the entry point if they are not yet"
+                        " reachable.\n\n"
+                        if lease.last_progress_message.strip()
                         else f"**Previous agent left no progress notes.**\n"
                         f"Check `git log {previous_branch}` and `git "
                         f"diff main {previous_branch}` to discover what "

--- a/tests/unit/core/test_assignment_lease.py
+++ b/tests/unit/core/test_assignment_lease.py
@@ -824,6 +824,67 @@ class TestRecoveryHandoffDualWrite:
             assert mock_task.recovery_info.time_spent_minutes > 0
 
     @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_recover_expired_lease_injects_progress_message(
+        self, lease_manager, mock_task
+    ):
+        """Test that last_progress_message is quoted in recovery instructions.
+
+        Verifies the production code path in recover_expired_lease() so a
+        regression in the string assembly would be caught here — not only
+        by the test_recovery_handoff.py tests which hardcode instructions.
+        Addresses Codex P2 from PR #395 review.
+        """
+        note = "Built NOAA solar algorithm.\nApp.tsx wiring still needed."
+        expired_lease = AssignmentLease(
+            task_id="task-123",
+            agent_id="agent-001",
+            assigned_at=datetime.now(timezone.utc) - timedelta(hours=2),
+            lease_expires=datetime.now(timezone.utc) - timedelta(hours=1),
+            last_renewed=datetime.now(timezone.utc) - timedelta(hours=2),
+            progress_percentage=50,
+            last_progress_message=note,
+        )
+
+        with patch.object(lease_manager, "_find_task", return_value=mock_task):
+            await lease_manager.recover_expired_lease(expired_lease)
+
+        instructions = mock_task.recovery_info.instructions
+        # Every line of the progress note must be blockquoted
+        assert "> Built NOAA solar algorithm." in instructions
+        assert "> App.tsx wiring still needed." in instructions
+        assert "last progress note" in instructions
+
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_recover_expired_lease_warns_when_no_progress_message(
+        self, lease_manager, mock_task
+    ):
+        """Test that empty last_progress_message produces the no-notes warning.
+
+        When an agent dies before its first progress report, the recovery note
+        must tell the recovering agent to inspect git diff rather than assuming
+        nothing was committed. Addresses Codex P2 from PR #395 review.
+        """
+        expired_lease = AssignmentLease(
+            task_id="task-123",
+            agent_id="agent-001",
+            assigned_at=datetime.now(timezone.utc) - timedelta(hours=2),
+            lease_expires=datetime.now(timezone.utc) - timedelta(hours=1),
+            last_renewed=datetime.now(timezone.utc) - timedelta(hours=2),
+            progress_percentage=0,
+            last_progress_message="",
+        )
+
+        with patch.object(lease_manager, "_find_task", return_value=mock_task):
+            await lease_manager.recover_expired_lease(expired_lease)
+
+        instructions = mock_task.recovery_info.instructions
+        assert "no progress notes" in instructions
+        assert "git diff main" in instructions
+        assert "Do NOT re-implement" in instructions
+
+    @pytest.mark.asyncio
     async def test_recover_expired_lease_dual_writes_to_kanban(
         self, lease_manager, mock_kanban_client, mock_task
     ):

--- a/tests/unit/mcp/test_recovery_handoff.py
+++ b/tests/unit/mcp/test_recovery_handoff.py
@@ -263,3 +263,94 @@ class TestRecoveryHandoffLayer:
         # Should still include recovery section (agent may have uncommitted work)
         assert "RECOVERY" in instructions
         assert "0%" in instructions
+
+    def test_recovery_includes_last_progress_note_when_present(self) -> None:
+        """Test that recovery instructions surface the dead agent's last note.
+
+        When the previous agent reported progress, that message must appear
+        in the handoff so the recovering agent knows what was built and what
+        still needs wiring — addressing the v91 scenario where Agent 2
+        re-derived work Agent 3 had already committed.
+        """
+        branch = "marcus/agent-3"
+        progress_note = (
+            "Built NOAA solar algorithm in sunriseSunset.ts. "
+            "SunriseSunsetTimes component ready. App.tsx wiring incomplete."
+        )
+        recovery = RecoveryInfo(
+            recovered_at=datetime.now(timezone.utc) - timedelta(minutes=5),
+            recovered_from_agent="agent-3",
+            previous_progress=75,
+            time_spent_minutes=30.0,
+            recovery_reason="lease_expired",
+            previous_agent_branch=branch,
+            instructions=(
+                f"⚠️ **RECOVERY ADDENDUM**\n\n"
+                f"```\ngit merge {branch} --no-edit\n```\n\n"
+                f"**Previous agent's last progress note:**\n"
+                f"> {progress_note}\n\n"
+                f"Use this note to understand what was built and "
+                f"what remains. Wire any completed components "
+                f"into the entry point if they are not yet reachable.\n\n"
+                f"**Recovery Context:**\n"
+                f"- Previous agent: agent-3\n"
+                f"- Previous branch: {branch}\n"
+            ),
+            recovery_expires_at=datetime.now(timezone.utc) + timedelta(hours=24),
+        )
+        task = _create_task(recovery_info=recovery)
+
+        instructions = build_tiered_instructions(
+            base_instructions="Base",
+            task=task,
+            context_data=None,
+            dependency_awareness=None,
+            predictions=None,
+        )
+
+        assert "last progress note" in instructions
+        assert "sunriseSunset.ts" in instructions
+        assert "App.tsx wiring incomplete" in instructions
+
+    def test_recovery_warns_when_no_progress_notes(self) -> None:
+        """Test that recovery instructions warn when dead agent left no notes.
+
+        When an agent dies before reporting any progress (e.g. v91 Agent 3
+        at 7 minutes), the handoff must tell the recovering agent to inspect
+        git diff rather than assuming nothing was done.
+        """
+        branch = "marcus/agent-3"
+        recovery = RecoveryInfo(
+            recovered_at=datetime.now(timezone.utc) - timedelta(minutes=5),
+            recovered_from_agent="agent-3",
+            previous_progress=0,
+            time_spent_minutes=7.0,
+            recovery_reason="lease_expired",
+            previous_agent_branch=branch,
+            instructions=(
+                f"⚠️ **RECOVERY ADDENDUM**\n\n"
+                f"```\ngit merge {branch} --no-edit\n```\n\n"
+                f"**Previous agent left no progress notes.**\n"
+                f"Check `git log {branch}` and `git "
+                f"diff main {branch}` to discover what "
+                f"was committed. Do NOT re-implement files that "
+                f"already exist on the branch — read them first.\n\n"
+                f"**Recovery Context:**\n"
+                f"- Previous agent: agent-3\n"
+                f"- Previous branch: {branch}\n"
+            ),
+            recovery_expires_at=datetime.now(timezone.utc) + timedelta(hours=24),
+        )
+        task = _create_task(recovery_info=recovery)
+
+        instructions = build_tiered_instructions(
+            base_instructions="Base",
+            task=task,
+            context_data=None,
+            dependency_awareness=None,
+            predictions=None,
+        )
+
+        assert "no progress notes" in instructions
+        assert "git diff main" in instructions
+        assert "Do NOT re-implement" in instructions


### PR DESCRIPTION
## Summary

- When a recovered task's dead agent left progress notes, they are now quoted verbatim in the handoff under "Previous agent's last progress note:" with an instruction to wire completed components into the entry point
- When the dead agent left no notes (e.g. v91 Agent 3, died at 7 min before first report), the handoff now warns explicitly and instructs `git diff main <branch>` before re-implementing anything

## Root cause (v91)

Agent 2 recovered Agent 3's Sunrise/Sunset task. It correctly ran `git merge marcus/agent_unicorn_3` and got the NOAA solar algorithm — but the old recovery note only said "previous agent reached 0%". Nothing indicated what was on the branch. Agent 2 took the simpler path (API data) and the NOAA code became dead code.

The fix: `last_progress_message` from `AssignmentLease` (line 78) was never injected into `RecoveryInfo.instructions`. Now it is.

## Test plan

- [x] `test_recovery_includes_last_progress_note_when_present` — progress note appears in instructions verbatim
- [x] `test_recovery_warns_when_no_progress_notes` — "no progress notes" warning + `git diff main` instruction present
- [x] All 10 recovery handoff tests pass
- [x] 796 unit tests passing

Closes #394

🤖 Generated with [Claude Code](https://claude.com/claude-code)