### PR TITLE
refactor(#456): unify outcome_coverage + spec_coverage behind GraphAugmenter Protocol

### DIFF
--- a/docs/architecture/adr/0011-graph-augmenter-protocol.md
+++ b/docs/architecture/adr/0011-graph-augmenter-protocol.md
@@ -238,6 +238,15 @@ Pattern for future augmenters (NFR coverage, security checks, etc.):
    registration time, but verify against existing augmenter names
    to avoid the `ValueError` at boot.
 
+6. **Stay stateless.** Augmenters are constructed per-call by
+   `AdvancedPRDParser._build_augmenter_chain()`. Adding instance
+   state (caches, retry budgets, rate-limit windows) silently
+   discards it across calls — see the lifetime-expectation note in
+   :class:`OutcomeCoverageAugmenter` for the tripwire pattern. If an
+   augmenter genuinely needs persistent state, audit the
+   construction site and move it to per-decomposer-instance or
+   per-process scope before adding the attribute.
+
 ---
 
 ## References

--- a/docs/architecture/adr/0011-graph-augmenter-protocol.md
+++ b/docs/architecture/adr/0011-graph-augmenter-protocol.md
@@ -1,0 +1,258 @@
+# ADR 0011: GraphAugmenter Protocol for Pre-Inference Task Synthesis
+
+**Status:** Accepted
+
+**Date:** 2026-04-30
+
+**Deciders:** Marcus Core Team
+
+**Issue:** [#456](https://github.com/lwgray/marcus/issues/456)
+
+---
+
+## Context
+
+Pre-#456, Marcus had two parallel pipelines that synthesized tasks
+into the graph after the decomposer produced its initial task list:
+
+1. **Outcome coverage** (`outcome_coverage` — issue #449) ran *inside*
+   the decomposer between `_create_detailed_tasks` and
+   `_infer_smart_dependencies`. Synthesized gap-fill tasks correctly
+   participated in dependency inference and foundation wiring.
+
+2. **Spec coverage** (`spec_coverage`) ran *after* the decomposer +
+   safety checks at `nlp_tools.py:1336`. Synthesized gap tasks were
+   appended to the task list with `dependencies=[]` — orphans that
+   bypassed both `_infer_smart_dependencies` and foundation wiring.
+   This was the v37 orphan-failure-mode.
+
+Both pipelines did the same fundamental thing: "look at the graph,
+detect a gap, synthesize a task to fill it." But they integrated at
+different points in the pipeline with different failure modes.
+
+The forcing function: a third would-be augmenter (NFR coverage,
+security checks, lint coverage…) faced an unclear question — *where*
+in the pipeline does it slot in? Each new addition risked being
+either (a) another orphan, like spec_coverage, or (b) a parallel
+implementation of the same lift-and-fill pattern.
+
+### Requirements
+
+- Single integration point for pre-inference task synthesis so all
+  augmenters land at the same correct location.
+- Synthesized tasks always participate in dependency inference and
+  foundation wiring as first-class graph members.
+- Defense-in-depth against augmenter exceptions — one buggy augmenter
+  must never crash the decomposer.
+- Telemetry namespace per augmenter so future additions don't
+  collide on event-payload keys.
+- Compatible with Marcus's existing duck-typing convention (no
+  inheritance-from-base requirement).
+- Observable: failures must be loud and named in logs so operators
+  can diagnose which augmenter failed without grepping for stack
+  traces.
+
+---
+
+## Decision
+
+Define a structural Protocol — `GraphAugmenter` — and a chain
+orchestrator — `run_augmenter_chain` — both in
+`src/marcus_mcp/coordinator/graph_augmentation.py`. Both decomposers
+(`parse_prd_to_tasks` and `decompose_by_contract`) route their
+post-`_create_detailed_tasks` task list through the chain before
+calling `_infer_smart_dependencies`.
+
+### The Protocol
+
+```python
+@runtime_checkable
+class GraphAugmenter(Protocol):
+    name: str
+
+    async def augment(
+        self,
+        *,
+        prd_analysis: "PRDAnalysis",
+        tasks: List[Task],
+        contract_artifacts: Optional[Dict[str, Any]] = None,
+    ) -> AugmentationResult: ...
+```
+
+**Why a Protocol (structural) and not an ABC (nominal):** Marcus's
+existing pipeline conventions favor duck typing; structural typing
+keeps the interface non-invasive to existing classes.
+`@runtime_checkable` lets the chain orchestrator validate registered
+augmenters with `isinstance` when registration happens.
+
+**Why `name: str`:** the chain namespaces telemetry by `augmenter.name`
+so each augmenter's payload sits in its own slice of the result dict.
+Cato consumers read `result.telemetry["outcome_coverage"]`,
+`result.telemetry["spec_coverage"]`, etc. without key collisions.
+
+**Why keyword-only `augment` parameters:** prevents positional-arg
+coupling as the parameter list evolves. Future augmenters can
+ignore parameters they don't need.
+
+### The Chain Orchestrator
+
+```python
+async def run_augmenter_chain(
+    augmenters: Sequence[GraphAugmenter],
+    *,
+    prd_analysis: "PRDAnalysis",
+    tasks: List[Task],
+    contract_artifacts: Optional[Dict[str, Any]] = None,
+) -> AugmentationResult:
+```
+
+**Behavior contract:**
+
+1. Validates name uniqueness at chain entry — duplicate names raise
+   `ValueError` before any augmenter runs (fail-fast, no half-applied
+   side effects).
+2. Augmenters run sequentially; each sees the post-previous-augmenter
+   task list, so synthesized tasks flow forward through the chain.
+3. Every `augment` call is wrapped in `try/except` — defense-in-depth.
+   A buggy or future augmenter that forgot to catch its own
+   exceptions cannot crash the decomposer. Failures log a warning
+   naming the augmenter and continue with prior tasks (no-op for
+   that step).
+4. Telemetry is namespaced by `augmenter.name`. Empty-telemetry
+   augmenters are omitted from the namespace so consumers can
+   distinguish "augmenter ran, no data" from "augmenter didn't run."
+
+### Single Registration Site
+
+Both decomposers call:
+
+```python
+augmenter_result = await run_augmenter_chain(
+    self._build_augmenter_chain(),
+    prd_analysis=prd_analysis,
+    tasks=tasks,
+    contract_artifacts=...,  # None for feature-based
+)
+```
+
+Where `_build_augmenter_chain()` is a single helper on
+`AdvancedPRDParser` returning the canonical chain — the only place
+that knows the chain order and registration set.
+
+---
+
+## Consequences
+
+### Positive
+
+- **Single integration point.** Future augmenters (NFR coverage,
+  security checks) join `_build_augmenter_chain()` and inherit
+  correct positioning automatically.
+- **No more orphans.** Spec-coverage gap tasks now flow through
+  `_infer_smart_dependencies`, foundation wiring, and safety checks
+  like any other implementation task. The v37 orphan-failure-mode
+  is closed.
+- **Observable failures.** Augmenter exceptions log with the
+  augmenter's name; no silent regressions.
+- **Telemetry future-proof.** Each augmenter owns its own keyspace.
+  Cato consumers don't break when a new augmenter joins.
+- **Order is load-bearing and tested.** `outcome_coverage` runs before
+  `spec_coverage` so the spec-feature scan sees outcome-fill tasks.
+  Pinned by `test_second_augmenter_sees_first_augmenter_tasks`.
+
+### Negative
+
+- **Augmenter chain runs synchronously per augmenter.** Two
+  independent augmenters that don't read each other's output could in
+  principle run concurrently with `asyncio.gather`, but the chain is
+  sequential to preserve the "downstream sees upstream output"
+  property. Future optimization opportunity: dependency-aware chain
+  scheduler.
+- **No retry/circuit-breaker per augmenter.** The chain catches
+  exceptions but doesn't retry. Each augmenter is responsible for
+  its own retry logic if needed (currently none do — both call
+  underlying functions that already handle LLM transients).
+
+### Trade-offs Considered
+
+**Inheritance vs Protocol:** chose Protocol. ABC requires existing
+classes to inherit from a base, which would have required modifying
+the parser. Protocol is non-invasive — any class with the right
+shape satisfies it.
+
+**Eager vs lazy chain construction:** chose eager (chain built once
+per decomposer call in `_build_augmenter_chain`). Augmenters are
+stateless apart from `llm_client` references, so per-call construction
+costs nothing. If future augmenters acquire state (caching, retry
+budgets), this needs revisiting.
+
+**Telemetry namespace shape:** chose `{augmenter.name: dict}` over
+flat merge. Namespace makes per-augmenter event payloads
+addressable from Cato (`result.telemetry["outcome_coverage"]`)
+without forcing a unified key schema across all augmenters.
+
+---
+
+## Adding a New Augmenter
+
+Pattern for future augmenters (NFR coverage, security checks, etc.):
+
+1. Create `src/marcus_mcp/coordinator/<name>_augmenter.py` with a
+   class that satisfies the `GraphAugmenter` Protocol:
+
+   ```python
+   class NfrCoverageAugmenter:
+       name: str = "nfr_coverage"
+
+       async def augment(
+           self,
+           *,
+           prd_analysis: "PRDAnalysis",
+           tasks: List[Task],
+           contract_artifacts: Optional[Dict[str, Any]] = None,
+       ) -> AugmentationResult:
+           # ... detect gaps, synthesize tasks, return result
+   ```
+
+2. Register it in
+   `AdvancedPRDParser._build_augmenter_chain()`:
+
+   ```python
+   return [
+       OutcomeCoverageAugmenter(llm_client=self.llm_client),
+       SpecCoverageAugmenter(),
+       NfrCoverageAugmenter(),
+   ]
+   ```
+
+3. Decide chain position by what the augmenter reads. If the new
+   augmenter scores against the post-outcome-coverage graph, place
+   after `OutcomeCoverageAugmenter`. If it operates on raw input
+   independent of upstream synthesis, position is flexible.
+
+4. Add unit tests covering Protocol satisfaction, the augmenter's
+   own behavior, and (if relevant) interaction with upstream
+   augmenters.
+
+5. Pick a unique `name` string. The chain enforces uniqueness at
+   registration time, but verify against existing augmenter names
+   to avoid the `ValueError` at boot.
+
+---
+
+## References
+
+- Issue #456 — GraphAugmenter unification
+- Issue #449 — Outcome coverage (intent fidelity)
+- Kaia review #2 (Simon `c26c7ec5`) — defense-in-depth try/except
+- Kaia review #3 (Simon `4453bd2c`) — lift helpers to public module
+  functions
+- Kaia review #4 (Simon `f36c49c4`) — augmenter-name uniqueness check
+- Kaia review #5 (Simon `a37d415d`) — Stage 5 cleanup gates
+- ADR 0001 — Layered Architecture with DDD (the coordinator layer)
+- `src/marcus_mcp/coordinator/graph_augmentation.py` — Protocol +
+  chain orchestrator
+- `src/marcus_mcp/coordinator/outcome_coverage_augmenter.py` —
+  reference implementation (dispatcher pattern)
+- `src/marcus_mcp/coordinator/spec_coverage_augmenter.py` —
+  reference implementation (single-helper delegation pattern)

--- a/src/ai/advanced/prd/advanced_parser.py
+++ b/src/ai/advanced/prd/advanced_parser.py
@@ -7,11 +7,9 @@ deep understanding, intelligent task breakdown, and risk assessment.
 
 import json
 import logging
-import re
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
 from typing import Any, Dict, List, Optional, Tuple
-from uuid import uuid4
 
 from src.ai.advanced.prd.outcome_extractor import (
     UserOutcome,
@@ -26,10 +24,6 @@ from src.intelligence.dependency_inferer_hybrid import HybridDependencyInferer
 from src.marcus_mcp.coordinator.graph_augmentation import (
     AugmentationResult,
     run_augmenter_chain,
-)
-from src.marcus_mcp.coordinator.outcome_coverage import (
-    OutcomeCoverageResult,
-    apply_outcome_coverage,
 )
 from src.marcus_mcp.coordinator.outcome_coverage_augmenter import (
     OutcomeCoverageAugmenter,
@@ -63,28 +57,6 @@ class PRDAnalysis:
     # decomposer paths read this field and feed it through
     # ``apply_outcome_coverage`` after task generation.
     user_outcomes: List[UserOutcome] = field(default_factory=list)
-
-
-@dataclass
-class ParserOutcomeCoverage:
-    """Parser-side wrapper bundling tasks with optional coverage telemetry.
-
-    ``augmented_tasks`` is always populated.  ``coverage`` is ``None``
-    when the outcome-coverage pipeline didn't run (flag off, no
-    outcomes, or LLM error caught and downgraded) — callers can still
-    read ``result.augmented_tasks`` uniformly.  When coverage ran,
-    ``coverage`` carries score + coverage maps + gaps for telemetry.
-
-    Returned by both :func:`parse_prd_to_tasks`'s internal helper and
-    :func:`decompose_by_contract` (Phase 4 tech-debt fix replaced the
-    ``List[Task]`` return type with this).  Single typed shape across
-    both decomposers means orchestrator reads are uniform:
-    ``tasks = result.augmented_tasks``,
-    ``score = result.coverage.intent_fidelity_score if result.coverage else None``.
-    """
-
-    augmented_tasks: List[Task]
-    coverage: Optional[OutcomeCoverageResult] = None
 
 
 @dataclass
@@ -297,7 +269,10 @@ class AdvancedPRDParser:
         # feature-based outcome-coverage path; spec_coverage ignores
         # the parameter (operates on spec text, not contracts).
         augmenter_result = await run_augmenter_chain(
-            [OutcomeCoverageAugmenter(parser=self), SpecCoverageAugmenter()],
+            [
+                OutcomeCoverageAugmenter(llm_client=self.llm_client),
+                SpecCoverageAugmenter(),
+            ],
             prd_analysis=prd_analysis,
             tasks=tasks,
             contract_artifacts=None,
@@ -405,16 +380,17 @@ class AdvancedPRDParser:
 
         Returns
         -------
-        ParserOutcomeCoverage
+        AugmentationResult
             ``augmented_tasks`` is the contract-owned tasks (with
             ``responsibility`` field set), in the order produced by
             the LLM, plus any synthesized gap-fill tasks when the
-            outcome-coverage pipeline ran.  ``coverage`` is the
-            :class:`OutcomeCoverageResult` when coverage ran, ``None``
-            otherwise.  Dependencies between tasks use the
-            ``provides``/``requires`` cross-parent wiring mechanism.
-            The caller is responsible for assigning kanban-backed IDs
-            and creating cards.
+            outcome-coverage augmenter ran.  ``telemetry`` is
+            namespaced by augmenter name (e.g.
+            ``{"outcome_coverage": {"intent_fidelity_score": ...}}``)
+            when an augmenter ran, empty otherwise.  Dependencies
+            between tasks use the ``provides``/``requires``
+            cross-parent wiring mechanism.  The caller is responsible
+            for assigning kanban-backed IDs and creating cards.
 
         Raises
         ------
@@ -777,7 +753,10 @@ class AdvancedPRDParser:
         # Behind MARCUS_OUTCOME_COVERAGE; both augmenters no-op with
         # empty telemetry on flag off / no outcomes / LLM error.
         return await run_augmenter_chain(
-            [OutcomeCoverageAugmenter(parser=self), SpecCoverageAugmenter()],
+            [
+                OutcomeCoverageAugmenter(llm_client=self.llm_client),
+                SpecCoverageAugmenter(),
+            ],
             prd_analysis=prd_analysis,
             tasks=tasks,
             contract_artifacts=contract_artifacts,
@@ -928,333 +907,6 @@ Return a JSON object with a "tasks" array. Each task has:
 
 Return ONLY the JSON object. Do not include commentary.
 """
-
-    async def _apply_outcome_coverage_to_graph(
-        self, *, prd_analysis: PRDAnalysis, tasks: List[Task]
-    ) -> Optional[ParserOutcomeCoverage]:
-        """Run the intent-fidelity coverage check against the task graph.
-
-        Issue #449 — feature-based path.  Calls
-        :func:`apply_outcome_coverage` with the PRD's user outcomes,
-        the freshly-decomposed task graph, and ``contract_artifacts=None``
-        (feature-based has no contracts).  Synthesized task dicts are
-        converted to :class:`Task` objects with sibling-inherited
-        defaults and appended to the graph.
-
-        Returns ``None`` when:
-
-        - The flag is off
-        - No outcomes were extracted (extraction failed earlier or no
-          outcomes in the PRD)
-        - The coverage pipeline raised (LLM error)
-
-        Otherwise returns a :class:`ParserOutcomeCoverage` carrying the
-        augmented task list and the underlying
-        :class:`OutcomeCoverageResult` for telemetry.  Same shape will
-        be reused by ``decompose_by_contract`` in Phase 4.
-
-        The original task list is never mutated; failures degrade
-        gracefully so a project is never blocked by an outcome-
-        coverage failure.
-        """
-        if not is_outcome_coverage_enabled():
-            return None
-        if not prd_analysis.user_outcomes:
-            return None
-
-        try:
-            result = await apply_outcome_coverage(
-                spec=prd_analysis.original_description or "",
-                outcomes=prd_analysis.user_outcomes,
-                tasks=tasks,
-                llm_client=self.llm_client,
-                contract_artifacts=None,
-            )
-        except Exception as exc:
-            # Catch broadly: timeouts, API errors, parse errors all
-            # downgrade to a logged warning.  The contract is "coverage
-            # failures must never block project creation" — the
-            # decomposer's pre-#449 behavior is the always-available
-            # fallback.  Narrow ``except ValueError`` would let
-            # transient LLM errors bubble up and crash project creation.
-            logger.warning("Outcome coverage failed; task graph unchanged: %s", exc)
-            return None
-
-        synthesized_tasks: List[Task] = [
-            self._build_gap_fill_task(idx=idx, gap_dict=d, sibling_tasks=tasks)
-            for idx, d in enumerate(result.synthesized_tasks)
-        ]
-        augmented = list(tasks) + synthesized_tasks
-
-        logger.info(
-            "Outcome coverage: score=%.2f, %d outcome(s), %d gap(s), "
-            "%d synthesized task(s)",
-            result.intent_fidelity_score,
-            len(prd_analysis.user_outcomes),
-            len(result.gaps),
-            len(synthesized_tasks),
-        )
-
-        return ParserOutcomeCoverage(augmented_tasks=augmented, coverage=result)
-
-    async def _apply_outcome_coverage_to_contract_graph(
-        self,
-        *,
-        prd_analysis: PRDAnalysis,
-        tasks: List[Task],
-        contract_artifacts: Dict[str, Optional[Dict[str, Any]]],
-    ) -> Optional[ParserOutcomeCoverage]:
-        """Run coverage against a contract-first task graph.
-
-        Issue #449 — contract-first path counterpart to
-        :meth:`_apply_outcome_coverage_to_graph`.  Calls
-        :func:`apply_outcome_coverage` with the contract artifacts so
-        the gap-fill LLM grounds its provides/requires/responsibility
-        in real interface names from the existing contracts.
-        Synthesized task dicts are converted to :class:`Task` objects
-        with ``responsibility`` set from the gap-fill output (matching
-        the convention native contract-first tasks already use).
-
-        Returns ``None`` when the flag is off, no outcomes were
-        extracted, or the coverage pipeline raised.  The original
-        task list is never mutated; failures degrade gracefully.
-
-        Distinct from :meth:`_apply_outcome_coverage_to_graph` because
-        contract-first tasks need ``responsibility`` set from the
-        gap-fill ``responsibility`` field (which the contract-aware
-        ``fill_gaps`` prompt asks the LLM for).
-        """
-        if not is_outcome_coverage_enabled():
-            return None
-        if not prd_analysis.user_outcomes:
-            return None
-
-        # Filter to the contract artifacts that actually have content;
-        # apply_outcome_coverage's prompt-builder expects a dict with
-        # populated ``artifacts`` lists, not the wrapper shape that
-        # decompose_by_contract receives (which can have None payloads).
-        usable_contracts: Dict[str, Any] = {
-            domain: payload
-            for domain, payload in contract_artifacts.items()
-            if payload and payload.get("artifacts")
-        }
-
-        try:
-            result = await apply_outcome_coverage(
-                spec=prd_analysis.original_description or "",
-                outcomes=prd_analysis.user_outcomes,
-                tasks=tasks,
-                llm_client=self.llm_client,
-                contract_artifacts=usable_contracts or None,
-            )
-        except Exception as exc:
-            # Catch broadly: timeouts, API errors, parse errors all
-            # downgrade to a logged warning.  Same contract as the
-            # feature-based path — coverage failures must never block
-            # project creation.
-            logger.warning(
-                "Outcome coverage (contract-first) failed; " "task graph unchanged: %s",
-                exc,
-            )
-            return None
-
-        synthesized_tasks: List[Task] = [
-            self._build_contract_gap_fill_task(idx=idx, gap_dict=d, sibling_tasks=tasks)
-            for idx, d in enumerate(result.synthesized_tasks)
-        ]
-        augmented = list(tasks) + synthesized_tasks
-
-        logger.info(
-            "Outcome coverage (contract-first): score=%.2f, %d outcome(s), "
-            "%d gap(s), %d synthesized task(s)",
-            result.intent_fidelity_score,
-            len(prd_analysis.user_outcomes),
-            len(result.gaps),
-            len(synthesized_tasks),
-        )
-
-        return ParserOutcomeCoverage(augmented_tasks=augmented, coverage=result)
-
-    def _build_contract_gap_fill_task(
-        self,
-        *,
-        idx: int,
-        gap_dict: Dict[str, Any],
-        sibling_tasks: List[Task],
-    ) -> Task:
-        """Convert a contract-first gap-fill dict into a full Task.
-
-        Differs from :meth:`_build_gap_fill_task` (feature-based) by
-        setting ``Task.responsibility`` from the gap-fill output's
-        ``responsibility`` field — that's how contract-first tasks
-        carry the "build this side of the contract" framing in the
-        agent prompt at ``build_tiered_instructions`` time.
-
-        Honest labeling (Phase 4 polish): the ``"contract"`` label is
-        added ONLY when ``responsibility`` is actually present in the
-        gap-fill output.  When the helper falls back to feature-based
-        gap-fill prompt (because contract artifacts were filtered to
-        empty), responsibility is None and the task is no different
-        from a feature-based gap-fill — labeling it ``"contract"``
-        would lie about the synthesis context.
-
-        ``source_context`` (Phase 4 polish): when the responsibility
-        string follows the canonical ``"implements <Iface> from
-        <path>"`` shape, the contract file path is parsed out into
-        ``source_context["contract_file"]`` so Layer 1.3 of
-        :func:`build_tiered_instructions` renders the full
-        "Read() the contract file at..." prompt for gap-fill tasks
-        the same way it does for native contract-first siblings.
-        Falls back to empty when the regex doesn't match — Layer 1.3
-        gracefully skips that section.
-        """
-        now = datetime.now(timezone.utc)
-
-        sibling_hours = sorted(
-            t.estimated_hours for t in sibling_tasks if t.estimated_hours > 0
-        )
-        median = sibling_hours[len(sibling_hours) // 2] if sibling_hours else 4.0
-
-        project_id = next((t.project_id for t in sibling_tasks if t.project_id), None)
-        project_name = next(
-            (t.project_name for t in sibling_tasks if t.project_name), None
-        )
-
-        responsibility = gap_dict.get("responsibility")
-
-        # Conditional "contract" label — only when responsibility is set.
-        labels = ["gap_fill", "intent_fidelity"]
-        if responsibility:
-            labels.append("contract")
-
-        # Best-effort parse of contract_file from the responsibility
-        # string.  The canonical format the gap-fill prompt requests
-        # is ``"implements <Iface> from <relative_path>"``.
-        #
-        # Known fragility (Kaia review): the regex captures any
-        # whitespace-bounded token containing a period (e.g. file
-        # extension).  Drift cases the path-separator guard rejects:
-        #
-        #   - ``"from RenderingAgent.draw"`` (method name) — no '/'
-        #   - ``"from src.module.thing"`` (dot-namespace) — no '/'
-        #
-        # The path-separator guard requires '/' or '\\' in the
-        # candidate before treating it as a contract file path.  A
-        # real relative path will always contain a separator; method
-        # names and dotted namespaces won't.  When the guard
-        # rejects, contract_file stays empty and Layer 1.3
-        # gracefully skips the "Read() the contract file at..."
-        # section rather than printing a wrong path.
-        source_context: Dict[str, Any] = {}
-        if isinstance(responsibility, str):
-            match = re.search(r"\bfrom\s+(\S+\.\S+)\b", responsibility)
-            if match:
-                candidate = match.group(1)
-                if "/" in candidate or "\\" in candidate:
-                    source_context["contract_file"] = candidate
-            # Also stash responsibility itself in source_context as a
-            # belt-and-braces measure for kanban providers that don't
-            # round-trip Task.responsibility as a top-level field
-            # (mirrors the pattern from native decompose_by_contract
-            # tasks at line ~640).
-            source_context["responsibility"] = responsibility
-
-        # Embed the MARCUS_CONTRACT_FIRST marker in description so
-        # contract metadata survives round-trip through providers that
-        # don't persist Task.responsibility OR source_context (Planka).
-        # ``_parse_contract_metadata`` (marcus_mcp/tools/task.py) reads
-        # this marker as priority-3 fallback after both top-level
-        # field and source_context are stripped.  Without the marker,
-        # ``build_tiered_instructions`` would silently drop the
-        # CONTRACT RESPONSIBILITY layer for reloaded gap-fill tasks
-        # even though they were synthesized with contract framing.
-        # Mirrors the native contract-first task path at line ~679.
-        # Codex review on PR #457.  No product_intent line — gap-fill
-        # tasks don't carry that field.
-        description = gap_dict["description"]
-        if isinstance(responsibility, str) and responsibility:
-            contract_file_for_marker = source_context.get("contract_file", "")
-            marker_lines = [
-                "<!-- MARCUS_CONTRACT_FIRST",
-                f"responsibility: {responsibility}",
-                f"contract_file: {contract_file_for_marker}",
-                "-->",
-            ]
-            description = f"{description}\n\n" + "\n".join(marker_lines)
-
-        return Task(
-            id=f"gap_fill_{uuid4().hex[:12]}",
-            name=gap_dict["name"],
-            description=description,
-            status=TaskStatus.TODO,
-            priority=Priority.MEDIUM,
-            assigned_to=None,
-            created_at=now,
-            updated_at=now,
-            due_date=None,
-            estimated_hours=median,
-            labels=labels,
-            project_id=project_id,
-            project_name=project_name,
-            provides=gap_dict.get("provides"),
-            requires=gap_dict.get("requires"),
-            responsibility=responsibility,
-            source_type="gap_fill_contract",
-            source_context=source_context if source_context else None,
-        )
-
-    def _build_gap_fill_task(
-        self,
-        *,
-        idx: int,
-        gap_dict: Dict[str, Any],
-        sibling_tasks: List[Task],
-    ) -> Task:
-        """Convert a gap-fill output dict into a fully-formed Task.
-
-        Inherits defaults from sibling tasks so synthesized tasks fit
-        naturally into the existing graph:
-
-        - ``estimated_hours``: median of sibling estimates (4.0 fallback)
-        - ``priority``: ``Priority.MEDIUM``
-        - ``project_id`` / ``project_name``: copied from any sibling
-        - ``status``: ``TaskStatus.TODO``
-        - ``provides`` / ``requires``: from the gap-fill dict — let
-          downstream wiring integrate naturally via the existing
-          contract mechanism
-        - ``labels``: ``["gap_fill", "intent_fidelity"]`` so audits
-          can identify synthesized tasks distinctly
-        """
-
-        now = datetime.now(timezone.utc)
-
-        sibling_hours = sorted(
-            t.estimated_hours for t in sibling_tasks if t.estimated_hours > 0
-        )
-        median = sibling_hours[len(sibling_hours) // 2] if sibling_hours else 4.0
-
-        project_id = next((t.project_id for t in sibling_tasks if t.project_id), None)
-        project_name = next(
-            (t.project_name for t in sibling_tasks if t.project_name), None
-        )
-
-        return Task(
-            id=f"gap_fill_{uuid4().hex[:12]}",
-            name=gap_dict["name"],
-            description=gap_dict["description"],
-            status=TaskStatus.TODO,
-            priority=Priority.MEDIUM,
-            assigned_to=None,
-            created_at=now,
-            updated_at=now,
-            due_date=None,
-            estimated_hours=median,
-            labels=["gap_fill", "intent_fidelity"],
-            project_id=project_id,
-            project_name=project_name,
-            provides=gap_dict.get("provides"),
-            requires=gap_dict.get("requires"),
-        )
 
     async def _analyze_prd_deeply(
         self, prd_content: str, constraints: ProjectConstraints

--- a/src/ai/advanced/prd/advanced_parser.py
+++ b/src/ai/advanced/prd/advanced_parser.py
@@ -34,6 +34,9 @@ from src.marcus_mcp.coordinator.outcome_coverage import (
 from src.marcus_mcp.coordinator.outcome_coverage_augmenter import (
     OutcomeCoverageAugmenter,
 )
+from src.marcus_mcp.coordinator.spec_coverage_augmenter import (
+    SpecCoverageAugmenter,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -284,17 +287,17 @@ class AdvancedPRDParser:
         )
         logger.info(f"Created {len(tasks)} detailed tasks")
 
-        # Step 3.5: Run the augmenter chain (issue #456 Stage 3) BEFORE
+        # Step 3.5: Run the augmenter chain (issue #456) BEFORE
         # dependency inference so synthesized gap-fill tasks are
         # treated as first-class members of the graph by
-        # ``_infer_smart_dependencies``.  The chain currently registers
-        # only ``OutcomeCoverageAugmenter`` (issue #449); Stage 4 will
-        # join ``SpecCoverageAugmenter``.  ``contract_artifacts=None``
-        # selects the feature-based outcome-coverage path inside the
-        # augmenter.  Behind MARCUS_OUTCOME_COVERAGE; the augmenter
-        # no-ops when off or when no outcomes were extracted.
+        # ``_infer_smart_dependencies``.  Chain order is load-bearing:
+        # ``SpecCoverageAugmenter`` runs after ``OutcomeCoverageAugmenter``
+        # so it sees any outcome gap-fill tasks when scoring spec
+        # feature coverage.  ``contract_artifacts=None`` selects the
+        # feature-based outcome-coverage path; spec_coverage ignores
+        # the parameter (operates on spec text, not contracts).
         augmenter_result = await run_augmenter_chain(
-            [OutcomeCoverageAugmenter(parser=self)],
+            [OutcomeCoverageAugmenter(parser=self), SpecCoverageAugmenter()],
             prd_analysis=prd_analysis,
             tasks=tasks,
             contract_artifacts=None,
@@ -759,22 +762,22 @@ class AdvancedPRDParser:
             f"contract-owned tasks from {len(usable_contracts)} domains"
         )
 
-        # Issue #456 Stage 3: route outcome coverage through the
-        # augmenter chain.  The chain currently registers only
-        # ``OutcomeCoverageAugmenter`` (issue #449); Stage 4 will
-        # join ``SpecCoverageAugmenter``.  The chain's
-        # ``AugmentationResult`` carries:
+        # Issue #456: route both coverage augmenters through the
+        # chain.  Chain order is load-bearing — spec_coverage sees
+        # outcome_coverage's gap-fill tasks when scoring spec feature
+        # coverage.  The chain's ``AugmentationResult`` carries:
         #
         # - ``augmented_tasks``: contract tasks plus any synthesized
-        #   gap-fill tasks
-        # - ``synthesized_ids``: IDs of tasks the augmenter chain added
+        #   outcome / spec gap-fill tasks
+        # - ``synthesized_ids``: IDs of every task the chain added
         # - ``telemetry``: namespaced by augmenter name, e.g.
-        #   ``{"outcome_coverage": {intent_fidelity_score: ...}}``
+        #   ``{"outcome_coverage": {intent_fidelity_score: ...},
+        #     "spec_coverage": {spec_gap_count: ...}}``
         #
-        # Behind MARCUS_OUTCOME_COVERAGE; the augmenter no-ops with
-        # empty telemetry when off / no outcomes / LLM error.
+        # Behind MARCUS_OUTCOME_COVERAGE; both augmenters no-op with
+        # empty telemetry on flag off / no outcomes / LLM error.
         return await run_augmenter_chain(
-            [OutcomeCoverageAugmenter(parser=self)],
+            [OutcomeCoverageAugmenter(parser=self), SpecCoverageAugmenter()],
             prd_analysis=prd_analysis,
             tasks=tasks,
             contract_artifacts=contract_artifacts,

--- a/src/ai/advanced/prd/advanced_parser.py
+++ b/src/ai/advanced/prd/advanced_parser.py
@@ -9,7 +9,7 @@ import json
 import logging
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Sequence, Tuple
 
 from src.ai.advanced.prd.outcome_extractor import (
     UserOutcome,
@@ -23,6 +23,7 @@ from src.integrations.ai_analysis_engine import AIAnalysisEngine
 from src.intelligence.dependency_inferer_hybrid import HybridDependencyInferer
 from src.marcus_mcp.coordinator.graph_augmentation import (
     AugmentationResult,
+    GraphAugmenter,
     run_augmenter_chain,
 )
 from src.marcus_mcp.coordinator.outcome_coverage_augmenter import (
@@ -219,6 +220,30 @@ class AdvancedPRDParser:
         # Fallback to default
         return default_minutes
 
+    def _build_augmenter_chain(self) -> Sequence[GraphAugmenter]:
+        """Build the canonical pre-inference augmenter chain.
+
+        Single source of truth for the chain order, used by both
+        :meth:`parse_prd_to_tasks` (feature-based) and
+        :meth:`decompose_by_contract` (contract-first).  Order is
+        load-bearing: ``SpecCoverageAugmenter`` runs after
+        ``OutcomeCoverageAugmenter`` so it sees any outcome gap-fill
+        tasks when scoring spec feature coverage (locked by
+        ``test_second_augmenter_sees_first_augmenter_tasks``).
+
+        Returns
+        -------
+        Sequence[GraphAugmenter]
+            ``[OutcomeCoverageAugmenter, SpecCoverageAugmenter]`` —
+            the production chain.  Future augmenters (NFR coverage,
+            security checks) can join here behind the same single
+            registration site.
+        """
+        return [
+            OutcomeCoverageAugmenter(llm_client=self.llm_client),
+            SpecCoverageAugmenter(),
+        ]
+
     async def parse_prd_to_tasks(
         self, prd_content: str, constraints: ProjectConstraints
     ) -> TaskGenerationResult:
@@ -269,10 +294,7 @@ class AdvancedPRDParser:
         # feature-based outcome-coverage path; spec_coverage ignores
         # the parameter (operates on spec text, not contracts).
         augmenter_result = await run_augmenter_chain(
-            [
-                OutcomeCoverageAugmenter(llm_client=self.llm_client),
-                SpecCoverageAugmenter(),
-            ],
+            self._build_augmenter_chain(),
             prd_analysis=prd_analysis,
             tasks=tasks,
             contract_artifacts=None,
@@ -753,10 +775,7 @@ class AdvancedPRDParser:
         # Behind MARCUS_OUTCOME_COVERAGE; both augmenters no-op with
         # empty telemetry on flag off / no outcomes / LLM error.
         return await run_augmenter_chain(
-            [
-                OutcomeCoverageAugmenter(llm_client=self.llm_client),
-                SpecCoverageAugmenter(),
-            ],
+            self._build_augmenter_chain(),
             prd_analysis=prd_analysis,
             tasks=tasks,
             contract_artifacts=contract_artifacts,

--- a/src/ai/advanced/prd/advanced_parser.py
+++ b/src/ai/advanced/prd/advanced_parser.py
@@ -23,9 +23,16 @@ from src.config.outcome_coverage_config import is_outcome_coverage_enabled
 from src.core.models import Priority, Task, TaskStatus
 from src.integrations.ai_analysis_engine import AIAnalysisEngine
 from src.intelligence.dependency_inferer_hybrid import HybridDependencyInferer
+from src.marcus_mcp.coordinator.graph_augmentation import (
+    AugmentationResult,
+    run_augmenter_chain,
+)
 from src.marcus_mcp.coordinator.outcome_coverage import (
     OutcomeCoverageResult,
     apply_outcome_coverage,
+)
+from src.marcus_mcp.coordinator.outcome_coverage_augmenter import (
+    OutcomeCoverageAugmenter,
 )
 
 logger = logging.getLogger(__name__)
@@ -277,17 +284,29 @@ class AdvancedPRDParser:
         )
         logger.info(f"Created {len(tasks)} detailed tasks")
 
-        # Step 3.5: Outcome coverage check (issue #449).  Runs BEFORE
+        # Step 3.5: Run the augmenter chain (issue #456 Stage 3) BEFORE
         # dependency inference so synthesized gap-fill tasks are
         # treated as first-class members of the graph by
-        # ``_infer_smart_dependencies``.  Behind
-        # MARCUS_OUTCOME_COVERAGE; no-ops when off or when no
-        # outcomes were extracted.
-        coverage_result = await self._apply_outcome_coverage_to_graph(
-            prd_analysis=prd_analysis, tasks=tasks
+        # ``_infer_smart_dependencies``.  The chain currently registers
+        # only ``OutcomeCoverageAugmenter`` (issue #449); Stage 4 will
+        # join ``SpecCoverageAugmenter``.  ``contract_artifacts=None``
+        # selects the feature-based outcome-coverage path inside the
+        # augmenter.  Behind MARCUS_OUTCOME_COVERAGE; the augmenter
+        # no-ops when off or when no outcomes were extracted.
+        augmenter_result = await run_augmenter_chain(
+            [OutcomeCoverageAugmenter(parser=self)],
+            prd_analysis=prd_analysis,
+            tasks=tasks,
+            contract_artifacts=None,
         )
-        if coverage_result is not None:
-            tasks = coverage_result.augmented_tasks
+        tasks = augmenter_result.augmented_tasks
+        # Telemetry is namespaced by augmenter name; pull the
+        # outcome_coverage slice for the legacy
+        # ``TaskGenerationResult`` fields below.  Empty dict when
+        # the augmenter no-opped (flag off / no outcomes / LLM error).
+        oc_telemetry: Dict[str, Any] = augmenter_result.telemetry.get(
+            "outcome_coverage", {}
+        )
 
         # Step 4: AI-powered dependency inference
         dependencies = await self._infer_smart_dependencies(tasks, prd_analysis)
@@ -316,30 +335,15 @@ class AdvancedPRDParser:
             estimated_timeline=timeline_prediction,
             resource_requirements=resource_requirements,
             success_criteria=success_criteria,
-            # ``coverage_result.coverage`` is Optional — when the
-            # helper returned a result but coverage didn't actually
-            # run, we still get a wrapper but the inner field is None.
-            # Two-step unwrap keeps mypy happy and reads explicitly.
-            intent_fidelity_score=(
-                coverage_result.coverage.intent_fidelity_score
-                if coverage_result and coverage_result.coverage
-                else None
-            ),
-            coverage_before_fill=(
-                coverage_result.coverage.coverage_before_fill
-                if coverage_result and coverage_result.coverage
-                else {}
-            ),
-            coverage_after_fill=(
-                coverage_result.coverage.coverage_after_fill
-                if coverage_result and coverage_result.coverage
-                else None
-            ),
-            gap_filled_outcomes=(
-                [g.id for g in coverage_result.coverage.gaps]
-                if coverage_result and coverage_result.coverage
-                else []
-            ),
+            # Telemetry pulled from the chain's outcome_coverage
+            # namespace (or empty dict if the augmenter no-opped).
+            # The wrapper has already extracted .id from each gap,
+            # flattened to the canonical event-payload shape, and
+            # pinned the four keys against PLANNING_INTENT_FIDELITY.
+            intent_fidelity_score=oc_telemetry.get("intent_fidelity_score"),
+            coverage_before_fill=oc_telemetry.get("coverage_before_fill", {}),
+            coverage_after_fill=oc_telemetry.get("coverage_after_fill"),
+            gap_filled_outcomes=oc_telemetry.get("gap_filled_outcomes", []),
             generation_confidence=self._calculate_generation_confidence(
                 prd_analysis, tasks
             ),
@@ -350,7 +354,7 @@ class AdvancedPRDParser:
         prd_analysis: PRDAnalysis,
         contract_artifacts: Dict[str, Optional[Dict[str, Any]]],
         constraints: Optional[ProjectConstraints] = None,
-    ) -> ParserOutcomeCoverage:
+    ) -> AugmentationResult:
         """
         Contract-first task decomposition (GH-320 PR 2).
 
@@ -755,23 +759,26 @@ class AdvancedPRDParser:
             f"contract-owned tasks from {len(usable_contracts)} domains"
         )
 
-        # Issue #449: outcome coverage check.  Behind
-        # MARCUS_OUTCOME_COVERAGE; no-ops when off / no outcomes / LLM
-        # failure.  Coverage result is bundled into the returned
-        # ParserOutcomeCoverage so callers can read score + telemetry
-        # via ``result.coverage`` (Phase 4 tech-debt fix replaced the
-        # ``List[Task]`` return + side-channel attribute with this
-        # typed wrapper).  When coverage didn't run, ``coverage`` is
-        # ``None`` but ``augmented_tasks`` still carries the original
-        # tasks unchanged.
-        coverage_result = await self._apply_outcome_coverage_to_contract_graph(
+        # Issue #456 Stage 3: route outcome coverage through the
+        # augmenter chain.  The chain currently registers only
+        # ``OutcomeCoverageAugmenter`` (issue #449); Stage 4 will
+        # join ``SpecCoverageAugmenter``.  The chain's
+        # ``AugmentationResult`` carries:
+        #
+        # - ``augmented_tasks``: contract tasks plus any synthesized
+        #   gap-fill tasks
+        # - ``synthesized_ids``: IDs of tasks the augmenter chain added
+        # - ``telemetry``: namespaced by augmenter name, e.g.
+        #   ``{"outcome_coverage": {intent_fidelity_score: ...}}``
+        #
+        # Behind MARCUS_OUTCOME_COVERAGE; the augmenter no-ops with
+        # empty telemetry when off / no outcomes / LLM error.
+        return await run_augmenter_chain(
+            [OutcomeCoverageAugmenter(parser=self)],
             prd_analysis=prd_analysis,
             tasks=tasks,
             contract_artifacts=contract_artifacts,
         )
-        if coverage_result is not None:
-            return coverage_result
-        return ParserOutcomeCoverage(augmented_tasks=tasks, coverage=None)
 
     def _build_contract_decomposition_prompt(
         self,

--- a/src/ai/advanced/prd/advanced_parser.py
+++ b/src/ai/advanced/prd/advanced_parser.py
@@ -354,6 +354,7 @@ class AdvancedPRDParser:
         prd_analysis: PRDAnalysis,
         contract_artifacts: Dict[str, Optional[Dict[str, Any]]],
         constraints: Optional[ProjectConstraints] = None,
+        pre_existing_tasks: Optional[List[Task]] = None,
     ) -> AugmentationResult:
         """
         Contract-first task decomposition (GH-320 PR 2).
@@ -765,19 +766,32 @@ class AdvancedPRDParser:
         # outcome_coverage's gap-fill tasks when scoring spec feature
         # coverage.  The chain's ``AugmentationResult`` carries:
         #
-        # - ``augmented_tasks``: contract tasks plus any synthesized
-        #   outcome / spec gap-fill tasks
+        # - ``augmented_tasks``: pre_existing + contract tasks plus
+        #   any synthesized outcome / spec gap-fill tasks
         # - ``synthesized_ids``: IDs of every task the chain added
         # - ``telemetry``: namespaced by augmenter name, e.g.
         #   ``{"outcome_coverage": {intent_fidelity_score: ...},
         #     "spec_coverage": {spec_gap_count: ...}}``
         #
+        # Codex P2 on PR #473: ``pre_existing_tasks`` carries
+        # foundation tasks synthesized pre-fork by
+        # ``_synthesize_shared_foundation``.  Including them in the
+        # chain input makes them visible to spec_coverage's keyword
+        # scan, preventing duplicate spec_gap synthesis when a
+        # foundation task already implements a spec feature (e.g.
+        # "Set up Auth foundation" covers spec keyword "auth").
+        # Pre-Stage-4 the post-safety-check call site saw the
+        # combined graph; threading foundation here restores that
+        # visibility while keeping the augmenters inside the
+        # decomposer.
+        #
         # Behind MARCUS_OUTCOME_COVERAGE; both augmenters no-op with
         # empty telemetry on flag off / no outcomes / LLM error.
+        chain_input_tasks = list(pre_existing_tasks or []) + tasks
         return await run_augmenter_chain(
             self._build_augmenter_chain(),
             prd_analysis=prd_analysis,
-            tasks=tasks,
+            tasks=chain_input_tasks,
             contract_artifacts=contract_artifacts,
         )
 

--- a/src/integrations/nlp_tools.py
+++ b/src/integrations/nlp_tools.py
@@ -615,33 +615,29 @@ class NaturalLanguageProjectCreator(NaturalLanguageTaskCreator):
                 contract_artifacts=contract_artifacts,
                 constraints=constraints,
             )
-            # Phase 4 tech-debt fix: decompose_by_contract now returns
-            # ParserOutcomeCoverage instead of List[Task].  The
-            # augmented task list is on the result's .augmented_tasks;
-            # .coverage carries intent_fidelity_score telemetry when
-            # the outcome-coverage pipeline ran.
-            # ``augmented_tasks`` is the right list to pass downstream
-            # — it includes any synthesized gap-fill tasks.
+            # Issue #456 Stage 3: decompose_by_contract returns
+            # AugmentationResult.  ``augmented_tasks`` carries the
+            # contract tasks plus any synthesized gap-fill tasks;
+            # ``telemetry`` is namespaced by augmenter name so each
+            # augmenter's payload sits in its own dict.
             tasks = decompose_result.augmented_tasks
 
             # Phase 5: emit intent-fidelity event for Cato telemetry.
-            # ``coverage`` is None when MARCUS_OUTCOME_COVERAGE was off
-            # or no outcomes were extracted; the helper no-ops in that
-            # case.  Score is the canonical handle for downstream
-            # observability — same payload shape as the feature-based
-            # path emits below.
-            if decompose_result.coverage is not None:
+            # The outcome_coverage augmenter contributes its slice
+            # under the ``outcome_coverage`` key.  When the augmenter
+            # no-opped (flag off / no outcomes / LLM error), the slice
+            # is absent — skip emission for the same reason as before.
+            oc_telemetry: Dict[str, Any] = decompose_result.telemetry.get(
+                "outcome_coverage", {}
+            )
+            if oc_telemetry:
                 await self._emit_intent_fidelity_event(
                     project_name=project_name,
                     decomposer="contract_first",
-                    intent_fidelity_score=(
-                        decompose_result.coverage.intent_fidelity_score
-                    ),
-                    coverage_before_fill=(
-                        decompose_result.coverage.coverage_before_fill
-                    ),
-                    coverage_after_fill=(decompose_result.coverage.coverage_after_fill),
-                    gap_filled_outcomes=[g.id for g in decompose_result.coverage.gaps],
+                    intent_fidelity_score=oc_telemetry["intent_fidelity_score"],
+                    coverage_before_fill=oc_telemetry.get("coverage_before_fill", {}),
+                    coverage_after_fill=oc_telemetry.get("coverage_after_fill"),
+                    gap_filled_outcomes=oc_telemetry.get("gap_filled_outcomes", []),
                 )
         except Exception as e:
             # Catch broadly so the fallback path is bulletproof. The

--- a/src/integrations/nlp_tools.py
+++ b/src/integrations/nlp_tools.py
@@ -867,7 +867,7 @@ class NaturalLanguageProjectCreator(NaturalLanguageTaskCreator):
         # Codex P2 (PR #472): ``tasks`` is
         # ``decompose_result.augmented_tasks`` which can include
         # outcome-coverage gap-fill tasks (source_type="gap_fill_contract"
-        # from advanced_parser._apply_outcome_coverage_to_contract_graph).
+        # synthesized by the contract-first outcome-coverage augmenter).
         # The composition trigger is "multi-domain wiring needed" —
         # gap-fill tasks address outcome coverage gaps, not domain
         # multiplicity, so they must NOT count toward the trigger.

--- a/src/integrations/nlp_tools.py
+++ b/src/integrations/nlp_tools.py
@@ -615,12 +615,19 @@ class NaturalLanguageProjectCreator(NaturalLanguageTaskCreator):
                 prd_analysis=prd_analysis,
                 contract_artifacts=contract_artifacts,
                 constraints=constraints,
+                # Codex P2 on PR #473: thread foundation tasks into the
+                # decomposer so the augmenter chain sees them during
+                # coverage scanning.  Without this, spec_coverage would
+                # only see contract tasks and could synthesize duplicate
+                # spec_gap tasks for features that foundation tasks
+                # already implement.
+                pre_existing_tasks=foundation_tasks,
             )
             # Issue #456 Stage 3: decompose_by_contract returns
-            # AugmentationResult.  ``augmented_tasks`` carries the
-            # contract tasks plus any synthesized gap-fill tasks;
-            # ``telemetry`` is namespaced by augmenter name so each
-            # augmenter's payload sits in its own dict.
+            # AugmentationResult.  ``augmented_tasks`` carries
+            # foundation + contract tasks plus any synthesized
+            # gap-fill tasks; ``telemetry`` is namespaced by augmenter
+            # name so each augmenter's payload sits in its own dict.
             tasks = decompose_result.augmented_tasks
 
             # Phase 5: emit intent-fidelity event for Cato telemetry.
@@ -825,10 +832,16 @@ class NaturalLanguageProjectCreator(NaturalLanguageTaskCreator):
         # Foundation tasks are TODO and must complete before domain agents
         # begin.  Ghost tasks (DONE) are excluded — they represent design
         # work that already happened and need not wait for foundation.
+        # Codex P2 on PR #473: ``tasks`` now includes foundation tasks
+        # themselves (threaded through decompose_by_contract via
+        # ``pre_existing_tasks``).  Skip foundation tasks in the loop so
+        # we don't add a foundation task as its own dependency.
         if foundation_tasks:
-            foundation_ids = [t.id for t in foundation_tasks]
+            foundation_id_set = {t.id for t in foundation_tasks}
             for task in tasks:
-                for fid in foundation_ids:
+                if task.id in foundation_id_set:
+                    continue
+                for fid in foundation_id_set:
                     if fid not in task.dependencies:
                         task.dependencies.append(fid)
 
@@ -886,10 +899,13 @@ class NaturalLanguageProjectCreator(NaturalLanguageTaskCreator):
         )
 
         # Design ghosts come first so the integration task's dependency
-        # walk picks them up alongside impl tasks.  Foundation tasks
-        # follow ghosts; impl tasks come next; composition (when
-        # synthesized) comes last because it depends on every impl task.
-        result_tasks: List[Task] = ghost_tasks + foundation_tasks + tasks
+        # walk picks them up alongside impl tasks.  ``tasks`` already
+        # contains foundation + contract + augmenter-synthesized tasks
+        # because foundation_tasks were threaded into
+        # decompose_by_contract via ``pre_existing_tasks`` (Codex P2 on
+        # PR #473).  Composition (when synthesized) comes last because
+        # it depends on every impl task.
+        result_tasks: List[Task] = ghost_tasks + tasks
         if composition_task is not None:
             result_tasks.append(composition_task)
             logger.info(

--- a/src/integrations/nlp_tools.py
+++ b/src/integrations/nlp_tools.py
@@ -1317,36 +1317,20 @@ class NaturalLanguageProjectCreator(NaturalLanguageTaskCreator):
                 safe_tasks = await self.apply_safety_checks(tasks)
                 logger.info(f"Safety checks passed, {len(safe_tasks)} tasks ready")
 
-                # Spec coverage check (dashboard-v88 post-mortem): verify all
-                # features mentioned in the spec have at least one task.
-                # Synthesizes gap tasks for anything silently dropped by the
-                # decomposer. Non-fatal: failures produce empty gap list so
-                # the pipeline never stalls.
+                # Spec coverage moved to the augmenter chain inside the
+                # decomposer (issue #456 Stage 4).  Gap tasks
+                # synthesized by spec_coverage now flow through
+                # ``_infer_smart_dependencies`` and foundation wiring
+                # like first-class graph members instead of being
+                # appended here as orphans (``dependencies=[]``).  This
+                # is the v37 orphan-failure-mode fix.
                 #
-                # Order matters: spec_coverage MUST run BEFORE
-                # enhance_project_with_integration / enhance_project_with_documentation
-                # below, because those compute their dependencies as
-                # "all existing tasks" at the moment they're called. If
-                # spec_coverage ran after, gap tasks would slip in
-                # without being dependencies of the integration /
-                # documentation tasks — the integration task would
-                # complete (or worse, run concurrently with) gap tasks
-                # that hadn't started yet, defeating the
-                # "verify everything together at the end" contract.
-                from src.integrations.spec_coverage import check_spec_coverage
-
-                gap_tasks = await check_spec_coverage(
-                    description=description,
-                    tasks=safe_tasks,
-                    project_name=project_name,
-                )
-                if gap_tasks:
-                    logger.warning(
-                        f"[spec_coverage] Adding {len(gap_tasks)} gap task(s) "
-                        f"for uncovered spec features: "
-                        f"{[t.name for t in gap_tasks]}"
-                    )
-                    safe_tasks = safe_tasks + gap_tasks
+                # Order property preserved: the augmenter chain runs
+                # before the decomposer returns, so by the time
+                # enhance_project_with_integration / documentation see
+                # "all existing tasks", the spec_gap tasks are in the
+                # pool and become dependencies of the integration /
+                # documentation tasks naturally.
 
                 # Add integration verification task if appropriate
                 # Must be added BEFORE documentation so doc task

--- a/src/integrations/nlp_tools.py
+++ b/src/integrations/nlp_tools.py
@@ -358,12 +358,13 @@ class NaturalLanguageProjectCreator(NaturalLanguageTaskCreator):
         no event system attached.
 
         Type asymmetry note: feature-based path reads these fields
-        from ``TaskGenerationResult`` (top-level fields) while
+        from ``TaskGenerationResult`` (top-level fields), while
         contract-first reads them from
-        ``decompose_result.coverage`` (a nested
-        :class:`OutcomeCoverageResult`).  The two paths flatten into
-        the same event payload here, so downstream consumers see one
-        uniform shape regardless of which decomposer ran.
+        ``decompose_result.telemetry["outcome_coverage"]`` — the
+        chain's namespaced telemetry slice (issue #456 Stage 3).
+        The two paths flatten into the same event payload here, so
+        downstream consumers see one uniform shape regardless of
+        which decomposer ran.
 
         Parameters
         ----------

--- a/src/integrations/spec_coverage.py
+++ b/src/integrations/spec_coverage.py
@@ -167,23 +167,22 @@ def find_uncovered_features(
 async def check_spec_coverage(
     description: str,
     tasks: List[Task],
-    project_name: str,
 ) -> List[Task]:
     """
     Verify all spec features have tasks; return gap tasks for any missing.
 
-    This is the main entry point. Called after task decomposition and
-    safety checks, before tasks are committed to the kanban board.
-    Non-fatal: any internal error returns [] so the pipeline never stalls.
+    Called by :class:`SpecCoverageAugmenter` inside the decomposer
+    chain (issue #456 Stage 4).  Synthesized gap tasks then flow
+    through ``_infer_smart_dependencies`` and foundation wiring as
+    first-class graph members.  Non-fatal: any internal error returns
+    [] so the pipeline never stalls.
 
     Parameters
     ----------
     description : str
         Original project description / specification.
     tasks : List[Task]
-        Current task list after decomposition and safety checks.
-    project_name : str
-        Project name (for gap task naming).
+        Current task list after decomposition.
 
     Returns
     -------

--- a/src/marcus_mcp/coordinator/graph_augmentation.py
+++ b/src/marcus_mcp/coordinator/graph_augmentation.py
@@ -179,9 +179,9 @@ class GraphAugmenter(Protocol):
         Implementations should catch their own exceptions and return
         a no-op result (``augmented_tasks=tasks, synthesized_ids=[]``)
         on failure — graceful degradation is each augmenter's primary
-        responsibility, matching the existing
-        ``_apply_outcome_coverage_to_graph`` pattern which catches
-        broadly and downgrades to a logged warning.
+        responsibility, matching the
+        :func:`apply_outcome_coverage_to_feature_graph` pattern which
+        catches broadly and downgrades to a logged warning.
 
         The chain orchestrator (:func:`run_augmenter_chain`) provides
         defense-in-depth: it wraps every ``augment`` call in

--- a/src/marcus_mcp/coordinator/graph_augmentation.py
+++ b/src/marcus_mcp/coordinator/graph_augmentation.py
@@ -241,6 +241,23 @@ async def run_augmenter_chain(
         produced non-empty telemetry; failed or empty-telemetry
         augmenters contribute no key.
     """
+    # Validate name uniqueness before running any augmenter.  Telemetry
+    # is namespaced by ``augmenter.name``; duplicate names would
+    # silently overwrite each other's slice in the result dict.  Fail
+    # fast at chain entry so the diagnostic is "wiring bug, fix the
+    # registration" rather than "augmenter A's data is gone, why?"
+    # (Kaia review #4, Simon ``f36c49c4``).
+    seen_names: Dict[str, int] = {}
+    for augmenter in augmenters:
+        seen_names[augmenter.name] = seen_names.get(augmenter.name, 0) + 1
+    duplicates = [name for name, count in seen_names.items() if count > 1]
+    if duplicates:
+        raise ValueError(
+            f"Augmenter chain has duplicate name(s): {sorted(duplicates)}. "
+            f"Each augmenter must have a unique ``name`` so its "
+            f"telemetry slice is addressable in the result."
+        )
+
     current_tasks: List[Task] = list(tasks)
     accumulated_synthesized_ids: List[str] = []
     namespaced_telemetry: Dict[str, Any] = {}

--- a/src/marcus_mcp/coordinator/graph_augmentation.py
+++ b/src/marcus_mcp/coordinator/graph_augmentation.py
@@ -52,8 +52,18 @@ interface.
 
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Protocol, runtime_checkable
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Dict,
+    List,
+    Optional,
+    Protocol,
+    Sequence,
+    runtime_checkable,
+)
 
 from src.core.models import Task
 
@@ -64,7 +74,9 @@ if TYPE_CHECKING:
     # load time here would close the cycle.
     from src.ai.advanced.prd.advanced_parser import PRDAnalysis
 
-__all__ = ["AugmentationResult", "GraphAugmenter"]
+logger = logging.getLogger(__name__)
+
+__all__ = ["AugmentationResult", "GraphAugmenter", "run_augmenter_chain"]
 
 
 @dataclass
@@ -164,11 +176,105 @@ class GraphAugmenter(Protocol):
 
         Notes
         -----
-        Implementations must catch their own exceptions and return a
-        no-op result (``augmented_tasks=tasks, synthesized_ids=[]``)
-        on failure.  The orchestrator does not catch — graceful
-        degradation is each augmenter's responsibility.  This matches
-        the existing ``_apply_outcome_coverage_to_graph`` pattern
-        which catches broadly and downgrades to a logged warning.
+        Implementations should catch their own exceptions and return
+        a no-op result (``augmented_tasks=tasks, synthesized_ids=[]``)
+        on failure — graceful degradation is each augmenter's primary
+        responsibility, matching the existing
+        ``_apply_outcome_coverage_to_graph`` pattern which catches
+        broadly and downgrades to a logged warning.
+
+        The chain orchestrator (:func:`run_augmenter_chain`) provides
+        defense-in-depth: it wraps every ``augment`` call in
+        ``try/except`` so an unexpected raise (programming error,
+        new code path that forgot to catch) cannot crash the
+        decomposer.  Augmenters must not rely on this — the
+        orchestrator catch is a safety net, not the primary contract.
         """
         ...
+
+
+async def run_augmenter_chain(
+    augmenters: Sequence[GraphAugmenter],
+    *,
+    prd_analysis: "PRDAnalysis",
+    tasks: List[Task],
+    contract_artifacts: Optional[Dict[str, Any]] = None,
+) -> AugmentationResult:
+    """Run augmenters sequentially over a task graph.
+
+    Each augmenter sees the post-previous-augmenter task list, so
+    synthesized tasks flow forward through the chain
+    (e.g., ``outcome_coverage``'s gap-fill task is visible to
+    ``spec_coverage``'s coverage check).  Telemetry is namespaced by
+    ``augmenter.name`` so future augmenters add their payload
+    alongside without key collisions.
+
+    Defense-in-depth (Kaia review #2, Simon ``c26c7ec5``): every
+    ``augment`` call is wrapped in ``try/except``.  Augmenters
+    catching their own exceptions remain the primary contract; the
+    chain catch is the last line of defense for programming errors
+    or future augmenters that forgot to catch.  Failures log a
+    warning naming the augmenter and continue with prior tasks
+    (no-op for that step).
+
+    Parameters
+    ----------
+    augmenters : sequence of GraphAugmenter
+        The chain, executed in iteration order.  Empty sequence is
+        valid and produces a passthrough result.
+    prd_analysis : PRDAnalysis
+        Forwarded to every augmenter.  Some augmenters
+        (``outcome_coverage``) require it; others may ignore.
+    tasks : list of Task
+        Initial task graph.  Not mutated.
+    contract_artifacts : dict, optional
+        Forwarded to every augmenter.  ``None`` for the feature-based
+        decomposer path; non-None for contract-first.
+
+    Returns
+    -------
+    AugmentationResult
+        ``augmented_tasks`` is the post-chain task list (input plus
+        any synthesized).  ``synthesized_ids`` is the union of IDs
+        each augmenter reported.  ``telemetry`` is ``{augmenter.name:
+        augmenter_telemetry}`` for every augmenter that ran and
+        produced non-empty telemetry; failed or empty-telemetry
+        augmenters contribute no key.
+    """
+    current_tasks: List[Task] = list(tasks)
+    accumulated_synthesized_ids: List[str] = []
+    namespaced_telemetry: Dict[str, Any] = {}
+
+    for augmenter in augmenters:
+        try:
+            result = await augmenter.augment(
+                prd_analysis=prd_analysis,
+                tasks=current_tasks,
+                contract_artifacts=contract_artifacts,
+            )
+        except Exception as exc:
+            # Defense-in-depth: a buggy or future augmenter that
+            # forgot to catch must not crash the decomposer.  Skip
+            # this augmenter, keep prior tasks, continue chain.  Log
+            # with augmenter name so the failure is diagnosable.
+            logger.warning(
+                "Augmenter %r raised %s; skipping: %s",
+                augmenter.name,
+                type(exc).__name__,
+                exc,
+            )
+            continue
+
+        current_tasks = result.augmented_tasks
+        accumulated_synthesized_ids.extend(result.synthesized_ids)
+        # Omit empty-telemetry augmenters from the namespace so
+        # consumers can distinguish "augmenter ran, no data" from
+        # "augmenter didn't run."
+        if result.telemetry:
+            namespaced_telemetry[augmenter.name] = result.telemetry
+
+    return AugmentationResult(
+        augmented_tasks=current_tasks,
+        synthesized_ids=accumulated_synthesized_ids,
+        telemetry=namespaced_telemetry,
+    )

--- a/src/marcus_mcp/coordinator/graph_augmentation.py
+++ b/src/marcus_mcp/coordinator/graph_augmentation.py
@@ -1,0 +1,174 @@
+"""
+Graph augmentation Protocol for pre-inference task synthesis (issue #456).
+
+Marcus's task decomposers (``parse_prd_to_tasks`` and
+``decompose_by_contract``) produce an initial task graph.  Before
+``_infer_smart_dependencies`` runs and foundation wiring fires, that
+graph can pass through one or more **augmenters** that synthesize
+additional tasks to fill gaps:
+
+* ``OutcomeCoverageAugmenter`` (Stage 2) — catches missing
+  user-visible outcomes (the v32 narrative; #449)
+* ``SpecCoverageAugmenter`` (Stage 4) — catches spec features
+  with no covering task (the v37 ``Implement Speed Progression``
+  orphan failure mode)
+
+Future augmenters (NFR coverage, security checks, etc.) can join
+the chain by satisfying the :class:`GraphAugmenter` Protocol.
+
+Why this Protocol exists
+------------------------
+Pre-#456, ``outcome_coverage`` and ``spec_coverage`` were parallel
+pipelines with divergent integration:
+
+* ``outcome_coverage`` ran *inside* the decomposer between
+  ``_create_detailed_tasks`` and ``_infer_smart_dependencies`` —
+  synthesized tasks correctly participated in dependency inference
+  and foundation wiring.
+* ``spec_coverage`` ran *after* the decomposer + safety checks
+  (``nlp_tools.py:1341``) — synthesized tasks were orphans
+  (``dependencies=[]``) bypassing both inference and foundation
+  wiring.
+
+The unified Protocol moves both pipelines to the same correct
+location, removes the parallel-implementation smell, and gives
+future augmenters a single plug-in point.
+
+Bright-line check
+-----------------
+Augmenters synthesize tasks Marcus thinks should exist (coordination
+contract).  Each task says WHAT to build; the agent picks HOW.
+Same authority Marcus already exercises via ``_synthesize_shared_foundation``.
+Coordination, not control.
+
+Stage 1 scope
+-------------
+This module defines only the abstract surface (``GraphAugmenter``
+Protocol + :class:`AugmentationResult` dataclass).  No augmenter
+implementation, no decomposer call-site change.  Stages 2-4 progressively
+migrate ``outcome_coverage`` and ``spec_coverage`` to use this
+interface.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Protocol, runtime_checkable
+
+from src.core.models import Task
+
+if TYPE_CHECKING:
+    # Imported only for type-checking to avoid the runtime circular
+    # import: ``advanced_parser`` already imports from
+    # ``marcus_mcp.coordinator``; importing PRDAnalysis at module
+    # load time here would close the cycle.
+    from src.ai.advanced.prd.advanced_parser import PRDAnalysis
+
+__all__ = ["AugmentationResult", "GraphAugmenter"]
+
+
+@dataclass
+class AugmentationResult:
+    """Result of running a :class:`GraphAugmenter` against a task graph.
+
+    Attributes
+    ----------
+    augmented_tasks : list of Task
+        Original tasks plus any synthesized.  This is the list the
+        decomposer continues with — passed to
+        ``_infer_smart_dependencies`` and downstream wiring.
+    synthesized_ids : list of str
+        IDs of newly-synthesized tasks (subset of
+        ``augmented_tasks``).  Useful for logging, telemetry, and
+        downstream filtering (e.g., "don't run augmenter X on
+        tasks augmenter Y just synthesized").
+    telemetry : dict
+        Augmenter-specific metrics for event emission.
+        Generic ``Dict[str, Any]`` keeps the Protocol simple — typed
+        Union would force every augmenter to declare a typed payload
+        upfront, premature when augmenter shapes are still evolving.
+    """
+
+    augmented_tasks: List[Task]
+    synthesized_ids: List[str] = field(default_factory=list)
+    telemetry: Dict[str, Any] = field(default_factory=dict)
+
+
+@runtime_checkable
+class GraphAugmenter(Protocol):
+    """Pre-inference task graph augmenter.
+
+    Implementations run inside ``parse_prd_to_tasks`` /
+    ``decompose_by_contract`` between ``_create_detailed_tasks`` and
+    ``_infer_smart_dependencies``, so synthesized tasks are
+    first-class participants in dependency inference and foundation
+    wiring.
+
+    Implementation contract
+    -----------------------
+    * ``name``: short identifier used as the telemetry event key
+      and in log lines (e.g. ``"outcome_coverage"``,
+      ``"spec_coverage"``).
+    * ``augment``: async method that takes the current state
+      (PRDAnalysis + task list + optional contract artifacts) and
+      returns the augmented task list plus telemetry.  **Must be a
+      pure function w.r.t. its inputs** — no mutation of ``tasks``,
+      no side effects beyond LLM calls.
+
+    Bright-line note
+    ----------------
+    Augmenters synthesize tasks Marcus thinks should exist.  Each
+    task's description must say WHAT to build (a coordination
+    contract), never HOW (which library, file, pattern).  Two agents
+    handed the same synthesized task must produce legitimately
+    different implementations.
+
+    See Also
+    --------
+    AugmentationResult : the typed return shape augmenters produce.
+    """
+
+    name: str
+
+    async def augment(
+        self,
+        *,
+        prd_analysis: "PRDAnalysis",
+        tasks: List[Task],
+        contract_artifacts: Optional[Dict[str, Any]] = None,
+    ) -> AugmentationResult:
+        """Synthesize tasks for any gaps the augmenter detects.
+
+        Parameters
+        ----------
+        prd_analysis
+            Deep PRD analysis from ``_analyze_prd_deeply``, including
+            ``original_description``, ``user_outcomes``, and
+            ``functional_requirements``.  Augmenters may use any of
+            these for gap detection.
+        tasks
+            Current task graph after ``_create_detailed_tasks`` (or
+            after ``decompose_by_contract`` for contract-first path).
+            **Must not be mutated** — return a new list.
+        contract_artifacts
+            Contract-first artifact dict from
+            ``_generate_contracts_by_domain``, or ``None`` for the
+            feature-based path.  Augmenters that ground gap-fill in
+            existing contracts (currently outcome_coverage) read this;
+            others may ignore.
+
+        Returns
+        -------
+        AugmentationResult
+            Augmented task list + synthesized IDs + telemetry.
+
+        Notes
+        -----
+        Implementations must catch their own exceptions and return a
+        no-op result (``augmented_tasks=tasks, synthesized_ids=[]``)
+        on failure.  The orchestrator does not catch — graceful
+        degradation is each augmenter's responsibility.  This matches
+        the existing ``_apply_outcome_coverage_to_graph`` pattern
+        which catches broadly and downgrades to a logged warning.
+        """
+        ...

--- a/src/marcus_mcp/coordinator/outcome_coverage.py
+++ b/src/marcus_mcp/coordinator/outcome_coverage.py
@@ -23,14 +23,25 @@ Two coverage strategies are available:
 from __future__ import annotations
 
 import json
+import logging
 import re
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
-from typing import Any, Callable, Dict, Iterable, List, Optional, Set
+from typing import TYPE_CHECKING, Any, Callable, Dict, Iterable, List, Optional, Set
+from uuid import uuid4
 
 from src.ai.advanced.prd.outcome_extractor import UserOutcome
+from src.config.outcome_coverage_config import is_outcome_coverage_enabled
 from src.core.models import Priority, Task, TaskStatus
+from src.marcus_mcp.coordinator.graph_augmentation import AugmentationResult
 from src.utils.json_parser import parse_ai_json_response
+
+if TYPE_CHECKING:
+    # TYPE_CHECKING-only to avoid the runtime cycle:
+    # advanced_parser imports from this module.
+    from src.ai.advanced.prd.advanced_parser import PRDAnalysis
+
+logger = logging.getLogger(__name__)
 
 # Words too common to discriminate between outcome and task.  Stripped
 # from the keyword sets before overlap is computed.
@@ -962,4 +973,330 @@ async def apply_outcome_coverage(
         coverage_before_fill=coverage_before,
         coverage_after_fill=coverage_after,
         gaps=gaps,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Graph-level adapters (issue #456 Stage 5)
+#
+# These functions take/return Task graphs (not just outcome data) and
+# adapt the lower-level :func:`apply_outcome_coverage` into the
+# :class:`AugmentationResult` shape that the augmenter chain consumes.
+#
+# Pre-#456-Stage-5 these lived as private methods on
+# ``AdvancedPRDParser``.  Lifting them to public module functions
+# decouples ``OutcomeCoverageAugmenter`` from the parser's private API
+# (Kaia review #3, Simon ``4453bd2c``) — the augmenter now constructs
+# with ``llm_client`` only and dispatches to these by name.
+# ---------------------------------------------------------------------------
+
+
+def _build_feature_gap_fill_task(
+    *,
+    idx: int,
+    gap_dict: Dict[str, Any],
+    sibling_tasks: List[Task],
+) -> Task:
+    """Convert a feature-based gap-fill output dict into a Task.
+
+    Inherits defaults from sibling tasks so synthesized tasks fit
+    naturally into the existing graph:
+
+    - ``estimated_hours``: median of sibling estimates (4.0 fallback)
+    - ``priority``: ``Priority.MEDIUM``
+    - ``project_id`` / ``project_name``: copied from any sibling
+    - ``status``: ``TaskStatus.TODO``
+    - ``provides`` / ``requires``: from the gap-fill dict so downstream
+      wiring integrates synthesized tasks via the existing contract
+      mechanism
+    - ``labels``: ``["gap_fill", "intent_fidelity"]`` so audits can
+      identify synthesized tasks distinctly
+    """
+    now = datetime.now(timezone.utc)
+
+    sibling_hours = sorted(
+        t.estimated_hours for t in sibling_tasks if t.estimated_hours > 0
+    )
+    median = sibling_hours[len(sibling_hours) // 2] if sibling_hours else 4.0
+
+    project_id = next((t.project_id for t in sibling_tasks if t.project_id), None)
+    project_name = next((t.project_name for t in sibling_tasks if t.project_name), None)
+
+    return Task(
+        id=f"gap_fill_{uuid4().hex[:12]}",
+        name=gap_dict["name"],
+        description=gap_dict["description"],
+        status=TaskStatus.TODO,
+        priority=Priority.MEDIUM,
+        assigned_to=None,
+        created_at=now,
+        updated_at=now,
+        due_date=None,
+        estimated_hours=median,
+        labels=["gap_fill", "intent_fidelity"],
+        project_id=project_id,
+        project_name=project_name,
+        provides=gap_dict.get("provides"),
+        requires=gap_dict.get("requires"),
+    )
+
+
+def _build_contract_gap_fill_task(
+    *,
+    idx: int,
+    gap_dict: Dict[str, Any],
+    sibling_tasks: List[Task],
+) -> Task:
+    """Convert a contract-first gap-fill dict into a full Task.
+
+    Differs from :func:`_build_feature_gap_fill_task` by setting
+    ``Task.responsibility`` from the gap-fill output's
+    ``responsibility`` field — that's how contract-first tasks carry
+    the "build this side of the contract" framing in the agent prompt
+    at ``build_tiered_instructions`` time.
+
+    The ``"contract"`` label is added ONLY when ``responsibility`` is
+    present.  When the gap-fill helper falls back to feature-based
+    output (because contract artifacts were filtered to empty),
+    responsibility is None and the task is no different from a
+    feature-based gap-fill — labeling it ``"contract"`` would lie
+    about the synthesis context.
+
+    ``source_context["contract_file"]`` is parsed from the
+    canonical ``"implements <Iface> from <path>"`` responsibility
+    string when the regex matches a path-separator-bearing token, so
+    Layer 1.3 of :func:`build_tiered_instructions` can render the full
+    "Read() the contract file at..." prompt.
+    """
+    now = datetime.now(timezone.utc)
+
+    sibling_hours = sorted(
+        t.estimated_hours for t in sibling_tasks if t.estimated_hours > 0
+    )
+    median = sibling_hours[len(sibling_hours) // 2] if sibling_hours else 4.0
+
+    project_id = next((t.project_id for t in sibling_tasks if t.project_id), None)
+    project_name = next((t.project_name for t in sibling_tasks if t.project_name), None)
+
+    responsibility = gap_dict.get("responsibility")
+
+    labels = ["gap_fill", "intent_fidelity"]
+    if responsibility:
+        labels.append("contract")
+
+    # Best-effort parse of contract_file from the responsibility
+    # string; the gap-fill prompt requests
+    # ``"implements <Iface> from <relative_path>"``.  The path-separator
+    # guard rejects method names ("from RenderingAgent.draw") and
+    # dotted namespaces ("from src.module.thing") — a real relative
+    # path will always contain '/' or '\\'.
+    source_context: Dict[str, Any] = {}
+    if isinstance(responsibility, str):
+        match = re.search(r"\bfrom\s+(\S+\.\S+)\b", responsibility)
+        if match:
+            candidate = match.group(1)
+            if "/" in candidate or "\\" in candidate:
+                source_context["contract_file"] = candidate
+        # Belt-and-braces: stash responsibility itself so providers
+        # that don't round-trip Task.responsibility (Planka) still
+        # surface the contract framing.
+        source_context["responsibility"] = responsibility
+
+    # Embed MARCUS_CONTRACT_FIRST marker so contract metadata
+    # survives round-trip through providers that don't persist
+    # Task.responsibility OR source_context.  Mirrors the native
+    # contract-first task path; ``_parse_contract_metadata`` reads
+    # this marker as priority-3 fallback.
+    description = gap_dict["description"]
+    if isinstance(responsibility, str) and responsibility:
+        contract_file_for_marker = source_context.get("contract_file", "")
+        marker_lines = [
+            "<!-- MARCUS_CONTRACT_FIRST",
+            f"responsibility: {responsibility}",
+            f"contract_file: {contract_file_for_marker}",
+            "-->",
+        ]
+        description = f"{description}\n\n" + "\n".join(marker_lines)
+
+    return Task(
+        id=f"gap_fill_{uuid4().hex[:12]}",
+        name=gap_dict["name"],
+        description=description,
+        status=TaskStatus.TODO,
+        priority=Priority.MEDIUM,
+        assigned_to=None,
+        created_at=now,
+        updated_at=now,
+        due_date=None,
+        estimated_hours=median,
+        labels=labels,
+        project_id=project_id,
+        project_name=project_name,
+        provides=gap_dict.get("provides"),
+        requires=gap_dict.get("requires"),
+        responsibility=responsibility,
+        source_type="gap_fill_contract",
+        source_context=source_context if source_context else None,
+    )
+
+
+def _coverage_to_telemetry(
+    coverage: OutcomeCoverageResult,
+) -> Dict[str, Any]:
+    """Flatten an OutcomeCoverageResult into PLANNING_INTENT_FIDELITY shape.
+
+    Keys are pinned to the event payload at
+    ``src/integrations/nlp_tools.py:396-399``:
+    ``intent_fidelity_score``, ``coverage_before_fill``,
+    ``coverage_after_fill``, ``gap_filled_outcomes``.  Cato consumers
+    read this slice via ``result.telemetry["outcome_coverage"]``.
+    """
+    return {
+        "intent_fidelity_score": coverage.intent_fidelity_score,
+        "coverage_before_fill": coverage.coverage_before_fill,
+        "coverage_after_fill": coverage.coverage_after_fill,
+        "gap_filled_outcomes": [g.id for g in coverage.gaps],
+    }
+
+
+async def apply_outcome_coverage_to_feature_graph(
+    *,
+    prd_analysis: "PRDAnalysis",
+    tasks: List[Task],
+    llm_client: Any,
+) -> AugmentationResult:
+    """Run the outcome-coverage check on a feature-based task graph.
+
+    Issue #449 + #456.  Returns the canonical
+    :class:`AugmentationResult` shape so the chain orchestrator can
+    consume it directly without a parser-side wrapper.
+
+    Returns an :class:`AugmentationResult` with empty telemetry when:
+
+    - The flag is off (``MARCUS_OUTCOME_COVERAGE`` unset/false)
+    - No outcomes were extracted (extraction failed earlier or no
+      in-scope outcomes in the PRD)
+    - The coverage pipeline raised (LLM error)
+
+    Otherwise carries the augmented task list (originals + any
+    synthesized gap-fill tasks), ``synthesized_ids`` of the new tasks,
+    and ``telemetry`` with the canonical event-payload keys.
+
+    Failures degrade gracefully — the input task list is returned
+    unchanged so a project is never blocked by an outcome-coverage
+    failure.
+    """
+    if not is_outcome_coverage_enabled():
+        return AugmentationResult(augmented_tasks=list(tasks))
+    if not prd_analysis.user_outcomes:
+        return AugmentationResult(augmented_tasks=list(tasks))
+
+    try:
+        result = await apply_outcome_coverage(
+            spec=prd_analysis.original_description or "",
+            outcomes=prd_analysis.user_outcomes,
+            tasks=tasks,
+            llm_client=llm_client,
+            contract_artifacts=None,
+        )
+    except Exception as exc:
+        # Catch broadly: timeouts, API errors, parse errors all
+        # downgrade to a logged warning.  Coverage failures must
+        # never block project creation; the decomposer's pre-#449
+        # behavior is the always-available fallback.
+        logger.warning("Outcome coverage failed; task graph unchanged: %s", exc)
+        return AugmentationResult(augmented_tasks=list(tasks))
+
+    synthesized_tasks = [
+        _build_feature_gap_fill_task(idx=idx, gap_dict=d, sibling_tasks=tasks)
+        for idx, d in enumerate(result.synthesized_tasks)
+    ]
+    augmented = list(tasks) + synthesized_tasks
+
+    logger.info(
+        "Outcome coverage: score=%.2f, %d outcome(s), %d gap(s), "
+        "%d synthesized task(s)",
+        result.intent_fidelity_score,
+        len(prd_analysis.user_outcomes),
+        len(result.gaps),
+        len(synthesized_tasks),
+    )
+
+    return AugmentationResult(
+        augmented_tasks=augmented,
+        synthesized_ids=[t.id for t in synthesized_tasks],
+        telemetry=_coverage_to_telemetry(result),
+    )
+
+
+async def apply_outcome_coverage_to_contract_graph(
+    *,
+    prd_analysis: "PRDAnalysis",
+    tasks: List[Task],
+    contract_artifacts: Dict[str, Optional[Dict[str, Any]]],
+    llm_client: Any,
+) -> AugmentationResult:
+    """Run outcome-coverage against a contract-first task graph.
+
+    Issue #449 + #456.  Returns :class:`AugmentationResult` so the
+    chain orchestrator can consume it directly.
+
+    Distinct from :func:`apply_outcome_coverage_to_feature_graph`
+    because contract-first tasks need ``responsibility`` set from the
+    gap-fill ``responsibility`` field (which the contract-aware
+    ``fill_gaps`` prompt asks the LLM for).
+
+    Returns an empty-telemetry :class:`AugmentationResult` (input
+    tasks unchanged) on flag off / no outcomes / LLM error — same
+    graceful-degradation contract as the feature-based path.
+    """
+    if not is_outcome_coverage_enabled():
+        return AugmentationResult(augmented_tasks=list(tasks))
+    if not prd_analysis.user_outcomes:
+        return AugmentationResult(augmented_tasks=list(tasks))
+
+    # Filter to contract artifacts that actually have content;
+    # apply_outcome_coverage's prompt-builder expects a dict with
+    # populated ``artifacts`` lists, not the wrapper shape that
+    # decompose_by_contract receives (which can have None payloads).
+    usable_contracts: Dict[str, Any] = {
+        domain: payload
+        for domain, payload in contract_artifacts.items()
+        if payload and payload.get("artifacts")
+    }
+
+    try:
+        result = await apply_outcome_coverage(
+            spec=prd_analysis.original_description or "",
+            outcomes=prd_analysis.user_outcomes,
+            tasks=tasks,
+            llm_client=llm_client,
+            contract_artifacts=usable_contracts or None,
+        )
+    except Exception as exc:
+        logger.warning(
+            "Outcome coverage (contract-first) failed; task graph unchanged: %s",
+            exc,
+        )
+        return AugmentationResult(augmented_tasks=list(tasks))
+
+    synthesized_tasks = [
+        _build_contract_gap_fill_task(idx=idx, gap_dict=d, sibling_tasks=tasks)
+        for idx, d in enumerate(result.synthesized_tasks)
+    ]
+    augmented = list(tasks) + synthesized_tasks
+
+    logger.info(
+        "Outcome coverage (contract-first): score=%.2f, %d outcome(s), "
+        "%d gap(s), %d synthesized task(s)",
+        result.intent_fidelity_score,
+        len(prd_analysis.user_outcomes),
+        len(result.gaps),
+        len(synthesized_tasks),
+    )
+
+    return AugmentationResult(
+        augmented_tasks=augmented,
+        synthesized_ids=[t.id for t in synthesized_tasks],
+        telemetry=_coverage_to_telemetry(result),
     )

--- a/src/marcus_mcp/coordinator/outcome_coverage_augmenter.py
+++ b/src/marcus_mcp/coordinator/outcome_coverage_augmenter.py
@@ -1,0 +1,166 @@
+"""Wrap the legacy outcome-coverage helpers behind GraphAugmenter (issue #456 Stage 2).
+
+Pre-#456, ``_apply_outcome_coverage_to_graph`` (feature-based) and
+``_apply_outcome_coverage_to_contract_graph`` (contract-first) were
+called directly from ``AdvancedPRDParser`` decompose paths.  This
+augmenter wraps both behind a single
+:class:`~src.marcus_mcp.coordinator.graph_augmentation.GraphAugmenter`
+surface so Stage-3 can route every decomposer through one
+augmenter chain instead of two parallel call sites.
+
+Stage-2 scope
+-------------
+Wrapper only — the underlying helpers are unchanged.  The wrapper
+delegates to whichever helper matches the path
+(``contract_artifacts is None`` → feature-based; else
+contract-first), then translates the helper's
+:class:`ParserOutcomeCoverage` return into an
+:class:`AugmentationResult` shaped for the Protocol.
+
+Telemetry-key contract
+----------------------
+``AugmentationResult.telemetry`` keys are pinned to the existing
+``PLANNING_INTENT_FIDELITY`` event payload at
+``src/integrations/nlp_tools.py:391-400`` so Cato consumers continue
+to read the same shape after Stage-3 routes the call through this
+augmenter:
+
+* ``intent_fidelity_score`` (``Optional[float]``)
+* ``coverage_before_fill`` (``Dict[str, List[str]]``)
+* ``coverage_after_fill`` (``Optional[Dict[str, List[str]]]``)
+* ``gap_filled_outcomes`` (``List[str]`` — outcome IDs)
+
+Silent key drift would break Cato silently; the
+``TestTelemetryKeyPinning`` suite locks these explicitly.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
+
+from src.core.models import Task
+from src.marcus_mcp.coordinator.graph_augmentation import AugmentationResult
+
+if TYPE_CHECKING:
+    # Imported only for type-checking to avoid the runtime circular
+    # import: ``advanced_parser`` already imports from
+    # ``marcus_mcp.coordinator``; importing AdvancedPRDParser /
+    # PRDAnalysis at module load time here would close the cycle.
+    from src.ai.advanced.prd.advanced_parser import AdvancedPRDParser, PRDAnalysis
+
+__all__ = ["OutcomeCoverageAugmenter"]
+
+
+class OutcomeCoverageAugmenter:
+    """Augmenter that delegates to the existing outcome-coverage helpers.
+
+    Satisfies the
+    :class:`~src.marcus_mcp.coordinator.graph_augmentation.GraphAugmenter`
+    Protocol.  Constructed with a parser instance whose private
+    ``_apply_outcome_coverage_to_graph`` and
+    ``_apply_outcome_coverage_to_contract_graph`` methods carry the
+    real coverage logic; the wrapper picks the right helper based on
+    whether ``contract_artifacts`` is provided.
+
+    Attributes
+    ----------
+    name : str
+        Stable identifier ``"outcome_coverage"`` used as the telemetry
+        event key, in log lines, and (Stage-3) as the augmenter chain
+        registration name.
+
+    Parameters
+    ----------
+    parser : AdvancedPRDParser
+        The parser whose helpers this augmenter delegates to.  Typed
+        as ``Any`` to keep the runtime import out of this module
+        (advanced_parser already imports from ``marcus_mcp.coordinator``
+        and would close the cycle).
+
+    Notes
+    -----
+    Stage-2 contract: behavior-preserving wrapper.  The underlying
+    helpers retain their own exception handling — they catch broadly
+    and return ``None`` on failure, which the wrapper translates into
+    a no-op :class:`AugmentationResult` (input tasks, empty
+    ``synthesized_ids``, empty ``telemetry``).
+    """
+
+    name: str = "outcome_coverage"
+
+    def __init__(self, *, parser: "AdvancedPRDParser") -> None:
+        self._parser = parser
+
+    async def augment(
+        self,
+        *,
+        prd_analysis: "PRDAnalysis",
+        tasks: List[Task],
+        contract_artifacts: Optional[Dict[str, Any]] = None,
+    ) -> AugmentationResult:
+        """Delegate to the appropriate outcome-coverage helper.
+
+        Parameters
+        ----------
+        prd_analysis : PRDAnalysis
+            Deep PRD analysis (carries ``original_description`` and
+            ``user_outcomes`` the underlying helpers consume).
+        tasks : list of Task
+            Current task graph from the decomposer.  Not mutated.
+        contract_artifacts : dict, optional
+            Contract-first artifact map (``{domain: {"artifacts": [...]}}``).
+            ``None`` for the feature-based path.  Presence selects
+            which helper runs.
+
+        Returns
+        -------
+        AugmentationResult
+            ``augmented_tasks`` is the helper's return list (or the
+            input list verbatim on no-op); ``synthesized_ids`` lists
+            IDs of any tasks the helper appended; ``telemetry`` carries
+            the canonical PLANNING_INTENT_FIDELITY keys when coverage
+            ran, empty otherwise.
+        """
+        if contract_artifacts is not None:
+            parser_result = (
+                await self._parser._apply_outcome_coverage_to_contract_graph(
+                    prd_analysis=prd_analysis,
+                    tasks=tasks,
+                    contract_artifacts=contract_artifacts,
+                )
+            )
+        else:
+            parser_result = await self._parser._apply_outcome_coverage_to_graph(
+                prd_analysis=prd_analysis,
+                tasks=tasks,
+            )
+
+        if parser_result is None:
+            # Helper returned None: flag off, no outcomes, or LLM error.
+            # Per Stage-2 contract, this is a no-op — the decomposer
+            # continues with the input task graph unchanged.
+            return AugmentationResult(augmented_tasks=list(tasks))
+
+        input_ids = {t.id for t in tasks}
+        synthesized_ids = [
+            t.id for t in parser_result.augmented_tasks if t.id not in input_ids
+        ]
+
+        telemetry: Dict[str, Any] = {}
+        coverage = parser_result.coverage
+        if coverage is not None:
+            # Pin keys to PLANNING_INTENT_FIDELITY event payload.
+            # Drift here breaks Cato consumers silently — see
+            # TestTelemetryKeyPinning for the locked contract.
+            telemetry = {
+                "intent_fidelity_score": coverage.intent_fidelity_score,
+                "coverage_before_fill": coverage.coverage_before_fill,
+                "coverage_after_fill": coverage.coverage_after_fill,
+                "gap_filled_outcomes": [g.id for g in coverage.gaps],
+            }
+
+        return AugmentationResult(
+            augmented_tasks=parser_result.augmented_tasks,
+            synthesized_ids=synthesized_ids,
+            telemetry=telemetry,
+        )

--- a/src/marcus_mcp/coordinator/outcome_coverage_augmenter.py
+++ b/src/marcus_mcp/coordinator/outcome_coverage_augmenter.py
@@ -1,37 +1,25 @@
-"""Wrap the legacy outcome-coverage helpers behind GraphAugmenter (issue #456 Stage 2).
+"""Augmenter that runs outcome-coverage gap-fill (issue #456 Stage 5).
 
-Pre-#456, ``_apply_outcome_coverage_to_graph`` (feature-based) and
-``_apply_outcome_coverage_to_contract_graph`` (contract-first) were
-called directly from ``AdvancedPRDParser`` decompose paths.  This
-augmenter wraps both behind a single
-:class:`~src.marcus_mcp.coordinator.graph_augmentation.GraphAugmenter`
-surface so Stage-3 can route every decomposer through one
-augmenter chain instead of two parallel call sites.
-
-Stage-2 scope
--------------
-Wrapper only — the underlying helpers are unchanged.  The wrapper
-delegates to whichever helper matches the path
-(``contract_artifacts is None`` → feature-based; else
-contract-first), then translates the helper's
-:class:`ParserOutcomeCoverage` return into an
-:class:`AugmentationResult` shaped for the Protocol.
+Dispatches between the feature-based and contract-first lifted helpers
+in :mod:`src.marcus_mcp.coordinator.outcome_coverage` based on whether
+``contract_artifacts`` is provided.  All behavior — flag check, no-op
+on missing outcomes, LLM exception handling, gap-fill task synthesis,
+canonical telemetry shape — lives in those module functions.  This
+class is a thin Protocol-satisfying dispatcher.
 
 Telemetry-key contract
 ----------------------
 ``AugmentationResult.telemetry`` keys are pinned to the existing
 ``PLANNING_INTENT_FIDELITY`` event payload at
-``src/integrations/nlp_tools.py:391-400`` so Cato consumers continue
-to read the same shape after Stage-3 routes the call through this
-augmenter:
+``src/integrations/nlp_tools.py:391-400``:
 
 * ``intent_fidelity_score`` (``Optional[float]``)
 * ``coverage_before_fill`` (``Dict[str, List[str]]``)
 * ``coverage_after_fill`` (``Optional[Dict[str, List[str]]]``)
 * ``gap_filled_outcomes`` (``List[str]`` — outcome IDs)
 
-Silent key drift would break Cato silently; the
-``TestTelemetryKeyPinning`` suite locks these explicitly.
+Cato consumers read this slice via
+``decompose_result.telemetry["outcome_coverage"]``.
 """
 
 from __future__ import annotations
@@ -40,85 +28,55 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
 from src.core.models import Task
 from src.marcus_mcp.coordinator.graph_augmentation import AugmentationResult
+from src.marcus_mcp.coordinator.outcome_coverage import (
+    apply_outcome_coverage_to_contract_graph,
+    apply_outcome_coverage_to_feature_graph,
+)
 
 if TYPE_CHECKING:
-    # Imported only for type-checking to avoid the runtime circular
-    # import: ``advanced_parser`` already imports from
-    # ``marcus_mcp.coordinator``; importing AdvancedPRDParser /
-    # PRDAnalysis at module load time here would close the cycle.
-    from src.ai.advanced.prd.advanced_parser import AdvancedPRDParser, PRDAnalysis
+    from src.ai.advanced.prd.advanced_parser import PRDAnalysis
 
 __all__ = ["OutcomeCoverageAugmenter"]
 
 
 class OutcomeCoverageAugmenter:
-    """Augmenter that delegates to the existing outcome-coverage helpers.
+    """Augmenter that dispatches to the outcome-coverage module helpers.
 
     Satisfies the
     :class:`~src.marcus_mcp.coordinator.graph_augmentation.GraphAugmenter`
-    Protocol.  Constructed with a parser instance whose private
-    ``_apply_outcome_coverage_to_graph`` and
-    ``_apply_outcome_coverage_to_contract_graph`` methods carry the
-    real coverage logic; the wrapper picks the right helper based on
-    whether ``contract_artifacts`` is provided.
+    Protocol.  Constructed with an LLM client and dispatches by
+    presence of ``contract_artifacts`` to one of the lifted module
+    functions.
 
     Attributes
     ----------
     name : str
         Stable identifier ``"outcome_coverage"`` used as the telemetry
-        event key, in log lines, and (Stage-3) as the augmenter chain
+        event key, in log lines, and as the augmenter chain
         registration name.
 
     Parameters
     ----------
-    parser : AdvancedPRDParser
-        The parser whose helpers this augmenter delegates to.  Typed
-        as ``Any`` to keep the runtime import out of this module
-        (advanced_parser already imports from ``marcus_mcp.coordinator``
-        and would close the cycle).
-
-    Notes
-    -----
-    Stage-2 contract: behavior-preserving wrapper.  The underlying
-    helpers retain their own exception handling — they catch broadly
-    and return ``None`` on failure, which the wrapper translates into
-    a no-op :class:`AugmentationResult` (input tasks, empty
-    ``synthesized_ids``, empty ``telemetry``).
+    llm_client : Any
+        The LLM client to thread into the coverage pipeline.  Typed
+        as ``Any`` because Marcus uses several LLM client shapes
+        (parser's ``LLMAbstraction``, test ``AsyncMock``s) and the
+        coverage pipeline duck-types against ``analyze``.
 
     Lifetime expectation
     --------------------
-    This augmenter is currently stateless — the only instance state is
-    the parser reference.  Decomposers construct one per-call (e.g.
-    ``OutcomeCoverageAugmenter(parser=self)``).  If future enhancements
-    add real state (caches, retry budgets, rate-limit windows), the
-    construction site must move from per-call to per-decomposer-instance
-    or per-process so the state is preserved across calls.  Treat this
-    note as a tripwire: the moment you add an attribute besides
-    ``_parser``, audit the call sites in ``parse_prd_to_tasks`` and
-    ``decompose_by_contract`` (Kaia review #4, Simon ``f36c49c4``).
-
-    .. warning:: TRANSITIONAL DEBT — Stage 5 cleanup is mandatory
-
-       This wrapper deliberately reaches into ``AdvancedPRDParser``'s
-       private ``_apply_outcome_coverage_to_*`` methods to preserve
-       behavior across the Stage-3 cutover (Kaia review #3, Simon
-       ``4453bd2c``).  This soft coupling is acceptable only as a
-       transitional state.  Stage 5 of issue #456 **must** either:
-
-       - inline the helper logic into this augmenter and delete the
-         parser-side methods, or
-       - lift the helpers to public coordinator-module functions and
-         call them by name (no underscore reach-in).
-
-       Do not merge the issue #456 PR while this wrapper still
-       depends on private methods of another class.  ``git grep
-       _apply_outcome_coverage`` should return zero hits at PR time.
+    Stateless apart from the LLM client reference.  Constructed
+    per-call inside ``parse_prd_to_tasks`` / ``decompose_by_contract``.
+    If future enhancements add real state (caches, retry budgets),
+    audit the construction sites in ``advanced_parser.py`` and move
+    construction to per-decomposer-instance or per-process so the
+    state is preserved across calls.
     """
 
     name: str = "outcome_coverage"
 
-    def __init__(self, *, parser: "AdvancedPRDParser") -> None:
-        self._parser = parser
+    def __init__(self, *, llm_client: Any) -> None:
+        self._llm_client = llm_client
 
     async def augment(
         self,
@@ -127,15 +85,15 @@ class OutcomeCoverageAugmenter:
         tasks: List[Task],
         contract_artifacts: Optional[Dict[str, Any]] = None,
     ) -> AugmentationResult:
-        """Delegate to the appropriate outcome-coverage helper.
+        """Dispatch to the matching coverage helper.
 
         Parameters
         ----------
         prd_analysis : PRDAnalysis
-            Deep PRD analysis (carries ``original_description`` and
-            ``user_outcomes`` the underlying helpers consume).
+            Carries ``original_description`` and ``user_outcomes`` the
+            helpers consume.
         tasks : list of Task
-            Current task graph from the decomposer.  Not mutated.
+            Current task graph.  Not mutated.
         contract_artifacts : dict, optional
             Contract-first artifact map (``{domain: {"artifacts": [...]}}``).
             ``None`` for the feature-based path.  Presence selects
@@ -144,52 +102,20 @@ class OutcomeCoverageAugmenter:
         Returns
         -------
         AugmentationResult
-            ``augmented_tasks`` is the helper's return list (or the
-            input list verbatim on no-op); ``synthesized_ids`` lists
-            IDs of any tasks the helper appended; ``telemetry`` carries
-            the canonical PLANNING_INTENT_FIDELITY keys when coverage
-            ran, empty otherwise.
+            Carries augmented_tasks (input plus any synthesized
+            gap-fill), synthesized_ids of the new tasks, and
+            telemetry with the canonical PLANNING_INTENT_FIDELITY
+            keys when coverage ran (empty when it didn't).
         """
         if contract_artifacts is not None:
-            parser_result = (
-                await self._parser._apply_outcome_coverage_to_contract_graph(
-                    prd_analysis=prd_analysis,
-                    tasks=tasks,
-                    contract_artifacts=contract_artifacts,
-                )
-            )
-        else:
-            parser_result = await self._parser._apply_outcome_coverage_to_graph(
+            return await apply_outcome_coverage_to_contract_graph(
                 prd_analysis=prd_analysis,
                 tasks=tasks,
+                contract_artifacts=contract_artifacts,
+                llm_client=self._llm_client,
             )
-
-        if parser_result is None:
-            # Helper returned None: flag off, no outcomes, or LLM error.
-            # Per Stage-2 contract, this is a no-op — the decomposer
-            # continues with the input task graph unchanged.
-            return AugmentationResult(augmented_tasks=list(tasks))
-
-        input_ids = {t.id for t in tasks}
-        synthesized_ids = [
-            t.id for t in parser_result.augmented_tasks if t.id not in input_ids
-        ]
-
-        telemetry: Dict[str, Any] = {}
-        coverage = parser_result.coverage
-        if coverage is not None:
-            # Pin keys to PLANNING_INTENT_FIDELITY event payload.
-            # Drift here breaks Cato consumers silently — see
-            # TestTelemetryKeyPinning for the locked contract.
-            telemetry = {
-                "intent_fidelity_score": coverage.intent_fidelity_score,
-                "coverage_before_fill": coverage.coverage_before_fill,
-                "coverage_after_fill": coverage.coverage_after_fill,
-                "gap_filled_outcomes": [g.id for g in coverage.gaps],
-            }
-
-        return AugmentationResult(
-            augmented_tasks=parser_result.augmented_tasks,
-            synthesized_ids=synthesized_ids,
-            telemetry=telemetry,
+        return await apply_outcome_coverage_to_feature_graph(
+            prd_analysis=prd_analysis,
+            tasks=tasks,
+            llm_client=self._llm_client,
         )

--- a/src/marcus_mcp/coordinator/outcome_coverage_augmenter.py
+++ b/src/marcus_mcp/coordinator/outcome_coverage_augmenter.py
@@ -85,6 +85,18 @@ class OutcomeCoverageAugmenter:
     a no-op :class:`AugmentationResult` (input tasks, empty
     ``synthesized_ids``, empty ``telemetry``).
 
+    Lifetime expectation
+    --------------------
+    This augmenter is currently stateless — the only instance state is
+    the parser reference.  Decomposers construct one per-call (e.g.
+    ``OutcomeCoverageAugmenter(parser=self)``).  If future enhancements
+    add real state (caches, retry budgets, rate-limit windows), the
+    construction site must move from per-call to per-decomposer-instance
+    or per-process so the state is preserved across calls.  Treat this
+    note as a tripwire: the moment you add an attribute besides
+    ``_parser``, audit the call sites in ``parse_prd_to_tasks`` and
+    ``decompose_by_contract`` (Kaia review #4, Simon ``f36c49c4``).
+
     .. warning:: TRANSITIONAL DEBT — Stage 5 cleanup is mandatory
 
        This wrapper deliberately reaches into ``AdvancedPRDParser``'s

--- a/src/marcus_mcp/coordinator/outcome_coverage_augmenter.py
+++ b/src/marcus_mcp/coordinator/outcome_coverage_augmenter.py
@@ -84,6 +84,23 @@ class OutcomeCoverageAugmenter:
     and return ``None`` on failure, which the wrapper translates into
     a no-op :class:`AugmentationResult` (input tasks, empty
     ``synthesized_ids``, empty ``telemetry``).
+
+    .. warning:: TRANSITIONAL DEBT — Stage 5 cleanup is mandatory
+
+       This wrapper deliberately reaches into ``AdvancedPRDParser``'s
+       private ``_apply_outcome_coverage_to_*`` methods to preserve
+       behavior across the Stage-3 cutover (Kaia review #3, Simon
+       ``4453bd2c``).  This soft coupling is acceptable only as a
+       transitional state.  Stage 5 of issue #456 **must** either:
+
+       - inline the helper logic into this augmenter and delete the
+         parser-side methods, or
+       - lift the helpers to public coordinator-module functions and
+         call them by name (no underscore reach-in).
+
+       Do not merge the issue #456 PR while this wrapper still
+       depends on private methods of another class.  ``git grep
+       _apply_outcome_coverage`` should return zero hits at PR time.
     """
 
     name: str = "outcome_coverage"

--- a/src/marcus_mcp/coordinator/spec_coverage_augmenter.py
+++ b/src/marcus_mcp/coordinator/spec_coverage_augmenter.py
@@ -1,0 +1,124 @@
+"""Wrap check_spec_coverage behind GraphAugmenter (issue #456 Stage 4).
+
+Pre-#456, ``check_spec_coverage`` was called from
+``nlp_tools.py:1336-1349`` *after* safety checks completed.  Gap
+tasks synthesized by spec coverage were appended to the task list
+with ``dependencies=[]``, making them orphans that bypassed both
+``_infer_smart_dependencies`` and foundation wiring.  This was the
+v37 orphan-failure-mode.
+
+Stage 4 moves spec coverage into the augmenter chain that runs
+*inside* the decomposer, between ``_create_detailed_tasks`` and
+``_infer_smart_dependencies``.  Synthesized gap tasks are now
+first-class graph members: dependency inference treats them like
+any other task, foundation wiring picks them up, and downstream
+integration verification finds them in the "all current tasks" pool.
+
+Chain order matters
+-------------------
+``OutcomeCoverageAugmenter`` runs before ``SpecCoverageAugmenter`` so
+spec coverage sees the post-outcome-coverage graph (including any
+synthesized outcome gap-fill tasks).  Locked by
+``test_second_augmenter_sees_first_augmenter_tasks`` in
+``test_augmenter_chain.py``.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
+
+from src.core.models import Task
+from src.integrations.spec_coverage import check_spec_coverage
+from src.marcus_mcp.coordinator.graph_augmentation import AugmentationResult
+
+if TYPE_CHECKING:
+    from src.ai.advanced.prd.advanced_parser import PRDAnalysis
+
+__all__ = ["SpecCoverageAugmenter"]
+
+
+class SpecCoverageAugmenter:
+    """Augmenter that delegates to :func:`check_spec_coverage`.
+
+    Satisfies the
+    :class:`~src.marcus_mcp.coordinator.graph_augmentation.GraphAugmenter`
+    Protocol.  Stateless — constructed without arguments; pulls the
+    spec text from ``prd_analysis.original_description`` at call time.
+
+    Attributes
+    ----------
+    name : str
+        Stable identifier ``"spec_coverage"`` used as the telemetry
+        key in the chain's namespaced result dict.
+
+    Notes
+    -----
+    Stage-4 contract: behavior-preserving wrapper.  The underlying
+    :func:`check_spec_coverage` retains its own broad
+    ``try/except`` and returns ``[]`` on any failure (LLM error,
+    timeout, parse error) — the augmenter translates an empty list
+    into a no-op :class:`AugmentationResult`.
+
+    Lifetime expectation
+    --------------------
+    Stateless.  Constructed per-call inside
+    ``parse_prd_to_tasks`` / ``decompose_by_contract``.  See the
+    matching note on :class:`OutcomeCoverageAugmenter` — the same
+    tripwire applies if state is ever added.
+    """
+
+    name: str = "spec_coverage"
+
+    async def augment(
+        self,
+        *,
+        prd_analysis: "PRDAnalysis",
+        tasks: List[Task],
+        contract_artifacts: Optional[Dict[str, Any]] = None,
+    ) -> AugmentationResult:
+        """Run spec coverage check, append gap tasks if any.
+
+        Parameters
+        ----------
+        prd_analysis : PRDAnalysis
+            Source of the spec text via ``original_description``.
+            Empty/missing description short-circuits to a no-op
+            (avoids a needless LLM round-trip).
+        tasks : list of Task
+            Current task graph.  Threaded into
+            :func:`check_spec_coverage` for the keyword-coverage
+            scan.  Not mutated.
+        contract_artifacts : dict, optional
+            Part of the Protocol surface but unused — spec coverage
+            operates on spec text, not contracts.  Accepted for
+            interface uniformity, ignored at runtime.
+
+        Returns
+        -------
+        AugmentationResult
+            ``augmented_tasks`` is the input list plus any synthesized
+            gap tasks.  ``synthesized_ids`` carries gap task IDs.
+            ``telemetry`` is empty when no gaps were filled, otherwise
+            ``{"spec_gap_count": N, "spec_gap_features": [...names]}``.
+        """
+        spec = prd_analysis.original_description or ""
+        if not spec:
+            return AugmentationResult(augmented_tasks=list(tasks))
+
+        gap_tasks = await check_spec_coverage(
+            description=spec,
+            tasks=tasks,
+            project_name="",  # vestigial: unused inside check_spec_coverage
+        )
+
+        if not gap_tasks:
+            return AugmentationResult(augmented_tasks=list(tasks))
+
+        return AugmentationResult(
+            augmented_tasks=list(tasks) + gap_tasks,
+            synthesized_ids=[t.id for t in gap_tasks],
+            telemetry={
+                "spec_gap_count": len(gap_tasks),
+                "spec_gap_features": [t.name for t in gap_tasks],
+            },
+        )

--- a/src/marcus_mcp/coordinator/spec_coverage_augmenter.py
+++ b/src/marcus_mcp/coordinator/spec_coverage_augmenter.py
@@ -108,7 +108,6 @@ class SpecCoverageAugmenter:
         gap_tasks = await check_spec_coverage(
             description=spec,
             tasks=tasks,
-            project_name="",  # vestigial: unused inside check_spec_coverage
         )
 
         if not gap_tasks:

--- a/tests/unit/ai/test_contract_first_outcome_integration.py
+++ b/tests/unit/ai/test_contract_first_outcome_integration.py
@@ -2,7 +2,7 @@
 
 Verifies the contract-first decomposer integration:
 
-- _apply_outcome_coverage_to_contract_graph passes contract_artifacts
+- apply_outcome_coverage_to_contract_graph passes contract_artifacts
   to fill_gaps so synthesized provides/requires/responsibility quote
   real interface names from the existing contracts
 - Synthesized contract-first tasks get responsibility set from the
@@ -10,11 +10,9 @@ Verifies the contract-first decomposer integration:
 - Synthesized tasks get ['gap_fill', 'intent_fidelity', 'contract']
   labels (the 'contract' marker distinguishes contract-aware
   synthesis from feature-based gap-fill in audits)
-- decompose_by_contract returns the augmented task list and stashes
-  ParserOutcomeCoverage on self._last_contract_decompose_coverage
-  for the orchestrator to read in Phase 5
-- Side-channel attribute is reset on entry so stale results don't
-  leak across calls
+- decompose_by_contract returns AugmentationResult with the augmented
+  task list and namespaced telemetry (issue #456 Stage 5 — formerly
+  ParserOutcomeCoverage on a side-channel attribute).
 """
 
 from datetime import datetime, timezone
@@ -23,13 +21,13 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
-from src.ai.advanced.prd.advanced_parser import (
-    ParserOutcomeCoverage,
-    PRDAnalysis,
-)
+from src.ai.advanced.prd.advanced_parser import PRDAnalysis
 from src.ai.advanced.prd.outcome_extractor import UserOutcome
 from src.config.outcome_coverage_config import ENV_VAR_NAME
 from src.core.models import Priority, Task, TaskStatus
+from src.marcus_mcp.coordinator.outcome_coverage import (
+    apply_outcome_coverage_to_contract_graph,
+)
 
 pytestmark = pytest.mark.unit
 
@@ -117,13 +115,14 @@ class TestContractCoverageHelper:
         monkeypatch.setenv(ENV_VAR_NAME, "false")
         parser = _build_parser()
 
-        result = await parser._apply_outcome_coverage_to_contract_graph(
+        result = await apply_outcome_coverage_to_contract_graph(
             prd_analysis=_bare_analysis([_outcome()]),
             tasks=[_contract_task()],
             contract_artifacts=_contract_artifacts(),
+            llm_client=parser.llm_client,
         )
 
-        assert result is None
+        assert result.telemetry == {}
         parser.llm_client.analyze.assert_not_called()
 
     @pytest.mark.asyncio
@@ -131,13 +130,14 @@ class TestContractCoverageHelper:
         monkeypatch.setenv(ENV_VAR_NAME, "true")
         parser = _build_parser()
 
-        result = await parser._apply_outcome_coverage_to_contract_graph(
+        result = await apply_outcome_coverage_to_contract_graph(
             prd_analysis=_bare_analysis([]),
             tasks=[_contract_task()],
             contract_artifacts=_contract_artifacts(),
+            llm_client=parser.llm_client,
         )
 
-        assert result is None
+        assert result.telemetry == {}
         parser.llm_client.analyze.assert_not_called()
 
     @pytest.mark.asyncio
@@ -174,14 +174,13 @@ class TestContractCoverageHelper:
             ]
         )
 
-        result = await parser._apply_outcome_coverage_to_contract_graph(
+        result = await apply_outcome_coverage_to_contract_graph(
             prd_analysis=_bare_analysis([_outcome()]),
             tasks=[_contract_task()],
             contract_artifacts=_contract_artifacts(),
+            llm_client=parser.llm_client,
         )
 
-        assert result is not None
-        assert isinstance(result, ParserOutcomeCoverage)
         assert len(result.augmented_tasks) == 2
         synthesized = result.augmented_tasks[1]
         assert synthesized.responsibility == (
@@ -216,10 +215,11 @@ class TestContractCoverageHelper:
             ]
         )
 
-        result = await parser._apply_outcome_coverage_to_contract_graph(
+        result = await apply_outcome_coverage_to_contract_graph(
             prd_analysis=_bare_analysis([_outcome()]),
             tasks=[_contract_task()],
             contract_artifacts=_contract_artifacts(),
+            llm_client=parser.llm_client,
         )
 
         assert result is not None
@@ -247,10 +247,11 @@ class TestContractCoverageHelper:
             ]
         )
 
-        await parser._apply_outcome_coverage_to_contract_graph(
+        await apply_outcome_coverage_to_contract_graph(
             prd_analysis=_bare_analysis([_outcome()]),
             tasks=[_contract_task()],
             contract_artifacts=_contract_artifacts(),
+            llm_client=parser.llm_client,
         )
 
         # The fill_gaps prompt is the second call; assert the contract
@@ -279,16 +280,17 @@ class TestContractCoverageHelper:
             ]
         )
 
-        result = await parser._apply_outcome_coverage_to_contract_graph(
+        result = await apply_outcome_coverage_to_contract_graph(
             prd_analysis=_bare_analysis([_outcome()]),
             tasks=[_contract_task()],
             contract_artifacts={"empty_domain": None},
+            llm_client=parser.llm_client,
         )
 
         assert result is not None
         # No gaps, no synthesis
         assert len(result.augmented_tasks) == 1
-        assert result.coverage.intent_fidelity_score == 1.0
+        assert result.telemetry["intent_fidelity_score"] == 1.0
 
     @pytest.mark.asyncio
     async def test_contract_label_omitted_when_responsibility_is_none(
@@ -315,11 +317,12 @@ class TestContractCoverageHelper:
             ]
         )
 
-        result = await parser._apply_outcome_coverage_to_contract_graph(
+        result = await apply_outcome_coverage_to_contract_graph(
             prd_analysis=_bare_analysis([_outcome()]),
             tasks=[_contract_task()],
             # All None → filtered to empty → fallback to None
             contract_artifacts={"d1": None, "d2": None},
+            llm_client=parser.llm_client,
         )
 
         assert result is not None
@@ -363,10 +366,11 @@ class TestContractCoverageHelper:
             ]
         )
 
-        result = await parser._apply_outcome_coverage_to_contract_graph(
+        result = await apply_outcome_coverage_to_contract_graph(
             prd_analysis=_bare_analysis([_outcome()]),
             tasks=[_contract_task()],
             contract_artifacts=_contract_artifacts(),
+            llm_client=parser.llm_client,
         )
 
         assert result is not None
@@ -400,10 +404,11 @@ class TestContractCoverageHelper:
             ]
         )
 
-        result = await parser._apply_outcome_coverage_to_contract_graph(
+        result = await apply_outcome_coverage_to_contract_graph(
             prd_analysis=_bare_analysis([_outcome()]),
             tasks=[_contract_task()],
-            contract_artifacts={"d": None},  # filtered to empty
+            contract_artifacts={"d": None},  # filtered to empty,
+            llm_client=parser.llm_client,
         )
 
         assert result is not None
@@ -443,10 +448,11 @@ class TestContractCoverageHelper:
             ]
         )
 
-        result = await parser._apply_outcome_coverage_to_contract_graph(
+        result = await apply_outcome_coverage_to_contract_graph(
             prd_analysis=_bare_analysis([_outcome()]),
             tasks=[_contract_task()],
             contract_artifacts=_contract_artifacts(),
+            llm_client=parser.llm_client,
         )
 
         assert result is not None
@@ -484,10 +490,11 @@ class TestContractCoverageHelper:
             ]
         )
 
-        result = await parser._apply_outcome_coverage_to_contract_graph(
+        result = await apply_outcome_coverage_to_contract_graph(
             prd_analysis=_bare_analysis([_outcome()]),
             tasks=[_contract_task()],
             contract_artifacts=_contract_artifacts(),
+            llm_client=parser.llm_client,
         )
 
         assert result is not None
@@ -516,10 +523,11 @@ class TestContractCoverageHelper:
             ]
         )
 
-        result = await parser._apply_outcome_coverage_to_contract_graph(
+        result = await apply_outcome_coverage_to_contract_graph(
             prd_analysis=_bare_analysis([_outcome()]),
             tasks=[_contract_task()],
             contract_artifacts=_contract_artifacts(),
+            llm_client=parser.llm_client,
         )
 
         assert result is not None
@@ -566,10 +574,11 @@ class TestContractCoverageHelper:
             ]
         )
 
-        result = await parser._apply_outcome_coverage_to_contract_graph(
+        result = await apply_outcome_coverage_to_contract_graph(
             prd_analysis=_bare_analysis([_outcome()]),
             tasks=[_contract_task()],
             contract_artifacts=_contract_artifacts(),
+            llm_client=parser.llm_client,
         )
 
         assert result is not None
@@ -627,10 +636,11 @@ class TestContractCoverageHelper:
             ]
         )
 
-        result = await parser._apply_outcome_coverage_to_contract_graph(
+        result = await apply_outcome_coverage_to_contract_graph(
             prd_analysis=_bare_analysis([_outcome()]),
             tasks=[_contract_task()],
             contract_artifacts=_contract_artifacts(),
+            llm_client=parser.llm_client,
         )
 
         assert result is not None
@@ -732,13 +742,16 @@ class TestDecomposeByContractReturnShape:
     async def test_returns_augmentation_result_with_outcome_coverage_telemetry(
         self, monkeypatch: Any
     ) -> None:
-        """Flag on, helper returns a result → outcome_coverage telemetry populated."""
+        """Flag on, lifted function returns telemetry → result carries it.
+
+        Issue #456 Stage 5: the chain calls
+        ``apply_outcome_coverage_to_contract_graph`` (lifted module
+        function) directly.  We patch that to control the
+        AugmentationResult that flows into the chain output.
+        """
         from src.ai.advanced.prd.advanced_parser import ProjectConstraints
         from src.marcus_mcp.coordinator.graph_augmentation import (
             AugmentationResult,
-        )
-        from src.marcus_mcp.coordinator.outcome_coverage import (
-            OutcomeCoverageResult,
         )
 
         monkeypatch.setenv(ENV_VAR_NAME, "true")
@@ -753,29 +766,31 @@ class TestDecomposeByContractReturnShape:
             )
             mock_engine_class.return_value = mock_engine
 
-            # Stub helper with a populated ParserOutcomeCoverage
-            # carrying a real OutcomeCoverageResult so the wrapper can
-            # extract telemetry fields by attribute access.
-            real_coverage = OutcomeCoverageResult(
-                synthesized_tasks=[],
-                intent_fidelity_score=0.9,
-                coverage_before_fill={"o1": ["t1"]},
-                coverage_after_fill={"o1": ["t1"]},
-                gaps=[],
-            )
-            stub_helper_result = ParserOutcomeCoverage(
-                augmented_tasks=[_contract_task()],
-                coverage=real_coverage,
-            )
-            parser._apply_outcome_coverage_to_contract_graph = AsyncMock(
-                return_value=stub_helper_result
+            # Stub the lifted function directly with a populated
+            # AugmentationResult carrying outcome-coverage telemetry.
+            stub_task = _contract_task()
+            stub_chain_result = AugmentationResult(
+                augmented_tasks=[stub_task],
+                synthesized_ids=[],
+                telemetry={
+                    "intent_fidelity_score": 0.9,
+                    "coverage_before_fill": {"o1": ["t1"]},
+                    "coverage_after_fill": {"o1": ["t1"]},
+                    "gap_filled_outcomes": [],
+                },
             )
 
-            result = await parser.decompose_by_contract(
-                prd_analysis=_bare_analysis([_outcome()]),
-                contract_artifacts=_contract_artifacts(),
-                constraints=ProjectConstraints(),
-            )
+            with patch(
+                "src.marcus_mcp.coordinator.outcome_coverage_augmenter."
+                "apply_outcome_coverage_to_contract_graph",
+                new_callable=AsyncMock,
+                return_value=stub_chain_result,
+            ) as mock_apply:
+                result = await parser.decompose_by_contract(
+                    prd_analysis=_bare_analysis([_outcome()]),
+                    contract_artifacts=_contract_artifacts(),
+                    constraints=ProjectConstraints(),
+                )
 
         assert isinstance(result, AugmentationResult)
         # Telemetry namespaced by augmenter name with canonical keys
@@ -783,8 +798,8 @@ class TestDecomposeByContractReturnShape:
         assert result.telemetry["outcome_coverage"]["coverage_before_fill"] == {
             "o1": ["t1"]
         }
-        assert result.augmented_tasks == stub_helper_result.augmented_tasks
-        parser._apply_outcome_coverage_to_contract_graph.assert_awaited_once()
+        assert result.augmented_tasks == [stub_task]
+        mock_apply.assert_awaited_once()
 
     @pytest.mark.asyncio
     async def test_no_side_channel_attribute_remains(self, monkeypatch: Any) -> None:

--- a/tests/unit/ai/test_contract_first_outcome_integration.py
+++ b/tests/unit/ai/test_contract_first_outcome_integration.py
@@ -641,18 +641,17 @@ class TestContractCoverageHelper:
 
 
 class TestDecomposeByContractReturnShape:
-    """decompose_by_contract returns ParserOutcomeCoverage uniformly.
+    """decompose_by_contract returns AugmentationResult uniformly.
 
-    Phase 4 tech-debt fix replaced the old ``List[Task]`` return +
-    side-channel attribute with a typed ``ParserOutcomeCoverage`` that
-    bundles tasks with optional coverage telemetry.  These tests lock
-    in the new shape:
+    Issue #456 Stage 3 routes the contract-first decomposer through
+    the augmenter chain.  These tests lock in the post-Stage-3 shape:
 
     - ``result.augmented_tasks`` is always populated with the contract
       task list (plus any synthesized gap-fill tasks)
-    - ``result.coverage`` is None when the outcome-coverage pipeline
+    - ``result.telemetry`` is empty when the outcome-coverage pipeline
       didn't run (flag off / no outcomes / LLM error)
-    - ``result.coverage`` is the ``OutcomeCoverageResult`` when it ran
+    - ``result.telemetry["outcome_coverage"]`` carries
+      ``intent_fidelity_score`` + sibling keys when coverage ran
     """
 
     @staticmethod
@@ -676,11 +675,14 @@ class TestDecomposeByContractReturnShape:
         }
 
     @pytest.mark.asyncio
-    async def test_returns_parser_outcome_coverage_with_coverage_none(
+    async def test_returns_augmentation_result_with_empty_telemetry(
         self, monkeypatch: Any
     ) -> None:
-        """Flag off → result.coverage is None, but augmented_tasks is populated."""
+        """Flag off → result.telemetry is empty, augmented_tasks populated."""
         from src.ai.advanced.prd.advanced_parser import ProjectConstraints
+        from src.marcus_mcp.coordinator.graph_augmentation import (
+            AugmentationResult,
+        )
 
         monkeypatch.setenv(ENV_VAR_NAME, "false")
         parser = _build_parser()
@@ -700,19 +702,25 @@ class TestDecomposeByContractReturnShape:
                 constraints=ProjectConstraints(),
             )
 
-        assert isinstance(result, ParserOutcomeCoverage)
-        # Coverage didn't run (flag off) → coverage attribute is None
-        assert result.coverage is None
-        # But augmented_tasks still has the one contract task
+        assert isinstance(result, AugmentationResult)
+        # Coverage didn't run (flag off) → no telemetry slice
+        assert "outcome_coverage" not in result.telemetry
+        # augmented_tasks still has the one contract task
         assert len(result.augmented_tasks) == 1
         assert result.augmented_tasks[0].name == "Engine"
 
     @pytest.mark.asyncio
-    async def test_returns_parser_outcome_coverage_with_coverage_populated(
+    async def test_returns_augmentation_result_with_outcome_coverage_telemetry(
         self, monkeypatch: Any
     ) -> None:
-        """Flag on, helper returns a result → coverage attribute populated."""
+        """Flag on, helper returns a result → outcome_coverage telemetry populated."""
         from src.ai.advanced.prd.advanced_parser import ProjectConstraints
+        from src.marcus_mcp.coordinator.graph_augmentation import (
+            AugmentationResult,
+        )
+        from src.marcus_mcp.coordinator.outcome_coverage import (
+            OutcomeCoverageResult,
+        )
 
         monkeypatch.setenv(ENV_VAR_NAME, "true")
         parser = _build_parser()
@@ -727,10 +735,18 @@ class TestDecomposeByContractReturnShape:
             mock_engine_class.return_value = mock_engine
 
             # Stub helper with a populated ParserOutcomeCoverage
-            stub_inner_coverage = AsyncMock()
+            # carrying a real OutcomeCoverageResult so the wrapper can
+            # extract telemetry fields by attribute access.
+            real_coverage = OutcomeCoverageResult(
+                synthesized_tasks=[],
+                intent_fidelity_score=0.9,
+                coverage_before_fill={"o1": ["t1"]},
+                coverage_after_fill={"o1": ["t1"]},
+                gaps=[],
+            )
             stub_helper_result = ParserOutcomeCoverage(
                 augmented_tasks=[_contract_task()],
-                coverage=stub_inner_coverage,
+                coverage=real_coverage,
             )
             parser._apply_outcome_coverage_to_contract_graph = AsyncMock(
                 return_value=stub_helper_result
@@ -742,8 +758,12 @@ class TestDecomposeByContractReturnShape:
                 constraints=ProjectConstraints(),
             )
 
-        assert isinstance(result, ParserOutcomeCoverage)
-        assert result.coverage is stub_inner_coverage
+        assert isinstance(result, AugmentationResult)
+        # Telemetry namespaced by augmenter name with canonical keys
+        assert result.telemetry["outcome_coverage"]["intent_fidelity_score"] == 0.9
+        assert result.telemetry["outcome_coverage"]["coverage_before_fill"] == {
+            "o1": ["t1"]
+        }
         assert result.augmented_tasks == stub_helper_result.augmented_tasks
         parser._apply_outcome_coverage_to_contract_graph.assert_awaited_once()
 

--- a/tests/unit/ai/test_contract_first_outcome_integration.py
+++ b/tests/unit/ai/test_contract_first_outcome_integration.py
@@ -16,7 +16,7 @@ Verifies the contract-first decomposer integration:
 """
 
 from datetime import datetime, timezone
-from typing import Any
+from typing import Any, List
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -813,3 +813,164 @@ class TestDecomposeByContractReturnShape:
         parser = _build_parser()
         # The old side-channel attribute should no longer exist.
         assert not hasattr(parser, "_last_contract_decompose_coverage")
+
+
+class TestPreExistingTasksThreading:
+    """``pre_existing_tasks`` parameter threads foundation tasks through
+    the augmenter chain (Codex P2 on PR #473).
+
+    Regression: pre-fix, ``SpecCoverageAugmenter`` saw only contract
+    tasks during decompose_by_contract.  Foundation tasks synthesized
+    pre-fork by ``_synthesize_shared_foundation`` were appended later
+    by the orchestrator, so spec_coverage's keyword scan could
+    falsely flag features as "uncovered" and synthesize duplicate
+    spec_gap tasks for foundation work that already covered them.
+
+    The fix threads foundation tasks into ``decompose_by_contract``
+    via ``pre_existing_tasks`` so the chain sees the full pre-fork
+    graph during scanning.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _no_spec_coverage(self) -> Any:
+        """Stub spec_coverage; tests focus on threading."""
+        with patch(
+            "src.marcus_mcp.coordinator.spec_coverage_augmenter." "check_spec_coverage",
+            new_callable=AsyncMock,
+            return_value=[],
+        ) as mock:
+            yield mock
+
+    @pytest.mark.asyncio
+    async def test_pre_existing_tasks_visible_to_chain(self, monkeypatch: Any) -> None:
+        """Foundation tasks appear in the chain's input task list."""
+        from datetime import datetime, timezone
+
+        from src.ai.advanced.prd.advanced_parser import ProjectConstraints
+        from src.core.models import Priority, Task, TaskStatus
+        from src.marcus_mcp.coordinator.graph_augmentation import (
+            AugmentationResult,
+        )
+
+        monkeypatch.setenv(ENV_VAR_NAME, "false")
+        parser = _build_parser()
+
+        now = datetime.now(timezone.utc)
+        foundation = Task(
+            id="foundation_auth",
+            name="Set up Auth foundation",
+            description="Bootstrap auth module",
+            status=TaskStatus.TODO,
+            priority=Priority.MEDIUM,
+            assigned_to=None,
+            created_at=now,
+            updated_at=now,
+            due_date=None,
+            estimated_hours=2.0,
+        )
+
+        with patch(
+            "src.ai.advanced.prd.advanced_parser.AIAnalysisEngine"
+        ) as mock_engine_class:
+            mock_engine = AsyncMock()
+            mock_engine.generate_structured_response = AsyncMock(
+                return_value={
+                    "tasks": [
+                        {
+                            "name": "Engine",
+                            "description": "build engine",
+                            "estimated_minutes": 240,
+                            "provides": "GameStateUpdate",
+                            "requires": "None",
+                            "responsibility": (
+                                "implements GameEngine from "
+                                "src/contracts/GameState.ts"
+                            ),
+                            "contract_file": "src/contracts/GameState.ts",
+                            "acceptance_criteria": [],
+                        }
+                    ]
+                }
+            )
+            mock_engine_class.return_value = mock_engine
+
+            # Spy on the chain's outcome-coverage helper so we can see
+            # what tasks list it received.
+            captured_chain_input: List[Task] = []
+
+            async def _spy(
+                *,
+                prd_analysis: Any,
+                tasks: List[Task],
+                contract_artifacts: Any,
+                llm_client: Any,
+            ) -> AugmentationResult:
+                captured_chain_input.extend(tasks)
+                return AugmentationResult(augmented_tasks=list(tasks))
+
+            with patch(
+                "src.marcus_mcp.coordinator.outcome_coverage_augmenter."
+                "apply_outcome_coverage_to_contract_graph",
+                new=_spy,
+            ):
+                result = await parser.decompose_by_contract(
+                    prd_analysis=_bare_analysis([_outcome()]),
+                    contract_artifacts=_contract_artifacts(),
+                    constraints=ProjectConstraints(),
+                    pre_existing_tasks=[foundation],
+                )
+
+        # The chain saw the foundation task during scanning
+        captured_ids = [t.id for t in captured_chain_input]
+        assert "foundation_auth" in captured_ids
+
+        # And the augmented result includes both foundation and contract task
+        result_ids = [t.id for t in result.augmented_tasks]
+        assert "foundation_auth" in result_ids
+        assert any("Engine" in t.name for t in result.augmented_tasks)
+
+    @pytest.mark.asyncio
+    async def test_pre_existing_tasks_default_none_backward_compat(
+        self, monkeypatch: Any
+    ) -> None:
+        """Calls without ``pre_existing_tasks`` still work — back-compat."""
+        from src.ai.advanced.prd.advanced_parser import ProjectConstraints
+        from src.marcus_mcp.coordinator.graph_augmentation import (
+            AugmentationResult,
+        )
+
+        monkeypatch.setenv(ENV_VAR_NAME, "false")
+        parser = _build_parser()
+
+        with patch(
+            "src.ai.advanced.prd.advanced_parser.AIAnalysisEngine"
+        ) as mock_engine_class:
+            mock_engine = AsyncMock()
+            mock_engine.generate_structured_response = AsyncMock(
+                return_value={
+                    "tasks": [
+                        {
+                            "name": "Engine",
+                            "description": "build",
+                            "estimated_minutes": 240,
+                            "provides": "X",
+                            "requires": "None",
+                            "responsibility": "implements X from a/b.ts",
+                            "contract_file": "a/b.ts",
+                            "acceptance_criteria": [],
+                        }
+                    ]
+                }
+            )
+            mock_engine_class.return_value = mock_engine
+
+            # Call with default (no pre_existing_tasks); must not raise
+            result = await parser.decompose_by_contract(
+                prd_analysis=_bare_analysis([_outcome()]),
+                contract_artifacts=_contract_artifacts(),
+                constraints=ProjectConstraints(),
+            )
+
+        assert isinstance(result, AugmentationResult)
+        assert len(result.augmented_tasks) == 1
+        assert result.augmented_tasks[0].name == "Engine"

--- a/tests/unit/ai/test_contract_first_outcome_integration.py
+++ b/tests/unit/ai/test_contract_first_outcome_integration.py
@@ -654,6 +654,25 @@ class TestDecomposeByContractReturnShape:
       ``intent_fidelity_score`` + sibling keys when coverage ran
     """
 
+    @pytest.fixture(autouse=True)
+    def _no_spec_coverage(self) -> Any:
+        """Stub SpecCoverageAugmenter — these tests assert shape only.
+
+        Issue #456 Stage 4 wires SpecCoverageAugmenter into the
+        decomposer chain alongside OutcomeCoverageAugmenter.  Without
+        stubbing, ``check_spec_coverage`` would make a real LLM call
+        and synthesize spec_gap tasks that contaminate the
+        return-shape assertions in this class.  Tests that need real
+        spec_coverage behavior live in
+        ``test_spec_coverage_augmenter.py``.
+        """
+        with patch(
+            "src.marcus_mcp.coordinator.spec_coverage_augmenter." "check_spec_coverage",
+            new_callable=AsyncMock,
+            return_value=[],
+        ) as mock:
+            yield mock
+
     @staticmethod
     def _stub_engine_output() -> dict[str, Any]:
         """Canonical contract-first LLM response with one task."""

--- a/tests/unit/ai/test_decompose_by_contract.py
+++ b/tests/unit/ai/test_decompose_by_contract.py
@@ -20,6 +20,7 @@ Test strategy
 """
 
 from datetime import datetime, timezone
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -121,6 +122,29 @@ def _make_contract_artifacts():
 
 class TestDecomposeByContract:
     """Test suite for AdvancedPRDParser.decompose_by_contract."""
+
+    @pytest.fixture(autouse=True)
+    def _no_spec_coverage(self) -> Any:
+        """Stub out the SpecCoverageAugmenter so these tests stay
+        focused on contract decomposition.
+
+        Issue #456 Stage 4 wires ``SpecCoverageAugmenter`` into
+        ``decompose_by_contract`` via the augmenter chain.  That
+        augmenter calls :func:`check_spec_coverage`, which makes a
+        real LLM call to extract spec features — which would both (a)
+        contaminate these unit tests with network I/O and (b) inflate
+        the returned task count with synthesized spec_gap tasks.
+        Tests in this class assert exact contract task shape, so we
+        replace ``check_spec_coverage`` with a no-op for the entire
+        class.  Tests that need real spec_coverage behavior should
+        live in ``test_spec_coverage_augmenter.py``.
+        """
+        with patch(
+            "src.marcus_mcp.coordinator.spec_coverage_augmenter." "check_spec_coverage",
+            new_callable=AsyncMock,
+            return_value=[],
+        ) as mock:
+            yield mock
 
     @pytest.mark.asyncio
     async def test_happy_path_produces_tasks_with_responsibility(self):

--- a/tests/unit/ai/test_parse_prd_outcome_integration.py
+++ b/tests/unit/ai/test_parse_prd_outcome_integration.py
@@ -3,14 +3,21 @@
 Verifies the feature-based decomposer integration:
 
 - Outcomes are extracted during _analyze_prd_deeply when flag is on
-- apply_outcome_coverage is called between _create_detailed_tasks and
-  _infer_smart_dependencies, so synthesized tasks participate in
-  dependency inference
+- ``apply_outcome_coverage_to_feature_graph`` runs between
+  ``_create_detailed_tasks`` and ``_infer_smart_dependencies`` so
+  synthesized tasks participate in dependency inference
 - Synthesized task dicts are converted to Task objects with
-  gap_fill_<uuid> ids and sibling-inherited defaults
+  ``gap_fill_<uuid>`` ids and sibling-inherited defaults
 - TaskGenerationResult exposes intent_fidelity_score plus coverage
   maps for telemetry
 - Flag-off path is a no-op (no extraction, no coverage check)
+
+Issue #456 Stage 5: the lifted module function
+``apply_outcome_coverage_to_feature_graph`` replaces the formerly-
+private ``AdvancedPRDParser._apply_outcome_coverage_to_graph``.  The
+function returns the canonical :class:`AugmentationResult` shape
+directly; tests assert on ``result.telemetry`` (the
+PLANNING_INTENT_FIDELITY-shaped dict) instead of ``result.coverage``.
 """
 
 from typing import Any
@@ -68,34 +75,47 @@ def _bare_analysis(outcomes: list[UserOutcome]) -> PRDAnalysis:
     )
 
 
-class TestApplyOutcomeCoverageToGraphHelper:
-    """The private helper bridges apply_outcome_coverage to the graph."""
+class TestApplyOutcomeCoverageToFeatureGraph:
+    """The lifted module function bridges apply_outcome_coverage to the graph."""
 
     @pytest.mark.asyncio
-    async def test_returns_none_when_flag_off(self, monkeypatch: Any) -> None:
-        monkeypatch.setenv(ENV_VAR_NAME, "false")
-        parser = _build_parser()
+    async def test_no_op_when_flag_off(self, monkeypatch: Any) -> None:
+        """Flag off → empty-telemetry passthrough, no LLM call."""
+        from src.marcus_mcp.coordinator.outcome_coverage import (
+            apply_outcome_coverage_to_feature_graph,
+        )
 
-        result = await parser._apply_outcome_coverage_to_graph(
+        monkeypatch.setenv(ENV_VAR_NAME, "false")
+        llm_client = AsyncMock()
+
+        result = await apply_outcome_coverage_to_feature_graph(
             prd_analysis=_bare_analysis([_outcome()]),
             tasks=[],
+            llm_client=llm_client,
         )
 
-        assert result is None
-        parser.llm_client.analyze.assert_not_called()
+        assert result.telemetry == {}
+        assert result.synthesized_ids == []
+        llm_client.analyze.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_returns_none_when_no_outcomes(self, monkeypatch: Any) -> None:
-        monkeypatch.setenv(ENV_VAR_NAME, "true")
-        parser = _build_parser()
-
-        result = await parser._apply_outcome_coverage_to_graph(
-            prd_analysis=_bare_analysis([]),
-            tasks=[],
+    async def test_no_op_when_no_outcomes(self, monkeypatch: Any) -> None:
+        """No in-scope outcomes → empty-telemetry passthrough."""
+        from src.marcus_mcp.coordinator.outcome_coverage import (
+            apply_outcome_coverage_to_feature_graph,
         )
 
-        assert result is None
-        parser.llm_client.analyze.assert_not_called()
+        monkeypatch.setenv(ENV_VAR_NAME, "true")
+        llm_client = AsyncMock()
+
+        result = await apply_outcome_coverage_to_feature_graph(
+            prd_analysis=_bare_analysis([]),
+            tasks=[],
+            llm_client=llm_client,
+        )
+
+        assert result.telemetry == {}
+        llm_client.analyze.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_appends_synthesized_tasks_with_gap_fill_id(
@@ -105,12 +125,14 @@ class TestApplyOutcomeCoverageToGraphHelper:
         from datetime import datetime, timezone
 
         from src.core.models import Priority, Task, TaskStatus
+        from src.marcus_mcp.coordinator.outcome_coverage import (
+            apply_outcome_coverage_to_feature_graph,
+        )
 
         monkeypatch.setenv(ENV_VAR_NAME, "true")
-        parser = _build_parser()
-
+        llm_client = AsyncMock()
         # 3 LLM responses: coverage (gap), fill, post-fill coverage
-        parser.llm_client.analyze = AsyncMock(
+        llm_client.analyze = AsyncMock(
             side_effect=[
                 '{"coverage": {"outcome_play": []}}',
                 (
@@ -141,12 +163,12 @@ class TestApplyOutcomeCoverageToGraphHelper:
             project_name="Snake",
         )
 
-        result = await parser._apply_outcome_coverage_to_graph(
+        result = await apply_outcome_coverage_to_feature_graph(
             prd_analysis=_bare_analysis([_outcome()]),
             tasks=[v31_task],
+            llm_client=llm_client,
         )
 
-        assert result is not None
         assert len(result.augmented_tasks) == 2
         synthesized = result.augmented_tasks[1]
         assert synthesized.id.startswith("gap_fill_")
@@ -159,18 +181,22 @@ class TestApplyOutcomeCoverageToGraphHelper:
         assert synthesized.project_name == "Snake"
         # Median of [2.0] is 2.0
         assert synthesized.estimated_hours == 2.0
+        # Synthesized ID surfaces in synthesized_ids
+        assert result.synthesized_ids == [synthesized.id]
 
     @pytest.mark.asyncio
-    async def test_score_and_coverage_maps_returned(self, monkeypatch: Any) -> None:
-        """Helper exposes score + coverage maps for TaskGenerationResult."""
+    async def test_score_and_coverage_maps_in_telemetry(self, monkeypatch: Any) -> None:
+        """Telemetry exposes the canonical PLANNING_INTENT_FIDELITY keys."""
         from datetime import datetime, timezone
 
         from src.core.models import Priority, Task, TaskStatus
+        from src.marcus_mcp.coordinator.outcome_coverage import (
+            apply_outcome_coverage_to_feature_graph,
+        )
 
         monkeypatch.setenv(ENV_VAR_NAME, "true")
-        parser = _build_parser()
-
-        parser.llm_client.analyze = AsyncMock(
+        llm_client = AsyncMock()
+        llm_client.analyze = AsyncMock(
             side_effect=[
                 '{"coverage": {"outcome_play": ["t_render"]}}',
             ]
@@ -190,64 +216,68 @@ class TestApplyOutcomeCoverageToGraphHelper:
             estimated_hours=2.0,
         )
 
-        result = await parser._apply_outcome_coverage_to_graph(
+        result = await apply_outcome_coverage_to_feature_graph(
             prd_analysis=_bare_analysis([_outcome()]),
             tasks=[complete_task],
+            llm_client=llm_client,
         )
 
-        assert result is not None
-        assert result.coverage.intent_fidelity_score == 1.0
-        assert result.coverage.coverage_before_fill == {"outcome_play": ["t_render"]}
-        assert result.coverage.coverage_after_fill is None  # no gap-fill ran
-        assert result.coverage.gaps == []
+        assert result.telemetry["intent_fidelity_score"] == 1.0
+        assert result.telemetry["coverage_before_fill"] == {
+            "outcome_play": ["t_render"]
+        }
+        assert result.telemetry["coverage_after_fill"] is None
+        assert result.telemetry["gap_filled_outcomes"] == []
         # Original tasks unchanged when coverage is full
         assert result.augmented_tasks == [complete_task]
 
     @pytest.mark.asyncio
-    async def test_coverage_failure_returns_none_does_not_raise(
+    async def test_coverage_failure_no_op_does_not_raise(
         self, monkeypatch: Any
     ) -> None:
-        """LLM error in coverage check is logged, helper returns None."""
-        monkeypatch.setenv(ENV_VAR_NAME, "true")
-        parser = _build_parser()
-        parser.llm_client.analyze = AsyncMock(return_value="not json")
-
-        result = await parser._apply_outcome_coverage_to_graph(
-            prd_analysis=_bare_analysis([_outcome()]),
-            tasks=[],
+        """LLM error in coverage check is logged; passthrough result."""
+        from src.marcus_mcp.coordinator.outcome_coverage import (
+            apply_outcome_coverage_to_feature_graph,
         )
 
-        assert result is None
+        monkeypatch.setenv(ENV_VAR_NAME, "true")
+        llm_client = AsyncMock()
+        llm_client.analyze = AsyncMock(return_value="not json")
+
+        result = await apply_outcome_coverage_to_feature_graph(
+            prd_analysis=_bare_analysis([_outcome()]),
+            tasks=[],
+            llm_client=llm_client,
+        )
+
+        # Empty telemetry signals coverage didn't successfully complete
+        assert result.telemetry == {}
+        assert result.augmented_tasks == []
 
 
-class TestParsePrdToTasksCallsCoverageHelper:
-    """Lock in the integration: parse_prd_to_tasks awaits the helper.
+class TestParsePrdToTasksCallsAugmenterChain:
+    """Lock in the integration: parse_prd_to_tasks awaits the chain.
 
-    Helper-only tests would still pass if someone removed the call
-    site between Step 3 and Step 4, silently degrading the integration.
-    This test fixates the call site itself.
+    The augmenter chain runs between Step 3 (``_create_detailed_tasks``)
+    and Step 4 (``_infer_smart_dependencies``).  This test fixates that
+    the lifted feature-graph function gets called via the chain.
     """
 
     @pytest.mark.asyncio
-    async def test_helper_called_during_parse_prd_to_tasks(
+    async def test_lifted_function_called_during_parse_prd_to_tasks(
         self, monkeypatch: Any
     ) -> None:
-        """parse_prd_to_tasks awaits _apply_outcome_coverage_to_graph.
+        """parse_prd_to_tasks awaits apply_outcome_coverage_to_feature_graph.
 
-        Mocks the entire downstream pipeline (hierarchy / detailed
-        tasks / dep inference / risk / timeline / resources / success
-        criteria) so the test focuses on whether the helper is wired
-        into the orchestration.
+        Mocks the entire downstream pipeline so the test focuses on
+        whether the lifted function is reached via the augmenter chain.
         """
         from datetime import datetime, timezone
 
-        from src.ai.advanced.prd.advanced_parser import (
-            AdvancedPRDParser,
-            ParserOutcomeCoverage,
-        )
+        from src.ai.advanced.prd.advanced_parser import AdvancedPRDParser
         from src.core.models import Priority, Task, TaskStatus
-        from src.marcus_mcp.coordinator.outcome_coverage import (
-            OutcomeCoverageResult,
+        from src.marcus_mcp.coordinator.graph_augmentation import (
+            AugmentationResult,
         )
 
         monkeypatch.setenv(ENV_VAR_NAME, "true")
@@ -285,27 +315,48 @@ class TestParsePrdToTasksCallsCoverageHelper:
             parser._analyze_resource_requirements = AsyncMock(return_value={})
             parser._generate_success_criteria = AsyncMock(return_value=[])
 
-            # Spy on the helper — return a no-op ParserOutcomeCoverage
-            # so the orchestration completes.
-            stub_helper_result = ParserOutcomeCoverage(
+            # Spy on the lifted function — return a populated
+            # AugmentationResult so the orchestration completes.
+            stub_chain_result = AugmentationResult(
                 augmented_tasks=[stub_task],
-                coverage=OutcomeCoverageResult(
-                    synthesized_tasks=[],
-                    intent_fidelity_score=1.0,
-                    coverage_before_fill={"outcome_play": ["t1"]},
-                    gaps=[],
-                ),
-            )
-            parser._apply_outcome_coverage_to_graph = AsyncMock(
-                return_value=stub_helper_result
+                synthesized_ids=[],
+                telemetry={
+                    "intent_fidelity_score": 1.0,
+                    "coverage_before_fill": {"outcome_play": ["t1"]},
+                    "coverage_after_fill": None,
+                    "gap_filled_outcomes": [],
+                },
             )
 
-            constraints = ProjectConstraints()
-            result = await parser.parse_prd_to_tasks("build a snake game", constraints)
+            with (
+                patch(
+                    "src.marcus_mcp.coordinator.outcome_coverage_augmenter."
+                    "apply_outcome_coverage_to_feature_graph",
+                    new_callable=AsyncMock,
+                    return_value=stub_chain_result,
+                ) as mock_apply,
+                patch(
+                    "src.ai.advanced.prd.advanced_parser.SpecCoverageAugmenter"
+                ) as mock_spec_class,
+            ):
+                # Stub spec_coverage augmenter so it doesn't make
+                # network calls; we're testing the outcome-coverage
+                # integration here.
+                mock_spec_aug = AsyncMock()
+                mock_spec_aug.name = "spec_coverage"
+                mock_spec_aug.augment = AsyncMock(
+                    return_value=AugmentationResult(augmented_tasks=[stub_task])
+                )
+                mock_spec_class.return_value = mock_spec_aug
 
-        # The call site exists and awaited the helper exactly once
-        parser._apply_outcome_coverage_to_graph.assert_awaited_once()
+                constraints = ProjectConstraints()
+                result = await parser.parse_prd_to_tasks(
+                    "build a snake game", constraints
+                )
 
-        # And the helper's result flowed into TaskGenerationResult
+        # The lifted function was reached via the augmenter chain
+        mock_apply.assert_awaited_once()
+
+        # And its telemetry flowed into TaskGenerationResult
         assert result.intent_fidelity_score == 1.0
         assert result.coverage_before_fill == {"outcome_play": ["t1"]}

--- a/tests/unit/coordinator/test_augmenter_chain.py
+++ b/tests/unit/coordinator/test_augmenter_chain.py
@@ -1,0 +1,435 @@
+"""Unit tests for ``run_augmenter_chain`` (issue #456 — Stage 3).
+
+The chain orchestrator runs registered augmenters sequentially over a
+task graph.  Each augmenter sees the post-previous-augmenter task list
+so synthesized tasks can flow forward (e.g., outcome_coverage's
+gap-fill task is visible to spec_coverage's coverage check).
+
+Defense-in-depth requirement (Kaia review #2, Simon ``c26c7ec5``):
+the orchestrator wraps every augmenter call in ``try/except`` so an
+unexpected raise from a future augmenter never crashes the decomposer.
+This is independent of each augmenter's own internal exception
+handling — the chain is the last line of defense.
+
+Telemetry is namespaced by augmenter ``name`` so future augmenters
+add their payload alongside outcome_coverage's without key collisions.
+The contract-first consumer at ``nlp_tools.py`` reads the
+``outcome_coverage`` slice to emit ``PLANNING_INTENT_FIDELITY``.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
+
+import pytest
+
+from src.core.models import Priority, Task, TaskStatus
+
+pytestmark = pytest.mark.unit
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_task(task_id: str, name: str = "Implement Foo") -> Task:
+    """Minimal Task for chain tests."""
+    now = datetime.now(timezone.utc)
+    return Task(
+        id=task_id,
+        name=name,
+        description="...",
+        status=TaskStatus.TODO,
+        priority=Priority.HIGH,
+        assigned_to=None,
+        created_at=now,
+        updated_at=now,
+        due_date=None,
+        estimated_hours=2.0,
+    )
+
+
+class _RecordingAugmenter:
+    """Augmenter stub that records calls and returns canned results."""
+
+    def __init__(
+        self,
+        *,
+        name: str,
+        tasks_to_append: Optional[List[Task]] = None,
+        telemetry: Optional[Dict[str, Any]] = None,
+        raises: Optional[BaseException] = None,
+    ) -> None:
+        self.name = name
+        self._tasks_to_append = tasks_to_append or []
+        self._telemetry = telemetry or {}
+        self._raises = raises
+        self.calls: List[Dict[str, Any]] = []
+
+    async def augment(
+        self,
+        *,
+        prd_analysis: Any,
+        tasks: List[Task],
+        contract_artifacts: Optional[Dict[str, Any]] = None,
+    ) -> Any:
+        from src.marcus_mcp.coordinator.graph_augmentation import (
+            AugmentationResult,
+        )
+
+        self.calls.append(
+            {
+                "prd_analysis": prd_analysis,
+                "tasks": list(tasks),
+                "contract_artifacts": contract_artifacts,
+            }
+        )
+        if self._raises is not None:
+            raise self._raises
+
+        appended = self._tasks_to_append
+        return AugmentationResult(
+            augmented_tasks=list(tasks) + appended,
+            synthesized_ids=[t.id for t in appended],
+            telemetry=dict(self._telemetry),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Module export
+# ---------------------------------------------------------------------------
+
+
+class TestRunAugmenterChainExport:
+    """The chain orchestrator is exported from the canonical module."""
+
+    def test_module_exports_run_augmenter_chain(self) -> None:
+        from src.marcus_mcp.coordinator.graph_augmentation import (
+            run_augmenter_chain,
+        )
+
+        assert run_augmenter_chain is not None
+
+
+# ---------------------------------------------------------------------------
+# Empty chain / single-augmenter passthrough
+# ---------------------------------------------------------------------------
+
+
+class TestEmptyAndSingleAugmenter:
+    """Trivial chain shapes produce expected results."""
+
+    @pytest.mark.asyncio
+    async def test_empty_chain_returns_input_tasks_unchanged(self) -> None:
+        """No augmenters → AugmentationResult mirrors input tasks."""
+        from src.marcus_mcp.coordinator.graph_augmentation import (
+            run_augmenter_chain,
+        )
+
+        tasks = [_make_task("t1"), _make_task("t2")]
+        result = await run_augmenter_chain([], prd_analysis=None, tasks=tasks)
+
+        assert result.augmented_tasks == tasks
+        assert result.synthesized_ids == []
+        assert result.telemetry == {}
+
+    @pytest.mark.asyncio
+    async def test_single_augmenter_called_with_inputs(self) -> None:
+        """Augmenter receives ``prd_analysis``, ``tasks``, ``contract_artifacts``."""
+        from src.marcus_mcp.coordinator.graph_augmentation import (
+            run_augmenter_chain,
+        )
+
+        augmenter = _RecordingAugmenter(name="aug")
+        tasks = [_make_task("t1")]
+        await run_augmenter_chain(
+            [augmenter],
+            prd_analysis="PRD",
+            tasks=tasks,
+            contract_artifacts={"Auth": {"artifacts": []}},
+        )
+
+        assert len(augmenter.calls) == 1
+        call = augmenter.calls[0]
+        assert call["prd_analysis"] == "PRD"
+        assert call["tasks"] == tasks
+        assert call["contract_artifacts"] == {"Auth": {"artifacts": []}}
+
+    @pytest.mark.asyncio
+    async def test_single_augmenter_result_propagates(self) -> None:
+        """Augmenter's augmented_tasks become chain output."""
+        from src.marcus_mcp.coordinator.graph_augmentation import (
+            run_augmenter_chain,
+        )
+
+        synth = _make_task("synth_1", "Synthesized")
+        augmenter = _RecordingAugmenter(
+            name="aug",
+            tasks_to_append=[synth],
+            telemetry={"score": 0.8},
+        )
+        tasks = [_make_task("t1")]
+
+        result = await run_augmenter_chain([augmenter], prd_analysis=None, tasks=tasks)
+
+        assert result.augmented_tasks == tasks + [synth]
+        assert result.synthesized_ids == ["synth_1"]
+
+
+# ---------------------------------------------------------------------------
+# Multi-augmenter chaining
+# ---------------------------------------------------------------------------
+
+
+class TestMultiAugmenterChaining:
+    """Augmenters run sequentially; each sees previous augmenter's output."""
+
+    @pytest.mark.asyncio
+    async def test_second_augmenter_sees_first_augmenter_tasks(self) -> None:
+        """Augmenter B's input includes augmenter A's synthesized tasks.
+
+        This is the load-bearing property — the whole point of the
+        chain is that downstream augmenters react to upstream
+        synthesis (e.g., spec_coverage scores against the post-
+        outcome_coverage graph).
+        """
+        from src.marcus_mcp.coordinator.graph_augmentation import (
+            run_augmenter_chain,
+        )
+
+        synth_a = _make_task("synth_a", "From A")
+        aug_a = _RecordingAugmenter(name="A", tasks_to_append=[synth_a])
+        aug_b = _RecordingAugmenter(name="B")
+        original = _make_task("t1")
+
+        await run_augmenter_chain([aug_a, aug_b], prd_analysis=None, tasks=[original])
+
+        # B's `tasks` argument must include synth_a appended by A
+        assert aug_b.calls[0]["tasks"] == [original, synth_a]
+
+    @pytest.mark.asyncio
+    async def test_synthesized_ids_accumulate_across_chain(self) -> None:
+        """Final synthesized_ids contains IDs from every augmenter."""
+        from src.marcus_mcp.coordinator.graph_augmentation import (
+            run_augmenter_chain,
+        )
+
+        aug_a = _RecordingAugmenter(name="A", tasks_to_append=[_make_task("synth_a")])
+        aug_b = _RecordingAugmenter(name="B", tasks_to_append=[_make_task("synth_b")])
+
+        result = await run_augmenter_chain(
+            [aug_a, aug_b], prd_analysis=None, tasks=[_make_task("t1")]
+        )
+
+        assert result.synthesized_ids == ["synth_a", "synth_b"]
+
+    @pytest.mark.asyncio
+    async def test_telemetry_namespaced_by_augmenter_name(self) -> None:
+        """Telemetry dict is keyed by ``augmenter.name`` per augmenter.
+
+        Namespacing avoids key collisions when a future augmenter
+        emits a key that another augmenter already uses.  Consumers
+        that need outcome_coverage-shaped data read
+        ``result.telemetry["outcome_coverage"]``.
+        """
+        from src.marcus_mcp.coordinator.graph_augmentation import (
+            run_augmenter_chain,
+        )
+
+        aug_a = _RecordingAugmenter(name="outcome_coverage", telemetry={"score": 0.8})
+        aug_b = _RecordingAugmenter(name="spec_coverage", telemetry={"missing": 1})
+
+        result = await run_augmenter_chain(
+            [aug_a, aug_b], prd_analysis=None, tasks=[_make_task("t1")]
+        )
+
+        assert result.telemetry == {
+            "outcome_coverage": {"score": 0.8},
+            "spec_coverage": {"missing": 1},
+        }
+
+    @pytest.mark.asyncio
+    async def test_empty_telemetry_omitted_from_namespace(self) -> None:
+        """Augmenter that returns empty telemetry contributes no key.
+
+        Saves consumers from a ``{"name": {}}`` no-op entry that
+        signals "augmenter ran but produced no data" vs "augmenter
+        didn't run".  Those should be distinguishable.
+        """
+        from src.marcus_mcp.coordinator.graph_augmentation import (
+            run_augmenter_chain,
+        )
+
+        aug_a = _RecordingAugmenter(name="A", telemetry={"k": 1})
+        aug_b = _RecordingAugmenter(name="B")  # default empty telemetry
+
+        result = await run_augmenter_chain(
+            [aug_a, aug_b], prd_analysis=None, tasks=[_make_task("t1")]
+        )
+
+        assert "A" in result.telemetry
+        assert "B" not in result.telemetry
+
+
+# ---------------------------------------------------------------------------
+# Defense-in-depth: try/except around each augmenter
+# ---------------------------------------------------------------------------
+
+
+class TestExceptionDefenseInDepth:
+    """The chain catches per-augmenter exceptions so a buggy augmenter
+    cannot crash the decomposer.  This is independent of each
+    augmenter's own internal exception handling.
+    """
+
+    @pytest.mark.asyncio
+    async def test_augmenter_exception_does_not_propagate(self) -> None:
+        """Augmenter raise → chain swallows, returns valid result."""
+        from src.marcus_mcp.coordinator.graph_augmentation import (
+            run_augmenter_chain,
+        )
+
+        aug = _RecordingAugmenter(name="bad", raises=RuntimeError("boom"))
+
+        # Must not raise
+        result = await run_augmenter_chain(
+            [aug], prd_analysis=None, tasks=[_make_task("t1")]
+        )
+        assert result is not None
+
+    @pytest.mark.asyncio
+    async def test_failed_augmenter_preserves_prior_tasks(self) -> None:
+        """When augmenter raises, chain continues with input tasks
+        unchanged for that step."""
+        from src.marcus_mcp.coordinator.graph_augmentation import (
+            run_augmenter_chain,
+        )
+
+        tasks = [_make_task("t1"), _make_task("t2")]
+        aug = _RecordingAugmenter(name="bad", raises=ValueError("oops"))
+
+        result = await run_augmenter_chain([aug], prd_analysis=None, tasks=tasks)
+
+        assert result.augmented_tasks == tasks
+        assert result.synthesized_ids == []
+
+    @pytest.mark.asyncio
+    async def test_failed_augmenter_omits_telemetry(self) -> None:
+        """Failed augmenter contributes no telemetry namespace."""
+        from src.marcus_mcp.coordinator.graph_augmentation import (
+            run_augmenter_chain,
+        )
+
+        aug = _RecordingAugmenter(name="bad", raises=RuntimeError("x"))
+        result = await run_augmenter_chain(
+            [aug], prd_analysis=None, tasks=[_make_task("t1")]
+        )
+        assert "bad" not in result.telemetry
+
+    @pytest.mark.asyncio
+    async def test_chain_continues_after_failure(self) -> None:
+        """A failed augmenter does not abort the chain — subsequent
+        augmenters still run with the pre-failure tasks.
+
+        This is the load-bearing property.  Without it, one buggy
+        future augmenter could silently neutralize all downstream
+        augmenters in the chain.
+        """
+        from src.marcus_mcp.coordinator.graph_augmentation import (
+            run_augmenter_chain,
+        )
+
+        bad = _RecordingAugmenter(name="bad", raises=RuntimeError("x"))
+        good = _RecordingAugmenter(
+            name="good",
+            tasks_to_append=[_make_task("synth_good")],
+            telemetry={"k": 1},
+        )
+        original = _make_task("t1")
+
+        result = await run_augmenter_chain(
+            [bad, good],
+            prd_analysis=None,
+            tasks=[original],
+        )
+
+        # ``good`` ran with the original tasks (bad's failure was a no-op)
+        assert good.calls[0]["tasks"] == [original]
+        assert "synth_good" in result.synthesized_ids
+        assert result.telemetry == {"good": {"k": 1}}
+
+    @pytest.mark.asyncio
+    async def test_exception_logged_with_augmenter_name(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Operators must know which augmenter failed.
+
+        Silent swallow + no log = invisible regression.  Log line
+        must include the augmenter's ``name`` so it's grep-able.
+        """
+        import logging
+
+        from src.marcus_mcp.coordinator.graph_augmentation import (
+            run_augmenter_chain,
+        )
+
+        aug = _RecordingAugmenter(name="myaug", raises=RuntimeError("boom"))
+        with caplog.at_level(logging.WARNING):
+            await run_augmenter_chain(
+                [aug], prd_analysis=None, tasks=[_make_task("t1")]
+            )
+
+        assert any("myaug" in rec.getMessage() for rec in caplog.records), (
+            "Augmenter name must appear in the warning log so failures "
+            "are diagnosable in production."
+        )
+
+
+# ---------------------------------------------------------------------------
+# Contract artifacts forwarding
+# ---------------------------------------------------------------------------
+
+
+class TestContractArtifactsForwarding:
+    """Each augmenter receives the same ``contract_artifacts``.
+
+    The chain is augmenter-agnostic about contract_artifacts — it
+    forwards the same value to every augmenter.  Augmenters that
+    don't care (spec_coverage today) ignore the parameter; those that
+    do (outcome_coverage) read it.
+    """
+
+    @pytest.mark.asyncio
+    async def test_contract_artifacts_forwarded_to_all_augmenters(
+        self,
+    ) -> None:
+        from src.marcus_mcp.coordinator.graph_augmentation import (
+            run_augmenter_chain,
+        )
+
+        aug_a = _RecordingAugmenter(name="A")
+        aug_b = _RecordingAugmenter(name="B")
+        artifacts = {"Auth": {"artifacts": [{"content": "..."}]}}
+
+        await run_augmenter_chain(
+            [aug_a, aug_b],
+            prd_analysis=None,
+            tasks=[_make_task("t1")],
+            contract_artifacts=artifacts,
+        )
+
+        assert aug_a.calls[0]["contract_artifacts"] == artifacts
+        assert aug_b.calls[0]["contract_artifacts"] == artifacts
+
+    @pytest.mark.asyncio
+    async def test_contract_artifacts_default_none(self) -> None:
+        """``contract_artifacts`` defaults to None when omitted."""
+        from src.marcus_mcp.coordinator.graph_augmentation import (
+            run_augmenter_chain,
+        )
+
+        aug = _RecordingAugmenter(name="A")
+        await run_augmenter_chain([aug], prd_analysis=None, tasks=[_make_task("t1")])
+        assert aug.calls[0]["contract_artifacts"] is None

--- a/tests/unit/coordinator/test_augmenter_chain.py
+++ b/tests/unit/coordinator/test_augmenter_chain.py
@@ -433,3 +433,98 @@ class TestContractArtifactsForwarding:
         aug = _RecordingAugmenter(name="A")
         await run_augmenter_chain([aug], prd_analysis=None, tasks=[_make_task("t1")])
         assert aug.calls[0]["contract_artifacts"] is None
+
+
+# ---------------------------------------------------------------------------
+# Augmenter name uniqueness (Kaia review #4 concern #2, Simon ``f36c49c4``)
+# ---------------------------------------------------------------------------
+
+
+class TestAugmenterNameUniqueness:
+    """Augmenter names must be unique within a chain.
+
+    Pre-check rationale: telemetry is namespaced by ``augmenter.name``.
+    Two augmenters with the same name silently overwrite each other's
+    telemetry slice in the result dict — a confusing failure mode for
+    plugin-developers and an observability hole.  The chain validates
+    name uniqueness at entry and fails loud with a clear message.
+    """
+
+    @pytest.mark.asyncio
+    async def test_duplicate_names_raise_value_error(self) -> None:
+        """Two augmenters sharing a name → ValueError at chain entry."""
+        from src.marcus_mcp.coordinator.graph_augmentation import (
+            run_augmenter_chain,
+        )
+
+        aug_a = _RecordingAugmenter(name="dup")
+        aug_b = _RecordingAugmenter(name="dup")
+
+        with pytest.raises(ValueError, match=r"duplicate"):
+            await run_augmenter_chain(
+                [aug_a, aug_b],
+                prd_analysis=None,
+                tasks=[_make_task("t1")],
+            )
+
+    @pytest.mark.asyncio
+    async def test_duplicate_name_error_includes_name(self) -> None:
+        """Error message names the duplicate so it's diagnosable."""
+        from src.marcus_mcp.coordinator.graph_augmentation import (
+            run_augmenter_chain,
+        )
+
+        aug_a = _RecordingAugmenter(name="outcome_coverage")
+        aug_b = _RecordingAugmenter(name="outcome_coverage")
+
+        with pytest.raises(ValueError, match=r"outcome_coverage"):
+            await run_augmenter_chain(
+                [aug_a, aug_b],
+                prd_analysis=None,
+                tasks=[_make_task("t1")],
+            )
+
+    @pytest.mark.asyncio
+    async def test_unique_names_no_error(self) -> None:
+        """Distinct names → chain runs normally."""
+        from src.marcus_mcp.coordinator.graph_augmentation import (
+            run_augmenter_chain,
+        )
+
+        aug_a = _RecordingAugmenter(name="A")
+        aug_b = _RecordingAugmenter(name="B")
+
+        # Must not raise
+        result = await run_augmenter_chain(
+            [aug_a, aug_b],
+            prd_analysis=None,
+            tasks=[_make_task("t1")],
+        )
+        assert result is not None
+
+    @pytest.mark.asyncio
+    async def test_uniqueness_check_runs_before_first_augment(self) -> None:
+        """Validation is at chain entry, before any augmenter executes.
+
+        Important so the failure mode is "fail fast at boot" rather
+        than "first augmenter does work, then we crash on the second
+        one."  Half-applied augmentation would leak side effects (LLM
+        cost, log lines).
+        """
+        from src.marcus_mcp.coordinator.graph_augmentation import (
+            run_augmenter_chain,
+        )
+
+        aug_a = _RecordingAugmenter(name="dup")
+        aug_b = _RecordingAugmenter(name="dup")
+
+        with pytest.raises(ValueError):
+            await run_augmenter_chain(
+                [aug_a, aug_b],
+                prd_analysis=None,
+                tasks=[_make_task("t1")],
+            )
+
+        # Neither augmenter ran
+        assert aug_a.calls == []
+        assert aug_b.calls == []

--- a/tests/unit/coordinator/test_graph_augmentation.py
+++ b/tests/unit/coordinator/test_graph_augmentation.py
@@ -1,0 +1,270 @@
+"""
+Unit tests for the ``GraphAugmenter`` protocol + ``AugmentationResult``
+dataclass (issue #456 — Stage 1).
+
+This stage defines the abstract surface only.  No behavior change
+yet.  Tests pin the Protocol shape, dataclass fields, and runtime-
+checkability so subsequent stages (OutcomeCoverageAugmenter,
+SpecCoverageAugmenter) can wrap existing implementations against a
+stable interface.
+
+Why a Protocol (structural) rather than ABC (nominal): Marcus's
+existing pipeline conventions favor duck typing; structural typing
+keeps the interface non-invasive to existing classes.  ``@runtime_checkable``
+lets the orchestrator validate registered augmenters with
+``isinstance`` when registration happens, without requiring those
+classes to inherit from a base.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+import pytest
+
+from src.core.models import Priority, Task, TaskStatus
+
+pytestmark = pytest.mark.unit
+
+
+# ---------------------------------------------------------------------------
+# AugmentationResult dataclass
+# ---------------------------------------------------------------------------
+
+
+class TestAugmentationResultDataclass:
+    """``AugmentationResult`` carries the canonical augmenter output shape."""
+
+    def test_module_exports_augmentation_result(self) -> None:
+        """``AugmentationResult`` is importable from the canonical module."""
+        from src.marcus_mcp.coordinator.graph_augmentation import (
+            AugmentationResult,
+        )
+
+        assert AugmentationResult is not None
+
+    def test_required_field_augmented_tasks(self) -> None:
+        """``augmented_tasks`` is a required field carrying the
+        post-augmentation graph (original tasks + any synthesized).
+        """
+        from src.marcus_mcp.coordinator.graph_augmentation import (
+            AugmentationResult,
+        )
+
+        result = AugmentationResult(augmented_tasks=[])
+        assert result.augmented_tasks == []
+
+    def test_synthesized_ids_defaults_to_empty_list(self) -> None:
+        """``synthesized_ids`` carries IDs of newly added tasks.
+
+        Subset of ``augmented_tasks``.  Empty when no synthesis ran.
+        Default factory so each instance gets its own list (no
+        mutable-default shared state).
+        """
+        from src.marcus_mcp.coordinator.graph_augmentation import (
+            AugmentationResult,
+        )
+
+        a = AugmentationResult(augmented_tasks=[])
+        b = AugmentationResult(augmented_tasks=[])
+        assert a.synthesized_ids == []
+        assert b.synthesized_ids == []
+        # Mutation on one must not affect the other (default-factory check)
+        a.synthesized_ids.append("x")
+        assert b.synthesized_ids == []
+
+    def test_telemetry_defaults_to_empty_dict(self) -> None:
+        """``telemetry`` is augmenter-specific metrics for event emission.
+
+        Generic ``Dict[str, Any]`` keeps the Protocol simple — typed
+        Union would force every augmenter to declare a typed payload
+        upfront, premature when the augmenter shapes are still
+        evolving.  Default factory so each instance gets its own dict.
+        """
+        from src.marcus_mcp.coordinator.graph_augmentation import (
+            AugmentationResult,
+        )
+
+        a = AugmentationResult(augmented_tasks=[])
+        b = AugmentationResult(augmented_tasks=[])
+        assert a.telemetry == {}
+        assert b.telemetry == {}
+        a.telemetry["score"] = 1.0
+        assert b.telemetry == {}
+
+    def test_can_construct_with_all_fields(self) -> None:
+        """Smoke test: dataclass accepts all three fields explicitly."""
+        from datetime import datetime, timezone
+
+        from src.marcus_mcp.coordinator.graph_augmentation import (
+            AugmentationResult,
+        )
+
+        now = datetime.now(timezone.utc)
+        task = Task(
+            id="t1",
+            name="Test",
+            description="...",
+            status=TaskStatus.TODO,
+            priority=Priority.MEDIUM,
+            assigned_to=None,
+            created_at=now,
+            updated_at=now,
+            due_date=None,
+            estimated_hours=1.0,
+        )
+        result = AugmentationResult(
+            augmented_tasks=[task],
+            synthesized_ids=["t1"],
+            telemetry={"score": 0.5, "extra": "data"},
+        )
+        assert len(result.augmented_tasks) == 1
+        assert result.synthesized_ids == ["t1"]
+        assert result.telemetry == {"score": 0.5, "extra": "data"}
+
+
+# ---------------------------------------------------------------------------
+# GraphAugmenter Protocol
+# ---------------------------------------------------------------------------
+
+
+class TestGraphAugmenterProtocol:
+    """``GraphAugmenter`` is a Protocol (structural type) for pre-inference
+    task graph augmentation.  Stage-2 will provide the first
+    implementation (OutcomeCoverageAugmenter); Stage-4 the second
+    (SpecCoverageAugmenter).
+    """
+
+    def test_module_exports_graph_augmenter(self) -> None:
+        """``GraphAugmenter`` is importable from the canonical module."""
+        from src.marcus_mcp.coordinator.graph_augmentation import (
+            GraphAugmenter,
+        )
+
+        assert GraphAugmenter is not None
+
+    def test_protocol_is_runtime_checkable(self) -> None:
+        """``@runtime_checkable`` lets the orchestrator validate
+        registered augmenters via ``isinstance``.
+
+        Pre-#456 Marcus had no augmenter registry.  Stage-3 adds one;
+        registration-time validation needs ``isinstance(thing, GraphAugmenter)``
+        to fail loud on misregistered classes that don't satisfy the
+        Protocol.  Without ``@runtime_checkable``, the failure would
+        only surface at first .augment() call.
+        """
+        from typing import _ProtocolMeta  # type: ignore[attr-defined]
+
+        from src.marcus_mcp.coordinator.graph_augmentation import (
+            GraphAugmenter,
+        )
+
+        # Protocol classes have a magic attribute set by @runtime_checkable
+        assert getattr(
+            GraphAugmenter, "_is_runtime_protocol", False
+        ), "GraphAugmenter must be decorated with @runtime_checkable"
+
+    def test_stub_implementation_satisfies_protocol(self) -> None:
+        """A concrete class with the right shape passes ``isinstance``.
+
+        Pins the Protocol surface: any class with ``name: str`` and
+        an async ``augment`` method matching the signature should be
+        accepted.  This is the contract Stage-2 / Stage-4 augmenters
+        must satisfy.
+        """
+        from src.marcus_mcp.coordinator.graph_augmentation import (
+            AugmentationResult,
+            GraphAugmenter,
+        )
+
+        class StubAugmenter:
+            """Minimal Protocol-satisfying stub for testing."""
+
+            name: str = "stub"
+
+            async def augment(
+                self,
+                *,
+                prd_analysis: Any,
+                tasks: List[Task],
+                contract_artifacts: Optional[Dict[str, Any]] = None,
+            ) -> AugmentationResult:
+                return AugmentationResult(augmented_tasks=tasks)
+
+        stub = StubAugmenter()
+        assert isinstance(stub, GraphAugmenter)
+
+    def test_class_missing_name_does_not_satisfy_protocol(self) -> None:
+        """Anti-regression: classes lacking ``name`` attribute fail
+        the Protocol check.
+
+        ``name`` is required for telemetry / event emission keying.
+        """
+        from src.marcus_mcp.coordinator.graph_augmentation import (
+            AugmentationResult,
+            GraphAugmenter,
+        )
+
+        class NoNameAugmenter:
+            async def augment(
+                self,
+                *,
+                prd_analysis: Any,
+                tasks: List[Task],
+                contract_artifacts: Optional[Dict[str, Any]] = None,
+            ) -> AugmentationResult:
+                return AugmentationResult(augmented_tasks=tasks)
+
+        no_name = NoNameAugmenter()
+        # runtime_checkable Protocol requires all attributes to exist
+        assert not isinstance(no_name, GraphAugmenter)
+
+    def test_class_missing_augment_does_not_satisfy_protocol(self) -> None:
+        """Anti-regression: classes lacking ``augment`` method fail.
+
+        The ``augment`` method is the augmenter's only behavioral
+        contract.  A class without it can't participate in the chain.
+        """
+        from src.marcus_mcp.coordinator.graph_augmentation import (
+            GraphAugmenter,
+        )
+
+        class NoAugmentAugmenter:
+            name: str = "broken"
+
+        broken = NoAugmentAugmenter()
+        assert not isinstance(broken, GraphAugmenter)
+
+
+# ---------------------------------------------------------------------------
+# Stage-1 contract: NO behavior change
+# ---------------------------------------------------------------------------
+
+
+class TestStage1NoBehaviorChange:
+    """Stage 1 only defines the abstract surface — no caller switches
+    to the new Protocol yet.  These tests pin that the existing
+    outcome_coverage and spec_coverage code paths remain untouched.
+
+    Stage-3 will switch parse_prd_to_tasks to the augmenter chain;
+    Stage-4 will join spec_coverage.  At Stage 1, both old call sites
+    must still exist as before.
+    """
+
+    def test_outcome_coverage_helpers_still_exist(self) -> None:
+        """``_apply_outcome_coverage_to_graph`` and
+        ``_apply_outcome_coverage_to_contract_graph`` still on
+        AdvancedPRDParser at Stage 1.  Stage-3 removes them.
+        """
+        from src.ai.advanced.prd.advanced_parser import AdvancedPRDParser
+
+        assert hasattr(AdvancedPRDParser, "_apply_outcome_coverage_to_graph")
+        assert hasattr(AdvancedPRDParser, "_apply_outcome_coverage_to_contract_graph")
+
+    def test_check_spec_coverage_still_callable(self) -> None:
+        """``check_spec_coverage`` public function still exists at Stage 1.
+        Stage-4 may remove it when the call site is migrated.
+        """
+        from src.integrations.spec_coverage import check_spec_coverage
+
+        assert callable(check_spec_coverage)

--- a/tests/unit/coordinator/test_graph_augmentation.py
+++ b/tests/unit/coordinator/test_graph_augmentation.py
@@ -143,26 +143,50 @@ class TestGraphAugmenterProtocol:
 
         assert GraphAugmenter is not None
 
-    def test_protocol_is_runtime_checkable(self) -> None:
-        """``@runtime_checkable`` lets the orchestrator validate
-        registered augmenters via ``isinstance``.
+    def test_protocol_supports_isinstance(self) -> None:
+        """``@runtime_checkable`` enables ``isinstance`` against the Protocol.
 
         Pre-#456 Marcus had no augmenter registry.  Stage-3 adds one;
-        registration-time validation needs ``isinstance(thing, GraphAugmenter)``
-        to fail loud on misregistered classes that don't satisfy the
-        Protocol.  Without ``@runtime_checkable``, the failure would
-        only surface at first .augment() call.
-        """
-        from typing import _ProtocolMeta  # type: ignore[attr-defined]
+        registration-time validation calls ``isinstance(thing, GraphAugmenter)``
+        to fail loud on misregistered classes.  Without
+        ``@runtime_checkable``, that call raises
+        ``TypeError: Protocols with non-method members don't support
+        issubclass()`` rather than returning a boolean.
 
+        Behavior test (Kaia review of Stage 1): assert
+        ``isinstance(stub, GraphAugmenter)`` returns a boolean rather
+        than raising.  Pre-#456 versions of this test inspected
+        Python's private ``_is_runtime_protocol`` marker, which
+        could rename across CPython versions and silently miss the
+        decorator's removal.  Behavior test fails loud regardless of
+        Python version.
+        """
         from src.marcus_mcp.coordinator.graph_augmentation import (
+            AugmentationResult,
             GraphAugmenter,
         )
 
-        # Protocol classes have a magic attribute set by @runtime_checkable
-        assert getattr(
-            GraphAugmenter, "_is_runtime_protocol", False
-        ), "GraphAugmenter must be decorated with @runtime_checkable"
+        class StubAugmenter:
+            name: str = "behavior-test-stub"
+
+            async def augment(
+                self,
+                *,
+                prd_analysis: Any,
+                tasks: List[Task],
+                contract_artifacts: Optional[Dict[str, Any]] = None,
+            ) -> AugmentationResult:
+                return AugmentationResult(augmented_tasks=tasks)
+
+        try:
+            result = isinstance(StubAugmenter(), GraphAugmenter)
+        except TypeError as exc:
+            pytest.fail(
+                f"GraphAugmenter must be decorated with @runtime_checkable "
+                f"so isinstance() returns a boolean.  Got TypeError: {exc}"
+            )
+
+        assert result is True
 
     def test_stub_implementation_satisfies_protocol(self) -> None:
         """A concrete class with the right shape passes ``isinstance``.

--- a/tests/unit/coordinator/test_graph_augmentation.py
+++ b/tests/unit/coordinator/test_graph_augmentation.py
@@ -261,34 +261,80 @@ class TestGraphAugmenterProtocol:
 
 
 # ---------------------------------------------------------------------------
-# Stage-1 contract: NO behavior change
+# Stage-5 anti-regression: legacy helpers are gone
 # ---------------------------------------------------------------------------
 
 
-class TestStage1NoBehaviorChange:
-    """Stage 1 only defines the abstract surface — no caller switches
-    to the new Protocol yet.  These tests pin that the existing
-    outcome_coverage and spec_coverage code paths remain untouched.
+class TestStage5LegacyHelpersRemoved:
+    """Stage 5 cleanup deletes the legacy parser-side helpers.
 
-    Stage-3 will switch parse_prd_to_tasks to the augmenter chain;
-    Stage-4 will join spec_coverage.  At Stage 1, both old call sites
-    must still exist as before.
+    The Stage-1 contract was "helpers still exist" as a temporary
+    invariant during the refactor.  Stage 5 inverts it: the helpers
+    must NOT exist anymore — the lifted module functions in
+    ``outcome_coverage.py`` are the only path.
+
+    Anti-regression: catches a future commit that re-adds the
+    underscored helpers to ``AdvancedPRDParser``, which would
+    silently re-introduce the parallel-pipeline smell that #456
+    eliminated.
     """
 
-    def test_outcome_coverage_helpers_still_exist(self) -> None:
-        """``_apply_outcome_coverage_to_graph`` and
-        ``_apply_outcome_coverage_to_contract_graph`` still on
-        AdvancedPRDParser at Stage 1.  Stage-3 removes them.
+    def test_legacy_outcome_coverage_helpers_deleted(self) -> None:
+        """``_apply_outcome_coverage_to_*`` methods are removed from
+        AdvancedPRDParser.  The lifted module functions in
+        ``src.marcus_mcp.coordinator.outcome_coverage`` replace them.
         """
         from src.ai.advanced.prd.advanced_parser import AdvancedPRDParser
 
-        assert hasattr(AdvancedPRDParser, "_apply_outcome_coverage_to_graph")
-        assert hasattr(AdvancedPRDParser, "_apply_outcome_coverage_to_contract_graph")
+        assert not hasattr(AdvancedPRDParser, "_apply_outcome_coverage_to_graph")
+        assert not hasattr(
+            AdvancedPRDParser, "_apply_outcome_coverage_to_contract_graph"
+        )
 
-    def test_check_spec_coverage_still_callable(self) -> None:
-        """``check_spec_coverage`` public function still exists at Stage 1.
-        Stage-4 may remove it when the call site is migrated.
+    def test_lifted_outcome_coverage_functions_exist(self) -> None:
+        """The lifted module functions are the canonical entry points."""
+        from src.marcus_mcp.coordinator.outcome_coverage import (
+            apply_outcome_coverage_to_contract_graph,
+            apply_outcome_coverage_to_feature_graph,
+        )
+
+        assert callable(apply_outcome_coverage_to_feature_graph)
+        assert callable(apply_outcome_coverage_to_contract_graph)
+
+    def test_parser_outcome_coverage_dataclass_deleted(self) -> None:
+        """``ParserOutcomeCoverage`` dataclass is removed.
+
+        The lifted functions return :class:`AugmentationResult`
+        directly — no parser-side wrapper type remains.
         """
+        import src.ai.advanced.prd.advanced_parser as parser_module
+
+        assert not hasattr(parser_module, "ParserOutcomeCoverage")
+
+    def test_check_spec_coverage_only_called_via_augmenter(self) -> None:
+        """``check_spec_coverage`` is reachable only through the augmenter.
+
+        The function still exists in ``spec_coverage.py`` because the
+        :class:`SpecCoverageAugmenter` delegates to it.  But there must
+        be no other production caller — the post-safety-check call
+        site at the old ``nlp_tools.py:1336`` is gone.
+        """
+        from pathlib import Path
+
         from src.integrations.spec_coverage import check_spec_coverage
 
         assert callable(check_spec_coverage)
+
+        # nlp_tools.py is the previous post-safety-check call site —
+        # confirm it no longer imports the function.
+        nlp_tools_path = (
+            Path(__file__).resolve().parents[3]
+            / "src"
+            / "integrations"
+            / "nlp_tools.py"
+        )
+        content = nlp_tools_path.read_text()
+        assert (
+            "from src.integrations.spec_coverage import check_spec_coverage"
+            not in content
+        )

--- a/tests/unit/coordinator/test_outcome_coverage.py
+++ b/tests/unit/coordinator/test_outcome_coverage.py
@@ -1072,3 +1072,54 @@ class TestStubTaskBuildingForRecoverage:
             "responsibility": None,
         }
         assert _build_recoverage_description(gap_dict) == "no contract"
+
+
+class TestCoverageToTelemetry:
+    """``_coverage_to_telemetry`` flattens OutcomeCoverageResult into the
+    canonical PLANNING_INTENT_FIDELITY event payload shape.
+
+    Issue #456 Stage 5 follow-up (Kaia review #6, Simon ``1efc9406``):
+    the four telemetry keys are load-bearing for Cato consumers — any
+    drift breaks the wire.  An explicit unit test here makes the
+    contract grep-able alongside the source, replacing the Stage 2
+    ``TestTelemetryKeyPinning`` class that was retired with the
+    wrapper rewrite.
+    """
+
+    def test_canonical_keys_pinned_exactly(self) -> None:
+        """Telemetry has exactly four keys; no more, no less."""
+        from src.marcus_mcp.coordinator.outcome_coverage import (
+            OutcomeCoverageResult,
+            _coverage_to_telemetry,
+        )
+
+        coverage = OutcomeCoverageResult(
+            synthesized_tasks=[],
+            intent_fidelity_score=0.75,
+            coverage_before_fill={"o1": ["t1"]},
+            coverage_after_fill={"o1": ["t1", "gap"]},
+            gaps=[
+                UserOutcome(
+                    id="o2",
+                    action="x",
+                    success_signal="y",
+                    scope="in_scope",
+                )
+            ],
+        )
+        telemetry = _coverage_to_telemetry(coverage)
+
+        # The four canonical keys, no extras (PLANNING_INTENT_FIDELITY
+        # event payload at nlp_tools.py:396-399).
+        assert set(telemetry.keys()) == {
+            "intent_fidelity_score",
+            "coverage_before_fill",
+            "coverage_after_fill",
+            "gap_filled_outcomes",
+        }
+        assert telemetry["intent_fidelity_score"] == 0.75
+        assert telemetry["coverage_before_fill"] == {"o1": ["t1"]}
+        assert telemetry["coverage_after_fill"] == {"o1": ["t1", "gap"]}
+        # gap_filled_outcomes is the list of UserOutcome IDs (strings),
+        # not the full UserOutcome objects — Cato consumes IDs.
+        assert telemetry["gap_filled_outcomes"] == ["o2"]

--- a/tests/unit/coordinator/test_outcome_coverage_augmenter.py
+++ b/tests/unit/coordinator/test_outcome_coverage_augmenter.py
@@ -1,0 +1,603 @@
+"""
+Unit tests for ``OutcomeCoverageAugmenter`` (issue #456 — Stage 2).
+
+Stage 2 wraps the existing
+``AdvancedPRDParser._apply_outcome_coverage_to_graph`` and
+``_apply_outcome_coverage_to_contract_graph`` helpers behind the
+``GraphAugmenter`` Protocol from Stage 1.
+
+**Critical concern from Kaia Stage-1 review (Simon ``0b97ec30``):**
+the wrapper must produce ``telemetry`` dict keys matching the
+existing ``PLANNING_INTENT_FIDELITY`` event payload exactly.  Silent
+key drift would break Cato consumers who already expect:
+
+- ``intent_fidelity_score``
+- ``coverage_before_fill``
+- ``coverage_after_fill``
+- ``gap_filled_outcomes``
+
+Tests pin those keys explicitly and the v32 behavior-preservation
+snapshot guards against subtle migration drift.
+
+Stage 2 contract: the wrapper delegates to the existing helpers — no
+behavior change.  Stage 3 will switch the decomposer call sites to
+the augmenter chain; Stage 5 will remove the now-unused helpers.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from src.core.models import Priority, Task, TaskStatus
+
+pytestmark = pytest.mark.unit
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_task(task_id: str, name: str = "Implement Foo") -> Task:
+    """Minimal Task for wrapper tests."""
+    now = datetime.now(timezone.utc)
+    return Task(
+        id=task_id,
+        name=name,
+        description="...",
+        status=TaskStatus.TODO,
+        priority=Priority.HIGH,
+        assigned_to=None,
+        created_at=now,
+        updated_at=now,
+        due_date=None,
+        estimated_hours=2.0,
+        labels=["contract_first", "implementation"],
+        source_type="contract_first",
+    )
+
+
+def _gap_fill_task(task_id: str, name: str = "Render snake to canvas") -> Task:
+    """Synthesized gap-fill task (matches what _build_gap_fill_task produces)."""
+    now = datetime.now(timezone.utc)
+    return Task(
+        id=task_id,
+        name=name,
+        description="draw on canvas",
+        status=TaskStatus.TODO,
+        priority=Priority.MEDIUM,
+        assigned_to=None,
+        created_at=now,
+        updated_at=now,
+        due_date=None,
+        estimated_hours=2.0,
+        labels=["gap_fill", "intent_fidelity"],
+    )
+
+
+def _make_parser_outcome_coverage(
+    augmented_tasks: List[Task],
+    *,
+    intent_fidelity_score: Optional[float] = None,
+    coverage_before_fill: Optional[Dict[str, List[str]]] = None,
+    coverage_after_fill: Optional[Dict[str, List[str]]] = None,
+    gap_outcome_ids: Optional[List[str]] = None,
+) -> Any:
+    """Build a ParserOutcomeCoverage with optional OutcomeCoverageResult."""
+    from src.ai.advanced.prd.advanced_parser import ParserOutcomeCoverage
+    from src.ai.advanced.prd.outcome_extractor import UserOutcome
+    from src.marcus_mcp.coordinator.outcome_coverage import (
+        OutcomeCoverageResult,
+    )
+
+    coverage: Optional[OutcomeCoverageResult] = None
+    if intent_fidelity_score is not None:
+        gaps = [
+            UserOutcome(id=oid, action="...", success_signal="...", scope="in_scope")
+            for oid in (gap_outcome_ids or [])
+        ]
+        coverage = OutcomeCoverageResult(
+            synthesized_tasks=[],
+            intent_fidelity_score=intent_fidelity_score,
+            coverage_before_fill=coverage_before_fill or {},
+            coverage_after_fill=coverage_after_fill,
+            gaps=gaps,
+        )
+    return ParserOutcomeCoverage(augmented_tasks=augmented_tasks, coverage=coverage)
+
+
+def _make_mock_parser() -> Any:
+    """Build a MagicMock standing in for AdvancedPRDParser."""
+    parser = MagicMock()
+    parser._apply_outcome_coverage_to_graph = AsyncMock()
+    parser._apply_outcome_coverage_to_contract_graph = AsyncMock()
+    return parser
+
+
+def _make_prd_analysis() -> Any:
+    """Minimal PRDAnalysis for wrapper input."""
+    from src.ai.advanced.prd.advanced_parser import PRDAnalysis
+
+    return PRDAnalysis(
+        functional_requirements=[],
+        non_functional_requirements=[],
+        technical_constraints=[],
+        business_objectives=[],
+        user_personas=[],
+        success_metrics=[],
+        implementation_approach="iterative",
+        complexity_assessment={},
+        risk_factors=[],
+        confidence=0.9,
+        original_description="build a snake game",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Protocol satisfaction
+# ---------------------------------------------------------------------------
+
+
+class TestOutcomeCoverageAugmenterProtocolSatisfaction:
+    """Augmenter satisfies the GraphAugmenter Protocol."""
+
+    def test_module_exports_augmenter(self) -> None:
+        from src.marcus_mcp.coordinator.outcome_coverage_augmenter import (
+            OutcomeCoverageAugmenter,
+        )
+
+        assert OutcomeCoverageAugmenter is not None
+
+    def test_augmenter_is_graph_augmenter(self) -> None:
+        """``isinstance(augmenter, GraphAugmenter)`` returns True."""
+        from src.marcus_mcp.coordinator.graph_augmentation import (
+            GraphAugmenter,
+        )
+        from src.marcus_mcp.coordinator.outcome_coverage_augmenter import (
+            OutcomeCoverageAugmenter,
+        )
+
+        augmenter = OutcomeCoverageAugmenter(parser=_make_mock_parser())
+        assert isinstance(augmenter, GraphAugmenter)
+
+    def test_name_is_outcome_coverage(self) -> None:
+        """Canonical name keys telemetry / log lines / event filters."""
+        from src.marcus_mcp.coordinator.outcome_coverage_augmenter import (
+            OutcomeCoverageAugmenter,
+        )
+
+        augmenter = OutcomeCoverageAugmenter(parser=_make_mock_parser())
+        assert augmenter.name == "outcome_coverage"
+
+
+# ---------------------------------------------------------------------------
+# Path dispatch: feature-based vs contract-first
+# ---------------------------------------------------------------------------
+
+
+class TestPathDispatch:
+    """Wrapper picks the right helper based on ``contract_artifacts``."""
+
+    @pytest.mark.asyncio
+    async def test_feature_based_path_when_no_contract_artifacts(self) -> None:
+        """``contract_artifacts=None`` → feature-based helper called."""
+        from src.marcus_mcp.coordinator.outcome_coverage_augmenter import (
+            OutcomeCoverageAugmenter,
+        )
+
+        parser = _make_mock_parser()
+        parser._apply_outcome_coverage_to_graph.return_value = (
+            _make_parser_outcome_coverage(augmented_tasks=[_make_task("t1")])
+        )
+        augmenter = OutcomeCoverageAugmenter(parser=parser)
+
+        await augmenter.augment(
+            prd_analysis=_make_prd_analysis(),
+            tasks=[_make_task("t1")],
+            contract_artifacts=None,
+        )
+
+        parser._apply_outcome_coverage_to_graph.assert_awaited_once()
+        parser._apply_outcome_coverage_to_contract_graph.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_contract_first_path_when_contract_artifacts_provided(
+        self,
+    ) -> None:
+        """``contract_artifacts`` non-None → contract-first helper called."""
+        from src.marcus_mcp.coordinator.outcome_coverage_augmenter import (
+            OutcomeCoverageAugmenter,
+        )
+
+        parser = _make_mock_parser()
+        parser._apply_outcome_coverage_to_contract_graph.return_value = (
+            _make_parser_outcome_coverage(augmented_tasks=[_make_task("t1")])
+        )
+        augmenter = OutcomeCoverageAugmenter(parser=parser)
+
+        await augmenter.augment(
+            prd_analysis=_make_prd_analysis(),
+            tasks=[_make_task("t1")],
+            contract_artifacts={"Auth": {"artifacts": [{"content": "..."}]}},
+        )
+
+        parser._apply_outcome_coverage_to_contract_graph.assert_awaited_once()
+        parser._apply_outcome_coverage_to_graph.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# Telemetry key pinning (CRITICAL — Kaia Stage-1 concern #3)
+# ---------------------------------------------------------------------------
+
+
+class TestTelemetryKeyPinning:
+    """Wrapper telemetry dict keys must match PLANNING_INTENT_FIDELITY
+    event payload exactly.
+
+    Existing event payload at ``nlp_tools.py:396-399``:
+
+    .. code-block:: python
+
+        {
+            "project_name": project_name,
+            "decomposer": decomposer,
+            "intent_fidelity_score": intent_fidelity_score,
+            "coverage_before_fill": coverage_before_fill,
+            "coverage_after_fill": coverage_after_fill,
+            "gap_filled_outcomes": gap_filled_outcomes,
+        }
+
+    Stage 2 wrapper produces the latter four (project_name +
+    decomposer are orchestrator-side fields).  Silent key drift would
+    break Cato consumers — these tests are the contract.
+    """
+
+    @pytest.mark.asyncio
+    async def test_telemetry_has_intent_fidelity_score_key(self) -> None:
+        from src.marcus_mcp.coordinator.outcome_coverage_augmenter import (
+            OutcomeCoverageAugmenter,
+        )
+
+        parser = _make_mock_parser()
+        parser._apply_outcome_coverage_to_graph.return_value = (
+            _make_parser_outcome_coverage(
+                augmented_tasks=[_make_task("t1")],
+                intent_fidelity_score=0.75,
+            )
+        )
+        augmenter = OutcomeCoverageAugmenter(parser=parser)
+
+        result = await augmenter.augment(
+            prd_analysis=_make_prd_analysis(),
+            tasks=[_make_task("t1")],
+        )
+        assert "intent_fidelity_score" in result.telemetry
+        assert result.telemetry["intent_fidelity_score"] == 0.75
+
+    @pytest.mark.asyncio
+    async def test_telemetry_has_coverage_before_fill_key(self) -> None:
+        from src.marcus_mcp.coordinator.outcome_coverage_augmenter import (
+            OutcomeCoverageAugmenter,
+        )
+
+        parser = _make_mock_parser()
+        coverage_before = {"outcome_play": ["t1"], "outcome_pause": []}
+        parser._apply_outcome_coverage_to_graph.return_value = (
+            _make_parser_outcome_coverage(
+                augmented_tasks=[_make_task("t1")],
+                intent_fidelity_score=1.0,
+                coverage_before_fill=coverage_before,
+            )
+        )
+        augmenter = OutcomeCoverageAugmenter(parser=parser)
+
+        result = await augmenter.augment(
+            prd_analysis=_make_prd_analysis(),
+            tasks=[_make_task("t1")],
+        )
+        assert "coverage_before_fill" in result.telemetry
+        assert result.telemetry["coverage_before_fill"] == coverage_before
+
+    @pytest.mark.asyncio
+    async def test_telemetry_has_coverage_after_fill_key(self) -> None:
+        from src.marcus_mcp.coordinator.outcome_coverage_augmenter import (
+            OutcomeCoverageAugmenter,
+        )
+
+        parser = _make_mock_parser()
+        coverage_after = {"outcome_play": ["t1", "gap_fill_xyz"]}
+        parser._apply_outcome_coverage_to_graph.return_value = (
+            _make_parser_outcome_coverage(
+                augmented_tasks=[_make_task("t1"), _gap_fill_task("gap_fill_xyz")],
+                intent_fidelity_score=1.0,
+                coverage_after_fill=coverage_after,
+            )
+        )
+        augmenter = OutcomeCoverageAugmenter(parser=parser)
+
+        result = await augmenter.augment(
+            prd_analysis=_make_prd_analysis(),
+            tasks=[_make_task("t1")],
+        )
+        assert "coverage_after_fill" in result.telemetry
+        assert result.telemetry["coverage_after_fill"] == coverage_after
+
+    @pytest.mark.asyncio
+    async def test_telemetry_has_gap_filled_outcomes_key(self) -> None:
+        """``gap_filled_outcomes`` is the list of UserOutcome IDs that
+        had gaps in the initial coverage check.
+
+        Per existing event payload at ``nlp_tools.py:399`` and the
+        emission helper at ``nlp_tools.py:644``, the value is a list
+        of outcome IDs (strings) — extracted from
+        ``coverage.gaps`` (list of UserOutcome) via list comprehension.
+        Wrapper must perform the same extraction.
+        """
+        from src.marcus_mcp.coordinator.outcome_coverage_augmenter import (
+            OutcomeCoverageAugmenter,
+        )
+
+        parser = _make_mock_parser()
+        parser._apply_outcome_coverage_to_graph.return_value = (
+            _make_parser_outcome_coverage(
+                augmented_tasks=[_make_task("t1")],
+                intent_fidelity_score=0.5,
+                gap_outcome_ids=["outcome_play", "outcome_score"],
+            )
+        )
+        augmenter = OutcomeCoverageAugmenter(parser=parser)
+
+        result = await augmenter.augment(
+            prd_analysis=_make_prd_analysis(),
+            tasks=[_make_task("t1")],
+        )
+        assert "gap_filled_outcomes" in result.telemetry
+        # Must be list of outcome IDs, not full UserOutcome objects
+        assert result.telemetry["gap_filled_outcomes"] == [
+            "outcome_play",
+            "outcome_score",
+        ]
+
+    @pytest.mark.asyncio
+    async def test_telemetry_keys_match_event_payload_exactly(self) -> None:
+        """Anti-regression: pin the exact set of telemetry keys.
+
+        If a Stage-2 refactor adds extra keys or removes existing
+        ones, downstream consumers (Cato) break silently.  This test
+        fails loud on either side of drift.
+        """
+        from src.marcus_mcp.coordinator.outcome_coverage_augmenter import (
+            OutcomeCoverageAugmenter,
+        )
+
+        parser = _make_mock_parser()
+        parser._apply_outcome_coverage_to_graph.return_value = (
+            _make_parser_outcome_coverage(
+                augmented_tasks=[_make_task("t1")],
+                intent_fidelity_score=1.0,
+                coverage_before_fill={"outcome_play": ["t1"]},
+                coverage_after_fill=None,
+                gap_outcome_ids=[],
+            )
+        )
+        augmenter = OutcomeCoverageAugmenter(parser=parser)
+
+        result = await augmenter.augment(
+            prd_analysis=_make_prd_analysis(),
+            tasks=[_make_task("t1")],
+        )
+
+        expected_keys = {
+            "intent_fidelity_score",
+            "coverage_before_fill",
+            "coverage_after_fill",
+            "gap_filled_outcomes",
+        }
+        assert set(result.telemetry.keys()) == expected_keys, (
+            f"Telemetry keys must match PLANNING_INTENT_FIDELITY event "
+            f"payload exactly.  Expected {expected_keys}, "
+            f"got {set(result.telemetry.keys())}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# No-op result handling (flag off / no outcomes / LLM failure)
+# ---------------------------------------------------------------------------
+
+
+class TestNoOpResult:
+    """When the helper returns ``None`` (coverage didn't run), the
+    wrapper produces a passthrough result: input tasks, no synthesized
+    IDs, empty telemetry."""
+
+    @pytest.mark.asyncio
+    async def test_helper_returns_none_passthrough_input_tasks(self) -> None:
+        """Wrapper passthrough behavior when coverage doesn't run."""
+        from src.marcus_mcp.coordinator.outcome_coverage_augmenter import (
+            OutcomeCoverageAugmenter,
+        )
+
+        parser = _make_mock_parser()
+        parser._apply_outcome_coverage_to_graph.return_value = None
+        augmenter = OutcomeCoverageAugmenter(parser=parser)
+
+        input_tasks = [_make_task("t1"), _make_task("t2")]
+        result = await augmenter.augment(
+            prd_analysis=_make_prd_analysis(),
+            tasks=input_tasks,
+        )
+
+        assert result.augmented_tasks == input_tasks
+        assert result.synthesized_ids == []
+        assert result.telemetry == {}
+
+    @pytest.mark.asyncio
+    async def test_helper_returns_none_does_not_mutate_input(self) -> None:
+        """Passthrough must return the same list contents but not mutate
+        the caller's list as a side effect."""
+        from src.marcus_mcp.coordinator.outcome_coverage_augmenter import (
+            OutcomeCoverageAugmenter,
+        )
+
+        parser = _make_mock_parser()
+        parser._apply_outcome_coverage_to_graph.return_value = None
+        augmenter = OutcomeCoverageAugmenter(parser=parser)
+
+        input_tasks = [_make_task("t1"), _make_task("t2")]
+        snapshot_ids = [t.id for t in input_tasks]
+
+        await augmenter.augment(
+            prd_analysis=_make_prd_analysis(),
+            tasks=input_tasks,
+        )
+
+        assert [t.id for t in input_tasks] == snapshot_ids
+
+
+# ---------------------------------------------------------------------------
+# Synthesized ID detection
+# ---------------------------------------------------------------------------
+
+
+class TestSynthesizedIds:
+    """``AugmentationResult.synthesized_ids`` must list the IDs of
+    tasks the augmenter added (subset of ``augmented_tasks``)."""
+
+    @pytest.mark.asyncio
+    async def test_no_gap_fill_synthesized_ids_empty(self) -> None:
+        """When no synthesis ran, synthesized_ids is empty list."""
+        from src.marcus_mcp.coordinator.outcome_coverage_augmenter import (
+            OutcomeCoverageAugmenter,
+        )
+
+        parser = _make_mock_parser()
+        input_tasks = [_make_task("t1"), _make_task("t2")]
+        parser._apply_outcome_coverage_to_graph.return_value = (
+            _make_parser_outcome_coverage(
+                augmented_tasks=input_tasks,
+                intent_fidelity_score=1.0,
+            )
+        )
+        augmenter = OutcomeCoverageAugmenter(parser=parser)
+
+        result = await augmenter.augment(
+            prd_analysis=_make_prd_analysis(), tasks=input_tasks
+        )
+        assert result.synthesized_ids == []
+
+    @pytest.mark.asyncio
+    async def test_gap_fill_ids_listed_in_synthesized_ids(self) -> None:
+        """When the helper appended gap-fill tasks, their IDs appear
+        in synthesized_ids (and only those — not the original tasks)."""
+        from src.marcus_mcp.coordinator.outcome_coverage_augmenter import (
+            OutcomeCoverageAugmenter,
+        )
+
+        parser = _make_mock_parser()
+        input_tasks = [_make_task("t1"), _make_task("t2")]
+        gap_fill = _gap_fill_task("gap_fill_abc123")
+        parser._apply_outcome_coverage_to_graph.return_value = (
+            _make_parser_outcome_coverage(
+                augmented_tasks=input_tasks + [gap_fill],
+                intent_fidelity_score=1.0,
+            )
+        )
+        augmenter = OutcomeCoverageAugmenter(parser=parser)
+
+        result = await augmenter.augment(
+            prd_analysis=_make_prd_analysis(), tasks=input_tasks
+        )
+        assert result.synthesized_ids == ["gap_fill_abc123"]
+
+
+# ---------------------------------------------------------------------------
+# v32 behavior preservation snapshot (Kaia regression-canary)
+# ---------------------------------------------------------------------------
+
+
+class TestV32BehaviorPreservation:
+    """Snapshot the wrapper's output for the v32-shaped scenario.
+
+    v32 narrative: outcome ``snake_visible`` initially uncovered →
+    gap-fill synthesizes a rendering task → recoverage shows
+    ``snake_visible`` covered by the synthesized task.  Score 1.0
+    after fill.
+
+    These tests assert the wrapper's ``AugmentationResult`` carries
+    the same data the existing event-emission code reads off
+    ``ParserOutcomeCoverage`` directly.  If Stage 3 swaps the call
+    site to use the wrapper, the ``PLANNING_INTENT_FIDELITY`` event
+    payload must be byte-identical.
+    """
+
+    @pytest.mark.asyncio
+    async def test_v32_scenario_telemetry_matches_event_payload(self) -> None:
+        """v32-shape input → wrapper telemetry matches the
+        keys/values the existing emission helper reads from
+        ``ParserOutcomeCoverage``."""
+        from src.marcus_mcp.coordinator.outcome_coverage_augmenter import (
+            OutcomeCoverageAugmenter,
+        )
+
+        parser = _make_mock_parser()
+
+        # v32 fixture: 2 input tasks, 1 synthesized gap-fill, 1 outcome
+        input_tasks = [
+            _make_task("t_state", "Snake state machine"),
+            _make_task("t_input", "Input handler"),
+        ]
+        gap_fill = _gap_fill_task("gap_fill_abc123", "Render snake to canvas")
+
+        parser._apply_outcome_coverage_to_graph.return_value = (
+            _make_parser_outcome_coverage(
+                augmented_tasks=input_tasks + [gap_fill],
+                intent_fidelity_score=1.0,
+                coverage_before_fill={"snake_visible": []},
+                coverage_after_fill={"snake_visible": ["_synth_for_coverage_0"]},
+                gap_outcome_ids=["snake_visible"],
+            )
+        )
+        augmenter = OutcomeCoverageAugmenter(parser=parser)
+
+        result = await augmenter.augment(
+            prd_analysis=_make_prd_analysis(),
+            tasks=input_tasks,
+        )
+
+        # Pin the exact event-payload-shaped values
+        assert result.telemetry == {
+            "intent_fidelity_score": 1.0,
+            "coverage_before_fill": {"snake_visible": []},
+            "coverage_after_fill": {"snake_visible": ["_synth_for_coverage_0"]},
+            "gap_filled_outcomes": ["snake_visible"],
+        }
+        # Augmented graph contains 3 tasks: 2 input + 1 synth
+        assert len(result.augmented_tasks) == 3
+        assert result.synthesized_ids == ["gap_fill_abc123"]
+
+
+# ---------------------------------------------------------------------------
+# Stage 2 contract: helpers still callable directly
+# ---------------------------------------------------------------------------
+
+
+class TestStage2NoBehaviorChange:
+    """Stage 2 only adds a wrapper.  The existing helpers on
+    ``AdvancedPRDParser`` must remain callable directly so Stage 3 can
+    switch the decomposer call sites in a separate commit.
+    """
+
+    def test_outcome_coverage_helpers_still_exist(self) -> None:
+        """``_apply_outcome_coverage_to_graph`` and
+        ``_apply_outcome_coverage_to_contract_graph`` are still
+        methods on AdvancedPRDParser at Stage 2.  Stage 3-5 will
+        eventually remove them once all callers migrate.
+        """
+        from src.ai.advanced.prd.advanced_parser import AdvancedPRDParser
+
+        assert hasattr(AdvancedPRDParser, "_apply_outcome_coverage_to_graph")
+        assert hasattr(AdvancedPRDParser, "_apply_outcome_coverage_to_contract_graph")

--- a/tests/unit/coordinator/test_outcome_coverage_augmenter.py
+++ b/tests/unit/coordinator/test_outcome_coverage_augmenter.py
@@ -1,34 +1,30 @@
-"""
-Unit tests for ``OutcomeCoverageAugmenter`` (issue #456 — Stage 2).
+"""Unit tests for ``OutcomeCoverageAugmenter`` (issue #456 Stage 5).
 
-Stage 2 wraps the existing
-``AdvancedPRDParser._apply_outcome_coverage_to_graph`` and
-``_apply_outcome_coverage_to_contract_graph`` helpers behind the
-``GraphAugmenter`` Protocol from Stage 1.
+Stage 5 simplified the augmenter to a thin Protocol-satisfying
+dispatcher: it picks between the two lifted module functions in
+:mod:`src.marcus_mcp.coordinator.outcome_coverage` based on whether
+``contract_artifacts`` is provided.
 
-**Critical concern from Kaia Stage-1 review (Simon ``0b97ec30``):**
-the wrapper must produce ``telemetry`` dict keys matching the
-existing ``PLANNING_INTENT_FIDELITY`` event payload exactly.  Silent
-key drift would break Cato consumers who already expect:
+Behavior tests for the lifted functions themselves
+(``apply_outcome_coverage_to_feature_graph`` and
+``apply_outcome_coverage_to_contract_graph``) live in
+``tests/unit/ai/test_parse_prd_outcome_integration.py`` and
+``tests/unit/ai/test_contract_first_outcome_integration.py``
+respectively.
 
-- ``intent_fidelity_score``
-- ``coverage_before_fill``
-- ``coverage_after_fill``
-- ``gap_filled_outcomes``
+This file pins:
 
-Tests pin those keys explicitly and the v32 behavior-preservation
-snapshot guards against subtle migration drift.
-
-Stage 2 contract: the wrapper delegates to the existing helpers — no
-behavior change.  Stage 3 will switch the decomposer call sites to
-the augmenter chain; Stage 5 will remove the now-unused helpers.
+* Protocol satisfaction (``isinstance(augmenter, GraphAugmenter)``)
+* Path dispatch (correct lifted function called by ``contract_artifacts``)
+* The augmenter forwards ``llm_client`` so the lifted function has
+  what it needs to call the LLM
 """
 
 from __future__ import annotations
 
 from datetime import datetime, timezone
-from typing import Any, Dict, List, Optional
-from unittest.mock import AsyncMock, MagicMock
+from typing import Any
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
@@ -43,7 +39,7 @@ pytestmark = pytest.mark.unit
 
 
 def _make_task(task_id: str, name: str = "Implement Foo") -> Task:
-    """Minimal Task for wrapper tests."""
+    """Minimal Task for dispatcher tests."""
     now = datetime.now(timezone.utc)
     return Task(
         id=task_id,
@@ -56,70 +52,11 @@ def _make_task(task_id: str, name: str = "Implement Foo") -> Task:
         updated_at=now,
         due_date=None,
         estimated_hours=2.0,
-        labels=["contract_first", "implementation"],
-        source_type="contract_first",
     )
-
-
-def _gap_fill_task(task_id: str, name: str = "Render snake to canvas") -> Task:
-    """Synthesized gap-fill task (matches what _build_gap_fill_task produces)."""
-    now = datetime.now(timezone.utc)
-    return Task(
-        id=task_id,
-        name=name,
-        description="draw on canvas",
-        status=TaskStatus.TODO,
-        priority=Priority.MEDIUM,
-        assigned_to=None,
-        created_at=now,
-        updated_at=now,
-        due_date=None,
-        estimated_hours=2.0,
-        labels=["gap_fill", "intent_fidelity"],
-    )
-
-
-def _make_parser_outcome_coverage(
-    augmented_tasks: List[Task],
-    *,
-    intent_fidelity_score: Optional[float] = None,
-    coverage_before_fill: Optional[Dict[str, List[str]]] = None,
-    coverage_after_fill: Optional[Dict[str, List[str]]] = None,
-    gap_outcome_ids: Optional[List[str]] = None,
-) -> Any:
-    """Build a ParserOutcomeCoverage with optional OutcomeCoverageResult."""
-    from src.ai.advanced.prd.advanced_parser import ParserOutcomeCoverage
-    from src.ai.advanced.prd.outcome_extractor import UserOutcome
-    from src.marcus_mcp.coordinator.outcome_coverage import (
-        OutcomeCoverageResult,
-    )
-
-    coverage: Optional[OutcomeCoverageResult] = None
-    if intent_fidelity_score is not None:
-        gaps = [
-            UserOutcome(id=oid, action="...", success_signal="...", scope="in_scope")
-            for oid in (gap_outcome_ids or [])
-        ]
-        coverage = OutcomeCoverageResult(
-            synthesized_tasks=[],
-            intent_fidelity_score=intent_fidelity_score,
-            coverage_before_fill=coverage_before_fill or {},
-            coverage_after_fill=coverage_after_fill,
-            gaps=gaps,
-        )
-    return ParserOutcomeCoverage(augmented_tasks=augmented_tasks, coverage=coverage)
-
-
-def _make_mock_parser() -> Any:
-    """Build a MagicMock standing in for AdvancedPRDParser."""
-    parser = MagicMock()
-    parser._apply_outcome_coverage_to_graph = AsyncMock()
-    parser._apply_outcome_coverage_to_contract_graph = AsyncMock()
-    return parser
 
 
 def _make_prd_analysis() -> Any:
-    """Minimal PRDAnalysis for wrapper input."""
+    """Minimal PRDAnalysis for dispatcher input."""
     from src.ai.advanced.prd.advanced_parser import PRDAnalysis
 
     return PRDAnalysis(
@@ -137,12 +74,21 @@ def _make_prd_analysis() -> Any:
     )
 
 
+def _stub_augmentation_result(tasks: list[Task]) -> Any:
+    """Build a passthrough AugmentationResult (no synthesis)."""
+    from src.marcus_mcp.coordinator.graph_augmentation import (
+        AugmentationResult,
+    )
+
+    return AugmentationResult(augmented_tasks=tasks)
+
+
 # ---------------------------------------------------------------------------
 # Protocol satisfaction
 # ---------------------------------------------------------------------------
 
 
-class TestOutcomeCoverageAugmenterProtocolSatisfaction:
+class TestProtocolSatisfaction:
     """Augmenter satisfies the GraphAugmenter Protocol."""
 
     def test_module_exports_augmenter(self) -> None:
@@ -161,7 +107,7 @@ class TestOutcomeCoverageAugmenterProtocolSatisfaction:
             OutcomeCoverageAugmenter,
         )
 
-        augmenter = OutcomeCoverageAugmenter(parser=_make_mock_parser())
+        augmenter = OutcomeCoverageAugmenter(llm_client=AsyncMock())
         assert isinstance(augmenter, GraphAugmenter)
 
     def test_name_is_outcome_coverage(self) -> None:
@@ -170,471 +116,135 @@ class TestOutcomeCoverageAugmenterProtocolSatisfaction:
             OutcomeCoverageAugmenter,
         )
 
-        augmenter = OutcomeCoverageAugmenter(parser=_make_mock_parser())
+        augmenter = OutcomeCoverageAugmenter(llm_client=AsyncMock())
         assert augmenter.name == "outcome_coverage"
 
 
 # ---------------------------------------------------------------------------
-# Path dispatch: feature-based vs contract-first
+# Path dispatch
 # ---------------------------------------------------------------------------
 
 
 class TestPathDispatch:
-    """Wrapper picks the right helper based on ``contract_artifacts``."""
+    """Augmenter picks the right lifted function based on
+    ``contract_artifacts``."""
 
     @pytest.mark.asyncio
-    async def test_feature_based_path_when_no_contract_artifacts(self) -> None:
-        """``contract_artifacts=None`` → feature-based helper called."""
+    async def test_feature_path_when_no_contract_artifacts(self) -> None:
+        """``contract_artifacts=None`` → feature-based lifted function."""
         from src.marcus_mcp.coordinator.outcome_coverage_augmenter import (
             OutcomeCoverageAugmenter,
         )
 
-        parser = _make_mock_parser()
-        parser._apply_outcome_coverage_to_graph.return_value = (
-            _make_parser_outcome_coverage(augmented_tasks=[_make_task("t1")])
-        )
-        augmenter = OutcomeCoverageAugmenter(parser=parser)
+        with (
+            patch(
+                "src.marcus_mcp.coordinator.outcome_coverage_augmenter."
+                "apply_outcome_coverage_to_feature_graph",
+                new_callable=AsyncMock,
+                return_value=_stub_augmentation_result([_make_task("t1")]),
+            ) as mock_feature,
+            patch(
+                "src.marcus_mcp.coordinator.outcome_coverage_augmenter."
+                "apply_outcome_coverage_to_contract_graph",
+                new_callable=AsyncMock,
+            ) as mock_contract,
+        ):
+            augmenter = OutcomeCoverageAugmenter(llm_client=AsyncMock())
+            await augmenter.augment(
+                prd_analysis=_make_prd_analysis(),
+                tasks=[_make_task("t1")],
+                contract_artifacts=None,
+            )
 
-        await augmenter.augment(
-            prd_analysis=_make_prd_analysis(),
-            tasks=[_make_task("t1")],
-            contract_artifacts=None,
-        )
-
-        parser._apply_outcome_coverage_to_graph.assert_awaited_once()
-        parser._apply_outcome_coverage_to_contract_graph.assert_not_awaited()
+        mock_feature.assert_awaited_once()
+        mock_contract.assert_not_awaited()
 
     @pytest.mark.asyncio
-    async def test_contract_first_path_when_contract_artifacts_provided(
+    async def test_contract_path_when_contract_artifacts_provided(
         self,
     ) -> None:
-        """``contract_artifacts`` non-None → contract-first helper called."""
+        """``contract_artifacts`` non-None → contract-first lifted function."""
         from src.marcus_mcp.coordinator.outcome_coverage_augmenter import (
             OutcomeCoverageAugmenter,
         )
 
-        parser = _make_mock_parser()
-        parser._apply_outcome_coverage_to_contract_graph.return_value = (
-            _make_parser_outcome_coverage(augmented_tasks=[_make_task("t1")])
-        )
-        augmenter = OutcomeCoverageAugmenter(parser=parser)
+        with (
+            patch(
+                "src.marcus_mcp.coordinator.outcome_coverage_augmenter."
+                "apply_outcome_coverage_to_feature_graph",
+                new_callable=AsyncMock,
+            ) as mock_feature,
+            patch(
+                "src.marcus_mcp.coordinator.outcome_coverage_augmenter."
+                "apply_outcome_coverage_to_contract_graph",
+                new_callable=AsyncMock,
+                return_value=_stub_augmentation_result([_make_task("t1")]),
+            ) as mock_contract,
+        ):
+            augmenter = OutcomeCoverageAugmenter(llm_client=AsyncMock())
+            await augmenter.augment(
+                prd_analysis=_make_prd_analysis(),
+                tasks=[_make_task("t1")],
+                contract_artifacts={"Auth": {"artifacts": [{"content": "..."}]}},
+            )
 
-        await augmenter.augment(
-            prd_analysis=_make_prd_analysis(),
-            tasks=[_make_task("t1")],
-            contract_artifacts={"Auth": {"artifacts": [{"content": "..."}]}},
-        )
-
-        parser._apply_outcome_coverage_to_contract_graph.assert_awaited_once()
-        parser._apply_outcome_coverage_to_graph.assert_not_awaited()
+        mock_contract.assert_awaited_once()
+        mock_feature.assert_not_awaited()
 
 
 # ---------------------------------------------------------------------------
-# Telemetry key pinning (CRITICAL — Kaia Stage-1 concern #3)
+# LLM client forwarding
 # ---------------------------------------------------------------------------
 
 
-class TestTelemetryKeyPinning:
-    """Wrapper telemetry dict keys must match PLANNING_INTENT_FIDELITY
-    event payload exactly.
+class TestLlmClientForwarding:
+    """Augmenter forwards its constructor ``llm_client`` to lifted functions.
 
-    Existing event payload at ``nlp_tools.py:396-399``:
-
-    .. code-block:: python
-
-        {
-            "project_name": project_name,
-            "decomposer": decomposer,
-            "intent_fidelity_score": intent_fidelity_score,
-            "coverage_before_fill": coverage_before_fill,
-            "coverage_after_fill": coverage_after_fill,
-            "gap_filled_outcomes": gap_filled_outcomes,
-        }
-
-    Stage 2 wrapper produces the latter four (project_name +
-    decomposer are orchestrator-side fields).  Silent key drift would
-    break Cato consumers — these tests are the contract.
+    The lifted functions need an LLM client to call the coverage and
+    fill-gaps prompts.  Without forwarding, the lifted function would
+    raise TypeError on missing kwarg, or worse, bind a None client and
+    crash inside the LLM call.  These tests pin the forwarding contract.
     """
 
     @pytest.mark.asyncio
-    async def test_telemetry_has_intent_fidelity_score_key(self) -> None:
+    async def test_feature_path_forwards_llm_client(self) -> None:
         from src.marcus_mcp.coordinator.outcome_coverage_augmenter import (
             OutcomeCoverageAugmenter,
         )
 
-        parser = _make_mock_parser()
-        parser._apply_outcome_coverage_to_graph.return_value = (
-            _make_parser_outcome_coverage(
-                augmented_tasks=[_make_task("t1")],
-                intent_fidelity_score=0.75,
+        my_llm = AsyncMock()
+        with patch(
+            "src.marcus_mcp.coordinator.outcome_coverage_augmenter."
+            "apply_outcome_coverage_to_feature_graph",
+            new_callable=AsyncMock,
+            return_value=_stub_augmentation_result([_make_task("t1")]),
+        ) as mock_feature:
+            augmenter = OutcomeCoverageAugmenter(llm_client=my_llm)
+            await augmenter.augment(
+                prd_analysis=_make_prd_analysis(),
+                tasks=[_make_task("t1")],
             )
-        )
-        augmenter = OutcomeCoverageAugmenter(parser=parser)
 
-        result = await augmenter.augment(
-            prd_analysis=_make_prd_analysis(),
-            tasks=[_make_task("t1")],
-        )
-        assert "intent_fidelity_score" in result.telemetry
-        assert result.telemetry["intent_fidelity_score"] == 0.75
+        assert mock_feature.call_args.kwargs["llm_client"] is my_llm
 
     @pytest.mark.asyncio
-    async def test_telemetry_has_coverage_before_fill_key(self) -> None:
+    async def test_contract_path_forwards_llm_client(self) -> None:
         from src.marcus_mcp.coordinator.outcome_coverage_augmenter import (
             OutcomeCoverageAugmenter,
         )
 
-        parser = _make_mock_parser()
-        coverage_before = {"outcome_play": ["t1"], "outcome_pause": []}
-        parser._apply_outcome_coverage_to_graph.return_value = (
-            _make_parser_outcome_coverage(
-                augmented_tasks=[_make_task("t1")],
-                intent_fidelity_score=1.0,
-                coverage_before_fill=coverage_before,
+        my_llm = AsyncMock()
+        with patch(
+            "src.marcus_mcp.coordinator.outcome_coverage_augmenter."
+            "apply_outcome_coverage_to_contract_graph",
+            new_callable=AsyncMock,
+            return_value=_stub_augmentation_result([_make_task("t1")]),
+        ) as mock_contract:
+            augmenter = OutcomeCoverageAugmenter(llm_client=my_llm)
+            await augmenter.augment(
+                prd_analysis=_make_prd_analysis(),
+                tasks=[_make_task("t1")],
+                contract_artifacts={"X": {"artifacts": []}},
             )
-        )
-        augmenter = OutcomeCoverageAugmenter(parser=parser)
 
-        result = await augmenter.augment(
-            prd_analysis=_make_prd_analysis(),
-            tasks=[_make_task("t1")],
-        )
-        assert "coverage_before_fill" in result.telemetry
-        assert result.telemetry["coverage_before_fill"] == coverage_before
-
-    @pytest.mark.asyncio
-    async def test_telemetry_has_coverage_after_fill_key(self) -> None:
-        from src.marcus_mcp.coordinator.outcome_coverage_augmenter import (
-            OutcomeCoverageAugmenter,
-        )
-
-        parser = _make_mock_parser()
-        coverage_after = {"outcome_play": ["t1", "gap_fill_xyz"]}
-        parser._apply_outcome_coverage_to_graph.return_value = (
-            _make_parser_outcome_coverage(
-                augmented_tasks=[_make_task("t1"), _gap_fill_task("gap_fill_xyz")],
-                intent_fidelity_score=1.0,
-                coverage_after_fill=coverage_after,
-            )
-        )
-        augmenter = OutcomeCoverageAugmenter(parser=parser)
-
-        result = await augmenter.augment(
-            prd_analysis=_make_prd_analysis(),
-            tasks=[_make_task("t1")],
-        )
-        assert "coverage_after_fill" in result.telemetry
-        assert result.telemetry["coverage_after_fill"] == coverage_after
-
-    @pytest.mark.asyncio
-    async def test_telemetry_has_gap_filled_outcomes_key(self) -> None:
-        """``gap_filled_outcomes`` is the list of UserOutcome IDs that
-        had gaps in the initial coverage check.
-
-        Per existing event payload at ``nlp_tools.py:399`` and the
-        emission helper at ``nlp_tools.py:644``, the value is a list
-        of outcome IDs (strings) — extracted from
-        ``coverage.gaps`` (list of UserOutcome) via list comprehension.
-        Wrapper must perform the same extraction.
-        """
-        from src.marcus_mcp.coordinator.outcome_coverage_augmenter import (
-            OutcomeCoverageAugmenter,
-        )
-
-        parser = _make_mock_parser()
-        parser._apply_outcome_coverage_to_graph.return_value = (
-            _make_parser_outcome_coverage(
-                augmented_tasks=[_make_task("t1")],
-                intent_fidelity_score=0.5,
-                gap_outcome_ids=["outcome_play", "outcome_score"],
-            )
-        )
-        augmenter = OutcomeCoverageAugmenter(parser=parser)
-
-        result = await augmenter.augment(
-            prd_analysis=_make_prd_analysis(),
-            tasks=[_make_task("t1")],
-        )
-        assert "gap_filled_outcomes" in result.telemetry
-        # Must be list of outcome IDs, not full UserOutcome objects
-        assert result.telemetry["gap_filled_outcomes"] == [
-            "outcome_play",
-            "outcome_score",
-        ]
-
-    @pytest.mark.asyncio
-    async def test_telemetry_keys_match_event_payload_exactly(self) -> None:
-        """Anti-regression: pin the exact set of telemetry keys.
-
-        If a Stage-2 refactor adds extra keys or removes existing
-        ones, downstream consumers (Cato) break silently.  This test
-        fails loud on either side of drift.
-        """
-        from src.marcus_mcp.coordinator.outcome_coverage_augmenter import (
-            OutcomeCoverageAugmenter,
-        )
-
-        parser = _make_mock_parser()
-        parser._apply_outcome_coverage_to_graph.return_value = (
-            _make_parser_outcome_coverage(
-                augmented_tasks=[_make_task("t1")],
-                intent_fidelity_score=1.0,
-                coverage_before_fill={"outcome_play": ["t1"]},
-                coverage_after_fill=None,
-                gap_outcome_ids=[],
-            )
-        )
-        augmenter = OutcomeCoverageAugmenter(parser=parser)
-
-        result = await augmenter.augment(
-            prd_analysis=_make_prd_analysis(),
-            tasks=[_make_task("t1")],
-        )
-
-        expected_keys = {
-            "intent_fidelity_score",
-            "coverage_before_fill",
-            "coverage_after_fill",
-            "gap_filled_outcomes",
-        }
-        assert set(result.telemetry.keys()) == expected_keys, (
-            f"Telemetry keys must match PLANNING_INTENT_FIDELITY event "
-            f"payload exactly.  Expected {expected_keys}, "
-            f"got {set(result.telemetry.keys())}"
-        )
-
-
-# ---------------------------------------------------------------------------
-# No-op result handling (flag off / no outcomes / LLM failure)
-# ---------------------------------------------------------------------------
-
-
-class TestNoOpResult:
-    """When the helper returns ``None`` (coverage didn't run), the
-    wrapper produces a passthrough result: input tasks, no synthesized
-    IDs, empty telemetry."""
-
-    @pytest.mark.asyncio
-    async def test_helper_returns_none_passthrough_input_tasks(self) -> None:
-        """Wrapper passthrough behavior when coverage doesn't run."""
-        from src.marcus_mcp.coordinator.outcome_coverage_augmenter import (
-            OutcomeCoverageAugmenter,
-        )
-
-        parser = _make_mock_parser()
-        parser._apply_outcome_coverage_to_graph.return_value = None
-        augmenter = OutcomeCoverageAugmenter(parser=parser)
-
-        input_tasks = [_make_task("t1"), _make_task("t2")]
-        result = await augmenter.augment(
-            prd_analysis=_make_prd_analysis(),
-            tasks=input_tasks,
-        )
-
-        assert result.augmented_tasks == input_tasks
-        assert result.synthesized_ids == []
-        assert result.telemetry == {}
-
-    @pytest.mark.asyncio
-    async def test_helper_returns_none_does_not_mutate_input(self) -> None:
-        """Passthrough must return the same list contents but not mutate
-        the caller's list as a side effect."""
-        from src.marcus_mcp.coordinator.outcome_coverage_augmenter import (
-            OutcomeCoverageAugmenter,
-        )
-
-        parser = _make_mock_parser()
-        parser._apply_outcome_coverage_to_graph.return_value = None
-        augmenter = OutcomeCoverageAugmenter(parser=parser)
-
-        input_tasks = [_make_task("t1"), _make_task("t2")]
-        snapshot_ids = [t.id for t in input_tasks]
-
-        await augmenter.augment(
-            prd_analysis=_make_prd_analysis(),
-            tasks=input_tasks,
-        )
-
-        assert [t.id for t in input_tasks] == snapshot_ids
-
-    @pytest.mark.asyncio
-    async def test_helper_returns_non_none_with_coverage_none(self) -> None:
-        """Edge case: ParserOutcomeCoverage returned with coverage=None.
-
-        Pinned per Kaia review #3 (Simon ``4453bd2c``).  The parser
-        returns ``ParserOutcomeCoverage(augmented_tasks=tasks,
-        coverage=None)`` from ``apply_outcome_coverage`` at
-        ``outcome_coverage.py:902,916`` when the coverage pipeline
-        no-ops with no synthesis.  Wrapper must produce empty
-        telemetry — not ``KeyError`` from accessing ``.coverage.*`` on
-        ``None``.
-        """
-        from src.marcus_mcp.coordinator.outcome_coverage_augmenter import (
-            OutcomeCoverageAugmenter,
-        )
-
-        parser = _make_mock_parser()
-        input_tasks = [_make_task("t1"), _make_task("t2")]
-        # ParserOutcomeCoverage non-None, coverage None — no
-        # intent_fidelity_score passed → coverage=None in helper.
-        parser._apply_outcome_coverage_to_graph.return_value = (
-            _make_parser_outcome_coverage(augmented_tasks=input_tasks)
-        )
-        augmenter = OutcomeCoverageAugmenter(parser=parser)
-
-        result = await augmenter.augment(
-            prd_analysis=_make_prd_analysis(),
-            tasks=input_tasks,
-        )
-
-        # Telemetry must be empty dict, not KeyError, not partially populated
-        assert result.telemetry == {}
-        # Augmented tasks come from the parser_result (still equals input here)
-        assert result.augmented_tasks == input_tasks
-        # No synthesized tasks since augmented_tasks == input
-        assert result.synthesized_ids == []
-
-
-# ---------------------------------------------------------------------------
-# Synthesized ID detection
-# ---------------------------------------------------------------------------
-
-
-class TestSynthesizedIds:
-    """``AugmentationResult.synthesized_ids`` must list the IDs of
-    tasks the augmenter added (subset of ``augmented_tasks``)."""
-
-    @pytest.mark.asyncio
-    async def test_no_gap_fill_synthesized_ids_empty(self) -> None:
-        """When no synthesis ran, synthesized_ids is empty list."""
-        from src.marcus_mcp.coordinator.outcome_coverage_augmenter import (
-            OutcomeCoverageAugmenter,
-        )
-
-        parser = _make_mock_parser()
-        input_tasks = [_make_task("t1"), _make_task("t2")]
-        parser._apply_outcome_coverage_to_graph.return_value = (
-            _make_parser_outcome_coverage(
-                augmented_tasks=input_tasks,
-                intent_fidelity_score=1.0,
-            )
-        )
-        augmenter = OutcomeCoverageAugmenter(parser=parser)
-
-        result = await augmenter.augment(
-            prd_analysis=_make_prd_analysis(), tasks=input_tasks
-        )
-        assert result.synthesized_ids == []
-
-    @pytest.mark.asyncio
-    async def test_gap_fill_ids_listed_in_synthesized_ids(self) -> None:
-        """When the helper appended gap-fill tasks, their IDs appear
-        in synthesized_ids (and only those — not the original tasks)."""
-        from src.marcus_mcp.coordinator.outcome_coverage_augmenter import (
-            OutcomeCoverageAugmenter,
-        )
-
-        parser = _make_mock_parser()
-        input_tasks = [_make_task("t1"), _make_task("t2")]
-        gap_fill = _gap_fill_task("gap_fill_abc123")
-        parser._apply_outcome_coverage_to_graph.return_value = (
-            _make_parser_outcome_coverage(
-                augmented_tasks=input_tasks + [gap_fill],
-                intent_fidelity_score=1.0,
-            )
-        )
-        augmenter = OutcomeCoverageAugmenter(parser=parser)
-
-        result = await augmenter.augment(
-            prd_analysis=_make_prd_analysis(), tasks=input_tasks
-        )
-        assert result.synthesized_ids == ["gap_fill_abc123"]
-
-
-# ---------------------------------------------------------------------------
-# v32 behavior preservation snapshot (Kaia regression-canary)
-# ---------------------------------------------------------------------------
-
-
-class TestV32BehaviorPreservation:
-    """Snapshot the wrapper's output for the v32-shaped scenario.
-
-    v32 narrative: outcome ``snake_visible`` initially uncovered →
-    gap-fill synthesizes a rendering task → recoverage shows
-    ``snake_visible`` covered by the synthesized task.  Score 1.0
-    after fill.
-
-    These tests assert the wrapper's ``AugmentationResult`` carries
-    the same data the existing event-emission code reads off
-    ``ParserOutcomeCoverage`` directly.  If Stage 3 swaps the call
-    site to use the wrapper, the ``PLANNING_INTENT_FIDELITY`` event
-    payload must be byte-identical.
-    """
-
-    @pytest.mark.asyncio
-    async def test_v32_scenario_telemetry_matches_event_payload(self) -> None:
-        """v32-shape input → wrapper telemetry matches the
-        keys/values the existing emission helper reads from
-        ``ParserOutcomeCoverage``."""
-        from src.marcus_mcp.coordinator.outcome_coverage_augmenter import (
-            OutcomeCoverageAugmenter,
-        )
-
-        parser = _make_mock_parser()
-
-        # v32 fixture: 2 input tasks, 1 synthesized gap-fill, 1 outcome
-        input_tasks = [
-            _make_task("t_state", "Snake state machine"),
-            _make_task("t_input", "Input handler"),
-        ]
-        gap_fill = _gap_fill_task("gap_fill_abc123", "Render snake to canvas")
-
-        parser._apply_outcome_coverage_to_graph.return_value = (
-            _make_parser_outcome_coverage(
-                augmented_tasks=input_tasks + [gap_fill],
-                intent_fidelity_score=1.0,
-                coverage_before_fill={"snake_visible": []},
-                coverage_after_fill={"snake_visible": ["_synth_for_coverage_0"]},
-                gap_outcome_ids=["snake_visible"],
-            )
-        )
-        augmenter = OutcomeCoverageAugmenter(parser=parser)
-
-        result = await augmenter.augment(
-            prd_analysis=_make_prd_analysis(),
-            tasks=input_tasks,
-        )
-
-        # Pin the exact event-payload-shaped values
-        assert result.telemetry == {
-            "intent_fidelity_score": 1.0,
-            "coverage_before_fill": {"snake_visible": []},
-            "coverage_after_fill": {"snake_visible": ["_synth_for_coverage_0"]},
-            "gap_filled_outcomes": ["snake_visible"],
-        }
-        # Augmented graph contains 3 tasks: 2 input + 1 synth
-        assert len(result.augmented_tasks) == 3
-        assert result.synthesized_ids == ["gap_fill_abc123"]
-
-
-# ---------------------------------------------------------------------------
-# Stage 2 contract: helpers still callable directly
-# ---------------------------------------------------------------------------
-
-
-class TestStage2NoBehaviorChange:
-    """Stage 2 only adds a wrapper.  The existing helpers on
-    ``AdvancedPRDParser`` must remain callable directly so Stage 3 can
-    switch the decomposer call sites in a separate commit.
-    """
-
-    def test_outcome_coverage_helpers_still_exist(self) -> None:
-        """``_apply_outcome_coverage_to_graph`` and
-        ``_apply_outcome_coverage_to_contract_graph`` are still
-        methods on AdvancedPRDParser at Stage 2.  Stage 3-5 will
-        eventually remove them once all callers migrate.
-        """
-        from src.ai.advanced.prd.advanced_parser import AdvancedPRDParser
-
-        assert hasattr(AdvancedPRDParser, "_apply_outcome_coverage_to_graph")
-        assert hasattr(AdvancedPRDParser, "_apply_outcome_coverage_to_contract_graph")
+        assert mock_contract.call_args.kwargs["llm_client"] is my_llm

--- a/tests/unit/coordinator/test_outcome_coverage_augmenter.py
+++ b/tests/unit/coordinator/test_outcome_coverage_augmenter.py
@@ -457,6 +457,43 @@ class TestNoOpResult:
 
         assert [t.id for t in input_tasks] == snapshot_ids
 
+    @pytest.mark.asyncio
+    async def test_helper_returns_non_none_with_coverage_none(self) -> None:
+        """Edge case: ParserOutcomeCoverage returned with coverage=None.
+
+        Pinned per Kaia review #3 (Simon ``4453bd2c``).  The parser
+        returns ``ParserOutcomeCoverage(augmented_tasks=tasks,
+        coverage=None)`` from ``apply_outcome_coverage`` at
+        ``outcome_coverage.py:902,916`` when the coverage pipeline
+        no-ops with no synthesis.  Wrapper must produce empty
+        telemetry — not ``KeyError`` from accessing ``.coverage.*`` on
+        ``None``.
+        """
+        from src.marcus_mcp.coordinator.outcome_coverage_augmenter import (
+            OutcomeCoverageAugmenter,
+        )
+
+        parser = _make_mock_parser()
+        input_tasks = [_make_task("t1"), _make_task("t2")]
+        # ParserOutcomeCoverage non-None, coverage None — no
+        # intent_fidelity_score passed → coverage=None in helper.
+        parser._apply_outcome_coverage_to_graph.return_value = (
+            _make_parser_outcome_coverage(augmented_tasks=input_tasks)
+        )
+        augmenter = OutcomeCoverageAugmenter(parser=parser)
+
+        result = await augmenter.augment(
+            prd_analysis=_make_prd_analysis(),
+            tasks=input_tasks,
+        )
+
+        # Telemetry must be empty dict, not KeyError, not partially populated
+        assert result.telemetry == {}
+        # Augmented tasks come from the parser_result (still equals input here)
+        assert result.augmented_tasks == input_tasks
+        # No synthesized tasks since augmented_tasks == input
+        assert result.synthesized_ids == []
+
 
 # ---------------------------------------------------------------------------
 # Synthesized ID detection

--- a/tests/unit/coordinator/test_spec_coverage_augmenter.py
+++ b/tests/unit/coordinator/test_spec_coverage_augmenter.py
@@ -135,7 +135,7 @@ class TestSpecCoverageAugmenterProtocolSatisfaction:
             SpecCoverageAugmenter,
         )
 
-        oc = OutcomeCoverageAugmenter(parser=AsyncMock())
+        oc = OutcomeCoverageAugmenter(llm_client=AsyncMock())
         sc = SpecCoverageAugmenter()
         assert oc.name != sc.name
 

--- a/tests/unit/coordinator/test_spec_coverage_augmenter.py
+++ b/tests/unit/coordinator/test_spec_coverage_augmenter.py
@@ -1,0 +1,494 @@
+"""Unit tests for ``SpecCoverageAugmenter`` (issue #456 — Stage 4).
+
+Stage 4 moves ``check_spec_coverage`` from the post-safety-check call
+site at ``nlp_tools.py:1336-1349`` to a chain augmenter that runs
+inside the decomposer.  The behavior change: gap tasks now flow
+through ``_infer_smart_dependencies`` and foundation wiring instead
+of being appended as orphans (``dependencies=[]``) — this is the
+v37 orphan-failure-mode fix.
+
+The augmenter delegates to the existing :func:`check_spec_coverage`
+function for behavior preservation; only the call-site location
+changes.  Stage 5 will sweep the now-unused ``project_name`` parameter.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, List, Optional
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from src.core.models import Priority, Task, TaskStatus
+
+pytestmark = pytest.mark.unit
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_task(task_id: str, name: str = "Implement Foo") -> Task:
+    """Minimal Task for augmenter tests."""
+    now = datetime.now(timezone.utc)
+    return Task(
+        id=task_id,
+        name=name,
+        description="...",
+        status=TaskStatus.TODO,
+        priority=Priority.HIGH,
+        assigned_to=None,
+        created_at=now,
+        updated_at=now,
+        due_date=None,
+        estimated_hours=2.0,
+    )
+
+
+def _make_gap_task(task_id: str, name: str = "Implement Auth") -> Task:
+    """Synthesized gap task (matches what check_spec_coverage produces)."""
+    now = datetime.now(timezone.utc)
+    return Task(
+        id=task_id,
+        name=name,
+        description="Spec coverage check found this feature missing",
+        status=TaskStatus.TODO,
+        priority=Priority.HIGH,
+        labels=["spec_gap"],
+        dependencies=[],
+        estimated_hours=3.0,
+        assigned_to=None,
+        created_at=now,
+        updated_at=now,
+        due_date=None,
+    )
+
+
+def _make_prd_analysis(description: str = "build a snake game") -> Any:
+    """Minimal PRDAnalysis whose ``original_description`` carries the spec."""
+    from src.ai.advanced.prd.advanced_parser import PRDAnalysis
+
+    return PRDAnalysis(
+        functional_requirements=[],
+        non_functional_requirements=[],
+        technical_constraints=[],
+        business_objectives=[],
+        user_personas=[],
+        success_metrics=[],
+        implementation_approach="iterative",
+        complexity_assessment={},
+        risk_factors=[],
+        confidence=0.9,
+        original_description=description,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Protocol satisfaction
+# ---------------------------------------------------------------------------
+
+
+class TestSpecCoverageAugmenterProtocolSatisfaction:
+    """Augmenter satisfies the GraphAugmenter Protocol."""
+
+    def test_module_exports_augmenter(self) -> None:
+        from src.marcus_mcp.coordinator.spec_coverage_augmenter import (
+            SpecCoverageAugmenter,
+        )
+
+        assert SpecCoverageAugmenter is not None
+
+    def test_augmenter_is_graph_augmenter(self) -> None:
+        """``isinstance(augmenter, GraphAugmenter)`` returns True."""
+        from src.marcus_mcp.coordinator.graph_augmentation import (
+            GraphAugmenter,
+        )
+        from src.marcus_mcp.coordinator.spec_coverage_augmenter import (
+            SpecCoverageAugmenter,
+        )
+
+        augmenter = SpecCoverageAugmenter()
+        assert isinstance(augmenter, GraphAugmenter)
+
+    def test_name_is_spec_coverage(self) -> None:
+        """Canonical name keys telemetry / log lines."""
+        from src.marcus_mcp.coordinator.spec_coverage_augmenter import (
+            SpecCoverageAugmenter,
+        )
+
+        augmenter = SpecCoverageAugmenter()
+        assert augmenter.name == "spec_coverage"
+
+    def test_name_distinct_from_outcome_coverage(self) -> None:
+        """Names must be distinct so chain uniqueness check accepts both.
+
+        Stage 4 registers ``[OutcomeCoverageAugmenter,
+        SpecCoverageAugmenter]`` together — their names cannot collide
+        or the chain rejects the registration at entry.
+        """
+        from src.marcus_mcp.coordinator.outcome_coverage_augmenter import (
+            OutcomeCoverageAugmenter,
+        )
+        from src.marcus_mcp.coordinator.spec_coverage_augmenter import (
+            SpecCoverageAugmenter,
+        )
+
+        oc = OutcomeCoverageAugmenter(parser=AsyncMock())
+        sc = SpecCoverageAugmenter()
+        assert oc.name != sc.name
+
+
+# ---------------------------------------------------------------------------
+# Delegation to check_spec_coverage
+# ---------------------------------------------------------------------------
+
+
+class TestDelegation:
+    """Augmenter delegates to ``check_spec_coverage`` with correct args."""
+
+    @pytest.mark.asyncio
+    async def test_delegates_with_prd_description(self) -> None:
+        """``description`` arg comes from ``prd_analysis.original_description``."""
+        from src.marcus_mcp.coordinator.spec_coverage_augmenter import (
+            SpecCoverageAugmenter,
+        )
+
+        with patch(
+            "src.marcus_mcp.coordinator.spec_coverage_augmenter." "check_spec_coverage",
+            new_callable=AsyncMock,
+            return_value=[],
+        ) as mock_check:
+            augmenter = SpecCoverageAugmenter()
+            await augmenter.augment(
+                prd_analysis=_make_prd_analysis("build a weather app"),
+                tasks=[_make_task("t1")],
+            )
+
+        mock_check.assert_awaited_once()
+        call_kwargs = mock_check.call_args.kwargs
+        assert call_kwargs["description"] == "build a weather app"
+
+    @pytest.mark.asyncio
+    async def test_delegates_with_input_tasks(self) -> None:
+        """``tasks`` arg threads through unchanged."""
+        from src.marcus_mcp.coordinator.spec_coverage_augmenter import (
+            SpecCoverageAugmenter,
+        )
+
+        input_tasks = [_make_task("t1"), _make_task("t2")]
+
+        with patch(
+            "src.marcus_mcp.coordinator.spec_coverage_augmenter." "check_spec_coverage",
+            new_callable=AsyncMock,
+            return_value=[],
+        ) as mock_check:
+            augmenter = SpecCoverageAugmenter()
+            await augmenter.augment(
+                prd_analysis=_make_prd_analysis(),
+                tasks=input_tasks,
+            )
+
+        assert mock_check.call_args.kwargs["tasks"] == input_tasks
+
+    @pytest.mark.asyncio
+    async def test_ignores_contract_artifacts(self) -> None:
+        """spec_coverage operates on spec text, not contracts.
+
+        ``contract_artifacts`` arg is part of the Protocol surface, but
+        spec_coverage doesn't read it — feature parity with the
+        post-safety-check call site that never had this parameter.
+        """
+        from src.marcus_mcp.coordinator.spec_coverage_augmenter import (
+            SpecCoverageAugmenter,
+        )
+
+        with patch(
+            "src.marcus_mcp.coordinator.spec_coverage_augmenter." "check_spec_coverage",
+            new_callable=AsyncMock,
+            return_value=[],
+        ) as mock_check:
+            augmenter = SpecCoverageAugmenter()
+            # Pass contract_artifacts; augmenter must not crash, must
+            # not forward to check_spec_coverage (which has no such param)
+            await augmenter.augment(
+                prd_analysis=_make_prd_analysis(),
+                tasks=[_make_task("t1")],
+                contract_artifacts={"Auth": {"artifacts": []}},
+            )
+
+        # check_spec_coverage shouldn't receive contract_artifacts
+        assert "contract_artifacts" not in mock_check.call_args.kwargs
+
+
+# ---------------------------------------------------------------------------
+# No-gap behavior (passthrough)
+# ---------------------------------------------------------------------------
+
+
+class TestNoGapPassthrough:
+    """When check_spec_coverage returns no gaps, augmenter no-ops."""
+
+    @pytest.mark.asyncio
+    async def test_empty_gap_list_passthrough_input_tasks(self) -> None:
+        """No gaps → augmented_tasks equals input."""
+        from src.marcus_mcp.coordinator.spec_coverage_augmenter import (
+            SpecCoverageAugmenter,
+        )
+
+        input_tasks = [_make_task("t1"), _make_task("t2")]
+
+        with patch(
+            "src.marcus_mcp.coordinator.spec_coverage_augmenter." "check_spec_coverage",
+            new_callable=AsyncMock,
+            return_value=[],
+        ):
+            augmenter = SpecCoverageAugmenter()
+            result = await augmenter.augment(
+                prd_analysis=_make_prd_analysis(),
+                tasks=input_tasks,
+            )
+
+        assert result.augmented_tasks == input_tasks
+        assert result.synthesized_ids == []
+
+    @pytest.mark.asyncio
+    async def test_empty_gap_list_no_telemetry(self) -> None:
+        """No gaps → no telemetry slice in chain namespace.
+
+        Empty telemetry dict so the chain orchestrator omits the
+        ``spec_coverage`` key entirely (signals "ran, no data" vs
+        "didn't run").
+        """
+        from src.marcus_mcp.coordinator.spec_coverage_augmenter import (
+            SpecCoverageAugmenter,
+        )
+
+        with patch(
+            "src.marcus_mcp.coordinator.spec_coverage_augmenter." "check_spec_coverage",
+            new_callable=AsyncMock,
+            return_value=[],
+        ):
+            augmenter = SpecCoverageAugmenter()
+            result = await augmenter.augment(
+                prd_analysis=_make_prd_analysis(),
+                tasks=[_make_task("t1")],
+            )
+
+        assert result.telemetry == {}
+
+
+# ---------------------------------------------------------------------------
+# Gap synthesis path
+# ---------------------------------------------------------------------------
+
+
+class TestGapSynthesis:
+    """When check_spec_coverage returns gap tasks, augmenter appends them."""
+
+    @pytest.mark.asyncio
+    async def test_gap_tasks_appended_to_input(self) -> None:
+        """Gap tasks added at the tail of augmented_tasks."""
+        from src.marcus_mcp.coordinator.spec_coverage_augmenter import (
+            SpecCoverageAugmenter,
+        )
+
+        input_tasks = [_make_task("t1")]
+        gap = _make_gap_task("gap_abc", "Implement Auth")
+
+        with patch(
+            "src.marcus_mcp.coordinator.spec_coverage_augmenter." "check_spec_coverage",
+            new_callable=AsyncMock,
+            return_value=[gap],
+        ):
+            augmenter = SpecCoverageAugmenter()
+            result = await augmenter.augment(
+                prd_analysis=_make_prd_analysis(),
+                tasks=input_tasks,
+            )
+
+        assert result.augmented_tasks == input_tasks + [gap]
+
+    @pytest.mark.asyncio
+    async def test_synthesized_ids_lists_gap_ids(self) -> None:
+        """``synthesized_ids`` carries IDs of all gap tasks."""
+        from src.marcus_mcp.coordinator.spec_coverage_augmenter import (
+            SpecCoverageAugmenter,
+        )
+
+        gap_a = _make_gap_task("gap_a", "Implement A")
+        gap_b = _make_gap_task("gap_b", "Implement B")
+
+        with patch(
+            "src.marcus_mcp.coordinator.spec_coverage_augmenter." "check_spec_coverage",
+            new_callable=AsyncMock,
+            return_value=[gap_a, gap_b],
+        ):
+            augmenter = SpecCoverageAugmenter()
+            result = await augmenter.augment(
+                prd_analysis=_make_prd_analysis(),
+                tasks=[_make_task("t1")],
+            )
+
+        assert result.synthesized_ids == ["gap_a", "gap_b"]
+
+    @pytest.mark.asyncio
+    async def test_telemetry_carries_gap_count(self) -> None:
+        """``telemetry["spec_gap_count"]`` reports number of gaps filled."""
+        from src.marcus_mcp.coordinator.spec_coverage_augmenter import (
+            SpecCoverageAugmenter,
+        )
+
+        gaps = [
+            _make_gap_task("g1", "Implement Auth"),
+            _make_gap_task("g2", "Implement Reports"),
+            _make_gap_task("g3", "Implement Search"),
+        ]
+
+        with patch(
+            "src.marcus_mcp.coordinator.spec_coverage_augmenter." "check_spec_coverage",
+            new_callable=AsyncMock,
+            return_value=gaps,
+        ):
+            augmenter = SpecCoverageAugmenter()
+            result = await augmenter.augment(
+                prd_analysis=_make_prd_analysis(),
+                tasks=[_make_task("t1")],
+            )
+
+        assert result.telemetry["spec_gap_count"] == 3
+
+    @pytest.mark.asyncio
+    async def test_telemetry_carries_gap_features(self) -> None:
+        """``telemetry["spec_gap_features"]`` lists synthesized task names.
+
+        Cato consumers can show "spec_coverage filled gaps for: A, B, C"
+        without having to introspect the augmented_tasks list.
+        """
+        from src.marcus_mcp.coordinator.spec_coverage_augmenter import (
+            SpecCoverageAugmenter,
+        )
+
+        gaps = [
+            _make_gap_task("g1", "Implement Auth"),
+            _make_gap_task("g2", "Implement Reports"),
+        ]
+
+        with patch(
+            "src.marcus_mcp.coordinator.spec_coverage_augmenter." "check_spec_coverage",
+            new_callable=AsyncMock,
+            return_value=gaps,
+        ):
+            augmenter = SpecCoverageAugmenter()
+            result = await augmenter.augment(
+                prd_analysis=_make_prd_analysis(),
+                tasks=[_make_task("t1")],
+            )
+
+        assert result.telemetry["spec_gap_features"] == [
+            "Implement Auth",
+            "Implement Reports",
+        ]
+
+
+# ---------------------------------------------------------------------------
+# Empty description handling
+# ---------------------------------------------------------------------------
+
+
+class TestEmptyDescription:
+    """When ``prd_analysis.original_description`` is empty, augmenter no-ops.
+
+    ``check_spec_coverage`` would extract zero features from an empty
+    spec and return [], but skipping the call avoids a needless LLM
+    round-trip.
+    """
+
+    @pytest.mark.asyncio
+    async def test_empty_description_skips_check(self) -> None:
+        from src.marcus_mcp.coordinator.spec_coverage_augmenter import (
+            SpecCoverageAugmenter,
+        )
+
+        with patch(
+            "src.marcus_mcp.coordinator.spec_coverage_augmenter." "check_spec_coverage",
+            new_callable=AsyncMock,
+            return_value=[],
+        ) as mock_check:
+            augmenter = SpecCoverageAugmenter()
+            await augmenter.augment(
+                prd_analysis=_make_prd_analysis(""),
+                tasks=[_make_task("t1")],
+            )
+
+        mock_check.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_empty_description_returns_passthrough(self) -> None:
+        """Empty description → input tasks returned unchanged."""
+        from src.marcus_mcp.coordinator.spec_coverage_augmenter import (
+            SpecCoverageAugmenter,
+        )
+
+        input_tasks = [_make_task("t1"), _make_task("t2")]
+        augmenter = SpecCoverageAugmenter()
+        result = await augmenter.augment(
+            prd_analysis=_make_prd_analysis(""),
+            tasks=input_tasks,
+        )
+
+        assert result.augmented_tasks == input_tasks
+        assert result.synthesized_ids == []
+        assert result.telemetry == {}
+
+
+# ---------------------------------------------------------------------------
+# Stage 4 contract: spec_coverage no longer wired post-safety-check
+# ---------------------------------------------------------------------------
+
+
+class TestStage4PostSafetyCheckCallSiteRemoved:
+    """Stage 4 removes the call site at ``nlp_tools.py:1336-1349``.
+
+    Before Stage 4: ``check_spec_coverage`` was called from
+    ``nlp_tools.py`` *after* safety checks; gap tasks were appended
+    with ``dependencies=[]`` (orphans).
+
+    After Stage 4: the augmenter runs *inside* the decomposer chain,
+    so gap tasks flow through ``_infer_smart_dependencies`` and
+    foundation wiring like first-class graph members.
+
+    Anti-regression: nlp_tools.py no longer imports or calls
+    ``check_spec_coverage`` directly.  The function still exists in
+    spec_coverage.py (the augmenter delegates to it).
+    """
+
+    def test_check_spec_coverage_function_still_exists(self) -> None:
+        """The underlying function is preserved (augmenter delegates to it)."""
+        from src.integrations.spec_coverage import check_spec_coverage
+
+        assert callable(check_spec_coverage)
+
+    def test_nlp_tools_no_longer_imports_check_spec_coverage(self) -> None:
+        """No import of ``check_spec_coverage`` in ``nlp_tools.py``.
+
+        Once the augmenter chain handles spec coverage, the legacy
+        post-safety-check call site is gone.  Catching this in a test
+        prevents a future regression that re-adds a parallel call.
+        """
+        from pathlib import Path
+
+        nlp_tools_path = (
+            Path(__file__).resolve().parents[3]
+            / "src"
+            / "integrations"
+            / "nlp_tools.py"
+        )
+        content = nlp_tools_path.read_text()
+        assert "from src.integrations.spec_coverage import check_spec_coverage" not in (
+            content
+        ), (
+            "nlp_tools.py must not import check_spec_coverage post-Stage-4 — "
+            "the augmenter chain handles spec coverage now."
+        )

--- a/tests/unit/integrations/test_contract_first_fallback.py
+++ b/tests/unit/integrations/test_contract_first_fallback.py
@@ -21,8 +21,9 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from src.ai.advanced.prd.advanced_parser import ParserOutcomeCoverage, PRDAnalysis
+from src.ai.advanced.prd.advanced_parser import PRDAnalysis
 from src.integrations.nlp_tools import NaturalLanguageProjectCreator
+from src.marcus_mcp.coordinator.graph_augmentation import AugmentationResult
 
 pytestmark = pytest.mark.unit
 
@@ -420,9 +421,7 @@ class TestContractFirstFallback:
                 creator.prd_parser,
                 "decompose_by_contract",
                 new_callable=AsyncMock,
-                return_value=ParserOutcomeCoverage(
-                    augmented_tasks=[impl_task], coverage=None
-                ),
+                return_value=AugmentationResult(augmented_tasks=[impl_task]),
             ),
         ):
             result = await creator._try_contract_first_decomposition(
@@ -585,10 +584,7 @@ class TestContractFirstCompositionTaskSynthesis:
                 creator.prd_parser,
                 "decompose_by_contract",
                 new_callable=AsyncMock,
-                return_value=ParserOutcomeCoverage(
-                    augmented_tasks=[impl_a, impl_b],
-                    coverage=None,
-                ),
+                return_value=AugmentationResult(augmented_tasks=[impl_a, impl_b]),
             ),
         ):
             result = await creator._try_contract_first_decomposition(
@@ -683,10 +679,7 @@ class TestContractFirstCompositionTaskSynthesis:
                 creator.prd_parser,
                 "decompose_by_contract",
                 new_callable=AsyncMock,
-                return_value=ParserOutcomeCoverage(
-                    augmented_tasks=[impl_a],
-                    coverage=None,
-                ),
+                return_value=AugmentationResult(augmented_tasks=[impl_a]),
             ),
         ):
             result = await creator._try_contract_first_decomposition(
@@ -798,9 +791,8 @@ class TestContractFirstCompositionTaskSynthesis:
                 creator.prd_parser,
                 "decompose_by_contract",
                 new_callable=AsyncMock,
-                return_value=ParserOutcomeCoverage(
-                    augmented_tasks=[contract_task, gap_fill_task],
-                    coverage=None,
+                return_value=AugmentationResult(
+                    augmented_tasks=[contract_task, gap_fill_task]
                 ),
             ),
         ):
@@ -941,9 +933,7 @@ class TestContractFirstDesignGhosts:
                 creator.prd_parser,
                 "decompose_by_contract",
                 new_callable=AsyncMock,
-                return_value=ParserOutcomeCoverage(
-                    augmented_tasks=[stub_impl], coverage=None
-                ),
+                return_value=AugmentationResult(augmented_tasks=[stub_impl]),
             ),
         ):
             result = await creator._try_contract_first_decomposition(
@@ -1087,8 +1077,8 @@ class TestContractFirstDesignGhosts:
                 creator.prd_parser,
                 "decompose_by_contract",
                 new_callable=AsyncMock,
-                return_value=ParserOutcomeCoverage(
-                    augmented_tasks=[weather_impl, time_impl], coverage=None
+                return_value=AugmentationResult(
+                    augmented_tasks=[weather_impl, time_impl]
                 ),
             ),
         ):
@@ -1199,9 +1189,7 @@ class TestContractFirstDesignGhosts:
                 creator.prd_parser,
                 "decompose_by_contract",
                 new_callable=AsyncMock,
-                return_value=ParserOutcomeCoverage(
-                    augmented_tasks=[impl_task], coverage=None
-                ),
+                return_value=AugmentationResult(augmented_tasks=[impl_task]),
             ),
         ):
             result = await creator._try_contract_first_decomposition(
@@ -1443,8 +1431,8 @@ class TestContractFirstDesignGhosts:
                 creator.prd_parser,
                 "decompose_by_contract",
                 new_callable=AsyncMock,
-                return_value=ParserOutcomeCoverage(
-                    augmented_tasks=[weather_impl, time_impl], coverage=None
+                return_value=AugmentationResult(
+                    augmented_tasks=[weather_impl, time_impl]
                 ),
             ),
         ):
@@ -1600,9 +1588,7 @@ class TestContractFirstDesignGhosts:
                 creator.prd_parser,
                 "decompose_by_contract",
                 new_callable=AsyncMock,
-                return_value=ParserOutcomeCoverage(
-                    augmented_tasks=[impl_task], coverage=None
-                ),
+                return_value=AugmentationResult(augmented_tasks=[impl_task]),
             ),
         ):
             await creator._try_contract_first_decomposition(

--- a/tests/unit/integrations/test_contract_first_fallback.py
+++ b/tests/unit/integrations/test_contract_first_fallback.py
@@ -705,7 +705,7 @@ class TestContractFirstCompositionTaskSynthesis:
 
         Codex P2 (PR #472): ``decompose_result.augmented_tasks`` can
         include ``source_type="gap_fill_contract"`` tasks synthesized
-        by ``_apply_outcome_coverage_to_contract_graph``.  These
+        by ``apply_outcome_coverage_to_contract_graph``.  These
         address outcome coverage gaps, not domain multiplicity, so
         they must NOT count toward the composition trigger.  Single-
         domain project with 1 contract task + 1 gap-fill should NOT
@@ -739,7 +739,7 @@ class TestContractFirstCompositionTaskSynthesis:
             responsibility="implements Auth interface",
         )
         # Synthesized gap-fill task (mimics
-        # _apply_outcome_coverage_to_contract_graph output shape)
+        # apply_outcome_coverage_to_contract_graph output shape)
         gap_fill_task = Task(
             id="gap_fill_abc123",
             name="Render Auth Status to UI",

--- a/tests/unit/integrations/test_snake_v32_intent_fidelity.py
+++ b/tests/unit/integrations/test_snake_v32_intent_fidelity.py
@@ -19,7 +19,7 @@ This test exercises the full chain through
 ``NaturalLanguageProjectCreator.process_natural_language``:
 
 - ``AdvancedPRDParser.parse_prd_to_tasks`` runs end-to-end
-- ``_apply_outcome_coverage_to_graph`` runs the real coverage pipeline
+- ``apply_outcome_coverage_to_feature_graph`` runs the real coverage pipeline
 - The augmented task list has the synthesized rendering task
 - ``_emit_intent_fidelity_event`` publishes the expected payload
 

--- a/tests/unit/integrations/test_snake_v32_intent_fidelity.py
+++ b/tests/unit/integrations/test_snake_v32_intent_fidelity.py
@@ -195,6 +195,25 @@ def _make_creator(state: Any) -> Any:
 class TestSnakeV32IntentFidelity:
     """Lock the v31→v32 narrative: gap detection, fill, telemetry."""
 
+    @pytest.fixture(autouse=True)
+    def _no_spec_coverage(self) -> Any:
+        """Stub SpecCoverageAugmenter for these outcome-coverage-only tests.
+
+        Issue #456 Stage 4 wires ``SpecCoverageAugmenter`` alongside
+        ``OutcomeCoverageAugmenter`` in the decomposer chain.  These
+        v32 tests assert specific task counts and lock outcome-coverage
+        behavior, so spec_coverage running concurrently would (a)
+        trigger a real LLM call for ``extract_spec_features`` and (b)
+        synthesize extra spec_gap tasks that change the assertion math.
+        Stub spec_coverage to a no-op for every test in this class.
+        """
+        with patch(
+            "src.marcus_mcp.coordinator.spec_coverage_augmenter." "check_spec_coverage",
+            new_callable=AsyncMock,
+            return_value=[],
+        ) as mock:
+            yield mock
+
     @pytest.mark.asyncio
     async def test_missing_rendering_task_is_synthesized(
         self, monkeypatch: Any

--- a/tests/unit/integrations/test_spec_coverage.py
+++ b/tests/unit/integrations/test_spec_coverage.py
@@ -219,7 +219,6 @@ class TestCheckSpecCoverage:
             gap_tasks = await check_spec_coverage(
                 description=NIMBUS_SPEC,
                 tasks=NIMBUS_TASKS_MISSING_FORECAST,
-                project_name="Nimbus",
             )
 
         assert len(gap_tasks) >= 1
@@ -242,7 +241,6 @@ class TestCheckSpecCoverage:
             gap_tasks = await check_spec_coverage(
                 description=NIMBUS_SPEC,
                 tasks=NIMBUS_TASKS_COMPLETE,
-                project_name="Nimbus",
             )
 
         assert gap_tasks == []
@@ -258,7 +256,6 @@ class TestCheckSpecCoverage:
             gap_tasks = await check_spec_coverage(
                 description=NIMBUS_SPEC,
                 tasks=NIMBUS_TASKS_MISSING_FORECAST,
-                project_name="Nimbus",
             )
 
         assert gap_tasks == []
@@ -274,7 +271,6 @@ class TestCheckSpecCoverage:
             gap_tasks = await check_spec_coverage(
                 description=NIMBUS_SPEC,
                 tasks=NIMBUS_TASKS_MISSING_FORECAST,
-                project_name="Nimbus",
             )
 
         assert len(gap_tasks) >= 1
@@ -292,7 +288,6 @@ class TestCheckSpecCoverage:
             gap_tasks = await check_spec_coverage(
                 description=NIMBUS_SPEC,
                 tasks=NIMBUS_TASKS_MISSING_FORECAST,
-                project_name="Nimbus",
             )
 
         assert len(gap_tasks) >= 1

--- a/tests/unit/integrations/test_spec_gap_integration_order.py
+++ b/tests/unit/integrations/test_spec_gap_integration_order.py
@@ -97,7 +97,6 @@ class TestSpecCoverageBeforeIntegrationOrder:
             gap_tasks = await check_spec_coverage(
                 description="Snake game with movement, food, and score",
                 tasks=existing,
-                project_name="snake-game",
             )
 
         assert len(gap_tasks) >= 1, "at least one gap task expected for this fixture"
@@ -107,7 +106,6 @@ class TestSpecCoverageBeforeIntegrationOrder:
         enhanced = enhance_project_with_integration(
             with_gaps,
             project_description="Snake game",
-            project_name="snake-game",
         )
 
         # Find the integration task
@@ -149,7 +147,6 @@ class TestSpecCoverageBeforeIntegrationOrder:
         enhanced = enhance_project_with_integration(
             existing,
             project_description="Snake game",
-            project_name="snake-game",
         )
 
         with patch(
@@ -161,7 +158,6 @@ class TestSpecCoverageBeforeIntegrationOrder:
             gap_tasks = await check_spec_coverage(
                 description="Snake game with movement, food, and score",
                 tasks=enhanced,
-                project_name="snake-game",
             )
 
         # Append gap tasks AFTER integration — the buggy order


### PR DESCRIPTION
## Summary

Closes #456. Replaces the parallel `outcome_coverage` (in-decomposer) and `spec_coverage` (post-safety-check) pipelines with a single `GraphAugmenter` Protocol + chain orchestrator. Both augmenters now run inside the decomposer between `_create_detailed_tasks` and `_infer_smart_dependencies`, so synthesized gap tasks flow through dependency inference and foundation wiring as first-class graph members instead of being appended later as orphans.

**Headline fix:** v37 orphan-failure-mode (spec_coverage gap tasks landing with `dependencies=[]`) is closed.

## What changed

- **New `GraphAugmenter` Protocol** + `AugmentationResult` dataclass at `src/marcus_mcp/coordinator/graph_augmentation.py`.
- **New `run_augmenter_chain` orchestrator** with defense-in-depth `try/except` around each augmenter, augmenter-name uniqueness validation at chain entry, telemetry namespacing by `augmenter.name`.
- **`OutcomeCoverageAugmenter`** dispatches to two new public module functions in `outcome_coverage.py`: `apply_outcome_coverage_to_feature_graph` and `apply_outcome_coverage_to_contract_graph`. The legacy parser-side helpers (`_apply_outcome_coverage_to_*`, `_build_*_gap_fill_task`, `ParserOutcomeCoverage` dataclass) are deleted.
- **`SpecCoverageAugmenter`** wraps the existing `check_spec_coverage` function. The legacy post-safety-check call site at `nlp_tools.py:1336` is removed. The `project_name` parameter (declared but unused) is dropped.
- **`AdvancedPRDParser._build_augmenter_chain()`** is the single registration site; both decomposer paths route through it.
- **ADR 0011** documents the pattern and the recipe for adding future augmenters.

## Bright-line gates (all pass)

```
git grep _apply_outcome_coverage -- src/   = 0
git grep ParserOutcomeCoverage    -- src/   = 0
git grep "from src.integrations.spec_coverage import check_spec_coverage" -- src/ = 1
```

## Stages

This landed as a 5-stage TDD migration with a Kaia review gate after each stage:

- **Stage 1** — Protocol + dataclass (12 tests)
- **Stage 2** — `OutcomeCoverageAugmenter` wrapper around legacy helpers (17 tests)
- **Stage 3** — `run_augmenter_chain` orchestrator + decomposer cutover (15 chain tests)
- **Stage 4** — `SpecCoverageAugmenter` joins chain, legacy call site removed (17 tests)
- **Stage 5** — Lift helpers, delete legacy, drop `project_name`, factor chain helper, ADR

## Test plan

- [x] `pytest -m unit` — 1208 passed, 1 skipped, no regressions
- [x] `mypy --strict` clean on all touched src files
- [x] `black` + `isort` + `pydocstyle` + `flake8` + `bandit` all pass via pre-commit
- [x] Augmenter-name uniqueness check fails loud on duplicate registration
- [x] v32 regression-canary test (`test_snake_v32_intent_fidelity`) still green
- [x] Spec-gap integration-order test (`test_spec_gap_integration_order`) still green
- [x] PLANNING_INTENT_FIDELITY event payload byte-identical to pre-#456 shape
- [x] Bright-line PR gates verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)