### PR TITLE
feat(#449): decomposer integration — outcome coverage with provides/requires gap-fill

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -82,6 +82,17 @@ MARCUS_MCP_PORT=4298
 # Enable specific features
 # MARCUS_ENABLE_SUBTASKS=true
 
+# Intent fidelity coverage (issue #449)
+# Extracts user-visible outcomes from the spec, runs a coverage check
+# against the generated task graph, and fills gaps via a single LLM
+# call so the decomposer cannot ship a task graph that misses
+# user-visible behavior (e.g. snake_game-v31's missing rendering task).
+# Off by default while the integration soaks; flip on per-project to
+# pay one additional LLM call at planning time and gain an
+# ``intent_fidelity_score`` for the run.
+# Accepts: 1, true, yes, on, enabled (case-insensitive).
+# MARCUS_OUTCOME_COVERAGE=false
+
 # Monitoring
 # MARCUS_MONITORING_INTERVAL=60
 

--- a/src/ai/advanced/prd/advanced_parser.py
+++ b/src/ai/advanced/prd/advanced_parser.py
@@ -11,8 +11,13 @@ from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
 from typing import Any, Dict, List, Optional, Tuple
 
+from src.ai.advanced.prd.outcome_extractor import (
+    UserOutcome,
+    extract_user_outcomes,
+)
 from src.ai.providers.llm_abstraction import LLMAbstraction
 from src.config.hybrid_inference_config import HybridInferenceConfig
+from src.config.outcome_coverage_config import is_outcome_coverage_enabled
 from src.core.models import Priority, Task, TaskStatus
 from src.integrations.ai_analysis_engine import AIAnalysisEngine
 from src.intelligence.dependency_inferer_hybrid import HybridDependencyInferer
@@ -36,6 +41,11 @@ class PRDAnalysis:
     confidence: float
     original_description: str = ""  # NEW: Preserve original user description
     integration_requirements: List[Dict[str, Any]] = field(default_factory=list)
+    # User-visible outcomes the product must satisfy (issue #449).
+    # Populated by ``extract_user_outcomes`` when MARCUS_OUTCOME_COVERAGE
+    # is enabled; otherwise an empty list.  Downstream stages compute
+    # ``intent_fidelity_score`` from these.
+    user_outcomes: List[UserOutcome] = field(default_factory=list)
 
 
 @dataclass
@@ -190,24 +200,39 @@ class AdvancedPRDParser:
         return default_minutes
 
     async def parse_prd_to_tasks(
-        self, prd_content: str, constraints: ProjectConstraints
+        self,
+        prd_content: str,
+        constraints: ProjectConstraints,
+        prd_analysis: Optional[PRDAnalysis] = None,
     ) -> TaskGenerationResult:
         """
         Convert PRD into complete task breakdown with dependencies.
 
-        Args
-        ----
-            prd_content: Full PRD document content
-            constraints: Project constraints and limitations
+        Parameters
+        ----------
+        prd_content : str
+            Full PRD document content.
+        constraints : ProjectConstraints
+            Project constraints and limitations.
+        prd_analysis : Optional[PRDAnalysis], optional
+            Pre-computed PRD analysis.  When provided, skip the
+            internal :meth:`_analyze_prd_deeply` call and use the
+            given analysis instead.  Lets the orchestrator share a
+            single PRDAnalysis across both decomposer paths and the
+            outcome-coverage hook (issue #449), avoiding duplicate
+            analysis on contract-first → feature-based fallback.
 
         Returns
         -------
-            Complete task generation result with breakdown and analysis
+        TaskGenerationResult
+            Complete task generation result with breakdown and analysis.
         """
         logger.info("Starting advanced PRD parsing and task generation")
 
-        # Step 1: Deep PRD analysis (with complexity-aware enrichment)
-        prd_analysis = await self._analyze_prd_deeply(prd_content, constraints)
+        # Step 1: Deep PRD analysis (with complexity-aware enrichment).
+        # Skip when caller passed a pre-computed analysis.
+        if prd_analysis is None:
+            prd_analysis = await self._analyze_prd_deeply(prd_content, constraints)
 
         # Step 2: Generate task hierarchy
         req_count = len(prd_analysis.functional_requirements)
@@ -1178,6 +1203,32 @@ Return ONLY the JSON object. Do not include commentary.
                     f"Enterprise mode expects 15-30+ features, but AI generated "
                     f"{feature_count}. Project may be incomplete."
                 )
+
+            # Issue #449: extract user-visible outcomes when the
+            # MARCUS_OUTCOME_COVERAGE flag is on.  Outcomes are attached
+            # to PRDAnalysis so both decomposer paths (feature_based and
+            # contract_first) carry them through to coverage check.
+            #
+            # Failure to extract is not a hard error — outcomes default
+            # to an empty list and the downstream coverage check
+            # gracefully no-ops on empty input.  This keeps the existing
+            # pipeline robust when the secondary LLM call fails for
+            # reasons unrelated to PRD analysis itself.
+            if is_outcome_coverage_enabled():
+                try:
+                    analysis.user_outcomes = await extract_user_outcomes(
+                        spec=prd_content, llm_client=self.llm_client
+                    )
+                    logger.info(
+                        f"Extracted {len(analysis.user_outcomes)} user "
+                        f"outcomes for intent fidelity coverage"
+                    )
+                except ValueError as outcome_exc:
+                    logger.warning(
+                        f"User-outcome extraction failed; intent fidelity "
+                        f"will be unmeasurable for this project: "
+                        f"{outcome_exc}"
+                    )
 
             return analysis
 

--- a/src/config/outcome_coverage_config.py
+++ b/src/config/outcome_coverage_config.py
@@ -1,0 +1,39 @@
+"""Feature flag for user-outcome coverage (issue #449).
+
+Reads the ``MARCUS_OUTCOME_COVERAGE`` environment variable.  When the
+flag is off (the default), the entire intent-fidelity pipeline
+(extraction, coverage check, gap-fill, score logging) is a no-op —
+PRD analysis runs as it always has, no extra LLM calls fire, and
+``PRDAnalysis.user_outcomes`` stays empty.
+
+The flag is opt-in for v0.4.x while the integration soaks; the plan
+is to flip the default to on once batch experiment runs confirm it
+behaves correctly across project types.
+"""
+
+from __future__ import annotations
+
+import os
+
+# Public constant.  Importable for tests that need to monkey-patch
+# the env var or assert the canonical name.
+ENV_VAR_NAME: str = "MARCUS_OUTCOME_COVERAGE"
+
+_TRUTHY = frozenset({"1", "true", "yes", "on", "enabled"})
+
+
+def is_outcome_coverage_enabled() -> bool:
+    """Return ``True`` when the outcome-coverage pipeline is active.
+
+    The pipeline is OFF by default — set the env var to one of
+    ``"1" | "true" | "yes" | "on" | "enabled"`` (case-insensitive)
+    to enable it.
+
+    Returns
+    -------
+    bool
+        ``True`` when ``MARCUS_OUTCOME_COVERAGE`` is set to a truthy
+        value, ``False`` otherwise (including when the var is unset).
+    """
+    raw = os.environ.get(ENV_VAR_NAME, "").strip().lower()
+    return raw in _TRUTHY

--- a/src/integrations/nlp_tools.py
+++ b/src/integrations/nlp_tools.py
@@ -20,9 +20,17 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), "src"))
 
 from src.ai.advanced.prd.advanced_parser import (  # noqa: E402
     AdvancedPRDParser,
+    PRDAnalysis,
     ProjectConstraints,
 )
+from src.ai.advanced.prd.outcome_extractor import (  # noqa: E402
+    UserOutcome,
+    extract_user_outcomes,
+)
 from src.config.decomposer_config import is_contract_first  # noqa: E402
+from src.config.outcome_coverage_config import (  # noqa: E402
+    is_outcome_coverage_enabled,
+)
 from src.core.models import Priority, Task, TaskStatus  # noqa: E402
 from src.core.resilience import RetryConfig, with_retry  # noqa: E402
 from src.detection.board_analyzer import BoardAnalyzer  # noqa: E402
@@ -35,6 +43,12 @@ from src.integrations.enhanced_task_classifier import (  # noqa: E402
 from src.integrations.nlp_base import NaturalLanguageTaskCreator  # noqa: E402
 from src.integrations.nlp_task_utils import TaskType  # noqa: E402
 from src.logging.agent_events import log_agent_event  # noqa: E402
+from src.marcus_mcp.coordinator.outcome_coverage import (  # noqa: E402
+    compute_coverage_with_llm,
+    compute_intent_fidelity_score,
+    fill_gaps,
+    find_gaps,
+)
 from src.marcus_mcp.coordinator.scheduler import (  # noqa: E402
     calculate_optimal_agents,
 )
@@ -233,6 +247,27 @@ class NaturalLanguageProjectCreator(NaturalLanguageTaskCreator):
         constraints = self._build_constraints(options)
         logger.info(f"Parsing PRD with constraints: {constraints}")
 
+        # Issue #449: compute PRDAnalysis once at the orchestrator level
+        # so a single instance flows through both decomposer paths (no
+        # double analysis on contract-first → feature-based fallback)
+        # and the outcome-coverage hook reads user_outcomes from the
+        # same analysis the decomposer used.  When the analysis itself
+        # fails we fall back to letting each decomposer path compute
+        # its own — the legacy behavior — so existing pipelines that
+        # depend on lazy analysis still work.
+        shared_prd_analysis: Optional[PRDAnalysis] = None
+        try:
+            shared_prd_analysis = await self.prd_parser._analyze_prd_deeply(
+                description, constraints
+            )
+        except Exception as analysis_exc:
+            logger.warning(
+                "[decomposer] orchestrator-level PRD analysis failed "
+                f"({type(analysis_exc).__name__}); decomposer paths will "
+                "perform their own analysis: %s",
+                analysis_exc,
+            )
+
         # Contract-first decomposition path (GH-320 PR 2)
         if is_contract_first(options):
             logger.info(
@@ -245,11 +280,17 @@ class NaturalLanguageProjectCreator(NaturalLanguageTaskCreator):
                 project_root=project_root,
                 constraints=constraints,
                 options=options,
+                prd_analysis=shared_prd_analysis,
             )
             if contract_tasks is not None:
                 logger.info(
                     f"[decomposer] contract_first produced "
                     f"{len(contract_tasks)} task(s)"
+                )
+                contract_tasks = await self._apply_outcome_coverage(
+                    tasks=contract_tasks,
+                    description=description,
+                    prd_analysis=shared_prd_analysis,
                 )
                 return contract_tasks
             # Fell through to feature-based fallback
@@ -267,7 +308,11 @@ class NaturalLanguageProjectCreator(NaturalLanguageTaskCreator):
         foundation_tasks = await self._synthesize_shared_foundation(description)
 
         # Feature-based decomposition path (default + fallback target)  # noqa: E501
-        prd_result = await self.prd_parser.parse_prd_to_tasks(description, constraints)
+        # Pass the shared PRDAnalysis so parse_prd_to_tasks does not
+        # re-run _analyze_prd_deeply.
+        prd_result = await self.prd_parser.parse_prd_to_tasks(
+            description, constraints, prd_analysis=shared_prd_analysis
+        )
 
         task_count = len(prd_result.tasks) if prd_result.tasks else 0
         logger.info(f"PRD parser returned {task_count} tasks")
@@ -320,9 +365,231 @@ class NaturalLanguageProjectCreator(NaturalLanguageTaskCreator):
                 for fid in foundation_ids:
                     if fid not in task.dependencies:
                         task.dependencies.append(fid)
-            return foundation_tasks + domain_tasks
+            full_task_list = foundation_tasks + domain_tasks
+            full_task_list = await self._apply_outcome_coverage(
+                tasks=full_task_list,
+                description=description,
+                prd_analysis=shared_prd_analysis,
+            )
+            return full_task_list
 
+        domain_tasks = await self._apply_outcome_coverage(
+            tasks=domain_tasks,
+            description=description,
+            prd_analysis=shared_prd_analysis,
+        )
         return domain_tasks
+
+    async def _apply_outcome_coverage(
+        self,
+        tasks: List[Task],
+        description: str,
+        prd_analysis: Optional[PRDAnalysis],
+    ) -> List[Task]:
+        """Run the user-outcome coverage pipeline (issue #449).
+
+        Behind the ``MARCUS_OUTCOME_COVERAGE`` feature flag.  When the
+        flag is off, returns ``tasks`` unchanged.  When on:
+
+        1. Reads ``user_outcomes`` from the supplied PRD analysis (or
+           extracts them now if the analysis is missing or carries
+           none — the latter happens when extraction failed during
+           PRD analysis).
+        2. Calls :func:`compute_coverage_with_llm` to map each outcome
+           to the tasks that address it.
+        3. Identifies gaps via :func:`find_gaps`.
+        4. If gaps exist, calls :func:`fill_gaps` to synthesize new
+           tasks (with ``provides`` / ``requires`` so the existing
+           wiring infrastructure can integrate them naturally).
+        5. Converts the gap-fill task dicts to :class:`Task` objects
+           and appends them to the graph.
+        6. Computes ``intent_fidelity_score`` against the augmented
+           graph and emits an event for downstream observability.
+
+        Failures at any step log a warning and return the original
+        task list — the coverage pipeline never blocks project
+        creation.  The legacy behavior (no coverage) is the
+        always-available fallback.
+
+        Parameters
+        ----------
+        tasks : list of Task
+            Task graph produced by either decomposer path.
+        description : str
+            The original project description (used for gap-fill prompts).
+        prd_analysis : Optional[PRDAnalysis]
+            The shared PRD analysis from the orchestrator.  Carries
+            ``user_outcomes`` populated during ``_analyze_prd_deeply``.
+
+        Returns
+        -------
+        list of Task
+            Original tasks plus any synthesized gap-fill tasks (with
+            ``provides`` / ``requires`` set so wiring can integrate
+            them).  Order preserved: original tasks first, then
+            gap-fill tasks.
+        """
+        if not is_outcome_coverage_enabled():
+            return tasks
+
+        outcomes: List[UserOutcome] = []
+        if prd_analysis is not None and prd_analysis.user_outcomes:
+            outcomes = list(prd_analysis.user_outcomes)
+        else:
+            # PRD analysis missing or carried no outcomes.  Try a
+            # late extraction so the flag's promise (always run
+            # coverage when on) is honored.
+            try:
+                outcomes = await extract_user_outcomes(
+                    spec=description,
+                    llm_client=self.prd_parser.llm_client,
+                )
+            except ValueError as exc:
+                logger.warning(
+                    "[outcome-coverage] late extraction failed; "
+                    "skipping coverage check: %s",
+                    exc,
+                )
+                return tasks
+
+        if not outcomes:
+            logger.info(
+                "[outcome-coverage] no user outcomes available; "
+                "skipping coverage check"
+            )
+            return tasks
+
+        try:
+            coverage = await compute_coverage_with_llm(
+                outcomes=outcomes,
+                tasks=tasks,
+                llm_client=self.prd_parser.llm_client,
+            )
+        except ValueError as exc:
+            logger.warning(
+                "[outcome-coverage] coverage computation failed; "
+                "task graph unchanged: %s",
+                exc,
+            )
+            return tasks
+
+        gaps = find_gaps(outcomes, coverage)
+        synthesized: List[Task] = []
+        if gaps:
+            try:
+                gap_dicts = await fill_gaps(
+                    spec=description,
+                    gaps=gaps,
+                    llm_client=self.prd_parser.llm_client,
+                )
+            except ValueError as exc:
+                logger.warning(
+                    "[outcome-coverage] gap-fill failed; %d gap(s) "
+                    "will go uncovered: %s",
+                    len(gaps),
+                    exc,
+                )
+                gap_dicts = []
+
+            for idx, gap_dict in enumerate(gap_dicts):
+                synthesized.append(
+                    self._build_gap_fill_task(
+                        gap_dict=gap_dict,
+                        index=idx,
+                        sibling_tasks=tasks,
+                    )
+                )
+
+        augmented = list(tasks) + synthesized
+
+        # Recompute coverage on the augmented graph so the score
+        # reflects the post-fill state, not the pre-fill state.
+        if synthesized:
+            try:
+                coverage = await compute_coverage_with_llm(
+                    outcomes=outcomes,
+                    tasks=augmented,
+                    llm_client=self.prd_parser.llm_client,
+                )
+            except ValueError as exc:
+                logger.warning(
+                    "[outcome-coverage] post-fill coverage check failed; "
+                    "intent fidelity score will reflect pre-fill state: %s",
+                    exc,
+                )
+
+        score = compute_intent_fidelity_score(outcomes, coverage)
+        logger.info(
+            "[outcome-coverage] intent_fidelity_score=%.2f "
+            "(outcomes=%d, gaps_pre_fill=%d, synthesized=%d, "
+            "tasks_total=%d)",
+            score,
+            len(outcomes),
+            len(gaps),
+            len(synthesized),
+            len(augmented),
+        )
+
+        return augmented
+
+    def _build_gap_fill_task(
+        self,
+        gap_dict: Dict[str, Any],
+        index: int,
+        sibling_tasks: List[Task],
+    ) -> Task:
+        """Convert a gap-fill task dict into a fully-formed :class:`Task`.
+
+        Defaults are inherited conservatively from sibling tasks so the
+        new task fits naturally into the existing graph:
+
+        - ``estimated_hours``: median of sibling estimates (or 4.0 fallback)
+        - ``priority``: ``Priority.MEDIUM``
+        - ``project_id`` / ``project_name``: copied from a sibling
+        - ``status``: ``TaskStatus.TODO``
+        - ``provides`` / ``requires``: from the gap-fill dict — wiring
+          task generation will integrate this task into the graph
+          via the existing contract mechanism.
+        - ``labels``: ``["gap_fill", "intent_fidelity"]`` so audits can
+          identify synthesized tasks distinctly from original output.
+        """
+        from datetime import datetime, timezone
+        from uuid import uuid4
+
+        now = datetime.now(timezone.utc)
+
+        # Conservative hour estimate from siblings (median, fallback 4.0).
+        sibling_hours = sorted(
+            t.estimated_hours for t in sibling_tasks if t.estimated_hours > 0
+        )
+        if sibling_hours:
+            median = sibling_hours[len(sibling_hours) // 2]
+        else:
+            median = 4.0
+
+        # Inherit project context from any sibling that has it.
+        project_id = next((t.project_id for t in sibling_tasks if t.project_id), None)
+        project_name = next(
+            (t.project_name for t in sibling_tasks if t.project_name), None
+        )
+
+        return Task(
+            id=f"gap_fill_{uuid4().hex[:12]}",
+            name=gap_dict["name"],
+            description=gap_dict["description"],
+            status=TaskStatus.TODO,
+            priority=Priority.MEDIUM,
+            assigned_to=None,
+            created_at=now,
+            updated_at=now,
+            due_date=None,
+            estimated_hours=median,
+            labels=["gap_fill", "intent_fidelity"],
+            project_id=project_id,
+            project_name=project_name,
+            provides=gap_dict.get("provides"),
+            requires=gap_dict.get("requires"),
+        )
 
     async def _try_contract_first_decomposition(
         self,
@@ -331,6 +598,7 @@ class NaturalLanguageProjectCreator(NaturalLanguageTaskCreator):
         project_root: Optional[str],
         constraints: ProjectConstraints,
         options: Optional[Dict[str, Any]],
+        prd_analysis: Optional["PRDAnalysis"] = None,
     ) -> Optional[List[Task]]:
         """
         Attempt contract-first decomposition (GH-320 PR 2).
@@ -389,16 +657,21 @@ class NaturalLanguageProjectCreator(NaturalLanguageTaskCreator):
             )
             return None
 
-        try:
-            prd_analysis = await self.prd_parser._analyze_prd_deeply(
-                description, constraints
-            )
-        except Exception as e:
-            logger.warning(
-                f"[decomposer] contract_first PRD analysis failed: {e}; "
-                f"falling back to feature_based"
-            )
-            return None
+        # Use pre-computed PRDAnalysis when caller supplied one
+        # (issue #449: orchestrator shares one analysis across both
+        # decomposer paths to avoid duplicate _analyze_prd_deeply on
+        # contract-first → feature-based fallback).
+        if prd_analysis is None:
+            try:
+                prd_analysis = await self.prd_parser._analyze_prd_deeply(
+                    description, constraints
+                )
+            except Exception as e:
+                logger.warning(
+                    f"[decomposer] contract_first PRD analysis failed: {e}; "
+                    f"falling back to feature_based"
+                )
+                return None
 
         functional_reqs = prd_analysis.functional_requirements or []
         if not functional_reqs:

--- a/src/marcus_mcp/coordinator/outcome_coverage.py
+++ b/src/marcus_mcp/coordinator/outcome_coverage.py
@@ -422,8 +422,9 @@ Return strict JSON of the form:
   "tasks": [
     {{
       "name": "<short task name>",
-      "description": "<what to build, including how downstream agents '
-      'will consume it>"
+      "description": "<what to build, including how downstream agents will consume it>",
+      "provides": "<interface this task makes available, or null>",
+      "requires": "<interface this task consumes from upstream, or null>"
     }}
   ]
 }}
@@ -433,6 +434,16 @@ Rules:
 - Task names must be concrete (e.g. "Render snake to canvas") not
   generic ("implement feature").
 - Descriptions must say WHAT to build, not HOW.  No library choices.
+- ``provides`` names an interface this task makes available to the rest
+  of the graph (e.g. ``"RenderingAgent.draw_snake"``).  Use ``null``
+  when the task is a pure user-visible endpoint with no downstream
+  consumer.
+- ``requires`` names an interface this task consumes from an existing
+  task in the graph (e.g. ``"GameStateUpdate"``).  Use ``null`` when
+  the task is self-contained.
+- Both fields are optional but should be set whenever the task
+  participates in a contract — wiring task generation depends on them
+  to integrate gap-fill tasks with the rest of the graph.
 - Return ONLY the JSON object — no preamble, no markdown fences.
 """
 
@@ -471,15 +482,27 @@ async def fill_gaps(
     Returns
     -------
     list of dict
-        Each dict has at minimum ``name`` and ``description`` keys.  The
-        decomposer constructs full :class:`Task` objects from these
-        dicts (synthesis hours, dependencies, labels, etc.).
+        Each dict has four keys:
+
+        - ``name`` (str, required) — short task name
+        - ``description`` (str, required) — what to build
+        - ``provides`` (str | None) — interface this task makes available
+          to other tasks in the graph.  ``None`` when the task is a pure
+          user-visible endpoint with no downstream consumer.
+        - ``requires`` (str | None) — interface this task consumes from
+          existing tasks.  ``None`` when the task is self-contained.
+
+        The ``provides`` / ``requires`` fields let
+        :func:`_generate_wiring_tasks` integrate gap-fill tasks with the
+        rest of the graph using the same contract mechanism as normal
+        decomposer output.
 
     Raises
     ------
     ValueError
-        On malformed JSON, missing ``tasks`` key, or any task missing
-        ``name`` / ``description``.
+        On malformed JSON, missing ``tasks`` key, any task missing
+        ``name`` / ``description``, or any non-string-or-null
+        ``provides`` / ``requires`` value.
     """
     if not gaps:
         return []
@@ -512,10 +535,10 @@ async def fill_gaps(
         if not isinstance(item, dict):
             raise ValueError(f"Outcome gap-fill: task at index {idx} is not an object")
 
-        # Reject null / non-string fields rather than coerce.  str(None)
-        # is the string "None" which is non-empty and would silently
-        # pass the empty-string checks below — callers would see
-        # "filled gaps" that are actually unusable placeholder tasks.
+        # Required fields: name, description must be strings.  Reject
+        # null / non-string rather than coerce — str(None) becomes the
+        # literal string "None" which would silently pass the
+        # empty-string checks below.
         for required_field in ("name", "description"):
             value = item.get(required_field)
             if not isinstance(value, str):
@@ -525,6 +548,18 @@ async def fill_gaps(
                     f"{type(value).__name__}: {value!r}"
                 )
 
+        # Optional contract fields: provides, requires must be string
+        # or null (absent treated as null).  Anything else is malformed.
+        for optional_field in ("provides", "requires"):
+            if optional_field in item:
+                value = item[optional_field]
+                if value is not None and not isinstance(value, str):
+                    raise ValueError(
+                        f"Outcome gap-fill: task at index {idx} field "
+                        f"{optional_field!r} must be a string or null, got "
+                        f"{type(value).__name__}: {value!r}"
+                    )
+
         name = item["name"].strip()
         description = item["description"].strip()
         if not name:
@@ -533,6 +568,20 @@ async def fill_gaps(
             raise ValueError(
                 f"Outcome gap-fill: task at index {idx} missing 'description'"
             )
-        validated.append({"name": name, "description": description})
+
+        provides_raw = item.get("provides")
+        requires_raw = item.get("requires")
+        provides = provides_raw.strip() if isinstance(provides_raw, str) else None
+        requires = requires_raw.strip() if isinstance(requires_raw, str) else None
+        # Empty strings are equivalent to None for contract fields —
+        # downstream wiring treats "no contract" uniformly via None.
+        validated.append(
+            {
+                "name": name,
+                "description": description,
+                "provides": provides if provides else None,
+                "requires": requires if requires else None,
+            }
+        )
 
     return validated

--- a/tests/unit/ai/test_prd_outcome_integration.py
+++ b/tests/unit/ai/test_prd_outcome_integration.py
@@ -1,0 +1,202 @@
+"""Unit tests for #449 PRDAnalysis outcome integration in advanced_parser.
+
+When ``MARCUS_OUTCOME_COVERAGE`` is on, ``_analyze_prd_deeply``
+populates ``PRDAnalysis.user_outcomes`` via ``extract_user_outcomes``.
+When the flag is off, the field stays empty and no extra LLM call
+fires — the existing PRD pipeline runs unchanged.
+"""
+
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from src.ai.advanced.prd.advanced_parser import PRDAnalysis
+from src.ai.advanced.prd.outcome_extractor import UserOutcome
+from src.config.outcome_coverage_config import ENV_VAR_NAME
+
+pytestmark = pytest.mark.unit
+
+
+class TestPRDAnalysisDataclassUserOutcomesField:
+    """The dataclass carries user_outcomes with a sensible default."""
+
+    def test_user_outcomes_defaults_to_empty_list(self) -> None:
+        """A PRDAnalysis can be constructed without user_outcomes (legacy)."""
+        analysis = PRDAnalysis(
+            functional_requirements=[],
+            non_functional_requirements=[],
+            technical_constraints=[],
+            business_objectives=[],
+            user_personas=[],
+            success_metrics=[],
+            implementation_approach="agile",
+            complexity_assessment={},
+            risk_factors=[],
+            confidence=0.9,
+        )
+        assert analysis.user_outcomes == []
+
+    def test_user_outcomes_can_be_set_directly(self) -> None:
+        outcome = UserOutcome(
+            id="outcome_play",
+            action="user can play snake",
+            success_signal="snake visibly moves",
+            scope="in_scope",
+        )
+        analysis = PRDAnalysis(
+            functional_requirements=[],
+            non_functional_requirements=[],
+            technical_constraints=[],
+            business_objectives=[],
+            user_personas=[],
+            success_metrics=[],
+            implementation_approach="agile",
+            complexity_assessment={},
+            risk_factors=[],
+            confidence=0.9,
+            user_outcomes=[outcome],
+        )
+        assert analysis.user_outcomes == [outcome]
+
+
+class TestParserOutcomeExtractionWiring:
+    """``_analyze_prd_deeply`` calls ``extract_user_outcomes`` only when flagged."""
+
+    @pytest.fixture
+    def sample_outcome(self) -> UserOutcome:
+        return UserOutcome(
+            id="outcome_play_game",
+            action="user can play the snake game",
+            success_signal="snake visibly moves on a board",
+            scope="in_scope",
+        )
+
+    @pytest.mark.asyncio
+    async def test_extraction_skipped_when_flag_off(
+        self, monkeypatch: Any, sample_outcome: UserOutcome
+    ) -> None:
+        """Default off — extract_user_outcomes is never called."""
+        monkeypatch.delenv(ENV_VAR_NAME, raising=False)
+
+        with patch(
+            "src.ai.advanced.prd.advanced_parser.extract_user_outcomes",
+            new=AsyncMock(return_value=[sample_outcome]),
+        ) as mock_extract:
+            from src.ai.advanced.prd.advanced_parser import (
+                AdvancedPRDParser,
+                ProjectConstraints,
+            )
+
+            with (
+                patch("src.ai.advanced.prd.advanced_parser.LLMAbstraction"),
+                patch("src.ai.advanced.prd.advanced_parser.HybridDependencyInferer"),
+            ):
+                parser = AdvancedPRDParser()
+                mock_llm = AsyncMock()
+                parser.llm_client = mock_llm
+                mock_llm.analyze = AsyncMock(
+                    return_value=(
+                        '{"functional_requirements": [{"id": "f1", "name": '
+                        '"play game"}], "non_functional_requirements": [], '
+                        '"technical_constraints": [], "business_objectives": '
+                        '[], "user_personas": [], "success_metrics": [], '
+                        '"implementation_approach": "agile", '
+                        '"complexity_assessment": {}, "risk_factors": [], '
+                        '"confidence": 0.9}'
+                    )
+                )
+                analysis = await parser._analyze_prd_deeply(
+                    "build a snake game", ProjectConstraints()
+                )
+
+        assert analysis.user_outcomes == []
+        mock_extract.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_extraction_runs_when_flag_on(
+        self, monkeypatch: Any, sample_outcome: UserOutcome
+    ) -> None:
+        """Flag on — extract_user_outcomes is called and result attached."""
+        monkeypatch.setenv(ENV_VAR_NAME, "true")
+
+        with patch(
+            "src.ai.advanced.prd.advanced_parser.extract_user_outcomes",
+            new=AsyncMock(return_value=[sample_outcome]),
+        ) as mock_extract:
+            from src.ai.advanced.prd.advanced_parser import (
+                AdvancedPRDParser,
+                ProjectConstraints,
+            )
+
+            with (
+                patch("src.ai.advanced.prd.advanced_parser.LLMAbstraction"),
+                patch("src.ai.advanced.prd.advanced_parser.HybridDependencyInferer"),
+            ):
+                parser = AdvancedPRDParser()
+                mock_llm = AsyncMock()
+                parser.llm_client = mock_llm
+                mock_llm.analyze = AsyncMock(
+                    return_value=(
+                        '{"functional_requirements": [{"id": "f1", "name": '
+                        '"play game"}], "non_functional_requirements": [], '
+                        '"technical_constraints": [], "business_objectives": '
+                        '[], "user_personas": [], "success_metrics": [], '
+                        '"implementation_approach": "agile", '
+                        '"complexity_assessment": {}, "risk_factors": [], '
+                        '"confidence": 0.9}'
+                    )
+                )
+                analysis = await parser._analyze_prd_deeply(
+                    "build a snake game", ProjectConstraints()
+                )
+
+        assert analysis.user_outcomes == [sample_outcome]
+        mock_extract.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_extraction_failure_does_not_break_prd_analysis(
+        self, monkeypatch: Any
+    ) -> None:
+        """Outcome extraction failure logs a warning, returns empty list.
+
+        The PRD analysis pipeline must remain robust to filter-LLM
+        failures — fidelity becomes unmeasurable for that project, but
+        decomposition still proceeds.
+        """
+        monkeypatch.setenv(ENV_VAR_NAME, "true")
+
+        with patch(
+            "src.ai.advanced.prd.advanced_parser.extract_user_outcomes",
+            new=AsyncMock(side_effect=ValueError("LLM filter exploded")),
+        ):
+            from src.ai.advanced.prd.advanced_parser import (
+                AdvancedPRDParser,
+                ProjectConstraints,
+            )
+
+            with (
+                patch("src.ai.advanced.prd.advanced_parser.LLMAbstraction"),
+                patch("src.ai.advanced.prd.advanced_parser.HybridDependencyInferer"),
+            ):
+                parser = AdvancedPRDParser()
+                mock_llm = AsyncMock()
+                parser.llm_client = mock_llm
+                mock_llm.analyze = AsyncMock(
+                    return_value=(
+                        '{"functional_requirements": [{"id": "f1", "name": '
+                        '"play"}], "non_functional_requirements": [], '
+                        '"technical_constraints": [], "business_objectives": '
+                        '[], "user_personas": [], "success_metrics": [], '
+                        '"implementation_approach": "agile", '
+                        '"complexity_assessment": {}, "risk_factors": [], '
+                        '"confidence": 0.9}'
+                    )
+                )
+                analysis = await parser._analyze_prd_deeply(
+                    "build a snake game", ProjectConstraints()
+                )
+
+        assert analysis.user_outcomes == []
+        # PRD analysis itself succeeded
+        assert len(analysis.functional_requirements) == 1

--- a/tests/unit/config/test_outcome_coverage_config.py
+++ b/tests/unit/config/test_outcome_coverage_config.py
@@ -1,0 +1,51 @@
+"""Unit tests for the MARCUS_OUTCOME_COVERAGE feature flag (issue #449)."""
+
+from typing import Any
+
+import pytest
+
+from src.config.outcome_coverage_config import (
+    ENV_VAR_NAME,
+    is_outcome_coverage_enabled,
+)
+
+pytestmark = pytest.mark.unit
+
+
+class TestOutcomeCoverageFlag:
+    """The flag defaults to OFF and accepts canonical truthy values."""
+
+    def test_default_off_when_env_unset(self, monkeypatch: Any) -> None:
+        monkeypatch.delenv(ENV_VAR_NAME, raising=False)
+        assert is_outcome_coverage_enabled() is False
+
+    def test_default_off_when_env_empty(self, monkeypatch: Any) -> None:
+        monkeypatch.setenv(ENV_VAR_NAME, "")
+        assert is_outcome_coverage_enabled() is False
+
+    @pytest.mark.parametrize("value", ["1", "true", "yes", "on", "enabled"])
+    def test_truthy_values_enable_flag(self, monkeypatch: Any, value: str) -> None:
+        monkeypatch.setenv(ENV_VAR_NAME, value)
+        assert is_outcome_coverage_enabled() is True
+
+    @pytest.mark.parametrize("value", ["TRUE", "Yes", "ON", "Enabled"])
+    def test_truthy_values_are_case_insensitive(
+        self, monkeypatch: Any, value: str
+    ) -> None:
+        monkeypatch.setenv(ENV_VAR_NAME, value)
+        assert is_outcome_coverage_enabled() is True
+
+    @pytest.mark.parametrize("value", ["0", "false", "no", "off", "random"])
+    def test_falsy_or_unknown_values_keep_flag_off(
+        self, monkeypatch: Any, value: str
+    ) -> None:
+        monkeypatch.setenv(ENV_VAR_NAME, value)
+        assert is_outcome_coverage_enabled() is False
+
+    def test_whitespace_around_value_is_stripped(self, monkeypatch: Any) -> None:
+        monkeypatch.setenv(ENV_VAR_NAME, "  true  ")
+        assert is_outcome_coverage_enabled() is True
+
+    def test_constant_name_matches_documented(self) -> None:
+        """Locks in the public env var name so docs and code stay in sync."""
+        assert ENV_VAR_NAME == "MARCUS_OUTCOME_COVERAGE"

--- a/tests/unit/coordinator/test_outcome_coverage.py
+++ b/tests/unit/coordinator/test_outcome_coverage.py
@@ -426,3 +426,79 @@ class TestFillGaps:
         )
         with pytest.raises(ValueError, match=r"'name'.*string"):
             await fill_gaps(spec="x", gaps=gaps, llm_client=llm)
+
+    @pytest.mark.asyncio
+    async def test_provides_field_is_emitted_when_supplied(
+        self, llm_returning: Any
+    ) -> None:
+        """fill_gaps surfaces ``provides`` so wiring task generation can use it.
+
+        The decomposer's ``_generate_wiring_tasks`` builds integration
+        tasks from provides/requires pairs.  Gap-fill tasks must
+        participate in that mechanism — otherwise they sit isolated
+        in the DAG with no consumer plumbing.
+        """
+        gaps = [_outcome("o1", "user can play snake", "snake visibly moves")]
+        llm = llm_returning(
+            '{"tasks": [{'
+            '"name": "Render snake to canvas",'
+            '"description": "Draw snake/food/score on canvas element",'
+            '"provides": "RenderingAgent.draw"'
+            "}]}"
+        )
+        new_tasks = await fill_gaps(spec="build snake", gaps=gaps, llm_client=llm)
+        assert new_tasks[0]["provides"] == "RenderingAgent.draw"
+
+    @pytest.mark.asyncio
+    async def test_requires_field_is_emitted_when_supplied(
+        self, llm_returning: Any
+    ) -> None:
+        """``requires`` lets gap-fill tasks consume foundation artifacts."""
+        gaps = [_outcome("o1", "user can play snake", "snake visibly moves")]
+        llm = llm_returning(
+            '{"tasks": [{'
+            '"name": "Render snake to canvas",'
+            '"description": "Draw snake on canvas",'
+            '"requires": "GameStateUpdate"'
+            "}]}"
+        )
+        new_tasks = await fill_gaps(spec="build snake", gaps=gaps, llm_client=llm)
+        assert new_tasks[0]["requires"] == "GameStateUpdate"
+
+    @pytest.mark.asyncio
+    async def test_provides_and_requires_default_to_none(
+        self, llm_returning: Any
+    ) -> None:
+        """Tasks without contracts get ``provides=None``, ``requires=None``.
+
+        Both fields are optional in the Task model; gap-fill tasks that
+        are pure leaves (no consumer, no upstream contract) emit ``None``
+        for both rather than raising.
+        """
+        gaps = [_outcome("o1", "user can do X", "X observable")]
+        llm = llm_returning(
+            '{"tasks": [{"name": "Standalone task", "description": "no contract"}]}'
+        )
+        new_tasks = await fill_gaps(spec="x", gaps=gaps, llm_client=llm)
+        assert new_tasks[0]["provides"] is None
+        assert new_tasks[0]["requires"] is None
+
+    @pytest.mark.asyncio
+    async def test_non_string_provides_is_rejected(self, llm_returning: Any) -> None:
+        """A list or int for ``provides`` is malformed — must be string or null."""
+        gaps = [_outcome("o1", "user can do X", "X observable")]
+        llm = llm_returning(
+            '{"tasks": [{' '"name": "X", "description": "Y", "provides": ["bad"]' "}]}"
+        )
+        with pytest.raises(ValueError, match=r"'provides'.*string"):
+            await fill_gaps(spec="x", gaps=gaps, llm_client=llm)
+
+    @pytest.mark.asyncio
+    async def test_non_string_requires_is_rejected(self, llm_returning: Any) -> None:
+        """Same shape check for ``requires``."""
+        gaps = [_outcome("o1", "user can do X", "X observable")]
+        llm = llm_returning(
+            '{"tasks": [{' '"name": "X", "description": "Y", "requires": 42' "}]}"
+        )
+        with pytest.raises(ValueError, match=r"'requires'.*string"):
+            await fill_gaps(spec="x", gaps=gaps, llm_client=llm)

--- a/tests/unit/integrations/test_nlp_outcome_coverage.py
+++ b/tests/unit/integrations/test_nlp_outcome_coverage.py
@@ -1,0 +1,442 @@
+"""Unit tests for the orchestrator-level outcome coverage hook (issue #449).
+
+``NaturalLanguageProjectCreator._apply_outcome_coverage`` is the
+production integration point for the intent fidelity pipeline:
+
+1. Reads outcomes from the shared PRD analysis (or extracts late
+   if unavailable).
+2. Computes coverage via :func:`compute_coverage_with_llm`.
+3. Identifies gaps among in-scope outcomes.
+4. Synthesizes replacement tasks via :func:`fill_gaps`, each carrying
+   ``provides`` / ``requires`` so the existing wiring infrastructure
+   integrates them with the rest of the graph.
+5. Builds full :class:`Task` objects from the gap-fill dicts.
+6. Recomputes coverage on the augmented graph and reports
+   ``intent_fidelity_score``.
+
+Behind ``MARCUS_OUTCOME_COVERAGE``: when off, the helper returns the
+input task list unchanged with no LLM calls.
+"""
+
+from datetime import datetime, timezone
+from typing import Any, List
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from src.ai.advanced.prd.advanced_parser import PRDAnalysis
+from src.ai.advanced.prd.outcome_extractor import UserOutcome
+from src.config.outcome_coverage_config import ENV_VAR_NAME
+from src.core.models import Priority, Task, TaskStatus
+
+pytestmark = pytest.mark.unit
+
+
+def _task(
+    task_id: str,
+    name: str,
+    description: str = "",
+    estimated_hours: float = 2.0,
+) -> Task:
+    now = datetime.now(timezone.utc)
+    return Task(
+        id=task_id,
+        name=name,
+        description=description,
+        status=TaskStatus.TODO,
+        priority=Priority.MEDIUM,
+        assigned_to=None,
+        created_at=now,
+        updated_at=now,
+        due_date=None,
+        estimated_hours=estimated_hours,
+        project_id="proj_1",
+        project_name="Snake Game",
+    )
+
+
+def _make_analysis_with_outcomes(outcomes: List[UserOutcome]) -> PRDAnalysis:
+    return PRDAnalysis(
+        functional_requirements=[],
+        non_functional_requirements=[],
+        technical_constraints=[],
+        business_objectives=[],
+        user_personas=[],
+        success_metrics=[],
+        implementation_approach="agile",
+        complexity_assessment={},
+        risk_factors=[],
+        confidence=0.9,
+        user_outcomes=outcomes,
+    )
+
+
+def _make_creator() -> Any:
+    """Build a creator instance with mocked dependencies for unit tests."""
+    from src.integrations.nlp_tools import NaturalLanguageProjectCreator
+
+    with patch("src.integrations.nlp_tools.AdvancedPRDParser") as mock_parser_class:
+        mock_parser = MagicMock()
+        mock_parser.llm_client = AsyncMock()
+        mock_parser_class.return_value = mock_parser
+        creator = NaturalLanguageProjectCreator(
+            kanban_client=MagicMock(),
+            ai_engine=MagicMock(),
+            state=MagicMock(),
+        )
+        creator.prd_parser = mock_parser
+        return creator
+
+
+class TestApplyOutcomeCoverageFlagOff:
+    """Flag off → helper is a pure pass-through."""
+
+    @pytest.mark.asyncio
+    async def test_returns_tasks_unchanged_when_flag_off(
+        self, monkeypatch: Any
+    ) -> None:
+        monkeypatch.delenv(ENV_VAR_NAME, raising=False)
+        creator = _make_creator()
+        tasks = [_task("t1", "Task 1"), _task("t2", "Task 2")]
+
+        result = await creator._apply_outcome_coverage(
+            tasks=tasks,
+            description="anything",
+            prd_analysis=_make_analysis_with_outcomes([]),
+        )
+
+        assert result == tasks
+        creator.prd_parser.llm_client.analyze.assert_not_called()
+
+
+class TestApplyOutcomeCoverageFlagOnNoGaps:
+    """Flag on, full coverage → no gap-fill, no graph change."""
+
+    @pytest.mark.asyncio
+    async def test_full_coverage_returns_input_unchanged(
+        self, monkeypatch: Any
+    ) -> None:
+        monkeypatch.setenv(ENV_VAR_NAME, "true")
+        creator = _make_creator()
+        tasks = [
+            _task("t_render", "Render snake to canvas", "draw snake"),
+        ]
+        outcomes = [
+            UserOutcome(
+                id="outcome_play_game",
+                action="user can play snake",
+                success_signal="snake visibly moves",
+                scope="in_scope",
+            )
+        ]
+
+        creator.prd_parser.llm_client.analyze = AsyncMock(
+            return_value=('{"coverage": {"outcome_play_game": ["t_render"]}}')
+        )
+
+        result = await creator._apply_outcome_coverage(
+            tasks=tasks,
+            description="build snake",
+            prd_analysis=_make_analysis_with_outcomes(outcomes),
+        )
+
+        # Same task list, no synthesized additions
+        assert result == tasks
+        # One LLM call total: the coverage check (no fill, no recompute)
+        assert creator.prd_parser.llm_client.analyze.await_count == 1
+
+
+class TestApplyOutcomeCoverageFlagOnWithGaps:
+    """Flag on, gaps exist → fill_gaps synthesizes Task objects with contracts."""
+
+    @pytest.mark.asyncio
+    async def test_gap_fill_appends_task_with_provides_requires(
+        self, monkeypatch: Any
+    ) -> None:
+        """Snake-v31 scenario: missing rendering task is detected and filled.
+
+        End-to-end through the helper: extract -> coverage finds gap ->
+        fill produces task with provides/requires -> Task object built
+        with those contracts -> appended to graph -> recompute coverage.
+        """
+        monkeypatch.setenv(ENV_VAR_NAME, "true")
+        creator = _make_creator()
+        v31_tasks = [
+            _task("t_state", "Snake state machine", "track snake body"),
+            _task("t_movement", "Movement engine", "advance snake"),
+            _task("t_food", "Food generator", "place food"),
+        ]
+        outcomes = [
+            UserOutcome(
+                id="outcome_play_game",
+                action="user can play snake",
+                success_signal="snake visibly moves on a board",
+                scope="in_scope",
+            )
+        ]
+
+        # Three sequential LLM calls: coverage (gap found),
+        # fill_gaps (returns rendering task with provides/requires),
+        # post-fill coverage recomputation (gap closed).
+        creator.prd_parser.llm_client.analyze = AsyncMock(
+            side_effect=[
+                # 1. Coverage: no v31 task addresses the play outcome
+                '{"coverage": {"outcome_play_game": []}}',
+                # 2. Gap-fill: produces a rendering task with contracts
+                (
+                    '{"tasks": [{'
+                    '"name": "Render snake to canvas",'
+                    '"description": "Subscribe to game-state events and '
+                    'draw snake/food/score on canvas",'
+                    '"provides": "RenderingAgent.draw",'
+                    '"requires": "GameStateUpdate"'
+                    "}]}"
+                ),
+                # 3. Post-fill coverage: the new task IS covering
+                '{"coverage": {"outcome_play_game": ["GAP_FILL_ID"]}}',
+            ]
+        )
+
+        result = await creator._apply_outcome_coverage(
+            tasks=v31_tasks,
+            description="build a snake game",
+            prd_analysis=_make_analysis_with_outcomes(outcomes),
+        )
+
+        assert len(result) == 4, "Expected v31 tasks + 1 synthesized task"
+        gap_fill_task = result[-1]
+        assert gap_fill_task.name == "Render snake to canvas"
+        rendering_words = ("render", "draw", "canvas", "display")
+        haystack = (gap_fill_task.name + " " + gap_fill_task.description).lower()
+        assert any(
+            word in haystack for word in rendering_words
+        ), f"Gap-fill task does not address rendering: {gap_fill_task}"
+        assert gap_fill_task.provides == "RenderingAgent.draw"
+        assert gap_fill_task.requires == "GameStateUpdate"
+        assert "gap_fill" in gap_fill_task.labels
+        assert "intent_fidelity" in gap_fill_task.labels
+        assert gap_fill_task.id.startswith("gap_fill_")
+        assert gap_fill_task.status == TaskStatus.TODO
+        # Inherits project context from siblings
+        assert gap_fill_task.project_id == "proj_1"
+        assert gap_fill_task.project_name == "Snake Game"
+
+    @pytest.mark.asyncio
+    async def test_gap_fill_task_inherits_median_estimated_hours(
+        self, monkeypatch: Any
+    ) -> None:
+        """Synthesized tasks get a sensible hour estimate from siblings."""
+        monkeypatch.setenv(ENV_VAR_NAME, "true")
+        creator = _make_creator()
+        siblings = [
+            _task("t1", "Task 1", "", estimated_hours=2.0),
+            _task("t2", "Task 2", "", estimated_hours=4.0),
+            _task("t3", "Task 3", "", estimated_hours=6.0),
+        ]
+        outcomes = [
+            UserOutcome(
+                id="o1",
+                action="user can do X",
+                success_signal="X visible",
+                scope="in_scope",
+            )
+        ]
+        creator.prd_parser.llm_client.analyze = AsyncMock(
+            side_effect=[
+                '{"coverage": {"o1": []}}',
+                (
+                    '{"tasks": [{'
+                    '"name": "Filled task", "description": "fill the gap"'
+                    "}]}"
+                ),
+                '{"coverage": {"o1": ["filled"]}}',
+            ]
+        )
+
+        result = await creator._apply_outcome_coverage(
+            tasks=siblings,
+            description="x",
+            prd_analysis=_make_analysis_with_outcomes(outcomes),
+        )
+
+        # Median of [2, 4, 6] is 4.0
+        assert result[-1].estimated_hours == 4.0
+
+    @pytest.mark.asyncio
+    async def test_gap_fill_task_provides_requires_default_to_none(
+        self, monkeypatch: Any
+    ) -> None:
+        """Tasks without contract metadata get None — wiring leaves them alone."""
+        monkeypatch.setenv(ENV_VAR_NAME, "true")
+        creator = _make_creator()
+        outcomes = [
+            UserOutcome(
+                id="o1",
+                action="user can do X",
+                success_signal="X visible",
+                scope="in_scope",
+            )
+        ]
+        creator.prd_parser.llm_client.analyze = AsyncMock(
+            side_effect=[
+                '{"coverage": {"o1": []}}',
+                (
+                    '{"tasks": [{"name": "Standalone", '
+                    '"description": "no contracts"}]}'
+                ),
+                '{"coverage": {"o1": ["x"]}}',
+            ]
+        )
+
+        result = await creator._apply_outcome_coverage(
+            tasks=[_task("t1", "T1")],
+            description="x",
+            prd_analysis=_make_analysis_with_outcomes(outcomes),
+        )
+
+        assert result[-1].provides is None
+        assert result[-1].requires is None
+
+
+class TestApplyOutcomeCoverageRobustness:
+    """Failures in any LLM step degrade gracefully — never block creation."""
+
+    @pytest.mark.asyncio
+    async def test_late_extraction_when_prd_analysis_lacks_outcomes(
+        self, monkeypatch: Any
+    ) -> None:
+        """When prd_analysis is None, helper extracts outcomes inline."""
+        monkeypatch.setenv(ENV_VAR_NAME, "true")
+        creator = _make_creator()
+        tasks = [_task("t1", "Task 1")]
+
+        with patch(
+            "src.integrations.nlp_tools.extract_user_outcomes",
+            new=AsyncMock(
+                return_value=[
+                    UserOutcome(
+                        id="o1",
+                        action="user can do X",
+                        success_signal="X visible",
+                        scope="in_scope",
+                    )
+                ]
+            ),
+        ) as mock_extract:
+            creator.prd_parser.llm_client.analyze = AsyncMock(
+                return_value='{"coverage": {"o1": ["t1"]}}'
+            )
+            result = await creator._apply_outcome_coverage(
+                tasks=tasks, description="x", prd_analysis=None
+            )
+
+        mock_extract.assert_awaited_once()
+        assert result == tasks
+
+    @pytest.mark.asyncio
+    async def test_late_extraction_failure_returns_tasks_unchanged(
+        self, monkeypatch: Any
+    ) -> None:
+        """Extraction failure logs a warning, returns original tasks."""
+        monkeypatch.setenv(ENV_VAR_NAME, "true")
+        creator = _make_creator()
+        tasks = [_task("t1", "Task 1")]
+
+        with patch(
+            "src.integrations.nlp_tools.extract_user_outcomes",
+            new=AsyncMock(side_effect=ValueError("LLM exploded")),
+        ):
+            result = await creator._apply_outcome_coverage(
+                tasks=tasks, description="x", prd_analysis=None
+            )
+
+        assert result == tasks
+        creator.prd_parser.llm_client.analyze.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_no_outcomes_skips_coverage_check(self, monkeypatch: Any) -> None:
+        """When outcomes list is empty, no coverage call fires."""
+        monkeypatch.setenv(ENV_VAR_NAME, "true")
+        creator = _make_creator()
+        tasks = [_task("t1", "Task 1")]
+
+        result = await creator._apply_outcome_coverage(
+            tasks=tasks,
+            description="x",
+            prd_analysis=_make_analysis_with_outcomes([]),
+        )
+
+        # When prd_analysis exists but carries no outcomes, helper
+        # falls through to late extraction.  Provide a mock for that.
+        with patch(
+            "src.integrations.nlp_tools.extract_user_outcomes",
+            new=AsyncMock(return_value=[]),
+        ):
+            result = await creator._apply_outcome_coverage(
+                tasks=tasks,
+                description="x",
+                prd_analysis=_make_analysis_with_outcomes([]),
+            )
+
+        assert result == tasks
+
+    @pytest.mark.asyncio
+    async def test_coverage_failure_returns_tasks_unchanged(
+        self, monkeypatch: Any
+    ) -> None:
+        """LLM coverage failure logs a warning, returns original tasks."""
+        monkeypatch.setenv(ENV_VAR_NAME, "true")
+        creator = _make_creator()
+        tasks = [_task("t1", "Task 1")]
+        outcomes = [
+            UserOutcome(
+                id="o1",
+                action="user can do X",
+                success_signal="X",
+                scope="in_scope",
+            )
+        ]
+
+        creator.prd_parser.llm_client.analyze = AsyncMock(return_value="not json")
+
+        result = await creator._apply_outcome_coverage(
+            tasks=tasks,
+            description="x",
+            prd_analysis=_make_analysis_with_outcomes(outcomes),
+        )
+
+        assert result == tasks
+
+    @pytest.mark.asyncio
+    async def test_fill_failure_returns_original_when_gap_present(
+        self, monkeypatch: Any
+    ) -> None:
+        """Gap-fill failure leaves gaps unaddressed but does not block."""
+        monkeypatch.setenv(ENV_VAR_NAME, "true")
+        creator = _make_creator()
+        tasks = [_task("t1", "Task 1")]
+        outcomes = [
+            UserOutcome(
+                id="o1",
+                action="user can do X",
+                success_signal="X",
+                scope="in_scope",
+            )
+        ]
+        creator.prd_parser.llm_client.analyze = AsyncMock(
+            side_effect=[
+                # Coverage finds gap
+                '{"coverage": {"o1": []}}',
+                # Gap-fill returns malformed JSON
+                "not json",
+            ]
+        )
+
+        result = await creator._apply_outcome_coverage(
+            tasks=tasks,
+            description="x",
+            prd_analysis=_make_analysis_with_outcomes(outcomes),
+        )
+
+        # Original tasks unchanged — fill failure logged, no synthesis
+        assert result == tasks


### PR DESCRIPTION
Closes the remaining scope of #449.  The previous PR (#453) shipped the foundational modules (extractor, coverage, gap-fill); this PR wires them into the production decomposer flow.

## Summary

Behind a new `MARCUS_OUTCOME_COVERAGE` feature flag (default off), every project created via natural-language flow now:

1. Extracts user-visible outcomes from the spec (one LLM call)
2. Generates the task graph via either decomposer path (contract_first or feature_based)
3. Runs the coverage check (one LLM call) to find outcomes with no covering task
4. Calls `fill_gaps` on any uncovered in-scope outcomes — gap-fill tasks now emit `provides` and `requires` so the existing `_generate_wiring_tasks` infrastructure integrates them with the rest of the graph
5. Builds full `Task` objects from the gap-fill dicts (median sibling hours, inherited project context, `gap_fill` and `intent_fidelity` labels for audit visibility)
6. Recomputes coverage on the augmented graph and logs `intent_fidelity_score`

Every step degrades gracefully — failure at any LLM call logs a warning and returns the original task list. Coverage never blocks project creation.

## Architectural note

The orchestrator now computes the PRD analysis **once** upfront and shares it across both decomposer paths. This eliminates a duplicate `_analyze_prd_deeply` call that was firing on contract-first → feature-based fallback in the existing codebase. Net result: fewer LLM calls in normal operation, plus a clean home for the outcome-coverage hook.

## What's in this PR

### New modules
- `src/config/outcome_coverage_config.py` — `MARCUS_OUTCOME_COVERAGE` flag + `is_outcome_coverage_enabled()` (truthy values: `1`, `true`, `yes`, `on`, `enabled`, case-insensitive)

### Modified modules
- `src/marcus_mcp/coordinator/outcome_coverage.py` — `fill_gaps` now emits `provides`/`requires` per task with strict validation (rejects non-string-or-null values)
- `src/ai/advanced/prd/advanced_parser.py` — `PRDAnalysis` adds `user_outcomes` field; `parse_prd_to_tasks` accepts optional pre-computed `prd_analysis`; `_analyze_prd_deeply` calls `extract_user_outcomes` when flag is on
- `src/integrations/nlp_tools.py` — `process_natural_language` computes shared PRDAnalysis upfront; `_apply_outcome_coverage` helper runs the full pipeline; `_build_gap_fill_task` converts gap-fill dicts to full `Task` objects; `_try_contract_first_decomposition` accepts optional pre-computed analysis

### Tests (38 new)
- `tests/unit/config/test_outcome_coverage_config.py` (18) — flag default off, truthy values, case insensitivity, whitespace tolerance, constant lock-in
- `tests/unit/coordinator/test_outcome_coverage.py` (5 new) — fill_gaps `provides`/`requires` emission and validation
- `tests/unit/ai/test_prd_outcome_integration.py` (5) — PRDAnalysis dataclass field, parser wiring with flag on/off, extraction failure robustness
- `tests/unit/integrations/test_nlp_outcome_coverage.py` (10) — flag off pass-through, full coverage no-op, snake-v31 gap-fill end-to-end, hour inheritance, contract-default-None, robustness (late extraction, no outcomes, coverage failure, fill failure)

### Configuration
- `.env.example` — documents `MARCUS_OUTCOME_COVERAGE` with usage notes

## Bright Line / Multi-Agency Compliance

`UserOutcome.action` says **WHAT** the user must be able to do. `success_signal` describes observable evidence. Gap-fill tasks emit `provides`/`requires` (interface names, not implementation hints). Two agents given a synthesized task `"Render snake to canvas"` with `provides="RenderingAgent.draw"` and `requires="GameStateUpdate"` can implement it with canvas, DOM, SVG, WebGL, or ASCII — the contract names are coordination, not control. ✅

## Test plan

- [x] `pytest -m unit` — 1043/1043 pass (was 1005)
- [x] `mypy --strict` on all new/modified source files
- [x] `pre-commit run` clean (mypy, pydocstyle, black, isort, flake8, bandit)
- [ ] Real-LLM integration test on a snake-game spec — verify the LLM evaluation actually catches the missing rendering task in production conditions (deferred to a follow-up integration test on a separate PR)

## Related

- Foundational layer: PR #453 (already merged)
- Issue: #449
- v31 audit motivation: `docs/audit-reports/snake_game-v31-2026-04-28.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)