### PR TITLE
feat(#463): synthesize composition task for multi-domain contract-first projects

### DIFF
--- a/src/integrations/composition_synthesis.py
+++ b/src/integrations/composition_synthesis.py
@@ -1,0 +1,175 @@
+"""
+Composition task synthesis for multi-domain contract-first projects.
+
+Issue #463 — Marcus's task decomposer can produce a multi-domain
+project where every domain ships correctly but no task owns wiring
+them into the application's composition root.  v38 audit case
+(snake-game-v38, 2026-04-29): three domain implementations
+(engine, bus, renderer) shipped clean but ``App.tsx`` returned
+``null``.  Unit tests passed.  The bundle built.  But the rendered
+DOM was empty — the integration verification catch-all rescued it
+at the cost of ~15 min cleanup absorbed by an agent on top of
+their other work.
+
+Fix (Variant V3 per Kaia review checkpoint #1): synthesize a
+dedicated composition task when ``len(impl_tasks) >= 2``.  Marcus
+says WHAT (a wiring task with explicit deliverables — log_decision
++ log_artifact); the agent picks HOW (which file is the entry
+point, which wiring strategy).  Multiple framework examples are
+included in the description so Marcus is not picking a single
+file.
+
+Bright-line check: two foundation agents handed this task can
+produce legitimately different wirings — different file choices,
+different mounting strategies.  Coordination, not control.
+
+Layering with ``enhance_project_with_integration``: composition
+is **narrow scope** (entry-point wiring only), assigned **early**
+when impls complete.  Integration verification is the **broad
+catch-all** (orphan scan, missing components, contract
+verification), assigned **late**.  Intentional layered safety,
+not redundant — composition makes wiring an explicit deliverable
+with explicit ownership; IV catches anything composition missed.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import List, Optional
+from uuid import uuid4
+
+from src.core.models import Priority, Task, TaskStatus
+
+__all__ = ["build_composition_task"]
+
+
+def _has_existing_composition_task(impl_tasks: List[Task]) -> bool:
+    """Return True if a composition task is already present in the list.
+
+    Idempotency guard: skip synthesis if the caller already has a
+    composition task in the input list.  Two detection routes:
+
+    1. ``"composition"`` label present (canonical Marcus tag)
+    2. ``source_type == "composition_synthesis"`` (canonical source
+       marker — survives kanban round-trips that strip labels)
+    """
+    for task in impl_tasks:
+        labels = task.labels or []
+        if "composition" in labels:
+            return True
+        if getattr(task, "source_type", None) == "composition_synthesis":
+            return True
+    return False
+
+
+def _build_composition_description(project_name: str) -> str:
+    """Render the composition task description (Variant V3).
+
+    The description must:
+
+    - List multiple framework entry-point examples (so Marcus is not
+      picking one — agents legitimately use different framework
+      conventions)
+    - Tell the agent to **discover** the entry point from the scaffold
+    - Require ``log_decision`` titled ``"Entry point wired"`` so
+      downstream tools can verify wiring happened
+    - Require ``log_artifact`` for the wired file (file-level surface
+      for the structured-decision metadata)
+
+    Bright-line guard: the description must NOT name a specific entry
+    point file (e.g., ``"the entry point is App.tsx"``).  Multiple
+    examples are listed; the agent picks which applies to their
+    scaffold.
+    """
+    return (
+        f"Wire {project_name}'s implementation domains into a working "
+        f"composition root.  The entry point is the file that boots "
+        f"the project — discover it from the scaffold (e.g. App.tsx "
+        f"for Vite/CRA, main.py for Python, index.ts for Node — "
+        f"whichever your scaffold uses).\n\n"
+        f"Required deliverables:\n"
+        f"1. Wire all domain implementations into the entry point so "
+        f"the composed product is functionally end-to-end.\n"
+        f"2. Call log_decision titled 'Entry point wired' with the "
+        f"actual file path you chose, the domains you composed, and "
+        f"the wiring approach (DI container, direct mounting, etc.).\n"
+        f"3. Call log_artifact for the entry-point file you modified "
+        f"so downstream verification can locate it.\n"
+        f"4. Verify the composed product runs (smoke test the "
+        f"composition root)."
+    )
+
+
+def build_composition_task(
+    *,
+    project_name: str,
+    impl_tasks: List[Task],
+) -> Optional[Task]:
+    """Synthesize a composition task when ``len(impl_tasks) >= 2``.
+
+    Issue #463 — multi-domain projects need an explicit wiring task
+    or domains ship correctly while ``App.tsx`` returns ``null``.
+
+    The synthesized task carries hard dependencies on every input
+    impl task; the agent that picks it up must wait until all impls
+    complete before wiring.  Foundation deps are NOT direct — they
+    flow transitively via impl deps already wired at
+    ``nlp_tools.py:332``.
+
+    Parameters
+    ----------
+    project_name : str
+        Project name, used in the task name and description so the
+        agent has context.
+    impl_tasks : List[Task]
+        Contract-first implementation tasks the caller has already
+        produced.  Caller filters to impl tasks (excluding foundation,
+        design ghosts, etc.) before passing.  This list is **not
+        mutated** — the helper is a pure function.
+
+    Returns
+    -------
+    Optional[Task]
+        A new composition task with hard deps on every input impl
+        task, or ``None`` when:
+
+        - ``len(impl_tasks) < 2`` (no need for explicit composition;
+          single-impl projects compose naturally)
+        - A composition task is already present in ``impl_tasks``
+          (idempotency guard)
+
+    Notes
+    -----
+    Bright-line: Marcus says WHAT must be produced (a coordination
+    task with explicit deliverables); agent picks HOW (which file,
+    which wiring strategy).  Two agents handed this task can produce
+    legitimately different implementations.  Coordination, not
+    control.
+    """
+    if len(impl_tasks) < 2:
+        return None
+    if _has_existing_composition_task(impl_tasks):
+        return None
+
+    now = datetime.now(timezone.utc)
+    return Task(
+        id=f"composition_{uuid4().hex[:12]}",
+        name=f"Compose {project_name} entry point",
+        description=_build_composition_description(project_name),
+        status=TaskStatus.TODO,
+        priority=Priority.HIGH,
+        assigned_to=None,
+        created_at=now,
+        updated_at=now,
+        due_date=None,
+        estimated_hours=1.5,
+        # Hard deps on every impl task — composition must wait until
+        # all implementations complete (nothing to wire otherwise).
+        dependencies=[t.id for t in impl_tasks],
+        labels=["composition", "marcus_synthesized"],
+        source_type="composition_synthesis",
+        # responsibility surfaces in build_tiered_instructions as the
+        # CONTRACT RESPONSIBILITY layer so the agent prompt frames
+        # this as a coordination boundary, not a prescriptive spec.
+        responsibility="Wires the application entry point",
+    )

--- a/src/integrations/nlp_tools.py
+++ b/src/integrations/nlp_tools.py
@@ -857,10 +857,37 @@ class NaturalLanguageProjectCreator(NaturalLanguageTaskCreator):
             f"contract content stashed for background Phase B"
         )
 
+        # Issue #463: synthesize a composition task when len(impl_tasks)
+        # >= 2.  Multi-domain contract-first projects can ship with no
+        # task owning entry-point wiring — every domain implements
+        # cleanly but App.tsx returns null.  v38 audit case caught this
+        # via integration verification's catch-all at the cost of
+        # ~15 min cleanup absorbed by an agent.  Composition makes the
+        # wiring an explicit deliverable with explicit ownership.
+        # Layered safety with enhance_project_with_integration's
+        # orphan scan (composition = narrow + early; IV = broad + late).
+        from src.integrations.composition_synthesis import (
+            build_composition_task,
+        )
+
+        composition_task = build_composition_task(
+            project_name=project_name,
+            impl_tasks=tasks,
+        )
+
         # Design ghosts come first so the integration task's dependency
         # walk picks them up alongside impl tasks.  Foundation tasks
-        # follow ghosts; impl tasks come last.
-        return ghost_tasks + foundation_tasks + tasks
+        # follow ghosts; impl tasks come next; composition (when
+        # synthesized) comes last because it depends on every impl task.
+        result_tasks: List[Task] = ghost_tasks + foundation_tasks + tasks
+        if composition_task is not None:
+            result_tasks.append(composition_task)
+            logger.info(
+                f"[decomposer] contract_first: synthesized composition "
+                f"task '{composition_task.name}' with "
+                f"{len(composition_task.dependencies)} impl-task dep(s)"
+            )
+        return result_tasks
 
     async def _synthesize_shared_foundation(
         self,

--- a/src/integrations/nlp_tools.py
+++ b/src/integrations/nlp_tools.py
@@ -866,13 +866,26 @@ class NaturalLanguageProjectCreator(NaturalLanguageTaskCreator):
         # wiring an explicit deliverable with explicit ownership.
         # Layered safety with enhance_project_with_integration's
         # orphan scan (composition = narrow + early; IV = broad + late).
+        #
+        # Codex P2 (PR #472): ``tasks`` is
+        # ``decompose_result.augmented_tasks`` which can include
+        # outcome-coverage gap-fill tasks (source_type="gap_fill_contract"
+        # from advanced_parser._apply_outcome_coverage_to_contract_graph).
+        # The composition trigger is "multi-domain wiring needed" —
+        # gap-fill tasks address outcome coverage gaps, not domain
+        # multiplicity, so they must NOT count toward the trigger.
+        # Filter to source_type="contract_first" before passing.  IV's
+        # broad catch-all still covers any wiring gaps in gap-fill tasks.
         from src.integrations.composition_synthesis import (
             build_composition_task,
         )
 
+        contract_first_impl_tasks = [
+            t for t in tasks if t.source_type == "contract_first"
+        ]
         composition_task = build_composition_task(
             project_name=project_name,
-            impl_tasks=tasks,
+            impl_tasks=contract_first_impl_tasks,
         )
 
         # Design ghosts come first so the integration task's dependency

--- a/tests/unit/integrations/test_composition_task_synthesis.py
+++ b/tests/unit/integrations/test_composition_task_synthesis.py
@@ -1,0 +1,475 @@
+"""
+Unit tests for composition task synthesis (issue #463).
+
+Issue #463 — v38 audit case: a multi-domain contract-first project
+shipped with no task owning ``App.tsx`` wiring.  All three domain
+implementations (engine, bus, renderer) shipped clean.  ``App.tsx``
+returned ``null``.  Unit tests passed.  The bundle built.  But the
+rendered DOM was empty.
+
+Marcus's existing safety net (``enhance_project_with_integration``)
+caught it as a catch-all during integration verification —
+``planning_gap_detected: true`` self-flagged by the agent — but that
+absorbed ~15 min cleanup at the end of the project.
+
+Fix (Variant V3, Kaia checkpoint #1): synthesize a dedicated
+composition task when N >= 2 contract-first domains exist.  Marcus
+says WHAT (a wiring task with explicit deliverables) and the agent
+picks HOW (which file is the entry point, which wiring strategy).
+
+Bright-line check: description lists multiple framework examples
+(App.tsx / main.py / index.ts) so Marcus is not picking the file —
+the agent discovers from the scaffold and ``log_decision``s the
+choice.  Two foundation agents handed this task can produce
+legitimately different wirings.  Coordination, not control.
+
+Layering with integration_verification: composition is narrow
+scope (entry-point only), early in the DAG.  Integration
+verification is broad catch-all (orphan scan, missing components,
+contract verification), end of the DAG.  Intentional layered
+safety, not redundant.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import List, Optional
+
+import pytest
+
+from src.core.models import Priority, Task, TaskStatus
+
+pytestmark = pytest.mark.unit
+
+
+def _impl_task(task_id: str, name: str = "Implement Foo") -> Task:
+    """Build a minimal contract-first implementation Task for tests."""
+    now = datetime.now(timezone.utc)
+    return Task(
+        id=task_id,
+        name=name,
+        description="...",
+        status=TaskStatus.TODO,
+        priority=Priority.HIGH,
+        assigned_to=None,
+        created_at=now,
+        updated_at=now,
+        due_date=None,
+        estimated_hours=2.0,
+        labels=["contract_first", "implementation"],
+        source_type="contract_first",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Trigger gate: only synthesize when N >= 2 domains
+# ---------------------------------------------------------------------------
+
+
+class TestCompositionSynthesisTrigger:
+    """Composition task is gated on multi-domain projects.
+
+    Single-domain projects don't need a composition task — the integration
+    verification catch-all already handles single-domain wiring concerns
+    and the agent typically wires their one domain naturally.
+    """
+
+    def test_returns_none_when_zero_impl_tasks(self) -> None:
+        """Empty impl_tasks list → no composition task (no project)."""
+        from src.integrations.composition_synthesis import (
+            build_composition_task,
+        )
+
+        result = build_composition_task(
+            project_name="my-project",
+            impl_tasks=[],
+        )
+        assert result is None
+
+    def test_returns_none_when_one_impl_task(self) -> None:
+        """Single-impl-task projects skip composition.
+
+        IV catch-all is sufficient.  A project with only one
+        implementation task has nothing meaningful to compose — the
+        agent wires their one domain naturally as part of the impl
+        work.
+        """
+        from src.integrations.composition_synthesis import (
+            build_composition_task,
+        )
+
+        result = build_composition_task(
+            project_name="my-project",
+            impl_tasks=[_impl_task("t1")],
+        )
+        assert result is None
+
+    def test_returns_task_when_two_impl_tasks(self) -> None:
+        """``len(impl_tasks) >= 2`` → composition task synthesized."""
+        from src.integrations.composition_synthesis import (
+            build_composition_task,
+        )
+
+        result = build_composition_task(
+            project_name="snake-game",
+            impl_tasks=[_impl_task("t1"), _impl_task("t2")],
+        )
+        assert result is not None
+        assert isinstance(result, Task)
+
+    def test_returns_task_when_three_impl_tasks(self) -> None:
+        """Trigger fires for any multi-impl-task project."""
+        from src.integrations.composition_synthesis import (
+            build_composition_task,
+        )
+
+        result = build_composition_task(
+            project_name="dashboard",
+            impl_tasks=[_impl_task("t1"), _impl_task("t2"), _impl_task("t3")],
+        )
+        assert result is not None
+
+
+# ---------------------------------------------------------------------------
+# Task structure: id, source_type, labels, priority, status
+# ---------------------------------------------------------------------------
+
+
+class TestCompositionTaskStructure:
+    """Generated composition task carries the canonical Marcus shape."""
+
+    @staticmethod
+    def _build() -> Task:
+        from src.integrations.composition_synthesis import (
+            build_composition_task,
+        )
+
+        result = build_composition_task(
+            project_name="snake-game",
+            impl_tasks=[_impl_task("t1"), _impl_task("t2")],
+        )
+        assert result is not None
+        return result
+
+    def test_id_uses_composition_prefix(self) -> None:
+        """ID starts with ``composition_`` for downstream filtering."""
+        task = self._build()
+        assert task.id.startswith("composition_")
+
+    def test_source_type_is_composition_synthesis(self) -> None:
+        """``source_type`` distinguishes Marcus-synthesized from LLM-derived."""
+        task = self._build()
+        assert task.source_type == "composition_synthesis"
+
+    def test_labels_include_composition_and_marcus_synthesized(self) -> None:
+        """Both labels present for downstream filtering and audit trails."""
+        task = self._build()
+        assert "composition" in task.labels
+        assert "marcus_synthesized" in task.labels
+
+    def test_priority_is_high(self) -> None:
+        """Composition gates the demo — wiring failure = product appears
+        broken — so it must outrank documentation / nice-to-haves."""
+        task = self._build()
+        assert task.priority == Priority.HIGH
+
+    def test_status_is_todo(self) -> None:
+        """Synthesized tasks ship as TODO so an agent picks them up."""
+        task = self._build()
+        assert task.status == TaskStatus.TODO
+
+    def test_estimated_hours_reasonable(self) -> None:
+        """Composition is mostly imports + mounting — small task."""
+        task = self._build()
+        assert task.estimated_hours is not None
+        assert 0.5 <= task.estimated_hours <= 3.0
+
+    def test_responsibility_set(self) -> None:
+        """``responsibility`` field set so ``build_tiered_instructions``
+        surfaces the contract-responsibility framing in the agent prompt.
+        """
+        task = self._build()
+        assert task.responsibility is not None
+        assert "entry point" in task.responsibility.lower()
+
+
+# ---------------------------------------------------------------------------
+# Dependencies: hard deps on every impl task, no foundation deps
+# ---------------------------------------------------------------------------
+
+
+class TestCompositionDependencies:
+    """Composition depends on every contract-first impl task (transitively
+    on foundation tasks via the impl deps already wired at
+    ``nlp_tools.py:332``)."""
+
+    def test_depends_on_every_impl_task(self) -> None:
+        """3 impl tasks → composition has all 3 in dependencies."""
+        from src.integrations.composition_synthesis import (
+            build_composition_task,
+        )
+
+        impls = [_impl_task("t1"), _impl_task("t2"), _impl_task("t3")]
+        task = build_composition_task(
+            project_name="dashboard",
+            impl_tasks=impls,
+        )
+        assert task is not None
+        assert set(task.dependencies) == {"t1", "t2", "t3"}
+
+    def test_no_self_dependency(self) -> None:
+        """Composition's own ID never appears in its dependencies list."""
+        from src.integrations.composition_synthesis import (
+            build_composition_task,
+        )
+
+        impls = [_impl_task("t1"), _impl_task("t2")]
+        task = build_composition_task(
+            project_name="x",
+            impl_tasks=impls,
+        )
+        assert task is not None
+        assert task.id not in task.dependencies
+
+    def test_no_foundation_task_dependency(self) -> None:
+        """Composition depends on impl tasks only — not on foundation tasks.
+
+        Foundation deps are already wired transitively via impl deps
+        (``nlp_tools.py:332`` makes every domain task depend on every
+        foundation task).  Direct foundation deps on the composition
+        task would clutter the DAG and risk over-blocking when
+        foundation work is split across multiple sub-tasks.
+
+        Caller filters input to ``contract_first`` impl tasks before
+        passing to the helper; this test pins that even if a
+        foundation-typed task slips through, it doesn't end up in
+        the composition's dependency edges.
+        """
+        from src.integrations.composition_synthesis import (
+            build_composition_task,
+        )
+
+        # Build a foundation-typed task and verify it doesn't drift
+        # into composition's deps.  Caller is expected to filter input
+        # to impl tasks only — this test guards the helper's behavior
+        # if the caller ever passes a heterogeneous list.
+        foundation = _impl_task("foundation_t1", name="Tech Foundation Setup")
+        foundation.source_type = "pre_fork_synthesis"
+        foundation.labels = ["pre-fork"]
+
+        impl_a = _impl_task("impl_a")
+        impl_b = _impl_task("impl_b")
+
+        # Helper takes only impl_tasks — passing impls only here.
+        # The contract: foundation tasks are NEVER input to this
+        # helper, but if they were, the dependencies should still
+        # reflect ONLY what was passed.
+        task = build_composition_task(
+            project_name="x",
+            impl_tasks=[impl_a, impl_b],
+        )
+        assert task is not None
+        assert "foundation_t1" not in task.dependencies, (
+            "Composition must not depend on foundation tasks "
+            "(transitive via impl deps already wired at nlp_tools.py:332)"
+        )
+
+    def test_does_not_mutate_input_impl_tasks(self) -> None:
+        """Helper is pure — must not modify the caller's impl_tasks list.
+
+        Python lists pass by reference.  If the helper appends, sorts,
+        or otherwise mutates the input, that's a silent side effect
+        bug that could surprise callers.  This test pins purity so a
+        future refactor can't introduce in-place mutation without
+        failing loud.
+        """
+        from src.integrations.composition_synthesis import (
+            build_composition_task,
+        )
+
+        impls = [_impl_task("t1"), _impl_task("t2")]
+        impls_snapshot_ids = [t.id for t in impls]
+        impls_snapshot_len = len(impls)
+
+        build_composition_task(
+            project_name="x",
+            impl_tasks=impls,
+        )
+
+        assert (
+            len(impls) == impls_snapshot_len
+        ), "Helper must not mutate input list length"
+        assert [
+            t.id for t in impls
+        ] == impls_snapshot_ids, "Helper must not reorder input list"
+
+
+# ---------------------------------------------------------------------------
+# Description content: V3 elements (multiple framework examples,
+# log_decision deliverable, log_artifact deliverable, "discover from
+# scaffold" framing)
+# ---------------------------------------------------------------------------
+
+
+class TestCompositionDescriptionV3:
+    """Description satisfies Variant V3 (Kaia checkpoint #1):
+
+    - lists multiple framework examples so Marcus is not picking
+    - says "discover from scaffold" so agent retains file-choice authority
+    - requires ``log_decision`` titled "Entry point wired"
+    - requires ``log_artifact`` for the wired file
+    - does NOT dictate a specific entry-point file (anti-V1 regression)
+    """
+
+    @staticmethod
+    def _build_description() -> str:
+        from src.integrations.composition_synthesis import (
+            build_composition_task,
+        )
+
+        task = build_composition_task(
+            project_name="snake-game",
+            impl_tasks=[_impl_task("t1"), _impl_task("t2")],
+        )
+        assert task is not None
+        return task.description
+
+    def test_description_lists_multiple_framework_examples(self) -> None:
+        """Multiple examples (App.tsx + main.py + index.ts at minimum)
+        so the LLM/agent sees Marcus is not picking a single file.
+
+        Bright-line: if Marcus listed only one example, the agent could
+        legitimately read it as a directive rather than an example.
+        Multiple examples make the "this is one of several possibilities"
+        framing explicit.
+        """
+        desc = self._build_description()
+        # At least three different framework conventions must be named
+        examples = ["App.tsx", "main.py", "index.ts"]
+        present = sum(1 for ex in examples if ex in desc)
+        assert present >= 3, (
+            f"Description must list at least 3 framework entry-point "
+            f"examples so Marcus is not picking a single file.  "
+            f"Found: {present} of {examples}"
+        )
+
+    def test_description_says_discover_from_scaffold(self) -> None:
+        """Locks the "agent discovers, Marcus doesn't pick" framing.
+
+        The phrase "scaffold" anchors the agent's file-choice authority
+        in the project's existing structure rather than Marcus's
+        proposal.
+        """
+        desc = self._build_description()
+        assert "scaffold" in desc.lower()
+        # Variants of "discover" or "find" or "identify" — at least one
+        # must signal that the agent does the discovery
+        discover_signals = ["discover", "find", "identify", "locate"]
+        assert any(
+            signal in desc.lower() for signal in discover_signals
+        ), "Description must signal agent-side discovery of entry point"
+
+    def test_description_requires_log_decision_entry_point_wired(self) -> None:
+        """Locks the canonical decision title so Cato/Epictetus can grep
+        compliance metrics consistently across runs (parallel to the
+        \"Public API surface\" decision title pattern from #446)."""
+        desc = self._build_description()
+        assert "log_decision" in desc
+        assert "Entry point wired" in desc
+
+    def test_description_requires_log_artifact_for_wired_file(self) -> None:
+        """log_artifact is the file-level surface; log_decision is the
+        structured-metadata surface.  Both required (same #446 pattern).
+        """
+        desc = self._build_description()
+        assert "log_artifact" in desc
+
+    def test_description_does_not_dictate_specific_entry_point(self) -> None:
+        """Anti-V1 regression: description must NOT instruct the agent
+        to wire a specific file (e.g., \"wire src/App.tsx\" or \"the
+        entry point is App.tsx\").
+
+        Bright-line guard: if Marcus picks the entry-point file, agents
+        lose the legitimate choice between framework conventions
+        (Vite vs Next.js vs CRA all use different entry filenames).
+        """
+        desc = self._build_description()
+        # Loose check: the description should NOT say "the entry point
+        # is X" or "wire FILENAME" with a specific filename.  Hard to
+        # assert negatively, but we can pin that the prescriptive
+        # phrasing isn't present.
+        bad_phrases = [
+            "the entry point is App.tsx",
+            "the entry point is main.py",
+            "wire src/App.tsx",
+            "wire src/main.py",
+            "wire index.ts",
+        ]
+        for bad in bad_phrases:
+            assert bad not in desc, (
+                f"Description must not dictate a specific entry-point "
+                f"file ({bad!r}) — that's HOW guidance.  Use scaffold "
+                f"discovery framing instead."
+            )
+
+    def test_description_names_project(self) -> None:
+        """Project name appears in the description so the agent has
+        context (which project's entry point are they wiring)."""
+        desc = self._build_description()
+        assert "snake-game" in desc
+
+
+# ---------------------------------------------------------------------------
+# Idempotency: don't double-synthesize
+# ---------------------------------------------------------------------------
+
+
+class TestCompositionIdempotency:
+    """Synthesis is idempotent — calling twice or being called when a
+    composition task is already present in impl_tasks does not produce
+    two composition tasks.
+
+    Defensive check: current call paths invoke synthesis once per
+    create_project, but a future re-run / retry / cache-miss could
+    invoke twice.  Skip if existing composition task is already in
+    the impl_tasks list.
+    """
+
+    def test_skipped_when_composition_task_already_in_impl_list(self) -> None:
+        """If impl_tasks contains a task with ``composition`` label,
+        synthesis returns None — no double-creation."""
+        from src.integrations.composition_synthesis import (
+            build_composition_task,
+        )
+
+        existing_composition = _impl_task("existing")
+        existing_composition.labels = list(existing_composition.labels) + [
+            "composition"
+        ]
+
+        result = build_composition_task(
+            project_name="x",
+            impl_tasks=[existing_composition, _impl_task("t1")],
+        )
+        assert result is None, (
+            "Synthesis must be idempotent — skip when a composition "
+            "task is already present in the input list"
+        )
+
+    def test_skipped_when_composition_task_already_in_input_by_source_type(
+        self,
+    ) -> None:
+        """Source-type-based detection of existing composition tasks
+        (in case labels got stripped during a kanban round-trip)."""
+        from src.integrations.composition_synthesis import (
+            build_composition_task,
+        )
+
+        existing_composition = _impl_task("existing")
+        existing_composition.source_type = "composition_synthesis"
+
+        result = build_composition_task(
+            project_name="x",
+            impl_tasks=[existing_composition, _impl_task("t1")],
+        )
+        assert result is None

--- a/tests/unit/integrations/test_contract_first_fallback.py
+++ b/tests/unit/integrations/test_contract_first_fallback.py
@@ -705,6 +705,125 @@ class TestContractFirstCompositionTaskSynthesis:
             len(composition_tasks) == 0
         ), "Single-impl-task projects must not get a composition task"
 
+    @pytest.mark.asyncio
+    async def test_gap_fill_contract_tasks_do_not_count_toward_trigger(self):
+        """Outcome-coverage gap-fill tasks are filtered out of the
+        composition trigger.
+
+        Codex P2 (PR #472): ``decompose_result.augmented_tasks`` can
+        include ``source_type="gap_fill_contract"`` tasks synthesized
+        by ``_apply_outcome_coverage_to_contract_graph``.  These
+        address outcome coverage gaps, not domain multiplicity, so
+        they must NOT count toward the composition trigger.  Single-
+        domain project with 1 contract task + 1 gap-fill should NOT
+        get a composition task.
+
+        Regression test for the specific failure mode: pre-fix,
+        ``len(tasks) == 2`` would falsely trigger composition for a
+        single-domain project that happened to have an outcome-
+        coverage gap-fill task.
+        """
+        from datetime import datetime, timezone
+
+        from src.core.models import Priority, Task, TaskStatus
+
+        creator = _make_creator()
+        constraints = MagicMock()
+
+        contract_task = Task(
+            id="contract_task_a",
+            name="Implement Auth Service",
+            description="...",
+            status=TaskStatus.TODO,
+            priority=Priority.HIGH,
+            assigned_to=None,
+            created_at=datetime.now(timezone.utc),
+            updated_at=datetime.now(timezone.utc),
+            due_date=None,
+            estimated_hours=2.0,
+            labels=["contract_first", "implementation"],
+            source_type="contract_first",
+            responsibility="implements Auth interface",
+        )
+        # Synthesized gap-fill task (mimics
+        # _apply_outcome_coverage_to_contract_graph output shape)
+        gap_fill_task = Task(
+            id="gap_fill_abc123",
+            name="Render Auth Status to UI",
+            description="Render auth status (synthesized gap-fill).",
+            status=TaskStatus.TODO,
+            priority=Priority.MEDIUM,
+            assigned_to=None,
+            created_at=datetime.now(timezone.utc),
+            updated_at=datetime.now(timezone.utc),
+            due_date=None,
+            estimated_hours=1.5,
+            labels=["gap_fill", "intent_fidelity", "contract"],
+            source_type="gap_fill_contract",
+            responsibility="implements RenderingAgent",
+        )
+
+        with (
+            patch.object(
+                creator.prd_parser,
+                "_analyze_prd_deeply",
+                new_callable=AsyncMock,
+                return_value=_make_prd_analysis(),
+            ),
+            patch.object(
+                creator.prd_parser,
+                "_discover_domains",
+                new_callable=AsyncMock,
+                return_value={"Auth": ["f1"]},
+            ),
+            patch(
+                "src.integrations.nlp_tools._generate_contracts_by_domain",
+                new_callable=AsyncMock,
+                return_value={
+                    "Auth": {
+                        "artifacts": [
+                            {
+                                "filename": "auth-contracts.md",
+                                "artifact_type": "specification",
+                                "content": "# Auth",
+                                "description": "Auth contracts",
+                                "relative_path": "docs/api/auth-contracts.md",
+                            }
+                        ],
+                        "decisions": [],
+                    }
+                },
+            ),
+            patch.object(
+                creator.prd_parser,
+                "decompose_by_contract",
+                new_callable=AsyncMock,
+                return_value=ParserOutcomeCoverage(
+                    augmented_tasks=[contract_task, gap_fill_task],
+                    coverage=None,
+                ),
+            ),
+        ):
+            result = await creator._try_contract_first_decomposition(
+                description="Build a thing",
+                project_name="auth-app",
+                project_root="/tmp/test",  # nosec B108
+                constraints=constraints,
+                options={"decomposer": "contract_first"},
+            )
+
+        assert result is not None
+        composition_tasks = [
+            t for t in result if t.source_type == "composition_synthesis"
+        ]
+        assert len(composition_tasks) == 0, (
+            f"Single-domain project with 1 contract_first + 1 "
+            f"gap_fill_contract task must NOT get a composition task "
+            f"— gap-fill tasks address outcome coverage, not domain "
+            f"multiplicity.  Got {len(composition_tasks)} composition "
+            f"task(s): {[t.name for t in composition_tasks]}"
+        )
+
 
 class TestContractFirstDesignGhosts:
     """

--- a/tests/unit/integrations/test_contract_first_fallback.py
+++ b/tests/unit/integrations/test_contract_first_fallback.py
@@ -483,6 +483,229 @@ class TestContractFirstFallback:
         assert len(stashed["Design Main"]["decisions"]) == 1
 
 
+class TestContractFirstCompositionTaskSynthesis:
+    """Integration: composition task is synthesized when ``len(impl_tasks) >= 2``.
+
+    Issue #463 / Kaia review checkpoint #2 — call-site contract.
+
+    The unit tests in ``test_composition_task_synthesis.py`` verify the
+    helper works in isolation.  This test verifies the helper is
+    actually CALLED from ``_try_contract_first_decomposition`` so a
+    future contributor cannot silently delete the call without failing
+    a test.
+    """
+
+    @pytest.mark.asyncio
+    async def test_composition_task_appended_when_two_impl_tasks(self):
+        """``_try_contract_first_decomposition`` returns a task list
+        that includes a composition task when ``decompose_by_contract``
+        produced ≥2 contract-first implementation tasks."""
+        from datetime import datetime, timezone
+
+        from src.core.models import Priority, Task, TaskStatus
+
+        creator = _make_creator()
+        constraints = MagicMock()
+
+        impl_a = Task(
+            id="contract_task_a",
+            name="Implement Auth Service",
+            description="...",
+            status=TaskStatus.TODO,
+            priority=Priority.HIGH,
+            assigned_to=None,
+            created_at=datetime.now(timezone.utc),
+            updated_at=datetime.now(timezone.utc),
+            due_date=None,
+            estimated_hours=2.0,
+            labels=["contract_first", "implementation"],
+            source_type="contract_first",
+            responsibility="implements Auth interface",
+        )
+        impl_b = Task(
+            id="contract_task_b",
+            name="Implement User Service",
+            description="...",
+            status=TaskStatus.TODO,
+            priority=Priority.HIGH,
+            assigned_to=None,
+            created_at=datetime.now(timezone.utc),
+            updated_at=datetime.now(timezone.utc),
+            due_date=None,
+            estimated_hours=2.0,
+            labels=["contract_first", "implementation"],
+            source_type="contract_first",
+            responsibility="implements User interface",
+        )
+
+        with (
+            patch.object(
+                creator.prd_parser,
+                "_analyze_prd_deeply",
+                new_callable=AsyncMock,
+                return_value=_make_prd_analysis(),
+            ),
+            patch.object(
+                creator.prd_parser,
+                "_discover_domains",
+                new_callable=AsyncMock,
+                return_value={"Auth": ["f1"], "User": ["f2"]},
+            ),
+            patch(
+                "src.integrations.nlp_tools._generate_contracts_by_domain",
+                new_callable=AsyncMock,
+                return_value={
+                    "Auth": {
+                        "artifacts": [
+                            {
+                                "filename": "auth-contracts.md",
+                                "artifact_type": "specification",
+                                "content": "# Auth",
+                                "description": "Auth contracts",
+                                "relative_path": "docs/api/auth-contracts.md",
+                            }
+                        ],
+                        "decisions": [],
+                    },
+                    "User": {
+                        "artifacts": [
+                            {
+                                "filename": "user-contracts.md",
+                                "artifact_type": "specification",
+                                "content": "# User",
+                                "description": "User contracts",
+                                "relative_path": "docs/api/user-contracts.md",
+                            }
+                        ],
+                        "decisions": [],
+                    },
+                },
+            ),
+            patch.object(
+                creator.prd_parser,
+                "decompose_by_contract",
+                new_callable=AsyncMock,
+                return_value=ParserOutcomeCoverage(
+                    augmented_tasks=[impl_a, impl_b],
+                    coverage=None,
+                ),
+            ),
+        ):
+            result = await creator._try_contract_first_decomposition(
+                description="Build a thing",
+                project_name="auth-app",
+                project_root="/tmp/test",  # nosec B108
+                constraints=constraints,
+                options={"decomposer": "contract_first"},
+            )
+
+        assert (
+            result is not None
+        ), "Contract-first decomposition succeeded; expected a task list"
+        composition_tasks = [
+            t for t in result if t.source_type == "composition_synthesis"
+        ]
+        assert len(composition_tasks) == 1, (
+            f"Expected exactly one composition task in the returned "
+            f"list (call site contract — verifies the helper is actually "
+            f"invoked from _try_contract_first_decomposition).  "
+            f"Got {len(composition_tasks)}: "
+            f"{[t.name for t in composition_tasks]}"
+        )
+        composition_task = composition_tasks[0]
+        # Composition depends on both impl tasks
+        assert "contract_task_a" in composition_task.dependencies
+        assert "contract_task_b" in composition_task.dependencies
+
+    @pytest.mark.asyncio
+    async def test_no_composition_task_when_one_impl_task(self):
+        """Single-impl-task path → no composition task synthesized.
+
+        Pins the trigger gate at the call site as well as in the
+        helper itself.  If the call site somehow bypassed the helper's
+        gate (e.g., always synthesizing), this test would catch it.
+        """
+        from datetime import datetime, timezone
+
+        from src.core.models import Priority, Task, TaskStatus
+
+        creator = _make_creator()
+        constraints = MagicMock()
+
+        impl_a = Task(
+            id="contract_task_a",
+            name="Implement Auth Service",
+            description="...",
+            status=TaskStatus.TODO,
+            priority=Priority.HIGH,
+            assigned_to=None,
+            created_at=datetime.now(timezone.utc),
+            updated_at=datetime.now(timezone.utc),
+            due_date=None,
+            estimated_hours=2.0,
+            labels=["contract_first", "implementation"],
+            source_type="contract_first",
+            responsibility="implements Auth interface",
+        )
+
+        with (
+            patch.object(
+                creator.prd_parser,
+                "_analyze_prd_deeply",
+                new_callable=AsyncMock,
+                return_value=_make_prd_analysis(),
+            ),
+            patch.object(
+                creator.prd_parser,
+                "_discover_domains",
+                new_callable=AsyncMock,
+                return_value={"Auth": ["f1"]},
+            ),
+            patch(
+                "src.integrations.nlp_tools._generate_contracts_by_domain",
+                new_callable=AsyncMock,
+                return_value={
+                    "Auth": {
+                        "artifacts": [
+                            {
+                                "filename": "auth-contracts.md",
+                                "artifact_type": "specification",
+                                "content": "# Auth",
+                                "description": "Auth contracts",
+                                "relative_path": "docs/api/auth-contracts.md",
+                            }
+                        ],
+                        "decisions": [],
+                    }
+                },
+            ),
+            patch.object(
+                creator.prd_parser,
+                "decompose_by_contract",
+                new_callable=AsyncMock,
+                return_value=ParserOutcomeCoverage(
+                    augmented_tasks=[impl_a],
+                    coverage=None,
+                ),
+            ),
+        ):
+            result = await creator._try_contract_first_decomposition(
+                description="Build a thing",
+                project_name="auth-app",
+                project_root="/tmp/test",  # nosec B108
+                constraints=constraints,
+                options={"decomposer": "contract_first"},
+            )
+
+        assert result is not None
+        composition_tasks = [
+            t for t in result if t.source_type == "composition_synthesis"
+        ]
+        assert (
+            len(composition_tasks) == 0
+        ), "Single-impl-task projects must not get a composition task"
+
+
 class TestContractFirstDesignGhosts:
     """
     Test design ghost task creation in contract-first decomposition.


### PR DESCRIPTION
Closes #463.  v0.3.6.post2 milestone.

## Summary

Synthesizes a dedicated composition task in ``_try_contract_first_decomposition`` when ``len(impl_tasks) >= 2``.  The composition task carries hard dependencies on every domain impl task and explicit deliverables (``log_decision`` titled ``\"Entry point wired\"`` + ``log_artifact`` for the wired file).

Resolves the v38 audit failure mode where every domain shipped clean but ``App.tsx`` returned ``null`` — caught by integration verification's catch-all but at the cost of ~15 min cleanup absorbed by an agent on top of their other work.

## v38 evidence

snake-game-v38 audit:

> A1 in interview: \"Task d65a70e3 did not tell me to wire App.tsx.  It scoped me to 'owns RenderFrame, RenderElement, VisualStyle and all rendering logic' — explicitly the rendering domain, not composition.  The integration-verification task explicitly says 'fill gaps left by task decomposition,' and that's where I caught it.\"
>
> A1 self-flagged ``planning_gap_detected: true`` in ``integration_remediation.json``.

This PR makes wiring an explicit deliverable with explicit ownership — moves it from \"absorbed cleanup at the end\" to \"its own task assigned when impls complete.\"

## Layering with existing integration_verification (intentional, not redundant)

* **Composition task** = narrow scope (entry-point wiring only), assigned **early** when impls complete
* **Integration verification** = broad catch-all (orphan scan, missing components, contract verification), assigned **late**

DAG order: ``impls → composition → integration_verification`` (IV transitively depends on composition because IV depends on every non-doc / non-integration task).  Composition catches what's expected; IV catches anything missed.

## Bright-line check

Description names multiple framework entry-point examples (``App.tsx`` for Vite/CRA, ``main.py`` for Python, ``index.ts`` for Node — and asks the agent to discover from the scaffold).  Marcus does NOT pick the file — different framework conventions legitimately use different entry filenames.  The agent picks; ``log_decision`` records the choice.

Two agents handed this task produce legitimately different wirings — different file choices, different mounting strategies (DI container, direct mounting, etc.).  **Coordination, not control.**

## Why ``len(impl_tasks) >= 2`` (not domain-label count)

Kaia review checkpoint #2 caught that domain labeling at ``nlp_tools.py:810-817`` is conditional — gap-fill tasks and edge cases don't get ``domain:X`` labels.  ``len(impl_tasks)`` is the directly-observable count of work to be wired, no caller-error class of bugs.

## Why Variant V3 (Kaia review checkpoint #1)

Three variants considered:
* **V1**: Marcus infers entry-point file from contract artifacts and names it in description — REJECTED, crosses bright line
* **V2**: Description-only \"discover from scaffold\" — works but loses observability
* **V3** (chosen): V2 + ``log_decision`` deliverable so Cato/Epictetus can verify wiring happened — same code cost as V2, observability gain matching V1

## Reviews applied

- **Kaia checkpoint #1** (pre-code design): chose V3 + corrected trigger to ``len(impl_tasks) >= 2``
- **Kaia checkpoint #2** (tests written, no impl): added 3 missing tests (no_foundation_dep, input-list-not-mutated, integration call-site contract) + signature simplification (drop ``n_domains`` parameter)
- **Kaia checkpoint #3** (post-impl): three minor non-blocking observations logged for follow-up

## Test plan

- [x] ``pytest -m unit`` — 1150 passed (+25 new in this PR)
- [x] ``mypy --strict`` clean on changed files
- [x] ``black`` / ``isort`` clean
- [x] Pre-commit hooks pass (incl bandit ``# nosec B108`` for test temp paths)

## Files

- ``src/integrations/composition_synthesis.py`` — new module with pure helper ``build_composition_task``
- ``src/integrations/nlp_tools.py`` — call site in ``_try_contract_first_decomposition``: appends composition task to ``result_tasks`` when synthesis fires
- ``tests/unit/integrations/test_composition_task_synthesis.py`` — 23 unit tests
- ``tests/unit/integrations/test_contract_first_fallback.py`` — 2 integration tests pinning the call site contract

## Follow-up

#471 — track ``\"Entry point wired\"`` decision compliance.  Forms the compliance trio with #468 (Public API surface) and #469 (foundation dedup) for v0.3.7 observability layer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)