### PR TITLE
feat(#389): auto-terminate agents when experiment completes

### DIFF
--- a/dev-tools/experiments/runners/run_experiment.py
+++ b/dev-tools/experiments/runners/run_experiment.py
@@ -237,6 +237,18 @@ Examples:
         help="Validate experiment configuration without running",
     )
 
+    parser.add_argument(
+        "--epictetus",
+        action="store_true",
+        default=False,
+        help=(
+            "Keep the tmux session alive after the experiment ends. "
+            "Use when running Epictetus post-experiment interrogation so "
+            "the tool can query agents after the project is complete. "
+            "Default: session is killed once all agents exit."
+        ),
+    )
+
     args = parser.parse_args()
 
     experiment_dir = Path(args.experiment_dir).resolve()
@@ -286,7 +298,7 @@ Examples:
 
     config_file = experiment_dir / "config.yaml"
     config = ExperimentConfig(config_file)
-    spawner = AgentSpawner(config, templates_dir)
+    spawner = AgentSpawner(config, templates_dir, epictetus=args.epictetus)
 
     success = spawner.run()
     sys.exit(0 if success else 1)

--- a/dev-tools/experiments/runners/spawn_agents.py
+++ b/dev-tools/experiments/runners/spawn_agents.py
@@ -292,7 +292,12 @@ class ExperimentConfig:
 class AgentSpawner:
     """Spawns and manages autonomous agents for an experiment."""
 
-    def __init__(self, config: ExperimentConfig, templates_dir: Path):
+    def __init__(
+        self,
+        config: ExperimentConfig,
+        templates_dir: Path,
+        epictetus: bool = False,
+    ):
         """
         Initialize the agent spawner.
 
@@ -302,9 +307,14 @@ class AgentSpawner:
             Experiment configuration
         templates_dir : Path
             Path to templates directory (in marcus repo)
+        epictetus : bool, optional
+            When True, suppresses tmux session kill on experiment completion
+            so that the Epictetus post-experiment interrogation tool can
+            query agents after the project is done.  Default: False (kill).
         """
         self.config = config
         self.templates_dir = templates_dir
+        self.epictetus = epictetus
         self.agent_prompt_template = templates_dir / "agent_prompt.md"
         self.processes: List[subprocess.Popen[bytes]] = []
         self.tmux_session = (
@@ -564,6 +574,40 @@ START NOW!
 """
         return worker_prompt
 
+    def _monitor_completion_action(self) -> str:
+        """
+        Return the completion-action instructions for the monitor prompt.
+
+        When epictetus mode is OFF (default), the monitor kills the tmux
+        session after a 60-second grace period so worker agents stop
+        burning tokens.  The kill targets ONLY this experiment's session
+        by name, leaving other concurrent Marcus sessions unaffected.
+
+        When epictetus mode is ON, the session is kept alive so that the
+        Epictetus post-experiment interrogation tool can query agents after
+        the project finishes.
+
+        Returns
+        -------
+        str
+            One or more instruction lines to embed in the monitor prompt.
+        """
+        if self.epictetus:
+            return (
+                'Print: "Epictetus mode active — session kept alive for '
+                'agent interrogation"\n'
+                "      - Exit this monitor process. Do NOT kill the tmux session."
+            )
+        return (
+            f"Sleep 60 seconds (grace period for agents to exit cleanly via "
+            f"the EXPERIMENT_COMPLETE signal from request_next_task)\n"
+            f"      - Run this bash command to terminate all agent panes:\n"
+            f"          tmux kill-session -t {self.tmux_session}\n"
+            f"        (This kills ONLY the '{self.tmux_session}' session. "
+            f"Other concurrent Marcus sessions are unaffected.)\n"
+            f"      - Exit"
+        )
+
     def create_monitor_prompt(self) -> str:
         """
         Create the prompt for the experiment monitor agent.
@@ -625,7 +669,7 @@ status["is_running"] is False:
       - Print "EXPERIMENT COMPLETE!"
       - Print the final values of total_tasks, completed_tasks,
         in_progress_tasks, blocked_tasks, and registered_agents
-      - Exit
+      - {self._monitor_completion_action()}
 
 CRITICAL INSTRUCTIONS:
 - Work in: {self.config.implementation_dir}

--- a/src/experiments/live_experiment_monitor.py
+++ b/src/experiments/live_experiment_monitor.py
@@ -81,6 +81,7 @@ class LiveExperimentMonitor:
 
         # Monitoring state
         self.is_running = False
+        self.was_started = False  # True once start() has been called
         self.monitor_task: Optional[asyncio.Task[None]] = None
         self.run_name: Optional[str] = None
 
@@ -154,6 +155,7 @@ class LiveExperimentMonitor:
         self.mlflow_experiment.start_run(run_name=run_name, params=params, tags=tags)
 
         # Start background monitoring
+        self.was_started = True
         self.is_running = True
         self.monitor_task = asyncio.create_task(self._monitor_loop())
 

--- a/src/marcus_mcp/server.py
+++ b/src/marcus_mcp/server.py
@@ -109,6 +109,12 @@ class MarcusServer:
         # so non-Planka startups are not blocked by kanban-mcp path detection.
         self.monitor = ProjectMonitor() if self.provider == "planka" else None
 
+        # Cached embedding model for cross-parent dependency wiring.
+        # Loaded once on first refresh_project_state call — avoids reloading
+        # the SentenceTransformer (all-MiniLM-L6-v2) on every create_project,
+        # which was adding ~40s to the first call and tripping MCP timeouts.
+        self._embedding_model: Optional[Any] = None
+
         # Token tracking for cost monitoring
         self.token_tracker = token_tracker
 
@@ -988,20 +994,28 @@ class MarcusServer:
 
                     logger.info("Wiring cross-parent dependencies...")
 
-                    # Try to load embedding model for candidate filtering
-                    embedding_model = None
-                    try:
-                        from sentence_transformers import SentenceTransformer
+                    # Use cached embedding model for candidate filtering.
+                    # Loaded lazily on first call; reused on subsequent calls to
+                    # avoid the ~40s SentenceTransformer load on every create_project.
+                    if self._embedding_model is None:
+                        try:
+                            from sentence_transformers import SentenceTransformer
 
-                        embedding_model = SentenceTransformer("all-MiniLM-L6-v2")
-                        logger.debug("Loaded embedding model for dependency matching")
-                    except ImportError:
-                        logger.debug(
-                            "sentence-transformers not available, "
-                            "using LLM-only matching"
-                        )
-                    except Exception as e:
-                        logger.warning(f"Failed to load embedding model: {e}")
+                            self._embedding_model = SentenceTransformer(
+                                "all-MiniLM-L6-v2"
+                            )
+                            logger.info(
+                                "Loaded embedding model for dependency matching "
+                                "(cached for subsequent calls)"
+                            )
+                        except ImportError:
+                            logger.debug(
+                                "sentence-transformers not available, "
+                                "using LLM-only matching"
+                            )
+                        except Exception as e:
+                            logger.warning(f"Failed to load embedding model: {e}")
+                    embedding_model = self._embedding_model
 
                     # Wire dependencies
                     stats = await wire_cross_parent_dependencies(

--- a/src/marcus_mcp/tools/nlp.py
+++ b/src/marcus_mcp/tools/nlp.py
@@ -104,8 +104,10 @@ async def _store_config_snapshot(
         logger.warning(f"Failed to store config snapshot: {e}")
 
 
-# Track recent create_project calls for dedup detection
-_recent_create_project_calls: Dict[str, float] = {}
+# Track recent create_project calls for dedup detection.
+# Value is (timestamp, result) — result is None while the call is in-flight,
+# populated after successful creation so retries can return cached success.
+_recent_create_project_calls: Dict[str, tuple[float, Optional[Dict[str, Any]]]] = {}
 
 
 async def create_project(
@@ -214,26 +216,40 @@ async def create_project(
         f"caller_stack:\n{call_stack}"
     )
 
-    # Dedup guard: reject duplicate calls for the same project within 10 minutes
+    # Dedup guard: reject duplicate calls for the same project within 10 minutes.
+    # When the first call already succeeded, return the cached result so the
+    # agent can proceed (avoids "project created but agent never got the ID"
+    # caused by Claude Code MCP timeouts triggering retries during slow creation).
     dedup_key = f"{project_name}:{description[:50]}"
     now = time.time()
     if dedup_key in _recent_create_project_calls:
-        elapsed = now - _recent_create_project_calls[dedup_key]
+        ts, cached_result = _recent_create_project_calls[dedup_key]
+        elapsed = now - ts
         if elapsed < 600:  # 10 minute window
-            logger.warning(
-                f"[CREATE_PROJECT DEDUP] Rejecting duplicate call for "
-                f"{project_name!r} — last call was {elapsed:.0f}s ago"
-            )
-            return {
-                "success": False,
-                "error": (
-                    f"Duplicate create_project call for '{project_name}' "
-                    f"detected ({elapsed:.0f}s since last call). "
-                    f"Use select_project to work with the existing project."
-                ),
-            }
-    # NOTE: dedup timestamp recorded after successful creation, not here.
-    # See end of function. (TODO: add TTL eviction to this cache)
+            if cached_result is not None:
+                # First call succeeded — return its result so the agent proceeds
+                logger.warning(
+                    f"[CREATE_PROJECT DEDUP] Returning cached result for "
+                    f"{project_name!r} — first call completed {elapsed:.0f}s ago"
+                )
+                return cached_result
+            else:
+                # First call still in-flight — block the duplicate
+                logger.warning(
+                    f"[CREATE_PROJECT DEDUP] Rejecting duplicate call for "
+                    f"{project_name!r} — first call is still in progress "
+                    f"({elapsed:.0f}s ago)"
+                )
+                return {
+                    "success": False,
+                    "error": (
+                        f"create_project for '{project_name}' is still running "
+                        f"(started {elapsed:.0f}s ago). Wait for it to complete."
+                    ),
+                }
+    # Mark call as in-flight (result=None) so concurrent duplicates are blocked.
+    # The entry is overwritten with (timestamp, result) after successful completion.
+    _recent_create_project_calls[dedup_key] = (now, None)
 
     # Validate required parameters
     if (
@@ -755,10 +771,12 @@ async def create_project(
         # Phase B silently. GH-320 consolidated both phases into
         # ``_run_design_phase`` so the handoff cannot break again.
 
-        # Record dedup timestamp AFTER successful creation so failed
-        # attempts don't poison the cache and block legitimate retries.
+        # Record dedup entry AFTER successful creation so failed attempts
+        # don't poison the cache and block legitimate retries.
+        # Store the result so retries (e.g. from MCP timeouts) get the
+        # cached success response and can proceed without re-running decomposition.
         if result.get("success"):
-            _recent_create_project_calls[dedup_key] = time.time()
+            _recent_create_project_calls[dedup_key] = (time.time(), result)
 
         return result
 

--- a/src/marcus_mcp/tools/nlp.py
+++ b/src/marcus_mcp/tools/nlp.py
@@ -249,6 +249,8 @@ async def create_project(
                 }
     # Mark call as in-flight (result=None) so concurrent duplicates are blocked.
     # The entry is overwritten with (timestamp, result) after successful completion.
+    # On any non-success exit (validation failure, exception) the key is deleted
+    # so that legitimate retries are not blocked for the full 10-minute window.
     _recent_create_project_calls[dedup_key] = (now, None)
 
     # Validate required parameters
@@ -257,6 +259,7 @@ async def create_project(
         or not description.strip()
         or description.lower() in ["test", "dummy", "example", "help"]
     ):
+        del _recent_create_project_calls[dedup_key]
         return {
             "success": False,
             "error": "Please provide a real project description",
@@ -777,10 +780,16 @@ async def create_project(
         # cached success response and can proceed without re-running decomposition.
         if result.get("success"):
             _recent_create_project_calls[dedup_key] = (time.time(), result)
+        else:
+            # Non-success result (e.g. internal error response) — clear the
+            # in-flight entry so retries are not blocked for 10 minutes.
+            _recent_create_project_calls.pop(dedup_key, None)
 
         return result
 
     except Exception:
+        # Clear in-flight entry on exception so legitimate retries can proceed.
+        _recent_create_project_calls.pop(dedup_key, None)
         raise
 
 

--- a/src/marcus_mcp/tools/task.py
+++ b/src/marcus_mcp/tools/task.py
@@ -1594,6 +1594,54 @@ async def request_next_task(agent_id: str, state: Any) -> Any:
                         },
                     )
 
+            # Check if the experiment has ended — return terminal signal so
+            # agents exit cleanly instead of retrying indefinitely.
+            #
+            # Guard: match the monitor's project_id to the agent's registered
+            # project.  Without this, a stale monitor from a previous
+            # experiment (auto-stopped, set_active_monitor not yet cleared)
+            # would fire EXPERIMENT_COMPLETE for agents of a new experiment
+            # that starts before the Marcus server is restarted.
+            from src.experiments.live_experiment_monitor import get_active_monitor
+
+            _monitor = get_active_monitor()
+            _agent_project_id = (
+                state.agent_project_map.get(agent_id, "")
+                if hasattr(state, "agent_project_map")
+                else ""
+            )
+            # Only fire if the agent's project is known AND matches the monitor.
+            # An empty _agent_project_id means the agent hasn't registered yet;
+            # treat that as "no match" so unregistered agents are never
+            # incorrectly terminated by a stale/finished monitor.
+            _project_id_matches = bool(_agent_project_id) and (
+                _monitor is not None
+                and hasattr(_monitor, "project_id")
+                and _monitor.project_id == _agent_project_id
+            )
+            if (
+                _monitor is not None
+                and _monitor.was_started
+                and not _monitor.is_running
+                and _project_id_matches
+            ):
+                sep = "=" * 70
+                return {
+                    "success": False,
+                    "status": "EXPERIMENT_COMPLETE",
+                    "message": (
+                        f"\n\n{sep}\n"
+                        "EXPERIMENT COMPLETE\n"
+                        f"{sep}\n\n"
+                        "The experiment has ended. All project work is done.\n\n"
+                        "REQUIRED ACTION:\n"
+                        "1. Print a brief summary of your contributions\n"
+                        "2. Exit — do NOT retry or request more tasks\n\n"
+                        f"{sep}\n"
+                    ),
+                    "should_exit": True,
+                }
+
             # Check if there are any TODO tasks remaining
             # Only run diagnostics for LOGGING if tasks exist but can't be assigned
             # DO NOT send diagnostics to agents - they interpret them as reasons to stop

--- a/tests/unit/marcus_mcp/test_experiment_termination.py
+++ b/tests/unit/marcus_mcp/test_experiment_termination.py
@@ -1,0 +1,444 @@
+"""
+Unit tests for GH-389: agent auto-termination when experiment completes.
+
+Two sub-systems are tested:
+
+1. LiveExperimentMonitor.was_started flag — distinguishes the startup
+   window (monitor exists but has not started yet) from the finished state
+   (monitor started and is now done).  Without this flag, request_next_task
+   cannot tell the difference and would incorrectly fire EXPERIMENT_COMPLETE
+   during the startup window.
+
+2. request_next_task EXPERIMENT_COMPLETE signal — when the monitor has been
+   started and then stopped, the no-task path returns a terminal response
+   (status="EXPERIMENT_COMPLETE", should_exit=True) instead of the normal
+   "DO NOT terminate — keep retrying" instructions.
+"""
+
+import asyncio
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_state(*, agent_project_id: str = "project-alpha") -> Mock:
+    """Minimal Marcus server state mock sufficient to reach the no-task path."""
+    state = Mock()
+    state.ensure_lease_monitor_running = AsyncMock()
+    state.log_event = Mock()
+    state.initialize_kanban = AsyncMock()
+    state.refresh_project_state = AsyncMock()
+    state.agent_status = {}  # unregistered agent → skip one-task check
+    state.project_tasks = []
+    state.agent_tasks = {}
+    state.gridlock_detector = None  # skip gridlock detection
+    # Agent is registered to agent_project_id (used for stale-monitor guard)
+    state.agent_project_map = {"agent-1": agent_project_id}
+    state.kanban_client = Mock()
+    state.tasks_being_assigned = set()
+    state.project_state = None
+    state.ai_engine = None
+    state.provider = "sqlite"  # skip GitHub code_analyzer path
+    state.code_analyzer = None
+    state.context = None
+    state.assignment_lock = asyncio.Lock()
+    return state
+
+
+def _make_monitor(
+    *,
+    was_started: bool,
+    is_running: bool,
+    project_id: str = "project-alpha",
+) -> Mock:
+    """Build a mock LiveExperimentMonitor with explicit lifecycle flags."""
+    monitor = Mock()
+    monitor.was_started = was_started
+    monitor.is_running = is_running
+    monitor.project_id = project_id
+    return monitor
+
+
+# ---------------------------------------------------------------------------
+# LiveExperimentMonitor.was_started flag
+# ---------------------------------------------------------------------------
+
+
+class TestWasStartedFlag:
+    """was_started is False on init, True after start()."""
+
+    def test_was_started_false_on_init(self) -> None:
+        """Monitor starts with was_started=False before start() is called."""
+        from src.experiments.live_experiment_monitor import LiveExperimentMonitor
+
+        monitor = LiveExperimentMonitor(
+            experiment_name="test-exp",
+            board_id="board-1",
+            project_id="project-1",
+        )
+
+        assert monitor.was_started is False
+        assert monitor.is_running is False
+
+    @pytest.mark.asyncio
+    async def test_was_started_true_after_start(self) -> None:
+        """start() flips both was_started and is_running to True."""
+        from src.experiments.live_experiment_monitor import LiveExperimentMonitor
+
+        monitor = LiveExperimentMonitor(
+            experiment_name="test-exp",
+            board_id="board-1",
+            project_id="project-1",
+        )
+
+        with (
+            patch.object(monitor.mlflow_experiment, "start_run"),
+            patch("asyncio.create_task"),
+        ):
+            await monitor.start(run_name="run-001")
+
+        assert monitor.was_started is True
+        assert monitor.is_running is True
+
+    @pytest.mark.asyncio
+    async def test_was_started_stays_true_after_stop(self) -> None:
+        """was_started remains True after the monitor is stopped."""
+        from src.experiments.live_experiment_monitor import LiveExperimentMonitor
+
+        monitor = LiveExperimentMonitor(
+            experiment_name="test-exp",
+            board_id="board-1",
+            project_id="project-1",
+        )
+
+        with (
+            patch.object(monitor.mlflow_experiment, "start_run"),
+            patch("asyncio.create_task"),
+        ):
+            await monitor.start(run_name="run-001")
+
+        # Simulate stop by flipping flags directly (avoids MLflow/task complexity)
+        monitor.is_running = False
+        monitor.monitor_task = None
+
+        assert monitor.was_started is True
+        assert monitor.is_running is False
+
+
+# ---------------------------------------------------------------------------
+# request_next_task EXPERIMENT_COMPLETE signal
+# ---------------------------------------------------------------------------
+
+
+class TestExperimentCompleteSignal:
+    """request_next_task returns EXPERIMENT_COMPLETE when experiment has ended."""
+
+    @pytest.mark.asyncio
+    async def test_returns_experiment_complete_when_experiment_ended(self) -> None:
+        """
+        EXPERIMENT_COMPLETE is returned when monitor.was_started=True
+        and monitor.is_running=False (experiment has ended).
+        """
+        from src.marcus_mcp.tools.task import request_next_task
+
+        state = _make_state()
+        finished_monitor = _make_monitor(was_started=True, is_running=False)
+
+        with (
+            patch(
+                "src.marcus_mcp.tools.task.find_optimal_task_for_agent",
+                new=AsyncMock(return_value=None),
+            ),
+            patch(
+                "src.experiments.live_experiment_monitor.get_active_monitor",
+                return_value=finished_monitor,
+            ),
+            patch("src.marcus_mcp.tools.task.conversation_logger"),
+            patch("src.marcus_mcp.tools.task.log_agent_event"),
+            patch("src.marcus_mcp.tools.task.log_thinking"),
+        ):
+            result = await request_next_task(agent_id="agent-1", state=state)
+
+        assert result["status"] == "EXPERIMENT_COMPLETE"
+        assert result["should_exit"] is True
+        assert "exit" in result["message"].lower()
+        assert result["success"] is False
+
+    @pytest.mark.asyncio
+    async def test_returns_retry_when_no_experiment_running(self) -> None:
+        """
+        Normal "no tasks" retry response is returned when no monitor is active
+        (no experiment running — standalone Marcus usage).
+        """
+        from src.marcus_mcp.tools.task import request_next_task
+
+        state = _make_state()
+
+        with (
+            patch(
+                "src.marcus_mcp.tools.task.find_optimal_task_for_agent",
+                new=AsyncMock(return_value=None),
+            ),
+            patch(
+                "src.experiments.live_experiment_monitor.get_active_monitor",
+                return_value=None,
+            ),
+            patch("src.marcus_mcp.tools.task.conversation_logger"),
+            patch("src.marcus_mcp.tools.task.log_agent_event"),
+            patch("src.marcus_mcp.tools.task.log_thinking"),
+            patch(
+                "src.marcus_mcp.tools.task.calculate_retry_after_seconds",
+                new=AsyncMock(
+                    return_value={"retry_after_seconds": 30, "reason": "no_tasks"}
+                ),
+            ),
+        ):
+            result = await request_next_task(agent_id="agent-1", state=state)
+
+        # Should be a retry response, not EXPERIMENT_COMPLETE
+        assert result.get("status") != "EXPERIMENT_COMPLETE"
+        assert result.get("should_exit") is not True
+        assert "retry_after_seconds" in result
+
+    @pytest.mark.asyncio
+    async def test_returns_retry_during_startup_window(self) -> None:
+        """
+        Normal "no tasks" retry is returned when monitor exists but has not
+        been started yet (startup window: create_project done, start_experiment
+        not yet called).  was_started=False distinguishes this from "ended".
+        """
+        from src.marcus_mcp.tools.task import request_next_task
+
+        state = _make_state()
+        startup_monitor = _make_monitor(was_started=False, is_running=False)
+
+        with (
+            patch(
+                "src.marcus_mcp.tools.task.find_optimal_task_for_agent",
+                new=AsyncMock(return_value=None),
+            ),
+            patch(
+                "src.experiments.live_experiment_monitor.get_active_monitor",
+                return_value=startup_monitor,
+            ),
+            patch("src.marcus_mcp.tools.task.conversation_logger"),
+            patch("src.marcus_mcp.tools.task.log_agent_event"),
+            patch("src.marcus_mcp.tools.task.log_thinking"),
+            patch(
+                "src.marcus_mcp.tools.task.calculate_retry_after_seconds",
+                new=AsyncMock(
+                    return_value={"retry_after_seconds": 30, "reason": "no_tasks"}
+                ),
+            ),
+        ):
+            result = await request_next_task(agent_id="agent-1", state=state)
+
+        # Must NOT be EXPERIMENT_COMPLETE — experiment hasn't started yet
+        assert result.get("status") != "EXPERIMENT_COMPLETE"
+        assert result.get("should_exit") is not True
+
+    @pytest.mark.asyncio
+    async def test_returns_retry_while_experiment_active(self) -> None:
+        """
+        Normal "no tasks" retry is returned when the experiment is still
+        running (was_started=True, is_running=True) — agent should keep polling.
+        """
+        from src.marcus_mcp.tools.task import request_next_task
+
+        state = _make_state()
+        active_monitor = _make_monitor(was_started=True, is_running=True)
+
+        with (
+            patch(
+                "src.marcus_mcp.tools.task.find_optimal_task_for_agent",
+                new=AsyncMock(return_value=None),
+            ),
+            patch(
+                "src.experiments.live_experiment_monitor.get_active_monitor",
+                return_value=active_monitor,
+            ),
+            patch("src.marcus_mcp.tools.task.conversation_logger"),
+            patch("src.marcus_mcp.tools.task.log_agent_event"),
+            patch("src.marcus_mcp.tools.task.log_thinking"),
+            patch(
+                "src.marcus_mcp.tools.task.calculate_retry_after_seconds",
+                new=AsyncMock(
+                    return_value={"retry_after_seconds": 30, "reason": "no_tasks"}
+                ),
+            ),
+        ):
+            result = await request_next_task(agent_id="agent-1", state=state)
+
+        # Must NOT be EXPERIMENT_COMPLETE — experiment is still active
+        assert result.get("status") != "EXPERIMENT_COMPLETE"
+        assert result.get("should_exit") is not True
+        assert "retry_after_seconds" in result
+
+    @pytest.mark.asyncio
+    async def test_experiment_complete_message_instructs_exit(self) -> None:
+        """EXPERIMENT_COMPLETE message explicitly tells the agent to exit."""
+        from src.marcus_mcp.tools.task import request_next_task
+
+        state = _make_state()
+        finished_monitor = _make_monitor(was_started=True, is_running=False)
+
+        with (
+            patch(
+                "src.marcus_mcp.tools.task.find_optimal_task_for_agent",
+                new=AsyncMock(return_value=None),
+            ),
+            patch(
+                "src.experiments.live_experiment_monitor.get_active_monitor",
+                return_value=finished_monitor,
+            ),
+            patch("src.marcus_mcp.tools.task.conversation_logger"),
+            patch("src.marcus_mcp.tools.task.log_agent_event"),
+            patch("src.marcus_mcp.tools.task.log_thinking"),
+        ):
+            result = await request_next_task(agent_id="agent-1", state=state)
+
+        msg = result["message"]
+        # Message must NOT contain "STAY ALIVE" or "DO NOT terminate"
+        assert "STAY ALIVE" not in msg
+        assert "DO NOT terminate" not in msg
+        # Message must instruct exit
+        assert "exit" in msg.lower() or "Exit" in msg
+
+    @pytest.mark.asyncio
+    async def test_stale_monitor_different_project_does_not_fire(self) -> None:
+        """
+        A stale monitor from a PREVIOUS experiment (different project_id)
+        must NOT trigger EXPERIMENT_COMPLETE for agents of a new experiment.
+
+        Root cause of the regression: when an experiment auto-stops via
+        _monitor_loop, set_active_monitor(None) is not called.  The stale
+        monitor lingers with was_started=True, is_running=False.  When the
+        next experiment's workers call request_next_task before
+        start_experiment replaces the monitor, they get EXPERIMENT_COMPLETE
+        and exit immediately — so no tasks are ever done.
+
+        Fix: gate the check on monitor.project_id == agent's project_id.
+        """
+        from src.marcus_mcp.tools.task import request_next_task
+
+        # Agent is registered to the NEW project
+        state = _make_state(agent_project_id="project-beta-new")
+        # Stale monitor from the OLD project
+        stale_monitor = _make_monitor(
+            was_started=True,
+            is_running=False,
+            project_id="project-alpha-old",  # different project!
+        )
+
+        with (
+            patch(
+                "src.marcus_mcp.tools.task.find_optimal_task_for_agent",
+                new=AsyncMock(return_value=None),
+            ),
+            patch(
+                "src.experiments.live_experiment_monitor.get_active_monitor",
+                return_value=stale_monitor,
+            ),
+            patch("src.marcus_mcp.tools.task.conversation_logger"),
+            patch("src.marcus_mcp.tools.task.log_agent_event"),
+            patch("src.marcus_mcp.tools.task.log_thinking"),
+            patch(
+                "src.marcus_mcp.tools.task.calculate_retry_after_seconds",
+                new=AsyncMock(
+                    return_value={"retry_after_seconds": 30, "reason": "no_tasks"}
+                ),
+            ),
+        ):
+            result = await request_next_task(agent_id="agent-1", state=state)
+
+        # Must NOT fire EXPERIMENT_COMPLETE for a different project's stale monitor
+        assert result.get("status") != "EXPERIMENT_COMPLETE"
+        assert result.get("should_exit") is not True
+        assert "retry_after_seconds" in result
+
+    @pytest.mark.asyncio
+    async def test_unregistered_agent_does_not_fire(self) -> None:
+        """
+        An agent that has NOT yet registered (agent_project_map has no entry)
+        must NOT get EXPERIMENT_COMPLETE from a finished monitor.
+
+        Root cause of the bug: the original guard used ``not _agent_project_id``
+        which evaluated to True for an empty string, making the empty-project
+        case match every monitor.  The fix requires a truthy project_id before
+        comparing.
+        """
+        from src.marcus_mcp.tools.task import request_next_task
+
+        # Agent "agent-99" is NOT in the project map → _agent_project_id = ""
+        state = _make_state(agent_project_id="project-alpha")
+        finished_monitor = _make_monitor(
+            was_started=True,
+            is_running=False,
+            project_id="project-alpha",
+        )
+
+        with (
+            patch(
+                "src.marcus_mcp.tools.task.find_optimal_task_for_agent",
+                new=AsyncMock(return_value=None),
+            ),
+            patch(
+                "src.experiments.live_experiment_monitor.get_active_monitor",
+                return_value=finished_monitor,
+            ),
+            patch("src.marcus_mcp.tools.task.conversation_logger"),
+            patch("src.marcus_mcp.tools.task.log_agent_event"),
+            patch("src.marcus_mcp.tools.task.log_thinking"),
+            patch(
+                "src.marcus_mcp.tools.task.calculate_retry_after_seconds",
+                new=AsyncMock(
+                    return_value={"retry_after_seconds": 30, "reason": "no_tasks"}
+                ),
+            ),
+        ):
+            # Use "agent-99" which is not in state.agent_project_map
+            result = await request_next_task(agent_id="agent-99", state=state)
+
+        # Must NOT fire — unregistered agent has no project to match against
+        assert result.get("status") != "EXPERIMENT_COMPLETE"
+        assert result.get("should_exit") is not True
+
+    @pytest.mark.asyncio
+    async def test_same_project_finished_monitor_fires(self) -> None:
+        """
+        EXPERIMENT_COMPLETE fires correctly when the monitor's project_id
+        matches the agent's registered project_id (normal happy path).
+        """
+        from src.marcus_mcp.tools.task import request_next_task
+
+        state = _make_state(agent_project_id="project-alpha")
+        finished_monitor = _make_monitor(
+            was_started=True,
+            is_running=False,
+            project_id="project-alpha",  # same project
+        )
+
+        with (
+            patch(
+                "src.marcus_mcp.tools.task.find_optimal_task_for_agent",
+                new=AsyncMock(return_value=None),
+            ),
+            patch(
+                "src.experiments.live_experiment_monitor.get_active_monitor",
+                return_value=finished_monitor,
+            ),
+            patch("src.marcus_mcp.tools.task.conversation_logger"),
+            patch("src.marcus_mcp.tools.task.log_agent_event"),
+            patch("src.marcus_mcp.tools.task.log_thinking"),
+        ):
+            result = await request_next_task(agent_id="agent-1", state=state)
+
+        assert result["status"] == "EXPERIMENT_COMPLETE"
+        assert result["should_exit"] is True


### PR DESCRIPTION
## Summary

- **Layer 1**: `request_next_task` returns `EXPERIMENT_COMPLETE` (`should_exit=True`) when the monitor has started and stopped — agents self-terminate instead of polling forever
- **Layer 2**: Monitor agent waits 60 s grace period then runs `tmux kill-session -t <session>` (session-specific; other concurrent Marcus sessions unaffected)
- **Layer 3**: `--epictetus` flag wired through `/marcus` skill → `run_experiment.py` → `AgentSpawner`; suppresses the tmux kill so Epictetus post-experiment interrogation can query agents after completion

**Supporting fixes:**
- `was_started` flag on `LiveExperimentMonitor` distinguishes the startup window (monitor exists, `start()` not yet called) from the finished state — prevents false EXPERIMENT_COMPLETE during agent startup
- Project-id guard: EXPERIMENT_COMPLETE only fires when `monitor.project_id == agent's registered project_id`, preventing stale monitors from previous experiments from killing agents in new ones
- Unregistered-agent guard: empty `agent_project_id` is treated as no-match (fixed inverted `not` logic that was matching everything)
- `server.py`: cache `_embedding_model` on the server instance — `SentenceTransformer` was reloading `all-MiniLM-L6-v2` from disk on every `refresh_project_state`, adding ~40 s to `create_project` and tripping MCP timeouts
- `nlp.py` dedup guard: now stores `(timestamp, result)`; retries after a successful creation return the cached success response so the project creator agent always gets the project_id

## Test plan

- [x] 11 new unit tests in `tests/unit/marcus_mcp/test_experiment_termination.py`
  - `was_started` lifecycle (False on init, True after start, stays True after stop)
  - EXPERIMENT_COMPLETE fires on finished same-project monitor
  - EXPERIMENT_COMPLETE does NOT fire: no monitor, startup window, active monitor, stale different-project monitor, unregistered agent
  - Message instructs exit, not "STAY ALIVE"
- [x] `pytest -m unit` — 810 passed
- [x] Live experiment ran to completion — worker panes exited, tmux session killed

🤖 Generated with [Claude Code](https://claude.com/claude-code)