### PR TITLE
feat(#449): user-outcome coverage foundation — extractor, coverage, gap-fill

### DIFF
--- a/src/ai/advanced/prd/outcome_extractor.py
+++ b/src/ai/advanced/prd/outcome_extractor.py
@@ -26,14 +26,28 @@ from typing import Any, List
 
 from src.utils.json_parser import parse_ai_json_response
 
-# Phrases that mark a real user-capability action.  At least one must
-# appear (case-insensitive) in :attr:`UserOutcome.action`.
-_USER_CAPABILITY_PHRASES: tuple[str, ...] = (
-    "user can",
-    "user is able to",
-    "user must be able to",
-    "users can",
-    "users are able to",
+# Patterns that mark a real user-capability action.  Word-boundary
+# regex (not substring) so that ``"user cannot ..."`` and ``"user
+# can't ..."`` do NOT match — those are negations and contradict the
+# positive-capability invariant.  The lookahead ``(?!')`` rejects the
+# ``"can't"`` contraction.
+_USER_CAPABILITY_PATTERNS: tuple["re.Pattern[str]", ...] = (
+    re.compile(r"\busers? can\b(?!')", re.IGNORECASE),
+    re.compile(r"\busers? (?:is|are) able to\b", re.IGNORECASE),
+    re.compile(r"\busers? must be able to\b", re.IGNORECASE),
+)
+
+# Negation markers — even if a positive pattern also matches, presence
+# of any of these phrases means the action is NOT a positive capability
+# (e.g. ``"user cannot play"`` or ``"user can never log in"``).
+_NEGATION_PATTERNS: tuple["re.Pattern[str]", ...] = (
+    re.compile(r"\bcannot\b", re.IGNORECASE),
+    re.compile(r"\bcan ?not\b", re.IGNORECASE),
+    re.compile(r"\bcan't\b", re.IGNORECASE),
+    re.compile(r"\bunable\b", re.IGNORECASE),
+    re.compile(r"\bnever\b", re.IGNORECASE),
+    re.compile(r"\bwon't\b", re.IGNORECASE),
+    re.compile(r"\bwill not\b", re.IGNORECASE),
 )
 
 # Vague verbs / phrases that pass the "user can" check but carry no
@@ -82,8 +96,10 @@ class UserOutcome:
         coverage check.  Convention: ``outcome_<short_action_verb>``.
     action : str
         Concrete user capability statement.  Must contain a phrase
-        from :data:`_USER_CAPABILITY_PHRASES`.  Vague phrasings such as
-        "user can use the app" are rejected.
+        from :data:`_USER_CAPABILITY_PATTERNS` (word-boundary regex).
+        Vague phrasings such as "user can use the app" are rejected;
+        negations such as "user cannot ..." or "user can't ..." are
+        also rejected via :data:`_NEGATION_PATTERNS`.
     success_signal : str
         Observable evidence that the outcome is satisfied.  Drives the
         Integration Verification gate (Stage 5, deferred): a Playwright
@@ -108,7 +124,7 @@ class UserOutcome:
     scope: str
 
     def __post_init__(self) -> None:
-        """Validate all fields; reject vague or malformed outcomes."""
+        """Validate all fields; reject vague, malformed, or negated outcomes."""
         if not self.id:
             raise ValueError("UserOutcome.id must be a non-empty string")
 
@@ -124,13 +140,25 @@ class UserOutcome:
                 f"got {self.scope!r}"
             )
 
-        action_lc = self.action.lower()
-        if not any(phrase in action_lc for phrase in _USER_CAPABILITY_PHRASES):
+        # Reject negations FIRST — "user cannot play" contains "user can"
+        # as a substring, so word-boundary positive matching alone is not
+        # enough.  An action with a negation marker is never a positive
+        # capability regardless of whether a positive pattern also matches.
+        if any(p.search(self.action) for p in _NEGATION_PATTERNS):
             raise ValueError(
-                "UserOutcome.action must express a user capability "
-                f"(one of {list(_USER_CAPABILITY_PHRASES)}); got {self.action!r}"
+                "UserOutcome.action contains a negation (cannot / can't / "
+                "unable / never / won't / will not) — outcomes must "
+                f"express positive capabilities; got {self.action!r}"
             )
 
+        if not any(p.search(self.action) for p in _USER_CAPABILITY_PATTERNS):
+            raise ValueError(
+                "UserOutcome.action must express a user capability "
+                "(e.g. 'user can <verb>', 'users are able to <verb>'); "
+                f"got {self.action!r}"
+            )
+
+        action_lc = self.action.lower()
         if any(vague in action_lc for vague in _VAGUE_PHRASES):
             raise ValueError(
                 f"UserOutcome.action is too vague to be verifiable: "
@@ -248,6 +276,20 @@ async def extract_user_outcomes(
                 f"User-outcome extractor: outcome at index {idx} is not "
                 f"an object: {item!r}"
             )
+
+        # Reject null / non-string fields rather than coerce.  str(None)
+        # is the string "None" which is non-empty and would silently
+        # bypass UserOutcome's empty-string checks, polluting outcome ids
+        # used by compute_coverage.
+        for required_field in ("id", "action", "success_signal", "scope"):
+            value = item.get(required_field)
+            if not isinstance(value, str):
+                raise ValueError(
+                    f"User-outcome extractor: outcome at index {idx} "
+                    f"field {required_field!r} must be a string, got "
+                    f"{type(value).__name__}: {value!r}"
+                )
+
         try:
             outcomes.append(
                 UserOutcome(
@@ -273,12 +315,3 @@ async def extract_user_outcomes(
         seen_ids.add(outcome.id)
 
     return outcomes
-
-
-# Re-exported for type-checking convenience; the regex is exposed in case
-# future callers need to test action strings without constructing an
-# :class:`UserOutcome` first.
-USER_CAPABILITY_PATTERN = re.compile(
-    "|".join(re.escape(p) for p in _USER_CAPABILITY_PHRASES),
-    flags=re.IGNORECASE,
-)

--- a/src/ai/advanced/prd/outcome_extractor.py
+++ b/src/ai/advanced/prd/outcome_extractor.py
@@ -16,11 +16,15 @@ Two LLM calls happen here:
 
 1. :func:`extract_user_outcomes` — turns a spec into outcome records.
 2. :func:`filter_to_verifiable_capabilities` — a second LLM pass that
-   acts as a quality gate, dropping outcomes that are not concrete
-   positive verifiable user capabilities.  This replaces hand-curated
-   denylists for negations, vague phrasings, and capability-pattern
-   matching, which would otherwise grow indefinitely as the LLM finds
-   new ways to phrase the same antipatterns.
+   acts as a quality gate, dropping outcomes that fail the
+   :data:`_USER_OUTCOME_CRITERIA` self-check.
+
+Both prompts share a single positive definition of what a user
+outcome MUST be (:data:`_USER_OUTCOME_CRITERIA`), rather than each
+prompt enumerating its own list of bad phrasings.  Defining success
+generalizes; enumerating failure modes is the band-aid pattern that
+:mod:`advanced_parser.py` accumulated as ``frontend`` /
+``e-commerce`` / ``UI/UX`` guards.
 
 The extractor itself is a thin wrapper around the LLM calls; validation
 in :class:`UserOutcome` is purely structural (types, non-empty fields,
@@ -39,6 +43,30 @@ from src.utils.json_parser import parse_ai_json_response
 logger = logging.getLogger(__name__)
 
 _VALID_SCOPES: frozenset[str] = frozenset({"in_scope", "out_of_scope"})
+
+
+# The single source of truth for what a user outcome must be.
+#
+# Both prompts reference this constant.  The three properties are
+# defined positively — what a good outcome IS, not what bad outcomes
+# look like — so the LLM evaluates against properties rather than
+# pattern-matching against an enumerated list of bad phrasings.
+# That is the architectural difference from the prior denylist
+# implementation: properties generalize, lists do not.
+_USER_OUTCOME_CRITERIA = """\
+A user outcome must satisfy ALL THREE of these properties:
+
+1. CONCRETE — names specific user-visible behavior such that an
+   observer running the product can point at what they see, hear,
+   or otherwise sense.
+
+2. POSITIVE — names a capability the user gains, framed as
+   something they CAN do.  An absence, restriction, or prohibition
+   is not a capability.
+
+3. VERIFIABLE — its satisfaction is decidable from observing the
+   running product.  Evidence either appears or it does not.
+"""
 
 
 @dataclass
@@ -103,13 +131,15 @@ class UserOutcome:
             )
 
 
-_EXTRACTION_PROMPT = """\
+_EXTRACTION_PROMPT_TEMPLATE = """\
 You are extracting user-visible outcomes from a project specification.
 
-A user outcome is a concrete capability the user must have when the
-product is finished — phrased as "user can <verb> <object> <observable
-detail>". Each outcome must be verifiable: an observer running the
-finished product must be able to tell yes/no whether it is satisfied.
+{criteria}
+
+Format ``action`` as a positive user-capability statement.  The
+canonical phrasing is ``"user can <verb> <object> <observable
+detail>"`` (e.g. ``"user can play the snake game in their browser"``)
+— but the surface form matters less than the three properties above.
 
 Return strict JSON of the form:
 
@@ -117,7 +147,7 @@ Return strict JSON of the form:
   "outcomes": [
     {{
       "id": "outcome_<short_verb>",
-      "action": "user can <verb> <object> ...",
+      "action": "<positive user-capability statement>",
       "success_signal": "<observable evidence>",
       "scope": "in_scope" | "out_of_scope"
     }}
@@ -125,20 +155,24 @@ Return strict JSON of the form:
 }}
 
 Rules:
-- Every action must contain "user can" (or "users can" / "is able to").
-- "user can use the app" is too vague — reject this phrasing. Use
-  concrete actions tied to the product domain.
-- Outcomes the spec explicitly excludes (e.g. "no auth", "no accounts")
-  must still be listed but tagged "out_of_scope" so the audit trail is
-  preserved.
-- Every project has at least one outcome — never return an empty list.
-- Provide a success_signal even for out-of-scope outcomes.
+- Outcomes the spec explicitly excludes must still be listed but
+  tagged ``out_of_scope`` so the audit trail records what was
+  considered and rejected based on spec language.
+- Every project implies at least one outcome — never return an empty
+  list.
+- Provide a success_signal even for out_of_scope outcomes.
 
 Specification:
 {spec}
 
 Respond with ONLY the JSON object — no preamble, no markdown fences.
 """
+
+# Substitute the criteria block at module load time.  ``replace``
+# leaves the ``{spec}`` placeholder intact for ``.format()`` later.
+_EXTRACTION_PROMPT = _EXTRACTION_PROMPT_TEMPLATE.replace(
+    "{criteria}", _USER_OUTCOME_CRITERIA
+)
 
 
 class _MaxTokensContext:
@@ -268,24 +302,15 @@ async def extract_user_outcomes(
     return outcomes
 
 
-_FILTER_PROMPT = """\
+_FILTER_PROMPT_TEMPLATE = """\
 You are a quality reviewer for user-outcome statements.
 
-Each outcome below should describe a CONCRETE, POSITIVE, VERIFIABLE
-thing a real user can do with the finished product.  Reject outcomes
-that are any of:
+{criteria}
 
-- Negations — the user is forbidden, unable, restricted, or cannot do
-  something (these violate the positive-capability invariant)
-- Vague — phrasings like "use the app", "interact with it", "do stuff",
-  or anything that doesn't tie to concrete user-visible behavior
-- Non-user-facing — describes internal system processing, not what a
-  user does or sees
-- Spec restatement — repeats the project name without specifying what
-  a user can DO
-
-For each outcome, return a verdict YES (keep) or NO (drop), with a
-short reason for the verdict.
+For each outcome below, return ``verifiable: true`` if it satisfies
+ALL THREE properties, ``verifiable: false`` otherwise.  Provide a
+short ``reason`` either way — the reason will be logged for debug
+visibility when an outcome is dropped.
 
 Outcomes:
 {outcomes_block}
@@ -296,7 +321,7 @@ Return strict JSON of the form:
   "verdicts": {{
     "<outcome_id>": {{
       "verifiable": true,
-      "reason": "<one short sentence — why kept or dropped>"
+      "reason": "<one short sentence>"
     }}
   }}
 }}
@@ -304,6 +329,10 @@ Return strict JSON of the form:
 Every outcome.id from the input must appear as a key in verdicts.
 Respond with ONLY the JSON object — no preamble, no markdown fences.
 """
+
+# Substitute the criteria block at module load time.  ``replace``
+# leaves ``{outcomes_block}`` intact for ``.format()`` at call time.
+_FILTER_PROMPT = _FILTER_PROMPT_TEMPLATE.replace("{criteria}", _USER_OUTCOME_CRITERIA)
 
 
 async def filter_to_verifiable_capabilities(

--- a/src/ai/advanced/prd/outcome_extractor.py
+++ b/src/ai/advanced/prd/outcome_extractor.py
@@ -1,0 +1,266 @@
+"""User-outcome extraction for intent fidelity coverage (issue #449).
+
+The decomposer historically treats specs as flat feature lists and never
+verifies that the union of features yields a usable product.  v31 of the
+snake-game experiment shipped a perfectly-tested engine with no rendering
+because no task said "render the snake" — the spec implied it but the
+decomposer had no representation of what "done" means to a user.
+
+This module produces a list of :class:`UserOutcome` records from a spec.
+Each outcome is a concrete user action ("user can play the snake game")
+paired with an observable success signal.  Downstream stages use the list
+as decomposition constraints (every in-scope outcome must map to at least
+one task) and to compute the ``intent_fidelity_score`` metric.
+
+The extractor itself is a thin wrapper around an LLM call that validates
+the result against the schema — the validation is what makes the
+abstraction useful, not the call itself.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass
+from typing import Any, List
+
+from src.utils.json_parser import parse_ai_json_response
+
+# Phrases that mark a real user-capability action.  At least one must
+# appear (case-insensitive) in :attr:`UserOutcome.action`.
+_USER_CAPABILITY_PHRASES: tuple[str, ...] = (
+    "user can",
+    "user is able to",
+    "user must be able to",
+    "users can",
+    "users are able to",
+)
+
+# Vague verbs / phrases that pass the "user can" check but carry no
+# observable meaning.  These are rejected to keep the outcome list useful
+# as a coverage gate.
+_VAGUE_PHRASES: tuple[str, ...] = (
+    "use the app",
+    "use the application",
+    "use the product",
+    "use it",
+    "interact with the app",
+    "interact with the application",
+    "do stuff",
+    "do things",
+)
+
+_VALID_SCOPES: frozenset[str] = frozenset({"in_scope", "out_of_scope"})
+
+
+@dataclass
+class UserOutcome:
+    """A user-visible outcome the product must satisfy.
+
+    Parameters
+    ----------
+    id : str
+        Stable identifier used to map outcomes to tasks during the
+        coverage check.  Convention: ``outcome_<short_action_verb>``.
+    action : str
+        Concrete user capability statement.  Must contain a phrase
+        from :data:`_USER_CAPABILITY_PHRASES`.  Vague phrasings such as
+        "user can use the app" are rejected.
+    success_signal : str
+        Observable evidence that the outcome is satisfied.  Drives the
+        Integration Verification gate (Stage 5, deferred): a Playwright
+        DOM check, curl assertion, or CLI invocation must produce
+        evidence matching this signal.
+    scope : str
+        ``"in_scope"`` or ``"out_of_scope"``.  Out-of-scope outcomes
+        are retained (not dropped) so the audit trail records what the
+        extractor considered and rejected based on spec language.
+
+    Raises
+    ------
+    ValueError
+        If any field violates its invariant.  Validation runs in
+        ``__post_init__`` so invalid outcomes can never reach the
+        coverage check.
+    """
+
+    id: str
+    action: str
+    success_signal: str
+    scope: str
+
+    def __post_init__(self) -> None:
+        """Validate all fields; reject vague or malformed outcomes."""
+        if not self.id:
+            raise ValueError("UserOutcome.id must be a non-empty string")
+
+        if not self.success_signal:
+            raise ValueError(
+                "UserOutcome.success_signal must be non-empty — without "
+                "an observable signal the outcome cannot be verified"
+            )
+
+        if self.scope not in _VALID_SCOPES:
+            raise ValueError(
+                f"UserOutcome.scope must be one of {sorted(_VALID_SCOPES)}, "
+                f"got {self.scope!r}"
+            )
+
+        action_lc = self.action.lower()
+        if not any(phrase in action_lc for phrase in _USER_CAPABILITY_PHRASES):
+            raise ValueError(
+                "UserOutcome.action must express a user capability "
+                f"(one of {list(_USER_CAPABILITY_PHRASES)}); got {self.action!r}"
+            )
+
+        if any(vague in action_lc for vague in _VAGUE_PHRASES):
+            raise ValueError(
+                f"UserOutcome.action is too vague to be verifiable: "
+                f"{self.action!r}.  Replace with a concrete user-visible "
+                "capability (e.g. 'user can play the snake game')."
+            )
+
+
+_EXTRACTION_PROMPT = """\
+You are extracting user-visible outcomes from a project specification.
+
+A user outcome is a concrete capability the user must have when the
+product is finished — phrased as "user can <verb> <object> <observable
+detail>". Each outcome must be verifiable: an observer running the
+finished product must be able to tell yes/no whether it is satisfied.
+
+Return strict JSON of the form:
+
+{{
+  "outcomes": [
+    {{
+      "id": "outcome_<short_verb>",
+      "action": "user can <verb> <object> ...",
+      "success_signal": "<observable evidence>",
+      "scope": "in_scope" | "out_of_scope"
+    }}
+  ]
+}}
+
+Rules:
+- Every action must contain "user can" (or "users can" / "is able to").
+- "user can use the app" is too vague — reject this phrasing. Use
+  concrete actions tied to the product domain.
+- Outcomes the spec explicitly excludes (e.g. "no auth", "no accounts")
+  must still be listed but tagged "out_of_scope" so the audit trail is
+  preserved.
+- Every project has at least one outcome — never return an empty list.
+- Provide a success_signal even for out-of-scope outcomes.
+
+Specification:
+{spec}
+
+Respond with ONLY the JSON object — no preamble, no markdown fences.
+"""
+
+
+class _MaxTokensContext:
+    """Minimal context wrapper passed to LLM clients that expect one."""
+
+    def __init__(self, max_tokens: int) -> None:
+        self.max_tokens = max_tokens
+
+
+async def extract_user_outcomes(
+    spec: str, llm_client: Any, max_tokens: int = 1500
+) -> List[UserOutcome]:
+    """Extract a list of :class:`UserOutcome` records from a project spec.
+
+    Parameters
+    ----------
+    spec : str
+        The raw project specification.  Passed to the LLM verbatim — the
+        extractor inherits scope language ("no auth", "no accounts")
+        from the spec itself rather than re-deriving it.
+    llm_client : Any
+        Any client exposing ``async analyze(prompt, context)`` and
+        returning a string.  Mocked in unit tests.
+    max_tokens : int, optional
+        Token budget for the LLM call (default ``1500``).  Outcomes are
+        small; the budget is generous to avoid truncation in
+        many-feature specs.
+
+    Returns
+    -------
+    list of UserOutcome
+        Validated outcomes, in the order the LLM produced them.  Both
+        in-scope and out-of-scope outcomes are returned; the coverage
+        check filters by scope.
+
+    Raises
+    ------
+    ValueError
+        If the LLM returns malformed JSON, an empty outcome list, or
+        any individual outcome fails :class:`UserOutcome` validation.
+    """
+    prompt = _EXTRACTION_PROMPT.format(spec=spec)
+    raw = await llm_client.analyze(prompt, _MaxTokensContext(max_tokens))
+    raw_text = str(raw) if raw is not None else ""
+
+    try:
+        payload = parse_ai_json_response(raw_text)
+    except (ValueError, json.JSONDecodeError) as exc:
+        raise ValueError(
+            f"User-outcome extractor: LLM returned malformed JSON: {exc}"
+        ) from exc
+
+    # parse_ai_json_response normalizes to a dict; the prompt asks for an
+    # object with an "outcomes" key.  Missing key = prompt ignored: hard fail.
+    raw_outcomes = payload.get("outcomes")
+    if raw_outcomes is None:
+        raise ValueError("User-outcome extractor: LLM JSON missing 'outcomes' key")
+    if not isinstance(raw_outcomes, list):
+        raise ValueError("User-outcome extractor: 'outcomes' must be a JSON array")
+
+    if not raw_outcomes:
+        raise ValueError(
+            "User-outcome extractor: LLM returned no outcomes — every spec "
+            "implies at least one user-visible capability"
+        )
+
+    outcomes: List[UserOutcome] = []
+    for idx, item in enumerate(raw_outcomes):
+        if not isinstance(item, dict):
+            raise ValueError(
+                f"User-outcome extractor: outcome at index {idx} is not "
+                f"an object: {item!r}"
+            )
+        try:
+            outcomes.append(
+                UserOutcome(
+                    id=str(item.get("id", "")).strip(),
+                    action=str(item.get("action", "")).strip(),
+                    success_signal=str(item.get("success_signal", "")).strip(),
+                    scope=str(item.get("scope", "")).strip(),
+                )
+            )
+        except ValueError as exc:
+            raise ValueError(
+                f"User-outcome extractor: outcome at index {idx} invalid: " f"{exc}"
+            ) from exc
+
+    # Reject ID collisions — they would silently overwrite each other in
+    # the coverage map.
+    seen_ids: set[str] = set()
+    for outcome in outcomes:
+        if outcome.id in seen_ids:
+            raise ValueError(
+                f"User-outcome extractor: duplicate outcome id {outcome.id!r}"
+            )
+        seen_ids.add(outcome.id)
+
+    return outcomes
+
+
+# Re-exported for type-checking convenience; the regex is exposed in case
+# future callers need to test action strings without constructing an
+# :class:`UserOutcome` first.
+USER_CAPABILITY_PATTERN = re.compile(
+    "|".join(re.escape(p) for p in _USER_CAPABILITY_PHRASES),
+    flags=re.IGNORECASE,
+)

--- a/src/ai/advanced/prd/outcome_extractor.py
+++ b/src/ai/advanced/prd/outcome_extractor.py
@@ -8,79 +8,35 @@ decomposer had no representation of what "done" means to a user.
 
 This module produces a list of :class:`UserOutcome` records from a spec.
 Each outcome is a concrete user action ("user can play the snake game")
-paired with an observable success signal.  Downstream stages use the list
-as decomposition constraints (every in-scope outcome must map to at least
-one task) and to compute the ``intent_fidelity_score`` metric.
+paired with an observable success signal.  Downstream stages use the
+list as decomposition constraints (every in-scope outcome must map to
+at least one task) and to compute the ``intent_fidelity_score`` metric.
 
-The extractor itself is a thin wrapper around an LLM call that validates
-the result against the schema — the validation is what makes the
-abstraction useful, not the call itself.
+Two LLM calls happen here:
+
+1. :func:`extract_user_outcomes` — turns a spec into outcome records.
+2. :func:`filter_to_verifiable_capabilities` — a second LLM pass that
+   acts as a quality gate, dropping outcomes that are not concrete
+   positive verifiable user capabilities.  This replaces hand-curated
+   denylists for negations, vague phrasings, and capability-pattern
+   matching, which would otherwise grow indefinitely as the LLM finds
+   new ways to phrase the same antipatterns.
+
+The extractor itself is a thin wrapper around the LLM calls; validation
+in :class:`UserOutcome` is purely structural (types, non-empty fields,
+scope enum).  Semantic correctness is the LLM filter's job.
 """
 
 from __future__ import annotations
 
 import json
-import re
+import logging
 from dataclasses import dataclass
 from typing import Any, List
 
 from src.utils.json_parser import parse_ai_json_response
 
-# Patterns that mark a real user-capability action.  Word-boundary
-# regex (not substring) so that ``"user cannot ..."`` and ``"user
-# can't ..."`` do NOT match — those are negations and contradict the
-# positive-capability invariant.  The lookahead ``(?!')`` rejects the
-# ``"can't"`` contraction.
-_USER_CAPABILITY_PATTERNS: tuple["re.Pattern[str]", ...] = (
-    re.compile(r"\busers? can\b(?!')", re.IGNORECASE),
-    re.compile(r"\busers? (?:is|are) able to\b", re.IGNORECASE),
-    re.compile(r"\busers? must be able to\b", re.IGNORECASE),
-)
-
-# Negation markers — even if a positive pattern also matches, presence
-# of any of these phrases means the action is NOT a positive capability
-# (e.g. ``"user cannot play"`` or ``"user can never log in"``).
-_NEGATION_PATTERNS: tuple["re.Pattern[str]", ...] = (
-    re.compile(r"\bcannot\b", re.IGNORECASE),
-    re.compile(r"\bcan ?not\b", re.IGNORECASE),
-    re.compile(r"\bcan't\b", re.IGNORECASE),
-    re.compile(r"\bunable\b", re.IGNORECASE),
-    re.compile(r"\bnever\b", re.IGNORECASE),
-    re.compile(r"\bwon't\b", re.IGNORECASE),
-    re.compile(r"\bwill not\b", re.IGNORECASE),
-)
-
-# Vague verbs / phrases that pass the "user can" check but carry no
-# observable meaning.  These are rejected to keep the outcome list useful
-# as a coverage gate.
-#
-# .. warning::
-#
-#     **DO NOT EXPAND THIS LIST.**  Maintaining a hand-curated denylist
-#     of vague phrasings is a band-aid that recreates the
-#     project-type-specific guard pattern this module was built to
-#     replace (see ``advanced_parser.py`` ``frontend`` / ``e-commerce``
-#     / ``UI/UX`` band-aids — that growth pattern was the original sin).
-#
-#     The structural fix is an LLM specificity self-check: after
-#     extraction, run a second LLM pass that scores each outcome's
-#     observability and rejects low-scoring ones.  That generalizes
-#     across phrasings without requiring this list to grow.
-#
-#     The current denylist is the minimum viable catch for the most
-#     common LLM failure modes ("user can use the app" was the v31
-#     antipattern).  When you find a new vague phrasing slipping
-#     through, add the LLM self-check, do not extend this tuple.
-_VAGUE_PHRASES: tuple[str, ...] = (
-    "use the app",
-    "use the application",
-    "use the product",
-    "use it",
-    "interact with the app",
-    "interact with the application",
-    "do stuff",
-    "do things",
-)
+logger = logging.getLogger(__name__)
 
 _VALID_SCOPES: frozenset[str] = frozenset({"in_scope", "out_of_scope"})
 
@@ -95,11 +51,12 @@ class UserOutcome:
         Stable identifier used to map outcomes to tasks during the
         coverage check.  Convention: ``outcome_<short_action_verb>``.
     action : str
-        Concrete user capability statement.  Must contain a phrase
-        from :data:`_USER_CAPABILITY_PATTERNS` (word-boundary regex).
-        Vague phrasings such as "user can use the app" are rejected;
-        negations such as "user cannot ..." or "user can't ..." are
-        also rejected via :data:`_NEGATION_PATTERNS`.
+        Concrete user capability statement (e.g. ``"user can play the
+        snake game in their browser"``).  Validated only structurally
+        here — non-empty after stripping.  Semantic checks (positive
+        capability, concreteness, no negation) happen in
+        :func:`filter_to_verifiable_capabilities` via an LLM call,
+        not via pattern matching against denylists in this module.
     success_signal : str
         Observable evidence that the outcome is satisfied.  Drives the
         Integration Verification gate (Stage 5, deferred): a Playwright
@@ -113,9 +70,11 @@ class UserOutcome:
     Raises
     ------
     ValueError
-        If any field violates its invariant.  Validation runs in
-        ``__post_init__`` so invalid outcomes can never reach the
-        coverage check.
+        If any field violates a structural invariant.  Validation runs
+        in ``__post_init__`` so malformed outcomes never enter the
+        pipeline.  Semantic invariants (action is a positive capability,
+        not vague, not a negation) are enforced separately by
+        :func:`filter_to_verifiable_capabilities`.
     """
 
     id: str
@@ -124,9 +83,12 @@ class UserOutcome:
     scope: str
 
     def __post_init__(self) -> None:
-        """Validate all fields; reject vague, malformed, or negated outcomes."""
+        """Validate structural invariants only — types and non-emptiness."""
         if not self.id:
             raise ValueError("UserOutcome.id must be a non-empty string")
+
+        if not self.action.strip():
+            raise ValueError("UserOutcome.action must be a non-empty string")
 
         if not self.success_signal:
             raise ValueError(
@@ -138,32 +100,6 @@ class UserOutcome:
             raise ValueError(
                 f"UserOutcome.scope must be one of {sorted(_VALID_SCOPES)}, "
                 f"got {self.scope!r}"
-            )
-
-        # Reject negations FIRST — "user cannot play" contains "user can"
-        # as a substring, so word-boundary positive matching alone is not
-        # enough.  An action with a negation marker is never a positive
-        # capability regardless of whether a positive pattern also matches.
-        if any(p.search(self.action) for p in _NEGATION_PATTERNS):
-            raise ValueError(
-                "UserOutcome.action contains a negation (cannot / can't / "
-                "unable / never / won't / will not) — outcomes must "
-                f"express positive capabilities; got {self.action!r}"
-            )
-
-        if not any(p.search(self.action) for p in _USER_CAPABILITY_PATTERNS):
-            raise ValueError(
-                "UserOutcome.action must express a user capability "
-                "(e.g. 'user can <verb>', 'users are able to <verb>'); "
-                f"got {self.action!r}"
-            )
-
-        action_lc = self.action.lower()
-        if any(vague in action_lc for vague in _VAGUE_PHRASES):
-            raise ValueError(
-                f"UserOutcome.action is too vague to be verifiable: "
-                f"{self.action!r}.  Replace with a concrete user-visible "
-                "capability (e.g. 'user can play the snake game')."
             )
 
 
@@ -314,4 +250,149 @@ async def extract_user_outcomes(
             )
         seen_ids.add(outcome.id)
 
+    # Quality gate: a second LLM pass drops outcomes that aren't
+    # concrete positive verifiable user capabilities.  This replaces
+    # hand-curated denylists for negations and vague phrasings — the
+    # LLM understands "user is forbidden from", "user shall avoid",
+    # "user has zero capacity to", and any other phrasing we never
+    # listed.
+    outcomes = await filter_to_verifiable_capabilities(outcomes, llm_client)
+
+    if not outcomes:
+        raise ValueError(
+            "User-outcome extractor: every extracted outcome failed the "
+            "verifiability self-check — the spec produced no concrete "
+            "positive user capabilities"
+        )
+
     return outcomes
+
+
+_FILTER_PROMPT = """\
+You are a quality reviewer for user-outcome statements.
+
+Each outcome below should describe a CONCRETE, POSITIVE, VERIFIABLE
+thing a real user can do with the finished product.  Reject outcomes
+that are any of:
+
+- Negations — the user is forbidden, unable, restricted, or cannot do
+  something (these violate the positive-capability invariant)
+- Vague — phrasings like "use the app", "interact with it", "do stuff",
+  or anything that doesn't tie to concrete user-visible behavior
+- Non-user-facing — describes internal system processing, not what a
+  user does or sees
+- Spec restatement — repeats the project name without specifying what
+  a user can DO
+
+For each outcome, return a verdict YES (keep) or NO (drop), with a
+short reason for the verdict.
+
+Outcomes:
+{outcomes_block}
+
+Return strict JSON of the form:
+
+{{
+  "verdicts": {{
+    "<outcome_id>": {{
+      "verifiable": true,
+      "reason": "<one short sentence — why kept or dropped>"
+    }}
+  }}
+}}
+
+Every outcome.id from the input must appear as a key in verdicts.
+Respond with ONLY the JSON object — no preamble, no markdown fences.
+"""
+
+
+async def filter_to_verifiable_capabilities(
+    outcomes: List[UserOutcome], llm_client: Any, max_tokens: int = 1500
+) -> List[UserOutcome]:
+    """Drop outcomes that are not concrete positive verifiable capabilities.
+
+    Single LLM call evaluates every outcome and returns YES/NO verdicts.
+    Outcomes marked NO are dropped from the returned list and logged at
+    INFO level for debug visibility.
+
+    This is the structural alternative to maintaining hand-curated
+    denylists for negations, vague phrasings, and capability-pattern
+    matching.  An LLM understands every phrasing we'd otherwise need
+    to enumerate — "user is forbidden from", "user has zero ability
+    to", "users shall avoid" — without us listing them.
+
+    Parameters
+    ----------
+    outcomes : list of UserOutcome
+        Structurally-validated outcomes from
+        :func:`extract_user_outcomes`.  Empty list is allowed and
+        returns immediately without an LLM call.
+    llm_client : Any
+        Async client exposing ``analyze(prompt, context)``.
+    max_tokens : int, optional
+        Token budget for the LLM call.
+
+    Returns
+    -------
+    list of UserOutcome
+        Outcomes the LLM judged verifiable, in original order.
+
+    Raises
+    ------
+    ValueError
+        On malformed JSON, missing ``verdicts`` key, or any verdict
+        with a non-boolean ``verifiable`` field.
+    """
+    if not outcomes:
+        return []
+
+    outcomes_block = "\n".join(
+        f"- {o.id}: {o.action} (signal: {o.success_signal}, scope: {o.scope})"
+        for o in outcomes
+    )
+    prompt = _FILTER_PROMPT.format(outcomes_block=outcomes_block)
+
+    raw = await llm_client.analyze(prompt, _MaxTokensContext(max_tokens))
+    raw_text = str(raw) if raw is not None else ""
+
+    try:
+        payload = parse_ai_json_response(raw_text)
+    except (ValueError, json.JSONDecodeError) as exc:
+        raise ValueError(
+            f"User-outcome filter: LLM returned malformed JSON: {exc}"
+        ) from exc
+
+    raw_verdicts = payload.get("verdicts")
+    if not isinstance(raw_verdicts, dict):
+        raise ValueError("User-outcome filter: response missing 'verdicts' object")
+
+    kept: List[UserOutcome] = []
+    for outcome in outcomes:
+        verdict = raw_verdicts.get(outcome.id)
+        if not isinstance(verdict, dict):
+            # Missing verdict = treat as ambiguous; default to KEEPING
+            # the outcome.  Dropping a structurally-valid outcome
+            # because the filter LLM forgot to evaluate it is worse
+            # than keeping a borderline one — a downstream coverage
+            # gap is recoverable, a vanished outcome is silent loss.
+            logger.warning(
+                "User-outcome filter: no verdict for %s — keeping by default",
+                outcome.id,
+            )
+            kept.append(outcome)
+            continue
+
+        verifiable = verdict.get("verifiable")
+        if not isinstance(verifiable, bool):
+            raise ValueError(
+                f"User-outcome filter: verdict for {outcome.id!r} "
+                f"missing or non-boolean 'verifiable' field: {verdict!r}"
+            )
+
+        if verifiable:
+            kept.append(outcome)
+        else:
+            reason = str(verdict.get("reason", "(no reason given)"))
+            logger.info("User-outcome filter: dropped %s — %s", outcome.id, reason)
+
+    return kept

--- a/src/ai/advanced/prd/outcome_extractor.py
+++ b/src/ai/advanced/prd/outcome_extractor.py
@@ -39,6 +39,24 @@ _USER_CAPABILITY_PHRASES: tuple[str, ...] = (
 # Vague verbs / phrases that pass the "user can" check but carry no
 # observable meaning.  These are rejected to keep the outcome list useful
 # as a coverage gate.
+#
+# .. warning::
+#
+#     **DO NOT EXPAND THIS LIST.**  Maintaining a hand-curated denylist
+#     of vague phrasings is a band-aid that recreates the
+#     project-type-specific guard pattern this module was built to
+#     replace (see ``advanced_parser.py`` ``frontend`` / ``e-commerce``
+#     / ``UI/UX`` band-aids — that growth pattern was the original sin).
+#
+#     The structural fix is an LLM specificity self-check: after
+#     extraction, run a second LLM pass that scores each outcome's
+#     observability and rejects low-scoring ones.  That generalizes
+#     across phrasings without requiring this list to grow.
+#
+#     The current denylist is the minimum viable catch for the most
+#     common LLM failure modes ("user can use the app" was the v31
+#     antipattern).  When you find a new vague phrasing slipping
+#     through, add the LLM self-check, do not extend this tuple.
 _VAGUE_PHRASES: tuple[str, ...] = (
     "use the app",
     "use the application",

--- a/src/marcus_mcp/coordinator/outcome_coverage.py
+++ b/src/marcus_mcp/coordinator/outcome_coverage.py
@@ -1,0 +1,373 @@
+"""User-outcome coverage check for intent fidelity (issue #449).
+
+Given a list of :class:`UserOutcome` records (from the extractor) and a
+list of :class:`Task` records (from the decomposer), this module answers:
+
+* Which tasks address each outcome? (:func:`compute_coverage`)
+* Which in-scope outcomes have no covering task? (:func:`find_gaps`)
+* What fraction of in-scope outcomes are covered?
+  (:func:`compute_intent_fidelity_score`)
+* When gaps exist, what tasks should be added? (:func:`fill_gaps`)
+
+The default coverage mapper is keyword-based — fast, deterministic, no
+LLM cost during the check.  Tests can inject an explicit mapper to bypass
+the default heuristic.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from typing import Any, Callable, Dict, Iterable, List, Optional, Set
+
+from src.ai.advanced.prd.outcome_extractor import UserOutcome
+from src.core.models import Task
+from src.utils.json_parser import parse_ai_json_response
+
+# Words too common to discriminate between outcome and task.  Stripped
+# from the keyword sets before overlap is computed.
+_STOPWORDS: frozenset[str] = frozenset(
+    {
+        "a",
+        "an",
+        "the",
+        "and",
+        "or",
+        "but",
+        "if",
+        "of",
+        "in",
+        "on",
+        "at",
+        "to",
+        "for",
+        "with",
+        "by",
+        "from",
+        "as",
+        "is",
+        "are",
+        "was",
+        "were",
+        "be",
+        "been",
+        "being",
+        "have",
+        "has",
+        "had",
+        "do",
+        "does",
+        "did",
+        "user",
+        "users",
+        "can",
+        "able",
+        "must",
+        "this",
+        "that",
+        "these",
+        "those",
+        "it",
+        "its",
+        "their",
+        "there",
+        "when",
+        "where",
+        "what",
+        "who",
+        "how",
+        "all",
+        "any",
+        "some",
+        "no",
+        "not",
+        "so",
+        "than",
+        "then",
+        "into",
+        "out",
+        "up",
+        "down",
+        "over",
+        "under",
+        "again",
+        "more",
+        "most",
+        "other",
+        "such",
+        "own",
+        "same",
+        "very",
+        "will",
+        "just",
+        "also",
+        # signal-domain noise
+        "observable",
+        "appears",
+        "shows",
+        "displays",
+        "set",
+        "works",
+        # action verbs that almost always appear in outcomes (don't help
+        # discriminate)
+        "see",
+        "view",
+        "use",
+        "make",
+        "get",
+        "go",
+    }
+)
+
+_TOKEN_RE = re.compile(r"[A-Za-z][A-Za-z0-9_-]+")
+
+
+def _tokens(text: str) -> Set[str]:
+    """Lower-cased, stopword-filtered token set for keyword overlap."""
+    return {
+        match.group().lower()
+        for match in _TOKEN_RE.finditer(text)
+        if match.group().lower() not in _STOPWORDS and len(match.group()) >= 3
+    }
+
+
+def _default_mapper(outcome: UserOutcome, task: Task) -> bool:
+    """Map outcome to task via keyword overlap (default coverage heuristic).
+
+    Combines ``action`` and ``success_signal`` for the outcome and
+    ``name`` and ``description`` for the task, then asks whether the
+    intersection (after stopword removal) is non-empty.
+
+    The threshold is intentionally low (≥1 shared token) — tasks that
+    are too narrow to share even one distinctive token with an outcome
+    are very likely not addressing it.  False positives in coverage
+    are recoverable (a task can address more than one outcome); false
+    negatives manifest as a gap, which triggers a single LLM call to
+    fill — the worst case.
+
+    Parameters
+    ----------
+    outcome : UserOutcome
+        The user-visible capability under check.
+    task : Task
+        The candidate task.
+
+    Returns
+    -------
+    bool
+        ``True`` if the task plausibly addresses the outcome.
+    """
+    outcome_tokens = _tokens(outcome.action + " " + outcome.success_signal)
+    task_tokens = _tokens(task.name + " " + (task.description or ""))
+    return bool(outcome_tokens & task_tokens)
+
+
+def compute_coverage(
+    outcomes: Iterable[UserOutcome],
+    tasks: Iterable[Task],
+    mapper: Optional[Callable[[UserOutcome, Task], bool]] = None,
+) -> Dict[str, List[str]]:
+    """Map every outcome (by id) to the task ids that address it.
+
+    Parameters
+    ----------
+    outcomes : iterable of UserOutcome
+        The outcomes extracted from the spec.  Order is preserved in the
+        returned dict via insertion order.
+    tasks : iterable of Task
+        Decomposer-generated tasks to test.
+    mapper : callable, optional
+        Custom ``(outcome, task) -> bool`` predicate.  When ``None``,
+        :func:`_default_mapper` (keyword overlap) is used.  Tests inject
+        explicit mappers to control coverage deterministically.
+
+    Returns
+    -------
+    dict
+        ``{outcome.id: [task.id, ...]}``.  Every outcome appears as a
+        key; the list is empty when no task covers it.
+    """
+    use_mapper = mapper or _default_mapper
+    task_list = list(tasks)
+    coverage: Dict[str, List[str]] = {}
+    for outcome in outcomes:
+        coverage[outcome.id] = [
+            task.id for task in task_list if use_mapper(outcome, task)
+        ]
+    return coverage
+
+
+def find_gaps(
+    outcomes: Iterable[UserOutcome],
+    coverage: Dict[str, List[str]],
+) -> List[UserOutcome]:
+    """Return in-scope outcomes that have no covering task.
+
+    Out-of-scope outcomes are excluded — they are tracked in the audit
+    trail but never count as gaps because the spec said not to build them.
+
+    Parameters
+    ----------
+    outcomes : iterable of UserOutcome
+        Outcomes to check.
+    coverage : dict
+        Output of :func:`compute_coverage`.
+
+    Returns
+    -------
+    list of UserOutcome
+        Outcomes that are in-scope and uncovered, in original order.
+    """
+    return [
+        outcome
+        for outcome in outcomes
+        if outcome.scope == "in_scope" and not coverage.get(outcome.id, [])
+    ]
+
+
+def compute_intent_fidelity_score(
+    outcomes: Iterable[UserOutcome],
+    coverage: Dict[str, List[str]],
+) -> float:
+    """Fraction of in-scope outcomes that have at least one covering task.
+
+    Returns ``1.0`` when there are no in-scope outcomes — vacuously
+    satisfied, since there is nothing to fail.  Other choices (NaN,
+    0.0, raise) all surprise consumers; treat absence as full fidelity.
+
+    Parameters
+    ----------
+    outcomes : iterable of UserOutcome
+        All outcomes (in-scope and out-of-scope).
+    coverage : dict
+        Output of :func:`compute_coverage`.
+
+    Returns
+    -------
+    float
+        Score in ``[0.0, 1.0]``.
+    """
+    in_scope = [o for o in outcomes if o.scope == "in_scope"]
+    if not in_scope:
+        return 1.0
+    covered = sum(1 for o in in_scope if coverage.get(o.id))
+    return covered / len(in_scope)
+
+
+_GAP_FILL_PROMPT = """\
+The following user-visible outcomes are required by the specification
+but the current task graph does not cover them.  Generate the minimum
+set of tasks that would address each gap.
+
+Specification:
+{spec}
+
+Uncovered outcomes:
+{gap_list}
+
+Return strict JSON of the form:
+
+{{
+  "tasks": [
+    {{
+      "name": "<short task name>",
+      "description": "<what to build, including how downstream agents '
+      'will consume it>"
+    }}
+  ]
+}}
+
+Rules:
+- One or more tasks per gap is allowed.
+- Task names must be concrete (e.g. "Render snake to canvas") not
+  generic ("implement feature").
+- Descriptions must say WHAT to build, not HOW.  No library choices.
+- Return ONLY the JSON object — no preamble, no markdown fences.
+"""
+
+
+class _MaxTokensContext:
+    """Minimal context wrapper passed to LLM clients that expect one."""
+
+    def __init__(self, max_tokens: int) -> None:
+        self.max_tokens = max_tokens
+
+
+async def fill_gaps(
+    spec: str,
+    gaps: List[UserOutcome],
+    llm_client: Any,
+    max_tokens: int = 1500,
+) -> List[Dict[str, Any]]:
+    """Generate replacement tasks for uncovered outcomes via a single LLM call.
+
+    No call is made when ``gaps`` is empty — coverage was full and we
+    save the round-trip.
+
+    Parameters
+    ----------
+    spec : str
+        The original project spec, included verbatim so the LLM can
+        respect scope language.
+    gaps : list of UserOutcome
+        Outcomes the decomposer missed.  Caller is expected to have
+        filtered out out-of-scope outcomes already.
+    llm_client : Any
+        Async client exposing ``analyze(prompt, context)``.
+    max_tokens : int, optional
+        Token budget for the LLM call.
+
+    Returns
+    -------
+    list of dict
+        Each dict has at minimum ``name`` and ``description`` keys.  The
+        decomposer constructs full :class:`Task` objects from these
+        dicts (synthesis hours, dependencies, labels, etc.).
+
+    Raises
+    ------
+    ValueError
+        On malformed JSON, missing ``tasks`` key, or any task missing
+        ``name`` / ``description``.
+    """
+    if not gaps:
+        return []
+
+    gap_lines = "\n".join(
+        f"- {gap.id}: {gap.action} (success: {gap.success_signal})" for gap in gaps
+    )
+    prompt = _GAP_FILL_PROMPT.format(spec=spec, gap_list=gap_lines)
+
+    raw = await llm_client.analyze(prompt, _MaxTokensContext(max_tokens))
+    raw_text = str(raw) if raw is not None else ""
+
+    try:
+        payload = parse_ai_json_response(raw_text)
+    except (ValueError, json.JSONDecodeError) as exc:
+        raise ValueError(
+            f"Outcome gap-fill: LLM returned malformed JSON: {exc}"
+        ) from exc
+
+    if not isinstance(payload, dict):
+        raise ValueError(
+            "Outcome gap-fill: LLM JSON must be an object with 'tasks' key"
+        )
+    raw_tasks = payload.get("tasks")
+    if not isinstance(raw_tasks, list):
+        raise ValueError("Outcome gap-fill: 'tasks' must be a JSON array")
+
+    validated: List[Dict[str, Any]] = []
+    for idx, item in enumerate(raw_tasks):
+        if not isinstance(item, dict):
+            raise ValueError(f"Outcome gap-fill: task at index {idx} is not an object")
+        name = str(item.get("name", "")).strip()
+        description = str(item.get("description", "")).strip()
+        if not name:
+            raise ValueError(f"Outcome gap-fill: task at index {idx} missing 'name'")
+        if not description:
+            raise ValueError(
+                f"Outcome gap-fill: task at index {idx} missing 'description'"
+            )
+        validated.append({"name": name, "description": description})
+
+    return validated

--- a/src/marcus_mcp/coordinator/outcome_coverage.py
+++ b/src/marcus_mcp/coordinator/outcome_coverage.py
@@ -511,8 +511,22 @@ async def fill_gaps(
     for idx, item in enumerate(raw_tasks):
         if not isinstance(item, dict):
             raise ValueError(f"Outcome gap-fill: task at index {idx} is not an object")
-        name = str(item.get("name", "")).strip()
-        description = str(item.get("description", "")).strip()
+
+        # Reject null / non-string fields rather than coerce.  str(None)
+        # is the string "None" which is non-empty and would silently
+        # pass the empty-string checks below — callers would see
+        # "filled gaps" that are actually unusable placeholder tasks.
+        for required_field in ("name", "description"):
+            value = item.get(required_field)
+            if not isinstance(value, str):
+                raise ValueError(
+                    f"Outcome gap-fill: task at index {idx} field "
+                    f"{required_field!r} must be a string, got "
+                    f"{type(value).__name__}: {value!r}"
+                )
+
+        name = item["name"].strip()
+        description = item["description"].strip()
         if not name:
             raise ValueError(f"Outcome gap-fill: task at index {idx} missing 'name'")
         if not description:

--- a/src/marcus_mcp/coordinator/outcome_coverage.py
+++ b/src/marcus_mcp/coordinator/outcome_coverage.py
@@ -9,16 +9,22 @@ list of :class:`Task` records (from the decomposer), this module answers:
   (:func:`compute_intent_fidelity_score`)
 * When gaps exist, what tasks should be added? (:func:`fill_gaps`)
 
-The default coverage mapper is keyword-based — fast, deterministic, no
-LLM cost during the check.  Tests can inject an explicit mapper to bypass
-the default heuristic.
+Two coverage strategies are available:
+
+* :func:`compute_coverage` — sync, requires an explicit mapper.  Use
+  :func:`keyword_overlap_mapper` for offline / test scenarios.  No
+  default mapper is provided because the only sync option produces
+  false positives on the snake_game-v31 case (#449's motivation).
+* :func:`compute_coverage_with_llm` — async, single LLM call maps
+  all outcomes to all tasks.  This is the production path; the LLM
+  has the global context to distinguish "supports" from "addresses".
 """
 
 from __future__ import annotations
 
 import json
 import re
-from typing import Any, Callable, Dict, Iterable, List, Optional, Set
+from typing import Any, Callable, Dict, Iterable, List, Set
 
 from src.ai.advanced.prd.outcome_extractor import UserOutcome
 from src.core.models import Task
@@ -131,19 +137,31 @@ def _tokens(text: str) -> Set[str]:
     }
 
 
-def _default_mapper(outcome: UserOutcome, task: Task) -> bool:
-    """Map outcome to task via keyword overlap (default coverage heuristic).
+def keyword_overlap_mapper(outcome: UserOutcome, task: Task) -> bool:
+    """Map outcome to task via keyword overlap (FALLBACK heuristic only).
 
-    Combines ``action`` and ``success_signal`` for the outcome and
-    ``name`` and ``description`` for the task, then asks whether the
-    intersection (after stopword removal) is non-empty.
+    .. warning::
 
-    The threshold is intentionally low (≥1 shared token) — tasks that
-    are too narrow to share even one distinctive token with an outcome
-    are very likely not addressing it.  False positives in coverage
-    are recoverable (a task can address more than one outcome); false
-    negatives manifest as a gap, which triggers a single LLM call to
-    fill — the worst case.
+        **Do not use this as the production coverage strategy.**  It is
+        provably inadequate on the snake_game-v31 case (the failure
+        mode that motivated #449): outcomes and internal logic tasks
+        share heavy domain-noun overlap (``snake``, ``food``, ``score``)
+        which produces false positives — every logic task is wrongly
+        marked as "covering" the play-the-game outcome.
+
+        Use this mapper only when:
+
+        * No LLM client is available (smoke tests, offline tooling)
+        * Writing unit tests that exercise :func:`compute_coverage`
+          mechanics and need a deterministic, sync mapper
+
+        For production decomposer integration use
+        :func:`compute_coverage_with_llm` instead — it issues a single
+        LLM call that maps all outcomes to all tasks at once.
+
+    Returns ``True`` when the lower-cased, stopword-filtered token sets
+    of ``(outcome.action + outcome.success_signal)`` and
+    ``(task.name + task.description)`` share at least one token.
 
     Parameters
     ----------
@@ -155,7 +173,9 @@ def _default_mapper(outcome: UserOutcome, task: Task) -> bool:
     Returns
     -------
     bool
-        ``True`` if the task plausibly addresses the outcome.
+        ``True`` if the token sets overlap.  This is necessary but not
+        sufficient evidence that the task addresses the outcome — see
+        the warning above.
     """
     outcome_tokens = _tokens(outcome.action + " " + outcome.success_signal)
     task_tokens = _tokens(task.name + " " + (task.description or ""))
@@ -165,21 +185,30 @@ def _default_mapper(outcome: UserOutcome, task: Task) -> bool:
 def compute_coverage(
     outcomes: Iterable[UserOutcome],
     tasks: Iterable[Task],
-    mapper: Optional[Callable[[UserOutcome, Task], bool]] = None,
+    mapper: Callable[[UserOutcome, Task], bool],
 ) -> Dict[str, List[str]]:
     """Map every outcome (by id) to the task ids that address it.
+
+    The ``mapper`` argument is **required**.  There is no implicit
+    default because the only sync mapper in this module
+    (:func:`keyword_overlap_mapper`) produces false positives on the
+    snake_game-v31 case the whole module exists to catch — a
+    contributor importing :func:`compute_coverage` without thinking
+    about which mapper to use would silently re-introduce the v31
+    regression.
 
     Parameters
     ----------
     outcomes : iterable of UserOutcome
-        The outcomes extracted from the spec.  Order is preserved in the
-        returned dict via insertion order.
+        The outcomes extracted from the spec.  Order is preserved in
+        the returned dict via insertion order.
     tasks : iterable of Task
         Decomposer-generated tasks to test.
-    mapper : callable, optional
-        Custom ``(outcome, task) -> bool`` predicate.  When ``None``,
-        :func:`_default_mapper` (keyword overlap) is used.  Tests inject
-        explicit mappers to control coverage deterministically.
+    mapper : callable
+        ``(outcome, task) -> bool`` predicate.  Pass
+        :func:`keyword_overlap_mapper` for fallback / testing only;
+        production callers should use :func:`compute_coverage_with_llm`
+        instead, which performs the mapping with a single LLM call.
 
     Returns
     -------
@@ -187,13 +216,10 @@ def compute_coverage(
         ``{outcome.id: [task.id, ...]}``.  Every outcome appears as a
         key; the list is empty when no task covers it.
     """
-    use_mapper = mapper or _default_mapper
     task_list = list(tasks)
     coverage: Dict[str, List[str]] = {}
     for outcome in outcomes:
-        coverage[outcome.id] = [
-            task.id for task in task_list if use_mapper(outcome, task)
-        ]
+        coverage[outcome.id] = [task.id for task in task_list if mapper(outcome, task)]
     return coverage
 
 
@@ -252,6 +278,131 @@ def compute_intent_fidelity_score(
         return 1.0
     covered = sum(1 for o in in_scope if coverage.get(o.id))
     return covered / len(in_scope)
+
+
+_LLM_COVERAGE_PROMPT = """\
+You are evaluating whether each user-visible outcome is addressed by
+at least one task in a decomposed task graph.
+
+A task "addresses" an outcome only when finishing it would contribute
+in a user-observable way to the outcome.  Internal logic that only
+maintains state, validates input, or supports another task does NOT
+address a user outcome unless it produces something the user sees,
+hears, or otherwise observes.
+
+Example (the snake_game-v31 case):
+- Outcome: "user can play the snake game" (signal: snake visibly
+  moves on a board)
+- Task "Snake state machine" (track snake body) — does NOT address
+  the outcome (no rendering)
+- Task "Render snake to canvas" (draw snake/food/score) — DOES
+  address the outcome (produces user-visible movement)
+
+Outcomes:
+{outcomes_block}
+
+Tasks:
+{tasks_block}
+
+Return strict JSON of the form:
+
+{{
+  "coverage": {{
+    "<outcome_id>": ["<task_id>", "<task_id>", ...]
+  }}
+}}
+
+Rules:
+- Every outcome.id must appear as a key, even if the list is empty.
+- Only include task ids that genuinely address the outcome — false
+  positives are worse than false negatives because they hide gaps.
+- Do not invent task ids.  Use exactly the ids from the input.
+- Respond with ONLY the JSON object — no preamble, no markdown fences.
+"""
+
+
+async def compute_coverage_with_llm(
+    outcomes: Iterable[UserOutcome],
+    tasks: Iterable[Task],
+    llm_client: Any,
+    max_tokens: int = 2000,
+) -> Dict[str, List[str]]:
+    """Compute outcome → task coverage via a single LLM call.
+
+    Production decomposer integration uses this function rather than
+    :func:`compute_coverage` with a sync mapper.  One LLM call evaluates
+    all outcomes against all tasks at once — cheaper than per-pair calls,
+    and the LLM has the global context to distinguish "supports" from
+    "addresses" (the keyword mapper cannot).
+
+    Parameters
+    ----------
+    outcomes : iterable of UserOutcome
+        Outcomes extracted from the spec.
+    tasks : iterable of Task
+        Tasks produced by the decomposer.
+    llm_client : Any
+        Async client exposing ``analyze(prompt, context)``.  Mocked in
+        tests.
+    max_tokens : int, optional
+        Token budget for the LLM call.  Larger task graphs may need
+        more headroom.
+
+    Returns
+    -------
+    dict
+        ``{outcome.id: [task.id, ...]}`` — same shape as
+        :func:`compute_coverage`.  Every outcome appears as a key;
+        unknown outcome ids in the LLM response are dropped, missing
+        outcome ids are filled with empty lists.
+
+    Raises
+    ------
+    ValueError
+        On malformed JSON or a missing ``coverage`` key.
+    """
+    outcome_list = list(outcomes)
+    task_list = list(tasks)
+
+    if not outcome_list:
+        return {}
+    if not task_list:
+        return {o.id: [] for o in outcome_list}
+
+    outcomes_block = "\n".join(
+        f"- {o.id}: {o.action} (signal: {o.success_signal})" for o in outcome_list
+    )
+    tasks_block = "\n".join(
+        f"- {t.id}: {t.name} — {t.description or '(no description)'}" for t in task_list
+    )
+    prompt = _LLM_COVERAGE_PROMPT.format(
+        outcomes_block=outcomes_block, tasks_block=tasks_block
+    )
+
+    raw = await llm_client.analyze(prompt, _MaxTokensContext(max_tokens))
+    raw_text = str(raw) if raw is not None else ""
+
+    try:
+        payload = parse_ai_json_response(raw_text)
+    except (ValueError, json.JSONDecodeError) as exc:
+        raise ValueError(f"LLM coverage: malformed JSON: {exc}") from exc
+
+    raw_coverage = payload.get("coverage")
+    if not isinstance(raw_coverage, dict):
+        raise ValueError("LLM coverage: response missing 'coverage' object")
+
+    valid_outcome_ids = {o.id for o in outcome_list}
+    valid_task_ids = {t.id for t in task_list}
+    coverage: Dict[str, List[str]] = {oid: [] for oid in valid_outcome_ids}
+    for outcome_id, task_ids in raw_coverage.items():
+        if outcome_id not in valid_outcome_ids:
+            continue
+        if not isinstance(task_ids, list):
+            continue
+        coverage[outcome_id] = [
+            tid for tid in task_ids if isinstance(tid, str) and tid in valid_task_ids
+        ]
+    return coverage
 
 
 _GAP_FILL_PROMPT = """\

--- a/tests/unit/ai/test_outcome_extractor.py
+++ b/tests/unit/ai/test_outcome_extractor.py
@@ -6,10 +6,11 @@ outcomes the product must satisfy.  ``extract_user_outcomes`` produces a
 list of ``UserOutcome`` records that downstream stages use as decomposition
 constraints and as the basis for the ``intent_fidelity_score`` metric.
 
-These tests exercise the extractor in isolation; the LLM is always mocked.
+These tests exercise the extractor in isolation; both LLM calls
+(extraction and the verifiability self-check) are mocked.
 """
 
-from typing import Any
+from typing import Any, Sequence
 from unittest.mock import AsyncMock
 
 import pytest
@@ -17,13 +18,39 @@ import pytest
 from src.ai.advanced.prd.outcome_extractor import (
     UserOutcome,
     extract_user_outcomes,
+    filter_to_verifiable_capabilities,
 )
 
 pytestmark = pytest.mark.unit
 
 
+# Filter response that approves a single play-game outcome.  Used by
+# extraction tests where the spec produces exactly one outcome.
+_FILTER_APPROVES_PLAY = (
+    '{"verdicts": {"outcome_play_game": '
+    '{"verifiable": true, "reason": "concrete user-visible action"}}}'
+)
+
+
+def _llm_with_responses(*responses: str) -> AsyncMock:
+    """Build an AsyncMock LLM that returns each response in sequence.
+
+    extract_user_outcomes makes two LLM calls (extraction + filter), so
+    most extraction tests need to provide both payloads in order.
+    """
+    mock = AsyncMock()
+    mock.analyze = AsyncMock(side_effect=list(responses))
+    return mock
+
+
 class TestUserOutcomeDataclass:
-    """``UserOutcome`` is a strict dataclass — invalid values raise."""
+    """``UserOutcome`` enforces structural invariants only.
+
+    Semantic invariants (positive capability, no negations, no vague
+    phrasings) are enforced by :func:`filter_to_verifiable_capabilities`
+    via an LLM self-check, NOT by pattern matching here.  The dataclass
+    only checks types and non-emptiness.
+    """
 
     def test_has_required_fields(self) -> None:
         """All four required fields are accepted as keyword args."""
@@ -34,34 +61,7 @@ class TestUserOutcomeDataclass:
             scope="in_scope",
         )
         assert outcome.id == "outcome_play_game"
-        assert outcome.action.startswith("user can")
-        assert outcome.success_signal
         assert outcome.scope == "in_scope"
-
-    def test_action_must_express_user_capability(self) -> None:
-        """An action without 'user can' / 'user is able to' is rejected.
-
-        The whole point is to capture user-visible outcomes; bare feature
-        descriptions like "implement rendering" are exactly the failure
-        mode this prevents.
-        """
-        with pytest.raises(ValueError, match="user can"):
-            UserOutcome(
-                id="outcome_render",
-                action="implement rendering",
-                success_signal="canvas draws snake",
-                scope="in_scope",
-            )
-
-    def test_action_rejects_vague_capability(self) -> None:
-        """'user can use the app' is too vague and rejected."""
-        with pytest.raises(ValueError, match="too vague"):
-            UserOutcome(
-                id="outcome_vague",
-                action="user can use the app",
-                success_signal="the app works",
-                scope="in_scope",
-            )
 
     def test_scope_must_be_known_value(self) -> None:
         """Scope must be 'in_scope' or 'out_of_scope'."""
@@ -93,60 +93,46 @@ class TestUserOutcomeDataclass:
                 scope="in_scope",
             )
 
-    def test_negation_cannot_is_rejected(self) -> None:
-        """'user cannot play' contains 'user can' as substring — reject it.
+    def test_action_must_be_non_empty(self) -> None:
+        """Empty action means nothing for downstream coverage to address."""
+        with pytest.raises(ValueError, match="action"):
+            UserOutcome(
+                id="outcome_x",
+                action="   ",
+                success_signal="X is observable",
+                scope="in_scope",
+            )
 
-        Codex P2 regression (PR #453): the original substring check
-        accepted negations because they share the prefix.  Word-boundary
-        regex + explicit negation pattern catches this.
+    def test_dataclass_does_not_enforce_semantic_constraints(self) -> None:
+        """Constructing a 'bad' outcome at the dataclass layer succeeds.
+
+        This is the design point: the dataclass validates SHAPE only.
+        Semantic checks (vague phrasings, negations, non-capability
+        actions) happen in :func:`filter_to_verifiable_capabilities`
+        via an LLM call.  We test that the LLM filter catches these
+        elsewhere.  The dataclass should not be enforcing language rules.
         """
-        with pytest.raises(ValueError, match="negation"):
-            UserOutcome(
-                id="outcome_x",
-                action="user cannot play the game",
-                success_signal="game is unplayable",
-                scope="in_scope",
-            )
-
-    def test_negation_cant_contraction_is_rejected(self) -> None:
-        """'user can't play' is also a negation."""
-        with pytest.raises(ValueError, match="negation"):
-            UserOutcome(
-                id="outcome_x",
-                action="user can't play the game",
-                success_signal="error appears",
-                scope="in_scope",
-            )
-
-    def test_negation_unable_is_rejected(self) -> None:
-        """'user is unable to ...' is a negation despite different phrasing."""
-        with pytest.raises(ValueError, match="negation"):
-            UserOutcome(
-                id="outcome_x",
-                action="user is unable to register",
-                success_signal="registration form rejects input",
-                scope="in_scope",
-            )
-
-    def test_negation_never_is_rejected(self) -> None:
-        """'user can never ...' contains a negation."""
-        with pytest.raises(ValueError, match="negation"):
-            UserOutcome(
-                id="outcome_x",
-                action="user can never log in twice",
-                success_signal="second login attempt fails",
-                scope="in_scope",
-            )
-
-    def test_capability_phrase_must_match_at_word_boundary(self) -> None:
-        """'usercan' (no boundary) does not satisfy the pattern."""
-        with pytest.raises(ValueError, match="user capability"):
-            UserOutcome(
-                id="outcome_x",
-                action="usercan play",
-                success_signal="something happens",
-                scope="in_scope",
-            )
+        # All of these would have raised under the old pattern-matching
+        # validation.  Now they construct cleanly because the LLM filter
+        # is the right place to evaluate them.
+        UserOutcome(
+            id="outcome_render",
+            action="implement rendering",
+            success_signal="canvas draws snake",
+            scope="in_scope",
+        )
+        UserOutcome(
+            id="outcome_negate",
+            action="user cannot log in",
+            success_signal="login fails",
+            scope="in_scope",
+        )
+        UserOutcome(
+            id="outcome_vague",
+            action="user can use the app",
+            success_signal="the app works",
+            scope="in_scope",
+        )
 
 
 class TestExtractUserOutcomes:
@@ -154,7 +140,13 @@ class TestExtractUserOutcomes:
 
     @pytest.fixture
     def llm_returning(self) -> Any:
-        """Build an AsyncMock LLM client that returns the given JSON string."""
+        """Build an AsyncMock LLM client that returns the given JSON string.
+
+        Single-payload variant — useful for tests that only get as far
+        as the extraction call (e.g. malformed-JSON tests).  For tests
+        that exercise the full pipeline, use ``_llm_with_responses``
+        directly with both extraction + filter payloads.
+        """
 
         def _build(payload: str) -> AsyncMock:
             mock = AsyncMock()
@@ -164,21 +156,22 @@ class TestExtractUserOutcomes:
         return _build
 
     @pytest.mark.asyncio
-    async def test_visual_spec_yields_render_outcome(self, llm_returning: Any) -> None:
+    async def test_visual_spec_yields_render_outcome(self) -> None:
         """Snake game spec must produce an outcome about playing/seeing the game.
 
         This is the v31-snake regression: ``"build a snake game"`` previously
         produced a task graph with no rendering task because the decomposer
         treated rendering as implicit.  The outcome layer makes it explicit.
         """
-        llm = llm_returning(
+        llm = _llm_with_responses(
             '{"outcomes": ['
             '{"id": "outcome_play_game",'
             ' "action": "user can play the snake game in their browser",'
             ' "success_signal": "snake visibly moves on a board, food appears,'
             ' score updates after each food eaten",'
             ' "scope": "in_scope"}'
-            "]}"
+            "]}",
+            _FILTER_APPROVES_PLAY,
         )
 
         outcomes = await extract_user_outcomes(
@@ -191,17 +184,17 @@ class TestExtractUserOutcomes:
         assert outcomes[0].scope == "in_scope"
 
     @pytest.mark.asyncio
-    async def test_api_spec_yields_endpoint_invocation_outcome(
-        self, llm_returning: Any
-    ) -> None:
+    async def test_api_spec_yields_endpoint_invocation_outcome(self) -> None:
         """API spec must produce outcomes about calling the endpoints."""
-        llm = llm_returning(
+        llm = _llm_with_responses(
             '{"outcomes": ['
             '{"id": "outcome_get_user",'
             ' "action": "user can call GET /users/:id and receive JSON",'
             ' "success_signal": "200 status, body contains id and name",'
             ' "scope": "in_scope"}'
-            "]}"
+            "]}",
+            '{"verdicts": {"outcome_get_user": '
+            '{"verifiable": true, "reason": "concrete API call"}}}',
         )
 
         outcomes = await extract_user_outcomes(
@@ -213,14 +206,14 @@ class TestExtractUserOutcomes:
         assert "call GET" in outcomes[0].action
 
     @pytest.mark.asyncio
-    async def test_scope_inheritance_from_spec(self, llm_returning: Any) -> None:
+    async def test_scope_inheritance_from_spec(self) -> None:
         """Outcomes the spec excludes must be tagged out_of_scope, not dropped.
 
         Out-of-scope retention is important so the audit trail preserves
         what the LLM considered and rejected — debuggable when an outcome
         looks missing.
         """
-        llm = llm_returning(
+        llm = _llm_with_responses(
             '{"outcomes": ['
             '{"id": "outcome_play",'
             ' "action": "user can play the snake game",'
@@ -230,7 +223,11 @@ class TestExtractUserOutcomes:
             ' "action": "user can log in with a password",'
             ' "success_signal": "credentials accepted, session cookie set",'
             ' "scope": "out_of_scope"}'
-            "]}"
+            "]}",
+            '{"verdicts": {'
+            '"outcome_play": {"verifiable": true, "reason": "concrete"},'
+            '"outcome_login": {"verifiable": true, "reason": "concrete"}'
+            "}}",
         )
 
         outcomes = await extract_user_outcomes(
@@ -245,22 +242,45 @@ class TestExtractUserOutcomes:
         assert "log in" in out_scope[0].action
 
     @pytest.mark.asyncio
-    async def test_vague_outcomes_are_rejected_at_extraction(
-        self, llm_returning: Any
-    ) -> None:
-        """If the LLM returns a vague outcome, extraction raises rather than
-        silently passing it downstream."""
-        llm = llm_returning(
+    async def test_vague_outcomes_are_rejected_by_llm_filter(self) -> None:
+        """LLM filter pass drops vague outcomes — replaces the old denylist.
+
+        The extractor LLM produces a vague outcome ("user can use the
+        application").  The filter LLM pass evaluates it as
+        verifiable=False and drops it.  Since it was the only outcome,
+        extract_user_outcomes raises rather than silently returning an
+        empty list — every spec implies at least one good outcome.
+        """
+        llm = _llm_with_responses(
             '{"outcomes": ['
             '{"id": "outcome_use",'
             ' "action": "user can use the application",'
             ' "success_signal": "it works",'
             ' "scope": "in_scope"}'
-            "]}"
+            "]}",
+            '{"verdicts": {"outcome_use": '
+            '{"verifiable": false, "reason": "vague — no concrete user action"}}}',
         )
 
-        with pytest.raises(ValueError, match="too vague"):
+        with pytest.raises(ValueError, match="failed the verifiability"):
             await extract_user_outcomes(spec="anything", llm_client=llm)
+
+    @pytest.mark.asyncio
+    async def test_negation_outcomes_are_rejected_by_llm_filter(self) -> None:
+        """LLM filter drops negations — replaces denylist regex matching."""
+        llm = _llm_with_responses(
+            '{"outcomes": ['
+            '{"id": "outcome_negate",'
+            ' "action": "user cannot bypass the paywall",'
+            ' "success_signal": "paywall blocks access",'
+            ' "scope": "in_scope"}'
+            "]}",
+            '{"verdicts": {"outcome_negate": '
+            '{"verifiable": false, "reason": "negation, not a positive capability"}}}',
+        )
+
+        with pytest.raises(ValueError, match="failed the verifiability"):
+            await extract_user_outcomes(spec="paywall app", llm_client=llm)
 
     @pytest.mark.asyncio
     async def test_malformed_llm_response_raises(self, llm_returning: Any) -> None:
@@ -326,3 +346,133 @@ class TestExtractUserOutcomes:
         llm = llm_returning('{"outcomes": []}')
         with pytest.raises(ValueError, match="no outcomes"):
             await extract_user_outcomes(spec="build something", llm_client=llm)
+
+
+def _outcome(
+    out_id: str = "o1",
+    action: str = "user can play the snake game",
+    signal: str = "snake visibly moves",
+    scope: str = "in_scope",
+) -> UserOutcome:
+    """Build a structurally-valid UserOutcome for filter tests."""
+    return UserOutcome(id=out_id, action=action, success_signal=signal, scope=scope)
+
+
+class TestFilterToVerifiableCapabilities:
+    """LLM self-check pass replaces hand-curated denylists.
+
+    Catches negations, vague phrasings, internal/non-user-facing
+    actions, and any other antipattern an LLM understands semantically
+    — without us maintaining a list of bad strings.
+    """
+
+    @staticmethod
+    def _llm(payload: str) -> AsyncMock:
+        mock = AsyncMock()
+        mock.analyze = AsyncMock(return_value=payload)
+        return mock
+
+    @pytest.mark.asyncio
+    async def test_keeps_outcomes_marked_verifiable(self) -> None:
+        outcomes = [
+            _outcome("o_play", "user can play snake", "snake moves"),
+            _outcome("o_score", "user can see score", "score visible in DOM"),
+        ]
+        llm = self._llm(
+            '{"verdicts": {'
+            '"o_play": {"verifiable": true, "reason": "concrete"},'
+            '"o_score": {"verifiable": true, "reason": "concrete"}'
+            "}}"
+        )
+        kept = await filter_to_verifiable_capabilities(outcomes, llm)
+        assert [o.id for o in kept] == ["o_play", "o_score"]
+
+    @pytest.mark.asyncio
+    async def test_drops_outcomes_marked_not_verifiable(self) -> None:
+        """LLM marks vague/negation outcomes as not verifiable; they drop."""
+        outcomes = [
+            _outcome("o_good", "user can play snake", "snake moves"),
+            _outcome("o_vague", "user can use the app", "app works"),
+            _outcome("o_negate", "user cannot register", "registration fails"),
+        ]
+        llm = self._llm(
+            '{"verdicts": {'
+            '"o_good": {"verifiable": true, "reason": "concrete"},'
+            '"o_vague": {"verifiable": false, "reason": "too vague"},'
+            '"o_negate": {"verifiable": false, "reason": "negation"}'
+            "}}"
+        )
+        kept = await filter_to_verifiable_capabilities(outcomes, llm)
+        assert [o.id for o in kept] == ["o_good"]
+
+    @pytest.mark.asyncio
+    async def test_empty_input_returns_empty_without_llm_call(self) -> None:
+        """No outcomes means no LLM call — saves cost."""
+        mock = AsyncMock()
+        mock.analyze = AsyncMock()
+        kept = await filter_to_verifiable_capabilities([], mock)
+        assert kept == []
+        mock.analyze.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_outcome_missing_from_llm_response_is_kept(self) -> None:
+        """A missing verdict defaults to keep, with a logged warning.
+
+        Dropping a structurally-valid outcome because the filter LLM
+        forgot it would be silent loss.  A coverage gap downstream is
+        recoverable; a missing outcome is not.
+        """
+        outcomes = [
+            _outcome("o_evaluated", "user can play", "moves"),
+            _outcome("o_forgotten", "user can score", "score visible"),
+        ]
+        llm = self._llm(
+            '{"verdicts": {'
+            '"o_evaluated": {"verifiable": true, "reason": "concrete"}'
+            "}}"
+        )
+        kept = await filter_to_verifiable_capabilities(outcomes, llm)
+        assert [o.id for o in kept] == ["o_evaluated", "o_forgotten"]
+
+    @pytest.mark.asyncio
+    async def test_malformed_response_raises(self) -> None:
+        outcomes = [_outcome()]
+        llm = self._llm("not json")
+        with pytest.raises(ValueError, match="malformed JSON"):
+            await filter_to_verifiable_capabilities(outcomes, llm)
+
+    @pytest.mark.asyncio
+    async def test_missing_verdicts_key_raises(self) -> None:
+        outcomes = [_outcome()]
+        llm = self._llm('{"wrong_key": {}}')
+        with pytest.raises(ValueError, match="verdicts"):
+            await filter_to_verifiable_capabilities(outcomes, llm)
+
+    @pytest.mark.asyncio
+    async def test_non_boolean_verifiable_raises(self) -> None:
+        """A verdict with non-boolean ``verifiable`` is malformed."""
+        outcomes = [_outcome("o1")]
+        llm = self._llm('{"verdicts": {"o1": {"verifiable": "yes", "reason": "x"}}}')
+        with pytest.raises(ValueError, match="verifiable"):
+            await filter_to_verifiable_capabilities(outcomes, llm)
+
+    @pytest.mark.asyncio
+    async def test_extract_raises_when_filter_drops_everything(self) -> None:
+        """If the filter drops every outcome, extraction surfaces the failure.
+
+        End-to-end coverage of the extractor's "every spec implies at
+        least one good outcome" invariant via the new filter step.
+        """
+        responses: Sequence[str] = (
+            '{"outcomes": ['
+            '{"id": "outcome_bad",'
+            ' "action": "user can use the app",'
+            ' "success_signal": "it works",'
+            ' "scope": "in_scope"}'
+            "]}",
+            '{"verdicts": {"outcome_bad": '
+            '{"verifiable": false, "reason": "vague"}}}',
+        )
+        llm = _llm_with_responses(*responses)
+        with pytest.raises(ValueError, match="failed the verifiability"):
+            await extract_user_outcomes(spec="x", llm_client=llm)

--- a/tests/unit/ai/test_outcome_extractor.py
+++ b/tests/unit/ai/test_outcome_extractor.py
@@ -93,6 +93,61 @@ class TestUserOutcomeDataclass:
                 scope="in_scope",
             )
 
+    def test_negation_cannot_is_rejected(self) -> None:
+        """'user cannot play' contains 'user can' as substring — reject it.
+
+        Codex P2 regression (PR #453): the original substring check
+        accepted negations because they share the prefix.  Word-boundary
+        regex + explicit negation pattern catches this.
+        """
+        with pytest.raises(ValueError, match="negation"):
+            UserOutcome(
+                id="outcome_x",
+                action="user cannot play the game",
+                success_signal="game is unplayable",
+                scope="in_scope",
+            )
+
+    def test_negation_cant_contraction_is_rejected(self) -> None:
+        """'user can't play' is also a negation."""
+        with pytest.raises(ValueError, match="negation"):
+            UserOutcome(
+                id="outcome_x",
+                action="user can't play the game",
+                success_signal="error appears",
+                scope="in_scope",
+            )
+
+    def test_negation_unable_is_rejected(self) -> None:
+        """'user is unable to ...' is a negation despite different phrasing."""
+        with pytest.raises(ValueError, match="negation"):
+            UserOutcome(
+                id="outcome_x",
+                action="user is unable to register",
+                success_signal="registration form rejects input",
+                scope="in_scope",
+            )
+
+    def test_negation_never_is_rejected(self) -> None:
+        """'user can never ...' contains a negation."""
+        with pytest.raises(ValueError, match="negation"):
+            UserOutcome(
+                id="outcome_x",
+                action="user can never log in twice",
+                success_signal="second login attempt fails",
+                scope="in_scope",
+            )
+
+    def test_capability_phrase_must_match_at_word_boundary(self) -> None:
+        """'usercan' (no boundary) does not satisfy the pattern."""
+        with pytest.raises(ValueError, match="user capability"):
+            UserOutcome(
+                id="outcome_x",
+                action="usercan play",
+                success_signal="something happens",
+                scope="in_scope",
+            )
+
 
 class TestExtractUserOutcomes:
     """``extract_user_outcomes`` queries the LLM and validates each result."""
@@ -213,6 +268,53 @@ class TestExtractUserOutcomes:
         llm = llm_returning("totally not json")
         with pytest.raises(ValueError, match="JSON"):
             await extract_user_outcomes(spec="anything", llm_client=llm)
+
+    @pytest.mark.asyncio
+    async def test_null_id_field_is_rejected(self, llm_returning: Any) -> None:
+        """LLM null for required field raises — must not coerce to 'None'.
+
+        Codex P1 regression (PR #453): the original ``str(item.get(...))``
+        coercion turned ``None`` into the literal string ``"None"`` which
+        is non-empty and silently passed validation, polluting outcome
+        ids used by ``compute_coverage``.
+        """
+        llm = llm_returning(
+            '{"outcomes": ['
+            '{"id": null,'
+            ' "action": "user can play",'
+            ' "success_signal": "snake moves",'
+            ' "scope": "in_scope"}'
+            "]}"
+        )
+        with pytest.raises(ValueError, match=r"'id'.*string"):
+            await extract_user_outcomes(spec="x", llm_client=llm)
+
+    @pytest.mark.asyncio
+    async def test_null_success_signal_is_rejected(self, llm_returning: Any) -> None:
+        llm = llm_returning(
+            '{"outcomes": ['
+            '{"id": "o1",'
+            ' "action": "user can play",'
+            ' "success_signal": null,'
+            ' "scope": "in_scope"}'
+            "]}"
+        )
+        with pytest.raises(ValueError, match=r"'success_signal'.*string"):
+            await extract_user_outcomes(spec="x", llm_client=llm)
+
+    @pytest.mark.asyncio
+    async def test_non_string_field_is_rejected(self, llm_returning: Any) -> None:
+        """An integer where a string is expected also raises."""
+        llm = llm_returning(
+            '{"outcomes": ['
+            '{"id": 42,'
+            ' "action": "user can play",'
+            ' "success_signal": "snake moves",'
+            ' "scope": "in_scope"}'
+            "]}"
+        )
+        with pytest.raises(ValueError, match=r"'id'.*string"):
+            await extract_user_outcomes(spec="x", llm_client=llm)
 
     @pytest.mark.asyncio
     async def test_empty_outcome_list_raises(self, llm_returning: Any) -> None:

--- a/tests/unit/ai/test_outcome_extractor.py
+++ b/tests/unit/ai/test_outcome_extractor.py
@@ -1,0 +1,226 @@
+"""
+Unit tests for user-outcome extraction (issue #449).
+
+The decomposer treats specs as flat feature lists, missing the user-visible
+outcomes the product must satisfy.  ``extract_user_outcomes`` produces a
+list of ``UserOutcome`` records that downstream stages use as decomposition
+constraints and as the basis for the ``intent_fidelity_score`` metric.
+
+These tests exercise the extractor in isolation; the LLM is always mocked.
+"""
+
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+
+from src.ai.advanced.prd.outcome_extractor import (
+    UserOutcome,
+    extract_user_outcomes,
+)
+
+pytestmark = pytest.mark.unit
+
+
+class TestUserOutcomeDataclass:
+    """``UserOutcome`` is a strict dataclass — invalid values raise."""
+
+    def test_has_required_fields(self) -> None:
+        """All four required fields are accepted as keyword args."""
+        outcome = UserOutcome(
+            id="outcome_play_game",
+            action="user can play the snake game in their browser",
+            success_signal="snake visibly moves, food appears, score updates",
+            scope="in_scope",
+        )
+        assert outcome.id == "outcome_play_game"
+        assert outcome.action.startswith("user can")
+        assert outcome.success_signal
+        assert outcome.scope == "in_scope"
+
+    def test_action_must_express_user_capability(self) -> None:
+        """An action without 'user can' / 'user is able to' is rejected.
+
+        The whole point is to capture user-visible outcomes; bare feature
+        descriptions like "implement rendering" are exactly the failure
+        mode this prevents.
+        """
+        with pytest.raises(ValueError, match="user can"):
+            UserOutcome(
+                id="outcome_render",
+                action="implement rendering",
+                success_signal="canvas draws snake",
+                scope="in_scope",
+            )
+
+    def test_action_rejects_vague_capability(self) -> None:
+        """'user can use the app' is too vague and rejected."""
+        with pytest.raises(ValueError, match="too vague"):
+            UserOutcome(
+                id="outcome_vague",
+                action="user can use the app",
+                success_signal="the app works",
+                scope="in_scope",
+            )
+
+    def test_scope_must_be_known_value(self) -> None:
+        """Scope must be 'in_scope' or 'out_of_scope'."""
+        with pytest.raises(ValueError, match="scope"):
+            UserOutcome(
+                id="outcome_x",
+                action="user can do X",
+                success_signal="X is observable",
+                scope="maybe",
+            )
+
+    def test_success_signal_required_non_empty(self) -> None:
+        """An empty success_signal makes coverage unverifiable — reject it."""
+        with pytest.raises(ValueError, match="success_signal"):
+            UserOutcome(
+                id="outcome_x",
+                action="user can do X",
+                success_signal="",
+                scope="in_scope",
+            )
+
+    def test_id_must_be_non_empty(self) -> None:
+        """An empty id breaks coverage mapping — reject it."""
+        with pytest.raises(ValueError, match="id"):
+            UserOutcome(
+                id="",
+                action="user can do X",
+                success_signal="X is observable",
+                scope="in_scope",
+            )
+
+
+class TestExtractUserOutcomes:
+    """``extract_user_outcomes`` queries the LLM and validates each result."""
+
+    @pytest.fixture
+    def llm_returning(self) -> Any:
+        """Build an AsyncMock LLM client that returns the given JSON string."""
+
+        def _build(payload: str) -> AsyncMock:
+            mock = AsyncMock()
+            mock.analyze = AsyncMock(return_value=payload)
+            return mock
+
+        return _build
+
+    @pytest.mark.asyncio
+    async def test_visual_spec_yields_render_outcome(self, llm_returning: Any) -> None:
+        """Snake game spec must produce an outcome about playing/seeing the game.
+
+        This is the v31-snake regression: ``"build a snake game"`` previously
+        produced a task graph with no rendering task because the decomposer
+        treated rendering as implicit.  The outcome layer makes it explicit.
+        """
+        llm = llm_returning(
+            '{"outcomes": ['
+            '{"id": "outcome_play_game",'
+            ' "action": "user can play the snake game in their browser",'
+            ' "success_signal": "snake visibly moves on a board, food appears,'
+            ' score updates after each food eaten",'
+            ' "scope": "in_scope"}'
+            "]}"
+        )
+
+        outcomes = await extract_user_outcomes(
+            spec="build a snake game", llm_client=llm
+        )
+
+        assert len(outcomes) == 1
+        assert outcomes[0].id == "outcome_play_game"
+        assert "play the snake game" in outcomes[0].action
+        assert outcomes[0].scope == "in_scope"
+
+    @pytest.mark.asyncio
+    async def test_api_spec_yields_endpoint_invocation_outcome(
+        self, llm_returning: Any
+    ) -> None:
+        """API spec must produce outcomes about calling the endpoints."""
+        llm = llm_returning(
+            '{"outcomes": ['
+            '{"id": "outcome_get_user",'
+            ' "action": "user can call GET /users/:id and receive JSON",'
+            ' "success_signal": "200 status, body contains id and name",'
+            ' "scope": "in_scope"}'
+            "]}"
+        )
+
+        outcomes = await extract_user_outcomes(
+            spec="user management service exposing CRUD endpoints",
+            llm_client=llm,
+        )
+
+        assert len(outcomes) == 1
+        assert "call GET" in outcomes[0].action
+
+    @pytest.mark.asyncio
+    async def test_scope_inheritance_from_spec(self, llm_returning: Any) -> None:
+        """Outcomes the spec excludes must be tagged out_of_scope, not dropped.
+
+        Out-of-scope retention is important so the audit trail preserves
+        what the LLM considered and rejected — debuggable when an outcome
+        looks missing.
+        """
+        llm = llm_returning(
+            '{"outcomes": ['
+            '{"id": "outcome_play",'
+            ' "action": "user can play the snake game",'
+            ' "success_signal": "game is visible and interactive",'
+            ' "scope": "in_scope"},'
+            '{"id": "outcome_login",'
+            ' "action": "user can log in with a password",'
+            ' "success_signal": "credentials accepted, session cookie set",'
+            ' "scope": "out_of_scope"}'
+            "]}"
+        )
+
+        outcomes = await extract_user_outcomes(
+            spec="build a snake game (no auth, no accounts)",
+            llm_client=llm,
+        )
+
+        in_scope = [o for o in outcomes if o.scope == "in_scope"]
+        out_scope = [o for o in outcomes if o.scope == "out_of_scope"]
+        assert len(in_scope) == 1
+        assert len(out_scope) == 1
+        assert "log in" in out_scope[0].action
+
+    @pytest.mark.asyncio
+    async def test_vague_outcomes_are_rejected_at_extraction(
+        self, llm_returning: Any
+    ) -> None:
+        """If the LLM returns a vague outcome, extraction raises rather than
+        silently passing it downstream."""
+        llm = llm_returning(
+            '{"outcomes": ['
+            '{"id": "outcome_use",'
+            ' "action": "user can use the application",'
+            ' "success_signal": "it works",'
+            ' "scope": "in_scope"}'
+            "]}"
+        )
+
+        with pytest.raises(ValueError, match="too vague"):
+            await extract_user_outcomes(spec="anything", llm_client=llm)
+
+    @pytest.mark.asyncio
+    async def test_malformed_llm_response_raises(self, llm_returning: Any) -> None:
+        """Non-JSON / missing 'outcomes' key surfaces a clear error."""
+        llm = llm_returning("totally not json")
+        with pytest.raises(ValueError, match="JSON"):
+            await extract_user_outcomes(spec="anything", llm_client=llm)
+
+    @pytest.mark.asyncio
+    async def test_empty_outcome_list_raises(self, llm_returning: Any) -> None:
+        """An LLM that produces no outcomes is a failure, not a clean result.
+
+        Every project spec implies at least one user-visible outcome; if the
+        extractor gets back zero, the LLM ignored the prompt.  Surface it.
+        """
+        llm = llm_returning('{"outcomes": []}')
+        with pytest.raises(ValueError, match="no outcomes"):
+            await extract_user_outcomes(spec="build something", llm_client=llm)

--- a/tests/unit/coordinator/test_intent_fidelity_pipeline.py
+++ b/tests/unit/coordinator/test_intent_fidelity_pipeline.py
@@ -1,11 +1,27 @@
 """End-to-end pipeline test for intent fidelity coverage (issue #449).
 
-Exercises the extractor → coverage → gap-fill chain with mocked LLMs.
-The snake-game regression case is the headline scenario: a spec of
-``"build a snake game"`` previously produced a task graph with no
-rendering task because the decomposer treated rendering as implicit.
-This test proves that with the outcome layer in place, the missing
-rendering task is detected as a gap and filled.
+Exercises the extractor -> coverage -> gap-fill chain with three mocked
+LLM calls (one per stage):
+
+1. Extractor LLM produces user outcomes from the spec
+2. Coverage LLM evaluates the v31 task graph against those outcomes
+3. Gap-fill LLM generates replacement tasks for uncovered outcomes
+
+The snake_game-v31 case is the headline scenario: ``"build a snake game"``
+previously produced a task graph with no rendering task because the
+decomposer treated rendering as implicit.  This test proves that with
+the outcome layer in place, an honest LLM coverage call surfaces the
+gap, gap-fill produces a rendering task, and a re-run of coverage on
+the augmented graph confirms full intent fidelity.
+
+Earlier drafts of this test used a hardcoded sync mapper
+(``_visual_play_mapper``) that pre-encoded the "rendering verbs"
+answer.  That tested the pipeline plumbing but not what an LLM
+evaluator would actually conclude — i.e. it proved
+"given a correct mapper, the pipeline detects gaps" rather than
+"given a snake-game spec, our system catches missing rendering."
+The current version mocks the coverage LLM directly so the test
+asserts pipeline behavior given honest coverage signals.
 """
 
 from datetime import datetime, timezone
@@ -14,37 +30,14 @@ from unittest.mock import AsyncMock
 
 import pytest
 
-from src.ai.advanced.prd.outcome_extractor import UserOutcome, extract_user_outcomes
+from src.ai.advanced.prd.outcome_extractor import extract_user_outcomes
 from src.core.models import Priority, Task, TaskStatus
 from src.marcus_mcp.coordinator.outcome_coverage import (
-    compute_coverage,
+    compute_coverage_with_llm,
     compute_intent_fidelity_score,
     fill_gaps,
     find_gaps,
 )
-
-# Visual-action verbs that signal a task produces something user-visible.
-# This is the kind of mapper an LLM would produce on the snake-v31 case;
-# we encode it explicitly here so the integration test is deterministic
-# and does not require a live LLM.  Production usage of compute_coverage
-# in the decomposer should pass an LLM-backed mapper.
-_VISUAL_ACTION_VERBS = ("render", "draw", "canvas", "display", "show", "paint")
-
-
-def _visual_play_mapper(outcome: UserOutcome, task: Task) -> bool:
-    """Coverage mapper for the play-the-game outcome.
-
-    Returns ``True`` only when a task's name or description contains a
-    visual-action verb.  This mirrors what an LLM evaluator would
-    conclude on the snake-v31 task graph: only rendering tasks
-    actually contribute to the user being able to play.
-    """
-    if outcome.id != "outcome_play_game":
-        # Out of scope for this mapper — defer to default behavior.
-        return False
-    haystack = (task.name + " " + (task.description or "")).lower()
-    return any(verb in haystack for verb in _VISUAL_ACTION_VERBS)
-
 
 pytestmark = pytest.mark.unit
 
@@ -65,87 +58,99 @@ def _task(task_id: str, name: str, description: str = "") -> Task:
     )
 
 
+def _llm_returning(payload: str) -> AsyncMock:
+    """Build an AsyncMock LLM client that returns the given JSON string."""
+    mock = AsyncMock()
+    mock.analyze = AsyncMock(return_value=payload)
+    return mock
+
+
 class TestSnakeGameRegression:
     """The snake_game-v31 audit scenario: rendering missing from task graph.
 
     Reproduces the conditions that caused the production failure:
 
-    1. Spec is open-ended ("build a snake game") — no explicit mention
-       of rendering, the LLM in the snake-v31 run dropped it as
-       "non-essential" under prototype capacity filtering
+    1. Spec is open-ended (``"build a snake game"``) — no explicit
+       mention of rendering, the LLM in the snake-v31 run dropped it
+       as "non-essential" under prototype capacity filtering
     2. Decomposer produces logic-only tasks (state, movement, food,
        collision, score) — exactly what the v31 board contained
     3. Outcome extractor sees the spec and returns ``user can play
-       the snake game`` (this is the kind of outcome an LLM correctly
-       produces from "snake game"; we mock it for determinism)
-    4. Coverage check finds no task addresses the play outcome
-    5. Gap-fill produces a rendering task
-    6. Final intent_fidelity_score after gap-fill is 1.0
+       the snake game`` (mocked for determinism)
+    4. Coverage LLM evaluates each task against the outcome and
+       correctly returns no covering tasks (mocked: this is what an
+       honest LLM would conclude on the v31 graph — internal logic
+       tasks do not produce user-visible movement)
+    5. Gap-fill produces a rendering task (mocked)
+    6. A second coverage call on the augmented graph confirms the
+       new render task covers the outcome — fidelity is 1.0
     """
 
     @pytest.fixture
     def extractor_llm(self) -> Any:
         """Mocked extractor LLM produces the play-game outcome."""
-        mock = AsyncMock()
-        mock.analyze = AsyncMock(
-            return_value=(
-                '{"outcomes": ['
-                '{"id": "outcome_play_game",'
-                ' "action": "user can play the snake game in their browser",'
-                ' "success_signal": "snake visibly moves on a board, food '
-                'appears, score updates after each food eaten",'
-                ' "scope": "in_scope"}'
-                "]}"
-            )
+        return _llm_returning(
+            '{"outcomes": ['
+            '{"id": "outcome_play_game",'
+            ' "action": "user can play the snake game in their browser",'
+            ' "success_signal": "snake visibly moves on a board, food '
+            'appears, score updates after each food eaten",'
+            ' "scope": "in_scope"}'
+            "]}"
         )
-        return mock
 
     @pytest.fixture
     def gap_fill_llm(self) -> Any:
         """Mocked gap-fill LLM produces a rendering task for the missing outcome."""
-        mock = AsyncMock()
-        mock.analyze = AsyncMock(
-            return_value=(
-                '{"tasks": ['
-                '{"name": "Render snake to canvas",'
-                ' "description": "Subscribe to game-state-update events and '
-                "draw the snake body, food, and score on a canvas element "
-                "inside the existing game-mount container.  Consumers: "
-                'browser DOM."}'
-                "]}"
-            )
+        return _llm_returning(
+            '{"tasks": ['
+            '{"name": "Render snake to canvas",'
+            ' "description": "Subscribe to game-state-update events and '
+            "draw the snake body, food, and score on a canvas element "
+            "inside the existing game-mount container.  Consumers: "
+            'browser DOM."}'
+            "]}"
         )
-        return mock
 
     @pytest.mark.asyncio
     async def test_missing_render_task_is_detected_and_filled(
         self, extractor_llm: Any, gap_fill_llm: Any
     ) -> None:
-        """Full pipeline detects the snake-v31 failure and recovers."""
+        """Full pipeline detects the snake-v31 failure and recovers.
+
+        Three LLM calls are mocked, in the order the pipeline issues
+        them:
+
+        1. Extractor: returns the play-game outcome
+        2. Coverage: returns ``{outcome_play_game: []}`` because no
+           v31 task is user-visible (this is what an honest LLM
+           evaluator concludes; the test mocks it directly so we
+           assert pipeline behavior, not LLM cleverness)
+        3. After gap-fill, a second coverage call returns
+           ``{outcome_play_game: [t_filled_0]}`` because the new
+           rendering task does address the outcome
+        """
         # 1. Extract outcomes from spec
         spec = "build a snake game"
         outcomes = await extract_user_outcomes(spec, llm_client=extractor_llm)
         assert any(o.id == "outcome_play_game" for o in outcomes)
 
-        # 2. Decomposer produces logic-only tasks (matches v31 reality:
-        # game state, movement, food, collision, score — but no rendering)
+        # 2. Decomposer produces logic-only tasks (matches v31 reality)
         v31_tasks = [
-            _task("t_state", "Snake state machine", "track snake body and direction"),
+            _task("t_state", "Snake state machine", "track snake body"),
             _task("t_movement", "Movement engine", "advance snake one cell per tick"),
             _task("t_food", "Food generator", "place food at random empty cell"),
-            _task(
-                "t_collision", "Collision detection", "detect wall and self collisions"
-            ),
+            _task("t_collision", "Collision detection", "detect wall collisions"),
             _task("t_score", "Score tracker", "increment score on food eaten"),
         ]
 
-        # 3. Coverage check identifies the gap.  We use the
-        # _visual_play_mapper because the default keyword heuristic is
-        # too permissive for this case (it would match on the shared
-        # "snake"/"food"/"score" domain nouns); production decomposer
-        # integration will use an LLM-backed mapper that reaches the
-        # same conclusion as our explicit visual-action-verb mapper.
-        coverage = compute_coverage(outcomes, v31_tasks, mapper=_visual_play_mapper)
+        # 3. Coverage LLM correctly identifies that no v31 task covers
+        # the play outcome — the mock returns the result an honest
+        # evaluator would produce on this graph
+        coverage_llm_v31 = _llm_returning('{"coverage": {"outcome_play_game": []}}')
+        coverage = await compute_coverage_with_llm(
+            outcomes, v31_tasks, llm_client=coverage_llm_v31
+        )
         gaps = find_gaps(outcomes, coverage)
         score_before = compute_intent_fidelity_score(outcomes, coverage)
 
@@ -162,26 +167,25 @@ class TestSnakeGameRegression:
         # 4. Gap-fill produces replacement tasks
         new_task_dicts = await fill_gaps(spec=spec, gaps=gaps, llm_client=gap_fill_llm)
         assert len(new_task_dicts) >= 1
-        # The new task description must mention rendering or canvas —
-        # otherwise the gap-fill LLM produced something unrelated
-        rendering_keywords = ("render", "canvas", "draw", "display")
-        assert any(
-            kw in new_task_dicts[0]["description"].lower() for kw in rendering_keywords
-        ), f"Gap-fill task does not address rendering: {new_task_dicts[0]}"
 
-        # 5. After appending the new task to the graph, fidelity is 1.0.
-        # Same mapper used as before for consistency.
+        # 5. Append the new task and re-run coverage.  The augmented
+        # graph now includes a rendering task; the coverage LLM
+        # correctly identifies it.
         new_tasks = list(v31_tasks) + [
             _task(f"t_filled_{i}", d["name"], d["description"])
             for i, d in enumerate(new_task_dicts)
         ]
-        coverage_after = compute_coverage(
-            outcomes, new_tasks, mapper=_visual_play_mapper
+        coverage_llm_after = _llm_returning(
+            '{"coverage": {"outcome_play_game": ["t_filled_0"]}}'
+        )
+        coverage_after = await compute_coverage_with_llm(
+            outcomes, new_tasks, llm_client=coverage_llm_after
         )
         score_after = compute_intent_fidelity_score(outcomes, coverage_after)
         assert score_after == 1.0, (
-            f"After gap-fill, intent fidelity must be 1.0 — got {score_after}. "
-            "Gap-fill produced tasks that don't actually cover the outcome."
+            f"After gap-fill, intent fidelity must be 1.0 — got "
+            f"{score_after}.  Gap-fill produced tasks that don't "
+            "actually cover the outcome."
         )
 
     @pytest.mark.asyncio
@@ -190,16 +194,14 @@ class TestSnakeGameRegression:
     ) -> None:
         """When the task graph already covers all outcomes, no LLM call fires.
 
-        This is the cost-control invariant: gap-fill is paid only when
-        the decomposer actually missed something.
+        Cost-control invariant: gap-fill is paid only when the
+        decomposer actually missed something.
         """
         outcomes = await extract_user_outcomes(
             "build a snake game", llm_client=extractor_llm
         )
 
-        # Task graph that DOES include rendering — same five logic
-        # tasks plus a render task whose description shares keywords
-        # ("snake", "play", "score", "food") with the outcome
+        # Task graph that DOES include rendering
         complete_tasks = [
             _task("t_state", "Snake state machine", "track snake body"),
             _task(
@@ -210,8 +212,11 @@ class TestSnakeGameRegression:
             ),
         ]
 
-        coverage = compute_coverage(
-            outcomes, complete_tasks, mapper=_visual_play_mapper
+        coverage_llm = _llm_returning(
+            '{"coverage": {"outcome_play_game": ["t_render"]}}'
+        )
+        coverage = await compute_coverage_with_llm(
+            outcomes, complete_tasks, llm_client=coverage_llm
         )
         gaps = find_gaps(outcomes, coverage)
         new_task_dicts = await fill_gaps(

--- a/tests/unit/coordinator/test_intent_fidelity_pipeline.py
+++ b/tests/unit/coordinator/test_intent_fidelity_pipeline.py
@@ -1,0 +1,223 @@
+"""End-to-end pipeline test for intent fidelity coverage (issue #449).
+
+Exercises the extractor → coverage → gap-fill chain with mocked LLMs.
+The snake-game regression case is the headline scenario: a spec of
+``"build a snake game"`` previously produced a task graph with no
+rendering task because the decomposer treated rendering as implicit.
+This test proves that with the outcome layer in place, the missing
+rendering task is detected as a gap and filled.
+"""
+
+from datetime import datetime, timezone
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+
+from src.ai.advanced.prd.outcome_extractor import UserOutcome, extract_user_outcomes
+from src.core.models import Priority, Task, TaskStatus
+from src.marcus_mcp.coordinator.outcome_coverage import (
+    compute_coverage,
+    compute_intent_fidelity_score,
+    fill_gaps,
+    find_gaps,
+)
+
+# Visual-action verbs that signal a task produces something user-visible.
+# This is the kind of mapper an LLM would produce on the snake-v31 case;
+# we encode it explicitly here so the integration test is deterministic
+# and does not require a live LLM.  Production usage of compute_coverage
+# in the decomposer should pass an LLM-backed mapper.
+_VISUAL_ACTION_VERBS = ("render", "draw", "canvas", "display", "show", "paint")
+
+
+def _visual_play_mapper(outcome: UserOutcome, task: Task) -> bool:
+    """Coverage mapper for the play-the-game outcome.
+
+    Returns ``True`` only when a task's name or description contains a
+    visual-action verb.  This mirrors what an LLM evaluator would
+    conclude on the snake-v31 task graph: only rendering tasks
+    actually contribute to the user being able to play.
+    """
+    if outcome.id != "outcome_play_game":
+        # Out of scope for this mapper — defer to default behavior.
+        return False
+    haystack = (task.name + " " + (task.description or "")).lower()
+    return any(verb in haystack for verb in _VISUAL_ACTION_VERBS)
+
+
+pytestmark = pytest.mark.unit
+
+
+def _task(task_id: str, name: str, description: str = "") -> Task:
+    now = datetime.now(timezone.utc)
+    return Task(
+        id=task_id,
+        name=name,
+        description=description,
+        status=TaskStatus.TODO,
+        priority=Priority.MEDIUM,
+        assigned_to=None,
+        created_at=now,
+        updated_at=now,
+        due_date=None,
+        estimated_hours=1.0,
+    )
+
+
+class TestSnakeGameRegression:
+    """The snake_game-v31 audit scenario: rendering missing from task graph.
+
+    Reproduces the conditions that caused the production failure:
+
+    1. Spec is open-ended ("build a snake game") — no explicit mention
+       of rendering, the LLM in the snake-v31 run dropped it as
+       "non-essential" under prototype capacity filtering
+    2. Decomposer produces logic-only tasks (state, movement, food,
+       collision, score) — exactly what the v31 board contained
+    3. Outcome extractor sees the spec and returns ``user can play
+       the snake game`` (this is the kind of outcome an LLM correctly
+       produces from "snake game"; we mock it for determinism)
+    4. Coverage check finds no task addresses the play outcome
+    5. Gap-fill produces a rendering task
+    6. Final intent_fidelity_score after gap-fill is 1.0
+    """
+
+    @pytest.fixture
+    def extractor_llm(self) -> Any:
+        """Mocked extractor LLM produces the play-game outcome."""
+        mock = AsyncMock()
+        mock.analyze = AsyncMock(
+            return_value=(
+                '{"outcomes": ['
+                '{"id": "outcome_play_game",'
+                ' "action": "user can play the snake game in their browser",'
+                ' "success_signal": "snake visibly moves on a board, food '
+                'appears, score updates after each food eaten",'
+                ' "scope": "in_scope"}'
+                "]}"
+            )
+        )
+        return mock
+
+    @pytest.fixture
+    def gap_fill_llm(self) -> Any:
+        """Mocked gap-fill LLM produces a rendering task for the missing outcome."""
+        mock = AsyncMock()
+        mock.analyze = AsyncMock(
+            return_value=(
+                '{"tasks": ['
+                '{"name": "Render snake to canvas",'
+                ' "description": "Subscribe to game-state-update events and '
+                "draw the snake body, food, and score on a canvas element "
+                "inside the existing game-mount container.  Consumers: "
+                'browser DOM."}'
+                "]}"
+            )
+        )
+        return mock
+
+    @pytest.mark.asyncio
+    async def test_missing_render_task_is_detected_and_filled(
+        self, extractor_llm: Any, gap_fill_llm: Any
+    ) -> None:
+        """Full pipeline detects the snake-v31 failure and recovers."""
+        # 1. Extract outcomes from spec
+        spec = "build a snake game"
+        outcomes = await extract_user_outcomes(spec, llm_client=extractor_llm)
+        assert any(o.id == "outcome_play_game" for o in outcomes)
+
+        # 2. Decomposer produces logic-only tasks (matches v31 reality:
+        # game state, movement, food, collision, score — but no rendering)
+        v31_tasks = [
+            _task("t_state", "Snake state machine", "track snake body and direction"),
+            _task("t_movement", "Movement engine", "advance snake one cell per tick"),
+            _task("t_food", "Food generator", "place food at random empty cell"),
+            _task(
+                "t_collision", "Collision detection", "detect wall and self collisions"
+            ),
+            _task("t_score", "Score tracker", "increment score on food eaten"),
+        ]
+
+        # 3. Coverage check identifies the gap.  We use the
+        # _visual_play_mapper because the default keyword heuristic is
+        # too permissive for this case (it would match on the shared
+        # "snake"/"food"/"score" domain nouns); production decomposer
+        # integration will use an LLM-backed mapper that reaches the
+        # same conclusion as our explicit visual-action-verb mapper.
+        coverage = compute_coverage(outcomes, v31_tasks, mapper=_visual_play_mapper)
+        gaps = find_gaps(outcomes, coverage)
+        score_before = compute_intent_fidelity_score(outcomes, coverage)
+
+        assert len(gaps) == 1, (
+            f"Expected exactly one gap (missing rendering); got "
+            f"{[g.id for g in gaps]}"
+        )
+        assert gaps[0].id == "outcome_play_game"
+        assert score_before == 0.0, (
+            "v31 had zero rendering tasks — intent fidelity must be 0.0 "
+            "before gap-fill, not silently passing"
+        )
+
+        # 4. Gap-fill produces replacement tasks
+        new_task_dicts = await fill_gaps(spec=spec, gaps=gaps, llm_client=gap_fill_llm)
+        assert len(new_task_dicts) >= 1
+        # The new task description must mention rendering or canvas —
+        # otherwise the gap-fill LLM produced something unrelated
+        rendering_keywords = ("render", "canvas", "draw", "display")
+        assert any(
+            kw in new_task_dicts[0]["description"].lower() for kw in rendering_keywords
+        ), f"Gap-fill task does not address rendering: {new_task_dicts[0]}"
+
+        # 5. After appending the new task to the graph, fidelity is 1.0.
+        # Same mapper used as before for consistency.
+        new_tasks = list(v31_tasks) + [
+            _task(f"t_filled_{i}", d["name"], d["description"])
+            for i, d in enumerate(new_task_dicts)
+        ]
+        coverage_after = compute_coverage(
+            outcomes, new_tasks, mapper=_visual_play_mapper
+        )
+        score_after = compute_intent_fidelity_score(outcomes, coverage_after)
+        assert score_after == 1.0, (
+            f"After gap-fill, intent fidelity must be 1.0 — got {score_after}. "
+            "Gap-fill produced tasks that don't actually cover the outcome."
+        )
+
+    @pytest.mark.asyncio
+    async def test_full_coverage_skips_gap_fill_call(
+        self, extractor_llm: Any, gap_fill_llm: Any
+    ) -> None:
+        """When the task graph already covers all outcomes, no LLM call fires.
+
+        This is the cost-control invariant: gap-fill is paid only when
+        the decomposer actually missed something.
+        """
+        outcomes = await extract_user_outcomes(
+            "build a snake game", llm_client=extractor_llm
+        )
+
+        # Task graph that DOES include rendering — same five logic
+        # tasks plus a render task whose description shares keywords
+        # ("snake", "play", "score", "food") with the outcome
+        complete_tasks = [
+            _task("t_state", "Snake state machine", "track snake body"),
+            _task(
+                "t_render",
+                "Render snake to canvas",
+                "draw snake, food, and score so the user can play "
+                "the snake game in the browser",
+            ),
+        ]
+
+        coverage = compute_coverage(
+            outcomes, complete_tasks, mapper=_visual_play_mapper
+        )
+        gaps = find_gaps(outcomes, coverage)
+        new_task_dicts = await fill_gaps(
+            spec="build a snake game", gaps=gaps, llm_client=gap_fill_llm
+        )
+
+        assert gaps == []
+        assert new_task_dicts == []
+        gap_fill_llm.analyze.assert_not_called()

--- a/tests/unit/coordinator/test_intent_fidelity_pipeline.py
+++ b/tests/unit/coordinator/test_intent_fidelity_pipeline.py
@@ -65,6 +65,18 @@ def _llm_returning(payload: str) -> AsyncMock:
     return mock
 
 
+def _llm_with_responses(*payloads: str) -> AsyncMock:
+    """Build an AsyncMock that returns each payload in sequence (one per call).
+
+    extract_user_outcomes makes two LLM calls (extraction + verifiability
+    filter), so tests that exercise the full extractor must provide
+    both payloads in order.
+    """
+    mock = AsyncMock()
+    mock.analyze = AsyncMock(side_effect=list(payloads))
+    return mock
+
+
 class TestSnakeGameRegression:
     """The snake_game-v31 audit scenario: rendering missing from task graph.
 
@@ -88,15 +100,21 @@ class TestSnakeGameRegression:
 
     @pytest.fixture
     def extractor_llm(self) -> Any:
-        """Mocked extractor LLM produces the play-game outcome."""
-        return _llm_returning(
+        """Mocked extractor LLM produces play-game outcome + filter approves it.
+
+        ``extract_user_outcomes`` makes two LLM calls now: extraction
+        plus a verifiability self-check.  Both responses are queued.
+        """
+        return _llm_with_responses(
             '{"outcomes": ['
             '{"id": "outcome_play_game",'
             ' "action": "user can play the snake game in their browser",'
             ' "success_signal": "snake visibly moves on a board, food '
             'appears, score updates after each food eaten",'
             ' "scope": "in_scope"}'
-            "]}"
+            "]}",
+            '{"verdicts": {"outcome_play_game": '
+            '{"verifiable": true, "reason": "concrete user-visible action"}}}',
         )
 
     @pytest.fixture

--- a/tests/unit/coordinator/test_outcome_coverage.py
+++ b/tests/unit/coordinator/test_outcome_coverage.py
@@ -23,9 +23,11 @@ from src.ai.advanced.prd.outcome_extractor import UserOutcome
 from src.core.models import Priority, Task, TaskStatus
 from src.marcus_mcp.coordinator.outcome_coverage import (
     compute_coverage,
+    compute_coverage_with_llm,
     compute_intent_fidelity_score,
     fill_gaps,
     find_gaps,
+    keyword_overlap_mapper,
 )
 
 pytestmark = pytest.mark.unit
@@ -58,10 +60,17 @@ def _outcome(
 
 
 class TestComputeCoverage:
-    """Coverage maps every outcome (by id) to the task ids that address it."""
+    """Coverage maps every outcome (by id) to the task ids that address it.
+
+    All tests pass an explicit mapper.  ``compute_coverage`` deliberately
+    has no default mapper — the only sync mapper available
+    (:func:`keyword_overlap_mapper`) produces false positives on the
+    snake_game-v31 case this whole module exists to catch.  Production
+    code should use :func:`compute_coverage_with_llm`.
+    """
 
     def test_keyword_overlap_marks_task_as_covering(self) -> None:
-        """Default keyword mapper covers outcome via overlapping nouns."""
+        """keyword_overlap_mapper covers outcome via overlapping nouns."""
         outcomes = [
             _outcome(
                 "outcome_play",
@@ -76,7 +85,7 @@ class TestComputeCoverage:
                 "Draw the snake, food, and score on a canvas element.",
             ),
         ]
-        coverage = compute_coverage(outcomes, tasks)
+        coverage = compute_coverage(outcomes, tasks, mapper=keyword_overlap_mapper)
         assert coverage["outcome_play"] == ["t1"]
 
     def test_no_overlap_yields_empty_coverage(self) -> None:
@@ -93,7 +102,7 @@ class TestComputeCoverage:
                 "t1", "Build authentication service", "JWT tokens and password hashing"
             ),
         ]
-        coverage = compute_coverage(outcomes, tasks)
+        coverage = compute_coverage(outcomes, tasks, mapper=keyword_overlap_mapper)
         assert coverage["outcome_play"] == []
 
     def test_multiple_tasks_can_cover_one_outcome(self) -> None:
@@ -107,11 +116,11 @@ class TestComputeCoverage:
             _task("t1", "Render snake on canvas", "draw snake body"),
             _task("t2", "Snake state machine", "moves snake each tick"),
         ]
-        coverage = compute_coverage(outcomes, tasks)
+        coverage = compute_coverage(outcomes, tasks, mapper=keyword_overlap_mapper)
         assert set(coverage["outcome_play"]) == {"t1", "t2"}
 
-    def test_explicit_mapper_overrides_default(self) -> None:
-        """Tests can inject an explicit mapper to bypass keyword logic."""
+    def test_explicit_mapper_overrides_keyword_default(self) -> None:
+        """Tests can inject custom mappers besides keyword_overlap_mapper."""
         outcomes = [_outcome("outcome_x", "user can do X", "X is observable")]
         tasks = [_task("t1", "totally unrelated", "nothing matches")]
 
@@ -127,8 +136,128 @@ class TestComputeCoverage:
             _outcome("o1", "user can do X", "X observable"),
             _outcome("o2", "user can do Y", "Y observable"),
         ]
-        coverage = compute_coverage(outcomes, [])
+        coverage = compute_coverage(outcomes, [], mapper=keyword_overlap_mapper)
         assert coverage == {"o1": [], "o2": []}
+
+    def test_mapper_argument_is_required(self) -> None:
+        """compute_coverage refuses to run without an explicit mapper.
+
+        This is the footgun guard: the only sync mapper available is
+        keyword_overlap_mapper, which produces false positives on the
+        snake_game-v31 case.  A contributor importing compute_coverage
+        without thinking about which mapper to use would silently
+        re-introduce the v31 regression.  Force the choice.
+        """
+        outcomes = [_outcome("o1", "user can do X", "X observable")]
+        tasks = [_task("t1", "task one", "")]
+        with pytest.raises(TypeError):
+            compute_coverage(outcomes, tasks)  # type: ignore[call-arg]
+
+
+class TestComputeCoverageWithLLM:
+    """LLM-backed coverage: one call maps all outcomes to all tasks."""
+
+    @pytest.fixture
+    def llm_returning(self) -> Any:
+        def _build(payload: str) -> AsyncMock:
+            mock = AsyncMock()
+            mock.analyze = AsyncMock(return_value=payload)
+            return mock
+
+        return _build
+
+    @pytest.mark.asyncio
+    async def test_returns_coverage_dict_from_llm_response(
+        self, llm_returning: Any
+    ) -> None:
+        outcomes = [
+            _outcome("o_play", "user can play snake", "snake visibly moves"),
+            _outcome("o_score", "user can see score", "score visible"),
+        ]
+        tasks = [
+            _task("t_state", "Snake state machine", "track snake body"),
+            _task("t_render", "Render snake to canvas", "draw snake"),
+            _task("t_score", "Score display", "render score in DOM"),
+        ]
+        llm = llm_returning(
+            '{"coverage": {' '"o_play": ["t_render"],' '"o_score": ["t_score"]' "}}"
+        )
+
+        coverage = await compute_coverage_with_llm(outcomes, tasks, llm)
+
+        assert coverage == {"o_play": ["t_render"], "o_score": ["t_score"]}
+
+    @pytest.mark.asyncio
+    async def test_unknown_task_ids_in_response_are_dropped(
+        self, llm_returning: Any
+    ) -> None:
+        """LLM hallucinations don't corrupt the coverage map."""
+        outcomes = [_outcome("o1", "user can play", "snake moves")]
+        tasks = [_task("t1", "real task", "real desc")]
+        llm = llm_returning('{"coverage": {"o1": ["t1", "t_does_not_exist"]}}')
+
+        coverage = await compute_coverage_with_llm(outcomes, tasks, llm)
+        assert coverage == {"o1": ["t1"]}
+
+    @pytest.mark.asyncio
+    async def test_unknown_outcome_ids_in_response_are_dropped(
+        self, llm_returning: Any
+    ) -> None:
+        outcomes = [_outcome("o1", "user can play", "moves")]
+        tasks = [_task("t1", "render", "draw")]
+        llm = llm_returning('{"coverage": {"o1": ["t1"], "o_phantom": ["t1"]}}')
+
+        coverage = await compute_coverage_with_llm(outcomes, tasks, llm)
+        assert "o_phantom" not in coverage
+        assert coverage == {"o1": ["t1"]}
+
+    @pytest.mark.asyncio
+    async def test_missing_outcome_in_response_filled_empty(
+        self, llm_returning: Any
+    ) -> None:
+        """LLM that forgets an outcome gets the empty-list default.
+
+        This mirrors find_gaps' contract — every outcome must have an
+        entry, even if the LLM skipped it.  Treating "skipped" as
+        "uncovered" surfaces the gap; treating it as "covered" would
+        hide it.
+        """
+        outcomes = [
+            _outcome("o1", "user can play", "moves"),
+            _outcome("o2", "user can score", "visible"),
+        ]
+        tasks = [_task("t1", "render", "draw")]
+        llm = llm_returning('{"coverage": {"o1": ["t1"]}}')
+
+        coverage = await compute_coverage_with_llm(outcomes, tasks, llm)
+        assert coverage == {"o1": ["t1"], "o2": []}
+
+    @pytest.mark.asyncio
+    async def test_malformed_json_raises(self, llm_returning: Any) -> None:
+        outcomes = [_outcome("o1", "user can play", "moves")]
+        tasks = [_task("t1", "render", "draw")]
+        llm = llm_returning("not json")
+        with pytest.raises(ValueError, match="malformed JSON"):
+            await compute_coverage_with_llm(outcomes, tasks, llm)
+
+    @pytest.mark.asyncio
+    async def test_missing_coverage_key_raises(self, llm_returning: Any) -> None:
+        outcomes = [_outcome("o1", "user can play", "moves")]
+        tasks = [_task("t1", "render", "draw")]
+        llm = llm_returning('{"wrong_key": {}}')
+        with pytest.raises(ValueError, match="coverage"):
+            await compute_coverage_with_llm(outcomes, tasks, llm)
+
+    @pytest.mark.asyncio
+    async def test_no_tasks_returns_empty_lists_without_llm_call(
+        self, llm_returning: Any
+    ) -> None:
+        """When the task graph is empty, no LLM call fires."""
+        outcomes = [_outcome("o1", "user can play", "moves")]
+        llm = llm_returning('{"coverage": {}}')
+        coverage = await compute_coverage_with_llm(outcomes, [], llm)
+        assert coverage == {"o1": []}
+        llm.analyze.assert_not_called()
 
 
 class TestFindGaps:

--- a/tests/unit/coordinator/test_outcome_coverage.py
+++ b/tests/unit/coordinator/test_outcome_coverage.py
@@ -1,0 +1,265 @@
+"""Unit tests for the user-outcome coverage check (issue #449).
+
+Verifies that:
+
+* :func:`compute_coverage` maps outcomes to the tasks that address them
+* :func:`find_gaps` returns only in-scope outcomes with no covering task
+* :func:`compute_intent_fidelity_score` reports the right ratio
+* :func:`fill_gaps` issues a single LLM call to generate replacement tasks
+
+These tests do not exercise the decomposer end-to-end; integration of the
+coverage layer with :mod:`src.marcus_mcp.coordinator.decomposer` is covered
+by tests in ``tests/unit/coordinator/test_decomposer_outcome_integration.py``
+(future).
+"""
+
+from datetime import datetime, timezone
+from typing import Any, List
+from unittest.mock import AsyncMock
+
+import pytest
+
+from src.ai.advanced.prd.outcome_extractor import UserOutcome
+from src.core.models import Priority, Task, TaskStatus
+from src.marcus_mcp.coordinator.outcome_coverage import (
+    compute_coverage,
+    compute_intent_fidelity_score,
+    fill_gaps,
+    find_gaps,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _task(task_id: str, name: str, description: str = "") -> Task:
+    """Build a minimally-populated :class:`Task` for coverage tests."""
+    now = datetime.now(timezone.utc)
+    return Task(
+        id=task_id,
+        name=name,
+        description=description,
+        status=TaskStatus.TODO,
+        priority=Priority.MEDIUM,
+        assigned_to=None,
+        created_at=now,
+        updated_at=now,
+        due_date=None,
+        estimated_hours=1.0,
+    )
+
+
+def _outcome(
+    out_id: str,
+    action: str,
+    signal: str,
+    scope: str = "in_scope",
+) -> UserOutcome:
+    return UserOutcome(id=out_id, action=action, success_signal=signal, scope=scope)
+
+
+class TestComputeCoverage:
+    """Coverage maps every outcome (by id) to the task ids that address it."""
+
+    def test_keyword_overlap_marks_task_as_covering(self) -> None:
+        """Default keyword mapper covers outcome via overlapping nouns."""
+        outcomes = [
+            _outcome(
+                "outcome_play",
+                "user can play the snake game",
+                "snake moves on a board, food appears, score updates",
+            )
+        ]
+        tasks = [
+            _task(
+                "t1",
+                "Render snake game to canvas",
+                "Draw the snake, food, and score on a canvas element.",
+            ),
+        ]
+        coverage = compute_coverage(outcomes, tasks)
+        assert coverage["outcome_play"] == ["t1"]
+
+    def test_no_overlap_yields_empty_coverage(self) -> None:
+        """When no task addresses an outcome, the list is empty."""
+        outcomes = [
+            _outcome(
+                "outcome_play",
+                "user can play the snake game",
+                "snake moves on a board, food appears",
+            )
+        ]
+        tasks = [
+            _task(
+                "t1", "Build authentication service", "JWT tokens and password hashing"
+            ),
+        ]
+        coverage = compute_coverage(outcomes, tasks)
+        assert coverage["outcome_play"] == []
+
+    def test_multiple_tasks_can_cover_one_outcome(self) -> None:
+        """An outcome with broad scope may map to several tasks."""
+        outcomes = [
+            _outcome(
+                "outcome_play", "user can play the snake game", "snake moves on a board"
+            )
+        ]
+        tasks = [
+            _task("t1", "Render snake on canvas", "draw snake body"),
+            _task("t2", "Snake state machine", "moves snake each tick"),
+        ]
+        coverage = compute_coverage(outcomes, tasks)
+        assert set(coverage["outcome_play"]) == {"t1", "t2"}
+
+    def test_explicit_mapper_overrides_default(self) -> None:
+        """Tests can inject an explicit mapper to bypass keyword logic."""
+        outcomes = [_outcome("outcome_x", "user can do X", "X is observable")]
+        tasks = [_task("t1", "totally unrelated", "nothing matches")]
+
+        def always_match(_outcome: UserOutcome, _task: Task) -> bool:
+            return True
+
+        coverage = compute_coverage(outcomes, tasks, mapper=always_match)
+        assert coverage["outcome_x"] == ["t1"]
+
+    def test_every_outcome_appears_in_coverage_even_with_zero_tasks(self) -> None:
+        """An empty task list produces a coverage dict with empty lists."""
+        outcomes = [
+            _outcome("o1", "user can do X", "X observable"),
+            _outcome("o2", "user can do Y", "Y observable"),
+        ]
+        coverage = compute_coverage(outcomes, [])
+        assert coverage == {"o1": [], "o2": []}
+
+
+class TestFindGaps:
+    """Gaps are in-scope outcomes that have no covering tasks."""
+
+    def test_in_scope_uncovered_outcomes_are_gaps(self) -> None:
+        outcomes = [
+            _outcome("o1", "user can play snake", "snake moves"),
+            _outcome("o2", "user can see score", "score visible"),
+        ]
+        coverage = {"o1": ["t1"], "o2": []}
+        gaps = find_gaps(outcomes, coverage)
+        assert [g.id for g in gaps] == ["o2"]
+
+    def test_out_of_scope_outcomes_never_count_as_gaps(self) -> None:
+        """Out-of-scope outcomes are tracked for audit but excluded from gaps."""
+        outcomes = [
+            _outcome("o1", "user can log in", "session set", scope="out_of_scope"),
+        ]
+        coverage = {"o1": []}
+        gaps = find_gaps(outcomes, coverage)
+        assert gaps == []
+
+    def test_no_gaps_when_all_covered(self) -> None:
+        outcomes = [_outcome("o1", "user can play", "moves")]
+        coverage = {"o1": ["t1"]}
+        assert find_gaps(outcomes, coverage) == []
+
+
+class TestIntentFidelityScore:
+    """Score is covered_in_scope / total_in_scope, in [0.0, 1.0]."""
+
+    def test_full_coverage_scores_one(self) -> None:
+        outcomes = [
+            _outcome("o1", "user can play", "moves"),
+            _outcome("o2", "user can score", "score visible"),
+        ]
+        coverage = {"o1": ["t1"], "o2": ["t2"]}
+        assert compute_intent_fidelity_score(outcomes, coverage) == 1.0
+
+    def test_partial_coverage(self) -> None:
+        outcomes = [
+            _outcome("o1", "user can play", "moves"),
+            _outcome("o2", "user can score", "score visible"),
+            _outcome("o3", "user can pause", "pause works"),
+            _outcome("o4", "user can restart", "restart works"),
+        ]
+        coverage = {"o1": ["t1"], "o2": [], "o3": ["t3"], "o4": []}
+        assert compute_intent_fidelity_score(outcomes, coverage) == 0.5
+
+    def test_out_of_scope_excluded_from_denominator(self) -> None:
+        """Out-of-scope outcomes do not count toward score."""
+        outcomes = [
+            _outcome("o1", "user can play", "moves"),
+            _outcome("o2", "user can log in", "auth", scope="out_of_scope"),
+        ]
+        coverage = {"o1": ["t1"], "o2": []}
+        # 1 in-scope outcome, 1 covered → 1.0
+        assert compute_intent_fidelity_score(outcomes, coverage) == 1.0
+
+    def test_no_in_scope_outcomes_yields_one(self) -> None:
+        """Empty denominator → vacuously satisfied (score = 1.0).
+
+        The alternative (NaN, 0.0, raise) all surprise consumers.  Since
+        there are no in-scope outcomes to fail, treat it as full fidelity.
+        """
+        outcomes = [
+            _outcome("o1", "user can x", "x", scope="out_of_scope"),
+        ]
+        coverage = {"o1": []}
+        assert compute_intent_fidelity_score(outcomes, coverage) == 1.0
+
+
+class TestFillGaps:
+    """Gap-fill issues a single LLM call returning task dicts."""
+
+    @pytest.fixture
+    def llm_returning(self) -> Any:
+        def _build(payload: str) -> AsyncMock:
+            mock = AsyncMock()
+            mock.analyze = AsyncMock(return_value=payload)
+            return mock
+
+        return _build
+
+    @pytest.mark.asyncio
+    async def test_returns_task_dicts_for_each_gap(self, llm_returning: Any) -> None:
+        """LLM returns a list of task dicts; one per gap (or more)."""
+        gaps = [
+            _outcome(
+                "outcome_render",
+                "user can play the snake game",
+                "snake visible on canvas",
+            )
+        ]
+        llm = llm_returning(
+            '{"tasks": ['
+            '{"name": "Render snake to canvas",'
+            ' "description": "Subscribe to game-state events and draw '
+            'snake/food/score on a canvas element"}'
+            "]}"
+        )
+        new_tasks = await fill_gaps(
+            spec="build a snake game", gaps=gaps, llm_client=llm
+        )
+        assert len(new_tasks) == 1
+        assert new_tasks[0]["name"] == "Render snake to canvas"
+
+    @pytest.mark.asyncio
+    async def test_empty_gaps_returns_empty_without_llm_call(
+        self, llm_returning: Any
+    ) -> None:
+        """No gaps means no LLM call — saves cost when coverage is full."""
+        llm = llm_returning('{"tasks": []}')
+        new_tasks = await fill_gaps(spec="anything", gaps=[], llm_client=llm)
+        assert new_tasks == []
+        llm.analyze.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_malformed_response_raises(self, llm_returning: Any) -> None:
+        gaps = [_outcome("o1", "user can do X", "X")]
+        llm = llm_returning("not json")
+        with pytest.raises(ValueError, match="JSON"):
+            await fill_gaps(spec="x", gaps=gaps, llm_client=llm)
+
+    @pytest.mark.asyncio
+    async def test_each_returned_task_has_name_and_description(
+        self, llm_returning: Any
+    ) -> None:
+        """A task dict missing required fields is rejected, not silently kept."""
+        gaps = [_outcome("o1", "user can do X", "X observable")]
+        llm = llm_returning('{"tasks": [{"name": "no description"}]}')
+        with pytest.raises(ValueError, match="description"):
+            await fill_gaps(spec="x", gaps=gaps, llm_client=llm)

--- a/tests/unit/coordinator/test_outcome_coverage.py
+++ b/tests/unit/coordinator/test_outcome_coverage.py
@@ -392,3 +392,37 @@ class TestFillGaps:
         llm = llm_returning('{"tasks": [{"name": "no description"}]}')
         with pytest.raises(ValueError, match="description"):
             await fill_gaps(spec="x", gaps=gaps, llm_client=llm)
+
+    @pytest.mark.asyncio
+    async def test_null_name_field_is_rejected(self, llm_returning: Any) -> None:
+        """Null name must raise — must not coerce 'None' through validation.
+
+        Codex P1 regression (PR #453): the original ``str(item.get(...))``
+        coercion turned ``None`` into the literal string ``"None"`` which
+        is non-empty and silently passed the empty-name check, so callers
+        thought gaps were filled with usable tasks when they were not.
+        """
+        gaps = [_outcome("o1", "user can do X", "X observable")]
+        llm = llm_returning(
+            '{"tasks": [{"name": null, "description": "valid description"}]}'
+        )
+        with pytest.raises(ValueError, match=r"'name'.*string"):
+            await fill_gaps(spec="x", gaps=gaps, llm_client=llm)
+
+    @pytest.mark.asyncio
+    async def test_null_description_field_is_rejected(self, llm_returning: Any) -> None:
+        """Null description must raise (same Codex P1 bug, other field)."""
+        gaps = [_outcome("o1", "user can do X", "X observable")]
+        llm = llm_returning('{"tasks": [{"name": "valid name", "description": null}]}')
+        with pytest.raises(ValueError, match=r"'description'.*string"):
+            await fill_gaps(spec="x", gaps=gaps, llm_client=llm)
+
+    @pytest.mark.asyncio
+    async def test_non_string_name_field_is_rejected(self, llm_returning: Any) -> None:
+        """An integer where a string is expected raises (no silent coercion)."""
+        gaps = [_outcome("o1", "user can do X", "X observable")]
+        llm = llm_returning(
+            '{"tasks": [{"name": 42, "description": "valid description"}]}'
+        )
+        with pytest.raises(ValueError, match=r"'name'.*string"):
+            await fill_gaps(spec="x", gaps=gaps, llm_client=llm)


### PR DESCRIPTION
Closes part of #449 — the foundational module layer.  Decomposer integration is the follow-up PR.

## Summary

Introduces three pure modules that turn the v31-snake failure mode into a measurable property:

- `src/ai/advanced/prd/outcome_extractor.py` — `UserOutcome` dataclass with strict `__post_init__` validation, plus `extract_user_outcomes(spec, llm_client)` to produce a list of outcomes from a spec via one LLM call.
- `src/marcus_mcp/coordinator/outcome_coverage.py` — `compute_coverage`, `find_gaps`, `compute_intent_fidelity_score`, `fill_gaps`.
- 30 new unit tests including a snake_game-v31 regression test that reproduces the production failure end-to-end with mocked LLMs.

## Why

snake_game-v31 audit (2026-04-28): the spec `"build a snake game"` produced a task graph with no rendering task because the decomposer treated rendering as implicit.  HTTP 200 + tests pass; user sees an empty `<main id="game-mount">`.

This pattern recurs across project types — APIs missing endpoint handlers, CLIs missing argparse, pipelines missing data ingestion.  The systemic fix is to treat user-visible outcomes as decomposition constraints, not optional metadata.  See #449 for the full failure-mode taxonomy.

## What's in this PR

### `UserOutcome` dataclass
Strict validation in `__post_init__`:
- `action` must contain `user can` / `user is able to` / `users can` / etc.
- Vague phrasings (`user can use the app`) rejected with a clear error
- `scope` must be `in_scope` or `out_of_scope`
- `id` and `success_signal` must be non-empty

### `extract_user_outcomes`
- One LLM call per spec, validated against the schema
- Out-of-scope outcomes are **retained** (not dropped) so the audit trail records what the LLM considered and rejected based on spec language (`"no auth"`, `"no accounts"`)
- Empty outcome lists raise — every spec implies at least one user-visible capability
- ID collisions raise — would silently corrupt the coverage map

### `outcome_coverage` module
- `compute_coverage(outcomes, tasks, mapper=None)` — outcome_id → list of task_ids that address it.  Default keyword-overlap mapper is suitable for unit tests; tests inject explicit mappers for deterministic behavior.  **Decomposer integration (next PR) will use an LLM-backed mapper** — the keyword default is provably inadequate for the snake-v31 case, where domain nouns (`snake`, `food`, `score`) overlap heavily between outcomes and internal logic tasks.  This is documented in the regression test.
- `find_gaps` returns only in-scope outcomes with no covering task.  Out-of-scope outcomes are retained for audit but excluded from gaps.
- `compute_intent_fidelity_score` = `covered_in_scope / total_in_scope`, vacuously `1.0` when there are no in-scope outcomes (alternative — NaN, 0, raise — surprises consumers).
- `fill_gaps(spec, gaps, llm_client)` — single LLM call producing replacement task dicts.  **No call when gaps is empty** — this is the cost invariant.

### Tests (30 new)
- `tests/unit/ai/test_outcome_extractor.py` — 12 tests covering dataclass invariants, extraction success, and every error path
- `tests/unit/coordinator/test_outcome_coverage.py` — 16 tests covering coverage, gaps, score, gap-fill
- `tests/unit/coordinator/test_intent_fidelity_pipeline.py` — 2 end-to-end tests reproducing the snake_game-v31 scenario:
  - `test_missing_render_task_is_detected_and_filled`: extracts outcome → simulates v31 logic-only task graph → coverage finds gap → gap-fill produces a render task → final fidelity is 1.0
  - `test_full_coverage_skips_gap_fill_call`: when the graph already covers all outcomes, no LLM call is made (cost invariant)

## What's NOT in this PR (deliberate)

- **Decomposer integration** — wiring `extract_user_outcomes` into `advanced_parser.py` and the coverage check into `decomposer.py`.  Those files are 4,500 and 1,100 lines respectively; integration deserves its own review and PR.
- **Feature flag `MARCUS_OUTCOME_COVERAGE`** — pairs with the integration above.
- **Cato surfacing of `intent_fidelity_score`** — covered by #447 scope.
- **Integration Verification using outcome `success_signal` as gate (Stage 5)** — explicitly deferred per #449 description.

## Bright Line / Multi-Agency Compliance

`UserOutcome.action` says **WHAT** the user must be able to do.  `success_signal` describes observable evidence.  Neither prescribes HOW.  Two agents given the outcome `"user can play the snake game"` can implement it with canvas, DOM, SVG, WebGL, or ASCII art in a terminal — all legitimately different.  Marcus says WHAT; agents pick HOW.  ✅ Coordination, not control.

## Test plan

- [x] `pytest tests/unit/ai/test_outcome_extractor.py tests/unit/coordinator/test_outcome_coverage.py tests/unit/coordinator/test_intent_fidelity_pipeline.py` — 30/30 pass
- [x] `mypy --strict src/ai/advanced/prd/outcome_extractor.py src/marcus_mcp/coordinator/outcome_coverage.py` — no issues
- [x] black / isort / flake8 / pydocstyle clean
- [ ] Full `pytest -m unit` — verify no regressions in the broader unit suite

## Related

- Closes part of #449 (foundational layer); decomposer integration to follow
- Builds on #446 (consumption contracts) and #447 (Cato planning visibility) — those address HOW tasks describe interfaces and observability of planning; this addresses WHICH tasks exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)