### PR TITLE
fix(tests): align decomposer wiring + lease cadence tests with current behavior

### DIFF
--- a/tests/unit/coordinator/test_decomposer.py
+++ b/tests/unit/coordinator/test_decomposer.py
@@ -370,7 +370,15 @@ class TestDecomposeTask:
     async def test_decompose_task_success(
         self, task, mock_ai_engine, sample_decomposition
     ):
-        """Test successful task decomposition."""
+        """Test successful task decomposition.
+
+        The sample decomposition declares one ``provides``/``requires``
+        pair (Build login endpoint requires User model), so the
+        decomposer auto-appends one integration-wiring subtask. This
+        was restored after the dashboard-v99 audit showed that
+        omitting wiring tasks produces hollow products where each
+        subtask passes in isolation but the composed system is broken.
+        """
         # Arrange
         mock_ai_engine.generate_structured_response.return_value = sample_decomposition
 
@@ -380,15 +388,19 @@ class TestDecomposeTask:
         # Assert
         assert result["success"] is True
         assert "subtasks" in result
-        # No longer adds integration subtask automatically
-        assert len(result["subtasks"]) == 2
+        # 2 AI-generated + 1 auto-generated wiring task
+        assert len(result["subtasks"]) == 3
         assert "shared_conventions" in result
 
     @pytest.mark.asyncio
     async def test_decompose_task_preserves_subtasks(
         self, task, mock_ai_engine, sample_decomposition
     ):
-        """Test decomposition preserves AI-generated subtasks."""
+        """Test decomposition preserves AI-generated subtasks and adds wiring.
+
+        AI subtasks must come through unchanged at indices 0..N-1, with
+        any auto-generated integration-wiring tasks appended after.
+        """
         # Arrange
         mock_ai_engine.generate_structured_response.return_value = sample_decomposition
 
@@ -396,10 +408,15 @@ class TestDecomposeTask:
         result = await decompose_task(task, mock_ai_engine)
 
         # Assert
-        # Verify both subtasks from AI response are preserved
-        assert len(result["subtasks"]) == 2
+        # AI's 2 subtasks preserved at the start
         assert result["subtasks"][0]["name"] == "Create User model"
         assert result["subtasks"][1]["name"] == "Build login endpoint"
+        # One auto-generated wiring task appended for the provides→requires pair
+        assert len(result["subtasks"]) == 3
+        wiring_task = result["subtasks"][2]
+        # Wiring task depends on both the provider and consumer
+        assert wiring_task["dependencies"] == ["task-1_sub_1", "task-1_sub_2"]
+        assert wiring_task["dependency_types"] == ["hard", "hard"]
 
     @pytest.mark.asyncio
     async def test_decompose_task_adjusts_dependencies_to_ids(

--- a/tests/unit/core/test_progressive_timeout.py
+++ b/tests/unit/core/test_progressive_timeout.py
@@ -56,6 +56,14 @@ def lease_manager_aggressive(mock_kanban_client, mock_assignment_persistence):
     aggressive end of the spectrum compared to the conservative
     multi-hour leases used in non-experiment mode, but the
     absolute values are higher.
+
+    ``silence_multiplier=1.5`` is pinned explicitly so the cadence
+    recovery tests in ``TestCadenceBasedRecovery`` continue to test
+    the cadence math their inline comments describe (median × 1.5).
+    The production default later moved to 5.0× after evidence that
+    1.5× recovered too aggressively under bursty agent activity;
+    the cadence tests want the original threshold to verify the
+    boundary logic without depending on the default.
     """
     return AssignmentLeaseManager(
         kanban_client=mock_kanban_client,
@@ -64,6 +72,7 @@ def lease_manager_aggressive(mock_kanban_client, mock_assignment_persistence):
         grace_period_minutes=1.0,  # 60 seconds
         min_lease_hours=0.05,  # 180 seconds minimum (Phase 1/4)
         max_lease_hours=0.1,  # 360 seconds maximum (Phase 3 ceiling)
+        silence_multiplier=1.5,
     )
 
 


### PR DESCRIPTION
## Summary

Two clusters of stale unit tests broken by recent commits to `develop`. Both tests fail the moment you run the full suite (they're missing the `unit` marker so `pytest -m unit` skipped them — found via `pytest --ignore=tests/{future_features,performance}`).

### Decomposer (`tests/unit/coordinator/test_decomposer.py`)

`test_decompose_task_success` and `test_decompose_task_preserves_subtasks` asserted `len(subtasks) == 2`, but the decomposer now appends an integration-wiring subtask for every `provides`→`requires` pair the LLM declares. The wiring auto-generation was restored after the **dashboard-v99 audit** showed that omitting wiring produces hollow products: each subtask passes in isolation but the composed system is broken (no service wiring, no trailhead fetcher, no hikingWindow producer).

Tests now assert 3 subtasks and verify the wiring task's hard dependencies on both endpoints.

### Progressive timeout (`tests/unit/core/test_progressive_timeout.py`)

`test_should_recover_silent_past_cadence` and `test_should_recover_slow_agent_gone_silent` assumed `silence_multiplier=1.5` — their inline math reads `1.5*60=90s` and `1.5*120=180s`. The production default moved to 5.0× after evidence that 1.5× recovered too aggressively under bursty agent activity.

Pinned `silence_multiplier=1.5` in the `lease_manager_aggressive` fixture so cadence tests continue to verify the boundary logic they were written for, independent of future default changes.

### Why pin rather than update assertions?

Both fixes pin tests to the contract under test rather than the moving default, so future drift in the production multiplier or wiring policy won't silently break boundary-condition coverage.

## Test plan
- [x] `pytest tests/unit/coordinator/test_decomposer.py tests/unit/core/test_progressive_timeout.py` passes (62 tests)
- [x] Full suite passes: `pytest --ignore=tests/future_features --ignore=tests/performance` → 2946 passed, 61 skipped, 0 failed
- [x] mypy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)