### PR TITLE
feat(#446): foundation tasks must log_decision their public API surface

### DIFF
--- a/src/integrations/nlp_tools.py
+++ b/src/integrations/nlp_tools.py
@@ -920,10 +920,30 @@ class NaturalLanguageProjectCreator(NaturalLanguageTaskCreator):
         # discover the output via get_task_context.  This is not HOW
         # guidance; it is standard Marcus workflow that applies to all
         # tasks that produce artifacts consumed by other tasks.
+        #
+        # Issue #446 (Kaia review checkpoint #2): foundation agents must
+        # also call log_decision titled "Public API surface" so the
+        # structured public-API metadata (import paths, exported
+        # symbols, config keys, usage constraints) flows downstream
+        # via Context.get_context (core/context.py:334-346 already
+        # pulls dependency decisions into architectural_decisions).
+        # Without this decision, downstream agents have no canonical
+        # structured way to discover the foundation surface and may
+        # invent paths — v80 audit case (agent_unicorn_2 read
+        # tokens.json instead of tokens.css because no canonical
+        # decision existed).  The agent picks the actual paths /
+        # names / module organization — Marcus only requires that
+        # the chosen surface be published.  Bright-line: coordination
+        # contract requirement, not implementation guidance.
         _WORKFLOW_REMINDER = (
             " Call log_artifact for every file you produce so that "
             "downstream agents can discover your output via "
-            "get_task_context."
+            "get_task_context. Also call log_decision titled "
+            "'Public API surface' listing the exact import paths, "
+            "exported symbols, config keys, and usage constraints "
+            "downstream consumers must coordinate against — without "
+            "this decision, downstream agents may invent paths and "
+            "miss your work."
         )
 
         # Build optional domain-contract section for higher-fidelity

--- a/tests/unit/integrations/test_shared_foundation_synthesis.py
+++ b/tests/unit/integrations/test_shared_foundation_synthesis.py
@@ -317,6 +317,152 @@ class TestSynthesizeSharedFoundation:
 
 
 # ---------------------------------------------------------------------------
+# Public API surface reminder tests (issue #446)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+class TestPublicApiSurfaceReminder:
+    """Foundation task descriptions must instruct the agent to log a
+    Public API surface decision so downstream consumers can discover it.
+
+    Issue #446 / Kaia review checkpoint #2.  v80 audit showed downstream
+    agents inventing import paths (``tokens.json`` vs actual
+    ``tokens.css``) because foundation agents had no canonical
+    structured way to publish their public API.  ``log_decision`` flow
+    already reaches dependent tasks via ``Context.get_context``
+    (``core/context.py:334-346``) — these tests pin that the foundation
+    task description requires the agent to use it.
+
+    Bright-line check: Marcus says "produce a coordination contract."
+    Agent picks the contract shape (paths, names, organization).  Two
+    foundation agents produce different contracts and both are valid.
+    Coordination, not control.
+    """
+
+    async def _foundation_task(self) -> Any:
+        """Helper: drive ``_synthesize_shared_foundation`` once and
+        return the first generated Task."""
+        creator = _make_creator()
+        creator.prd_parser.llm_client.analyze.return_value = json.dumps(
+            {
+                "foundation_tasks": [
+                    {
+                        "name": "Design System Setup",
+                        "description": "Create shared design tokens.",
+                        "estimated_hours": 2.0,
+                    }
+                ]
+            }
+        )
+        result = await creator._synthesize_shared_foundation("Build a dashboard.")
+        assert len(result) == 1
+        return result[0]
+
+    async def test_description_includes_log_decision_instruction(self) -> None:
+        """Foundation task description must instruct ``log_decision`` use."""
+        task = await self._foundation_task()
+        assert "log_decision" in task.description
+
+    async def test_description_uses_public_api_surface_title(self) -> None:
+        """Description names the canonical decision title for downstream
+        consumers to grep / parse.
+
+        Locking the title (``Public API surface``) so a future
+        prompt edit doesn't drift to ``Public API``, ``API surface``,
+        or any other variant — keeping a stable identifier across
+        runs lets Cato / Epictetus measure compliance reliably.
+        """
+        task = await self._foundation_task()
+        assert "Public API surface" in task.description
+
+    async def test_description_lists_required_decision_fields(self) -> None:
+        """Description names the four expected decision payload fields.
+
+        Without an explicit field list, agents log free-text decisions
+        of varying quality.  These four fields are the minimum
+        downstream consumers need:
+
+        - import paths (where to find the artifact)
+        - exported symbols (what's importable)
+        - config keys (any env / build-tool config consumers must set)
+        - usage constraints (preconditions, ordering, etc.)
+        """
+        task = await self._foundation_task()
+        for required_field in (
+            "import",
+            "symbol",
+            "config",
+            "constraint",
+        ):
+            assert required_field in task.description.lower(), (
+                f"Foundation task description missing required field reference: "
+                f"{required_field!r}"
+            )
+
+    async def test_description_explains_skip_consequence(self) -> None:
+        """Description must explain why skipping the decision matters.
+
+        v80 audit evidence: downstream agent invented ``tokens.json``
+        because no canonical path existed.  Description must motivate
+        the agent to actually log the decision — explicit consequence
+        framing > polite request.
+        """
+        task = await self._foundation_task()
+        # Loose: must mention either downstream / consumer + invent /
+        # miss / wrong / discover so the consequence framing is real.
+        desc_lower = task.description.lower()
+        consequence_signals = ["downstream", "consumer", "discover"]
+        has_audience = any(signal in desc_lower for signal in consequence_signals)
+        risk_signals = ["invent", "miss", "wrong", "guess"]
+        has_risk = any(signal in desc_lower for signal in risk_signals)
+        assert has_audience and has_risk, (
+            f"Foundation task description must explain WHO is affected "
+            f"(downstream/consumer) AND the RISK if decision is skipped "
+            f"(invent/miss/guess paths).  Got: {task.description}"
+        )
+
+    async def test_log_artifact_reminder_still_present(self) -> None:
+        """Anti-regression: the existing ``log_artifact`` reminder must
+        not be removed when adding the ``log_decision`` instruction.
+
+        Both are coordination workflow steps — artifacts track files,
+        decisions track structured public-API metadata.  Foundation
+        agents should do both.
+        """
+        task = await self._foundation_task()
+        assert "log_artifact" in task.description
+
+    async def test_two_foundation_tasks_both_get_reminder(self) -> None:
+        """When LLM returns multiple foundation tasks, every one gets
+        the public-API reminder appended.  No drift across tasks."""
+        creator = _make_creator()
+        creator.prd_parser.llm_client.analyze.return_value = json.dumps(
+            {
+                "foundation_tasks": [
+                    {
+                        "name": "Design System",
+                        "description": "Create design tokens.",
+                        "estimated_hours": 2.0,
+                    },
+                    {
+                        "name": "Tech Foundation",
+                        "description": "Configure TypeScript and build tools.",
+                        "estimated_hours": 1.5,
+                    },
+                ]
+            }
+        )
+        result = await creator._synthesize_shared_foundation("Build a dashboard.")
+        assert len(result) == 2
+        for task in result:
+            assert "log_decision" in task.description
+            assert "Public API surface" in task.description
+            assert "log_artifact" in task.description
+
+
+# ---------------------------------------------------------------------------
 # Feature-based wiring tests
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Closes #446.  v0.3.6.post2 milestone.

## Summary

Extends ``_WORKFLOW_REMINDER`` in ``_synthesize_shared_foundation`` (``src/integrations/nlp_tools.py:923-952``) with an explicit ``log_decision`` instruction.  Foundation agents must publish a structured public API surface — import paths, exported symbols, config keys, usage constraints — under the canonical title ``"Public API surface"``.

## v80 evidence

Audit ``dashboard-v80-2026-04-17.md``:

> "Dependency info: ambiguous.  WeatherWidget depended on Design System but **context didn't specify HOW to consume CSS tokens**.  agent_unicorn_2 confirmed: read tokens.json, not tokens.css."

Foundation agent built ``tokens.css``.  Downstream agent invented ``tokens.json`` because no canonical structured mechanism existed for the foundation agent to publish their public API.  Result: 219-line CSS file never imported anywhere; design system inert at runtime.

## Why Variant B over original 30-line block proposal

Kaia review (checkpoint #2) caught that:

* ``context.py:261-266`` already injects ``_FOUNDATION_USAGE_GUIDANCE`` (\"SHARED FOUNDATION: import it, consume its exports\") on artifacts pulled from foundation deps
* ``core/context.py:334-346`` already pulls dependency decisions into ``architectural_decisions`` returned by ``get_task_context``

The wire to flow log_decision content downstream **already exists**.  The fix only needs to require foundation agents use it.  A 30-line ``_FOUNDATION_DELIVERABLES`` block was overkill — extending the existing one-sentence reminder by one more sentence delivers the same value with smaller prompt bloat and less redundancy with existing guidance.

## Bright-line check

Marcus says: \"log a decision titled X listing your import paths, exports, config keys, usage constraints.\"  Agent picks **what those paths/symbols/keys actually are**.  Two foundation agents producing different design systems would log different decisions — both valid coordination contracts.  **Coordination, not control.**

## What this fixes vs. doesn't

**Fixes** (foundation-side gap):
- No canonical structured way for foundation agents to publish public API → now have one

**Does NOT fix** (downstream-trust gap):
- v80 interpretation 3: agents may still ignore ``get_task_context`` and invent paths from training-data instinct
- Separate concern; defer to follow-up

## Reviews applied

- Kaia checkpoint #1 (pre-code): rejected Option 3 (Marcus pre-decides paths/symbols/build-tool keys) on bright-line grounds.  Option 1 (require log_decision deliverable) chosen.
- Kaia checkpoint #2 (post-design, pre-test): switched from 30-line ``_FOUNDATION_DELIVERABLES`` block to single-sentence extension of ``_WORKFLOW_REMINDER`` (Variant B).
- Kaia checkpoint #3 (skipped per cadence — small mechanical implementation)
- Kaia checkpoint #4 (post-impl): approved to ship.  Three minor non-blocking observations logged.

## Test plan

- [x] ``pytest -m unit`` — 1119 passed (+6 new in this PR)
- [x] ``mypy --strict`` clean on modified files
- [x] ``black`` / ``isort`` / ``flake8`` clean on changes
- [x] Pre-commit hooks pass

## Files

- ``src/integrations/nlp_tools.py`` — extends ``_WORKFLOW_REMINDER`` with log_decision instruction; comment block cites #446 / v80 / ``core/context.py:334-346``
- ``tests/unit/integrations/test_shared_foundation_synthesis.py`` — new ``TestPublicApiSurfaceReminder`` class with 6 tests:
  * ``log_decision`` instruction present
  * canonical title ``\"Public API surface\"`` present
  * required field references (import / symbol / config / constraint)
  * skip-consequence framing (downstream / risk signals)
  * ``log_artifact`` reminder still present (anti-regression)
  * multi-task no-drift

## Follow-ups (filed separately)

After this lands, file a compliance-measurement issue: track % of foundation tasks that produce a ``\"Public API surface\"`` decision via Cato/Epictetus.  Routes to v0.3.7 alongside #409 (cost dashboard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)