### PR TITLE
fix(#455): add setup tier — latent classifier bug (NOT v37 orphan fix; that's #456)

### DIFF
--- a/src/intelligence/dependency_inferer.py
+++ b/src/intelligence/dependency_inferer.py
@@ -15,6 +15,25 @@ from src.core.models import Task, TaskStatus
 
 logger = logging.getLogger(__name__)
 
+# Setup-tier keyword matcher (issue #455 / Codex P2 on PR #466).
+# Word-boundary anchored prefix match.  Prefixes are intentionally
+# shorter than the canonical word so common inflections match:
+#
+#   ``\binit\w*``     → init, initial, initialize, initialization
+#   ``\bconfig\w*``   → config, configure, configured, configuration
+#   ``\binstall\w*``  → install, installs, installer, installation
+#   ``\bscaffold\w*`` → scaffold, scaffolds, scaffolding
+#   ``\bsetup\w*``    → setup, setups
+#   ``\bfoundation\w*`` → foundation, foundations, foundational
+#
+# The ``\b`` boundary rejects un-/re-/pre-/post-prefixed false
+# positives: ``uninstall`` (preceded by 'n' — word char, no boundary),
+# ``reconfigure`` (preceded by 'e'), ``presetup``, ``postinit``.
+_SETUP_PATTERN: re.Pattern[str] = re.compile(
+    r"\b(setup|init|config|install|scaffold|foundation)\w*",
+    re.IGNORECASE,
+)
+
 
 @dataclass
 class DependencyPattern:
@@ -488,18 +507,24 @@ class DependencyInferer:
         # among named tiers so design / impl / testing / deployment
         # win when keywords overlap (e.g. "Design initial setup"
         # stays a design task).
-        if any(
-            word in name_lower
-            for word in [
-                "setup",
-                "init",
-                "initial",
-                "configure",
-                "install",
-                "scaffold",
-                "foundation",
-            ]
-        ):
+        #
+        # Word-boundary matching (Codex P2 / Claude bot review on
+        # PR #466): plain ``substring in name`` would match
+        # ``"install"`` inside ``"uninstall"``, classifying teardown
+        # tasks as setup and (combined with the new setup order 0.5)
+        # making them eligible prerequisites of impl tasks via
+        # ``setup_blocks_all`` — a regression my own PR would
+        # introduce.  Anchored prefix match (``\bword\w*``) accepts:
+        #
+        # - ``\binit\w*``      → init, initial, initialize, initialization
+        # - ``\binstall\w*``   → install, installs, installation
+        # - ``\bconfigure\w*`` → configure, configured, configuring
+        #
+        # And rejects:
+        # - ``uninstall`` (preceded by 'n', no \b boundary at 'i')
+        # - ``reconfigure`` (preceded by 'e', no \b boundary)
+        # - ``presetup`` / ``postsetup`` (preceded by word chars)
+        if _SETUP_PATTERN.search(name_lower):
             return "setup"
 
         return "other"

--- a/src/intelligence/dependency_inferer.py
+++ b/src/intelligence/dependency_inferer.py
@@ -383,8 +383,17 @@ class DependencyInferer:
         dependent_task_type = self._classify_task_type(dependent_task.name)
         dependency_task_type = self._classify_task_type(dependency_task.name)
 
-        # Define logical task ordering: design < implementation < testing < deployment
+        # Define logical task ordering:
+        # setup < design < implementation < testing < deployment
+        #
+        # ``setup`` (issue #455) sits below design so foundation /
+        # scaffolding tasks (e.g. "Tech Foundation Setup", "Install
+        # Dependencies") are valid prerequisites of design and impl
+        # tasks.  Pre-#455 they classified as ``other`` (order 2.5)
+        # which blocked them from being prereqs of impl (order 2.0)
+        # and produced orphan top-level nodes in the DAG.
         task_order = {
+            "setup": 0.5,
             "design": 1,
             "implementation": 2,
             "testing": 3,
@@ -417,7 +426,25 @@ class DependencyInferer:
         """
         Classify task into type based on name patterns.
 
-        Returns: 'design', 'implementation', 'testing', 'deployment', or 'other'
+        Returns
+        -------
+        str
+            One of ``'setup'``, ``'design'``, ``'testing'``,
+            ``'deployment'``, ``'implementation'``, or ``'other'``.
+
+        Notes
+        -----
+        Tier-checking order is significant.  Design / testing /
+        deployment / implementation are checked before setup because
+        their keywords are more semantically specific (e.g.,
+        "Design Initial Setup" is a design task, not a setup task).
+        Setup is checked last among the named tiers so it acts as a
+        catch-all for foundation / scaffolding work that doesn't
+        carry an implementation verb.
+
+        See issue #455 — pre-#455 setup tasks fell to ``'other'``
+        and were blocked from being prerequisites of implementation
+        tasks by the order check in :meth:`_is_logical_dependency`.
         """
         name_lower = task_name.lower()
 
@@ -450,12 +477,30 @@ class DependencyInferer:
         ):
             return "deployment"
 
-        # Implementation tasks (check last since many contain these words)
+        # Implementation tasks
         if any(
             word in name_lower
             for word in ["implement", "build", "create", "develop", "code", "write"]
         ):
             return "implementation"
+
+        # Setup / foundation / scaffolding tasks (issue #455).  Last
+        # among named tiers so design / impl / testing / deployment
+        # win when keywords overlap (e.g. "Design initial setup"
+        # stays a design task).
+        if any(
+            word in name_lower
+            for word in [
+                "setup",
+                "init",
+                "initial",
+                "configure",
+                "install",
+                "scaffold",
+                "foundation",
+            ]
+        ):
+            return "setup"
 
         return "other"
 

--- a/tests/unit/intelligence/test_classifier_setup_tier.py
+++ b/tests/unit/intelligence/test_classifier_setup_tier.py
@@ -93,6 +93,64 @@ class TestClassifyTaskTypeSetupTier:
         assert inferer._classify_task_type("Game State Data Structure") == "other"
 
 
+class TestClassifierWordBoundaryFalsePositives:
+    """Word-boundary matching prevents teardown tasks from being setup.
+
+    Codex P2 + Claude bot review on PR #466 caught a regression: plain
+    ``substring in name`` matched ``"install"`` inside ``"uninstall"``,
+    classifying teardown tasks as setup.  Combined with the new setup
+    order (0.5), the order gate accepted them as prereqs of impl tasks
+    via ``setup_blocks_all``.
+
+    Fix: ``\\bword\\w*`` regex.  Tests below pin the negative cases
+    that pre-Codex-fix would have been false-classified as setup.
+    """
+
+    @pytest.mark.parametrize(
+        "name",
+        [
+            "Uninstall Legacy Dependencies",
+            "Uninstall old packages",
+            "Reconfigure Settings",
+            "Reconfigure database",
+            "Presetup environment",
+            "Postsetup cleanup",
+            "Reinstall the bundler",
+        ],
+    )
+    def test_teardown_and_redo_tasks_are_not_setup(self, name: str) -> None:
+        """Tasks with un-/re-/pre-/post- prefixed setup words are not setup."""
+        inferer = _make_inferer()
+        assert inferer._classify_task_type(name) != "setup"
+
+    def test_initialize_database_still_classifies_as_setup(self) -> None:
+        """Word-boundary fix preserves ``initialize`` matching ``init``.
+
+        ``\\binit\\w*`` matches ``init``, ``initial``, ``initialize``,
+        ``initialization``.  This test pins that the prefix expansion
+        didn't break legitimate initial-state task names.
+        """
+        inferer = _make_inferer()
+        assert inferer._classify_task_type("Initialize Database") == "setup"
+        assert inferer._classify_task_type("Initialization phase") == "setup"
+
+    def test_installation_phase_still_classifies_as_setup(self) -> None:
+        """``\\binstall\\w*`` matches ``installation``.
+
+        Note: ``Installer build`` would classify as implementation
+        (``build`` is checked before setup, semantically specific tier
+        wins).  Test names below contain only setup keywords.
+        """
+        inferer = _make_inferer()
+        assert inferer._classify_task_type("Installation phase") == "setup"
+        assert inferer._classify_task_type("Run installer") == "setup"
+
+    def test_configuration_still_classifies_as_setup(self) -> None:
+        """``\\bconfigure\\w*`` matches ``configured``, ``configuring``."""
+        inferer = _make_inferer()
+        assert inferer._classify_task_type("Configuring CI") == "setup"
+
+
 class TestIsLogicalDependencyFoundationToImpl:
     """``_is_logical_dependency`` accepts foundation → implementation deps.
 

--- a/tests/unit/intelligence/test_classifier_setup_tier.py
+++ b/tests/unit/intelligence/test_classifier_setup_tier.py
@@ -1,0 +1,193 @@
+"""
+Unit tests for the setup-tier classifier in :class:`DependencyInferer`.
+
+Issue #455 — ``_is_logical_dependency`` rejected foundation/setup tasks
+as prerequisites of implementation tasks because ``_classify_task_type``
+returned ``"other"`` (order ``2.5``) for any name not matching the
+design / implementation / testing / deployment keyword sets, and
+``2.5 >= 2`` (implementation) blocked the dependency.
+
+Fix introduces a ``"setup"`` tier (order ``0.5``) with explicit keywords
+(``setup``, ``init``, ``configure``, ``install``, ``scaffold``,
+``foundation``).  Foundation tasks now correctly classify and pass
+the logical-order gate when the regex pattern fires.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+import pytest
+
+from src.core.models import Priority, Task, TaskStatus
+from src.intelligence.dependency_inferer import DependencyInferer
+
+pytestmark = pytest.mark.unit
+
+
+def _make_task(task_id: str, name: str, description: str = "") -> Task:
+    """Build a minimal Task for classifier tests."""
+    now = datetime.now(timezone.utc)
+    return Task(
+        id=task_id,
+        name=name,
+        description=description,
+        status=TaskStatus.TODO,
+        priority=Priority.MEDIUM,
+        assigned_to=None,
+        created_at=now,
+        updated_at=now,
+        due_date=None,
+        estimated_hours=2.0,
+    )
+
+
+def _make_inferer() -> Any:
+    """Construct a DependencyInferer with no AI engine (pattern-only)."""
+    return DependencyInferer()
+
+
+class TestClassifyTaskTypeSetupTier:
+    """``_classify_task_type`` recognizes setup/foundation task names."""
+
+    @pytest.mark.parametrize(
+        "name",
+        [
+            "Tech Foundation Setup",
+            "Initial Setup",
+            "Configure TypeScript",
+            "Install Dependencies",
+            "Scaffold Project Structure",
+            "Initialize Database",
+            "Foundation Layer",
+        ],
+    )
+    def test_setup_keywords_classify_as_setup(self, name: str) -> None:
+        """Names containing setup keywords land in the setup tier."""
+        inferer = _make_inferer()
+        assert inferer._classify_task_type(name) == "setup"
+
+    def test_design_still_wins_over_setup_when_both_present(self) -> None:
+        """Design task that mentions setup stays classified as design.
+
+        Currently the classifier checks design before setup — this test
+        pins that ordering so design tasks aren't accidentally
+        downgraded to the setup tier.  ``_classify_task_type`` checks
+        in declaration order; design comes first.
+        """
+        inferer = _make_inferer()
+        assert inferer._classify_task_type("Design Initial Setup Approach") == "design"
+
+    def test_implementation_still_wins_over_setup(self) -> None:
+        """``Implement initial X`` stays classified as implementation."""
+        inferer = _make_inferer()
+        assert (
+            inferer._classify_task_type("Implement Initial Configuration")
+            == "implementation"
+        )
+
+    def test_unknown_name_still_returns_other(self) -> None:
+        """Names matching no tier still classify as 'other'."""
+        inferer = _make_inferer()
+        assert inferer._classify_task_type("Game State Data Structure") == "other"
+
+
+class TestIsLogicalDependencyFoundationToImpl:
+    """``_is_logical_dependency`` accepts foundation → implementation deps.
+
+    Pre-#455 regression: ``Tech Foundation Setup`` (other, order 2.5)
+    couldn't be a prerequisite of ``Implement X`` (implementation,
+    order 2.0) because ``2.5 >= 2`` blocked the edge.  With setup tier
+    at order 0.5, the same dep passes the gate.
+    """
+
+    def test_tech_foundation_setup_is_valid_prereq_of_implement(self) -> None:
+        """``Tech Foundation Setup`` can be a prereq of ``Implement X``."""
+        inferer = _make_inferer()
+        dep_task = _make_task("t1", "Tech Foundation Setup")
+        dependent_task = _make_task("t2", "Implement Speed Progression")
+        # setup_blocks_all pattern is at index 0; pattern-agnostic check
+        # via the ``setup_blocks_all`` pattern object directly.
+        pattern = next(
+            p for p in inferer.dependency_patterns if p.name == "setup_blocks_all"
+        )
+        assert inferer._is_logical_dependency(
+            dependent_task=dependent_task,
+            dependency_task=dep_task,
+            pattern=pattern,
+        )
+
+    def test_install_dependencies_is_valid_prereq_of_implement(self) -> None:
+        """``Install Dependencies`` can be a prereq of ``Implement X``."""
+        inferer = _make_inferer()
+        dep_task = _make_task("t1", "Install Dependencies")
+        dependent_task = _make_task("t2", "Implement Auth Service")
+        pattern = next(
+            p for p in inferer.dependency_patterns if p.name == "setup_blocks_all"
+        )
+        assert inferer._is_logical_dependency(
+            dependent_task=dependent_task,
+            dependency_task=dep_task,
+            pattern=pattern,
+        )
+
+    def test_setup_can_precede_design(self) -> None:
+        """Setup tasks (order 0.5) sit below design tasks (order 1).
+
+        ``setup_blocks_all`` pattern condition doesn't include
+        ``design`` so this pattern wouldn't fire for setup→design
+        edges anyway.  This test asserts the order math: if any
+        future pattern fires setup→design, the order check accepts.
+        """
+        inferer = _make_inferer()
+        assert inferer._classify_task_type("Tech Foundation Setup") == "setup"
+        assert inferer._classify_task_type("Design User Authentication") == "design"
+
+    def test_no_regression_design_to_implement(self) -> None:
+        """Design → Implementation still works (the existing pattern).
+
+        This is the canonical case and must not regress.
+        """
+        inferer = _make_inferer()
+        dep_task = _make_task("t1", "Design User Authentication")
+        dependent_task = _make_task("t2", "Implement User Authentication")
+        pattern = next(
+            p
+            for p in inferer.dependency_patterns
+            if p.name == "design_before_implementation"
+        )
+        assert inferer._is_logical_dependency(
+            dependent_task=dependent_task,
+            dependency_task=dep_task,
+            pattern=pattern,
+        )
+
+    def test_no_regression_implement_to_test(self) -> None:
+        """Implementation → Testing still works."""
+        inferer = _make_inferer()
+        dep_task = _make_task("t1", "Implement User Authentication")
+        dependent_task = _make_task("t2", "Test User Authentication")
+        pattern = next(
+            p
+            for p in inferer.dependency_patterns
+            if p.name == "implementation_before_testing"
+        )
+        assert inferer._is_logical_dependency(
+            dependent_task=dependent_task,
+            dependency_task=dep_task,
+            pattern=pattern,
+        )
+
+    def test_setup_cannot_be_prereq_of_setup(self) -> None:
+        """Two setup tasks cannot have a typed-order edge between them.
+
+        Prevents accidental cycles within the setup tier.  Specific
+        sequencing between setup tasks must come from another signal
+        (explicit dep declaration, naming heuristic), not the type
+        classifier.  Same-tier order check: ``0.5 >= 0.5`` is True →
+        edge rejected.
+        """
+        inferer = _make_inferer()
+        assert inferer._classify_task_type("Configure TypeScript") == "setup"
+        assert inferer._classify_task_type("Install Dependencies") == "setup"

--- a/tests/unit/intelligence/test_classifier_setup_tier.py
+++ b/tests/unit/intelligence/test_classifier_setup_tier.py
@@ -135,14 +135,36 @@ class TestIsLogicalDependencyFoundationToImpl:
     def test_setup_can_precede_design(self) -> None:
         """Setup tasks (order 0.5) sit below design tasks (order 1).
 
-        ``setup_blocks_all`` pattern condition doesn't include
-        ``design`` so this pattern wouldn't fire for setup→design
-        edges anyway.  This test asserts the order math: if any
-        future pattern fires setup→design, the order check accepts.
+        Pattern-agnostic test: invokes ``_is_logical_dependency``
+        with an existing pattern object so the regex match check is
+        bypassed (we know the test pair wouldn't fire any real
+        pattern in production — that's not what we're testing).  The
+        assertion is that IF any future pattern fires setup→design,
+        the order gate accepts: ``setup`` (0.5) < ``design`` (1.0).
+
+        Strengthened from the prior version (Kaia review): previous
+        version only asserted classifications and trusted the math.
+        Now invokes the gate directly so a future ``task_order`` dict
+        change that breaks the relative ordering would fail this test.
         """
         inferer = _make_inferer()
-        assert inferer._classify_task_type("Tech Foundation Setup") == "setup"
-        assert inferer._classify_task_type("Design User Authentication") == "design"
+        dep_task = _make_task("t1", "Tech Foundation Setup")
+        dependent_task = _make_task("t2", "Design User Authentication")
+        # Pattern object reused as a stand-in; ``_is_logical_dependency``
+        # only cares about the pattern object identity for the
+        # ``component_implementation_order`` shared-word check, which
+        # we bypass here by using a different pattern.  The order-gate
+        # check at line 399 is what we're testing.
+        pattern = next(
+            p
+            for p in inferer.dependency_patterns
+            if p.name == "design_before_implementation"
+        )
+        assert inferer._is_logical_dependency(
+            dependent_task=dependent_task,
+            dependency_task=dep_task,
+            pattern=pattern,
+        )
 
     def test_no_regression_design_to_implement(self) -> None:
         """Design → Implementation still works (the existing pattern).
@@ -180,14 +202,28 @@ class TestIsLogicalDependencyFoundationToImpl:
         )
 
     def test_setup_cannot_be_prereq_of_setup(self) -> None:
-        """Two setup tasks cannot have a typed-order edge between them.
+        """Order gate rejects same-tier setup → setup edges.
 
         Prevents accidental cycles within the setup tier.  Specific
         sequencing between setup tasks must come from another signal
         (explicit dep declaration, naming heuristic), not the type
-        classifier.  Same-tier order check: ``0.5 >= 0.5`` is True →
-        edge rejected.
+        classifier.
+
+        Strengthened from the prior version (Kaia review): previous
+        version only asserted both names classify as ``setup`` and
+        trusted the order math.  Now invokes ``_is_logical_dependency``
+        directly so any future ``task_order["setup"]`` change that
+        accidentally allowed same-tier edges would fail this test.
         """
         inferer = _make_inferer()
-        assert inferer._classify_task_type("Configure TypeScript") == "setup"
-        assert inferer._classify_task_type("Install Dependencies") == "setup"
+        dep_task = _make_task("t1", "Configure TypeScript")
+        dependent_task = _make_task("t2", "Install Dependencies")
+        pattern = next(
+            p for p in inferer.dependency_patterns if p.name == "setup_blocks_all"
+        )
+        # Order gate: 0.5 >= 0.5 is True → returns False (rejected).
+        assert not inferer._is_logical_dependency(
+            dependent_task=dependent_task,
+            dependency_task=dep_task,
+            pattern=pattern,
+        )


### PR DESCRIPTION
Closes #455.  v0.3.6.post2 milestone.

## Scope correction (added 2026-04-30)

This PR fixes a **latent** classifier bug, NOT the v37 user-visible orphan symptom.  Original PR title implied this was the v37 fix; that was wrong.  Investigation in kanban.db showed v37's ``Implement Speed Progression`` was orphaned because it was a **spec_coverage gap task** with empty ``dependencies=[]``, NOT because the classifier rejected its parent edge.  The actual v37 fix is **#456** (GraphAugmenter unification — folds spec_coverage into pre-inference pipeline so synthesized tasks participate in dependency inference + foundation wiring).

What this PR DOES fix: the classifier's logical-order gate would reject ``setup → impl`` deps via the pattern-matching code path.  In current production, explicit foundation wiring at ``nlp_tools.py:332`` adds the edge regardless, so the rejection is dead-letter.  But the classifier is still wrong, and the rejection would matter for:

- AI-inferred deps in ``HybridDependencyInferer`` ambiguous paths
- Pattern matches between setup-named tasks not covered by the explicit foundation wiring
- Any future code path that doesn't go through the explicit foundation wiring

Cheap defensive correctness improvement.  Small scope, well-tested.

## Summary

- Adds ``"setup"`` tier (order 0.5) to dependency classifier so foundation/scaffolding tasks (``Tech Foundation Setup``, ``Install Dependencies``, ``Initialize Database``) can be valid prerequisites of design and implementation tasks via pattern matching.
- Pre-fix: setup-named tasks classified as ``"other"`` (order 2.5) and the logical-order gate rejected them as prereqs of impl (order 2.0).

## Tier-precedence design

Setup is checked LAST among named tiers in ``_classify_task_type``.  This keeps semantically specific tiers winning when keywords overlap:

- ``"Design Initial Setup Approach"`` → design (not setup)
- ``"Implement Initial Configuration"`` → implementation (not setup)
- ``"Tech Foundation Setup"`` → setup ✓ (no other tier matches)

Setup tier is below design in ``task_order`` (0.5 vs 1.0), so even when a future pattern fires setup→design, the order check accepts.

## Out of scope

``Game State Data Structure`` → ``Implement X``: no current dependency pattern fires on that pair.  Different bug, separate fix.  Should be filed separately if it surfaces as a real production gap.

The v37 user-visible orphan: see #456.  This PR does NOT fix it.

## Test plan

- [x] ``pytest -m unit`` — 1103 passed (+16 new in this PR)
- [x] ``mypy --strict`` clean on modified files
- [x] ``black`` / ``isort`` / ``flake8`` clean
- [x] Pre-commit hooks pass
- [x] Kaia review applied: two tests strengthened to invoke ``_is_logical_dependency`` directly instead of trusting the order math (commit ``0686a3a3``)

## Files

- ``src/intelligence/dependency_inferer.py`` — setup tier in ``task_order``, setup keywords in ``_classify_task_type``
- ``tests/unit/intelligence/test_classifier_setup_tier.py`` — 16 tests covering classification, tier precedence, logical-dep gate (setup→impl positives, design→impl + impl→test no-regression checks, same-tier cycle prevention)

## Related

- #456 — GraphAugmenter unification (the actual v37 ``Implement Speed Progression`` fix)
- #466 (this PR) — separate latent classifier correctness improvement

🤖 Generated with [Claude Code](https://claude.com/claude-code)