### PR TITLE
fix(#479): normalize snake_case slug names from weak LLM gap-fill

### DIFF
--- a/checklist.md
+++ b/checklist.md
@@ -25,3 +25,5 @@
 - [ ] [Bug] feature_based agents receive contract docs as primary spec, produce stubs instead of implementations (#353) 🔴
 - [ ] [Bug] Stale dedup cache causes project to be planned under literal name "CachedProject" (#419) 🔴
 - [ ] [Bug] project_config entries accumulate in marcus.db indefinitely — 184 orphaned rows with no matching kanban project (#420) 🟡
+- [ ] [Bug] MCP create_project silently falls back to feature_based when project_root missing — structural scaffolding lost (#478) 🔴
+- [ ] [Bug] OutcomeCoverageAugmenter gap-fill tasks get raw slug names on feature_based path when weak LLM is used (#479) 🟡

--- a/src/marcus_mcp/coordinator/outcome_coverage.py
+++ b/src/marcus_mcp/coordinator/outcome_coverage.py
@@ -785,6 +785,44 @@ class OutcomeCoverageResult:
 STUB_TASK_ID_PREFIX: str = "_synth_for_coverage_"
 
 
+def _normalize_gap_task_name(name: str) -> str:
+    """Convert ``snake_case`` LLM slug to a readable task name.
+
+    Weak local models occasionally ignore the prompt instruction to
+    produce concrete human-readable names (e.g. ``"Render snake to
+    canvas"``) and instead return Python-style slugs such as
+    ``"render_snake_to_canvas"``.  This normalizer detects the slug
+    pattern — underscores present, no spaces — and converts it to
+    Title Case.  Already-readable names pass through unchanged.
+
+    Parameters
+    ----------
+    name : str
+        Raw name from the gap-fill LLM response.
+
+    Returns
+    -------
+    str
+        Human-readable name; empty string when input is blank.
+
+    Examples
+    --------
+    >>> _normalize_gap_task_name("render_game_board")
+    'Render Game Board'
+    >>> _normalize_gap_task_name("Render game board")
+    'Render game board'
+    >>> _normalize_gap_task_name("")
+    ''
+    """
+    name = name.strip()
+    if not name:
+        return name
+    # Slug detection: underscores present AND no spaces
+    if "_" in name and " " not in name:
+        return " ".join(word.capitalize() for word in name.split("_"))
+    return name
+
+
 def _build_recoverage_description(gap_dict: Dict[str, Any]) -> str:
     """Render a description that surfaces contract metadata for the recheck.
 
@@ -832,7 +870,7 @@ def _make_stub_task_for_coverage(idx: int, gap_dict: Dict[str, Any]) -> Task:
     now = datetime.now(timezone.utc)
     return Task(
         id=f"{STUB_TASK_ID_PREFIX}{idx}",
-        name=gap_dict["name"],
+        name=_normalize_gap_task_name(gap_dict["name"]),
         description=_build_recoverage_description(gap_dict),
         status=TaskStatus.TODO,
         priority=Priority.MEDIUM,
@@ -1024,7 +1062,7 @@ def _build_feature_gap_fill_task(
 
     return Task(
         id=f"gap_fill_{uuid4().hex[:12]}",
-        name=gap_dict["name"],
+        name=_normalize_gap_task_name(gap_dict["name"]),
         description=gap_dict["description"],
         status=TaskStatus.TODO,
         priority=Priority.MEDIUM,
@@ -1120,7 +1158,7 @@ def _build_contract_gap_fill_task(
 
     return Task(
         id=f"gap_fill_{uuid4().hex[:12]}",
-        name=gap_dict["name"],
+        name=_normalize_gap_task_name(gap_dict["name"]),
         description=description,
         status=TaskStatus.TODO,
         priority=Priority.MEDIUM,

--- a/tests/unit/coordinator/test_outcome_coverage.py
+++ b/tests/unit/coordinator/test_outcome_coverage.py
@@ -25,6 +25,7 @@ from src.marcus_mcp.coordinator.outcome_coverage import (
     STUB_TASK_ID_PREFIX,
     OutcomeCoverageResult,
     _build_recoverage_description,
+    _normalize_gap_task_name,
     apply_outcome_coverage,
     compute_coverage,
     compute_coverage_with_llm,
@@ -1123,3 +1124,53 @@ class TestCoverageToTelemetry:
         # gap_filled_outcomes is the list of UserOutcome IDs (strings),
         # not the full UserOutcome objects — Cato consumes IDs.
         assert telemetry["gap_filled_outcomes"] == ["o2"]
+
+
+class TestNormalizeGapTaskName:
+    """Tests for ``_normalize_gap_task_name`` (issue #479).
+
+    Weak LLMs (local models) sometimes return gap task names as
+    ``snake_case`` slugs instead of the human-readable strings the
+    prompt requests.  The normalizer detects and converts slugs so
+    structural scaffolding tasks show readable names on the board.
+    """
+
+    def test_snake_case_slug_is_converted_to_title_case(self) -> None:
+        """Classic Python-slug form must become readable title case."""
+        assert _normalize_gap_task_name("implement_snake_movement") == (
+            "Implement Snake Movement"
+        )
+
+    def test_single_word_without_underscores_passes_through(self) -> None:
+        """A single lowercase word with no underscores is not a slug — pass through."""
+        assert _normalize_gap_task_name("render") == "render"
+
+    def test_already_readable_name_is_unchanged(self) -> None:
+        """Human-readable names must pass through without modification."""
+        assert _normalize_gap_task_name("Render snake to canvas") == (
+            "Render snake to canvas"
+        )
+
+    def test_mixed_case_readable_name_is_unchanged(self) -> None:
+        """CamelWord name must pass through without modification."""
+        assert _normalize_gap_task_name("Implement SnakeGame core loop") == (
+            "Implement SnakeGame core loop"
+        )
+
+    def test_empty_string_returns_empty_string(self) -> None:
+        """Edge case: empty string must not raise."""
+        assert _normalize_gap_task_name("") == ""
+
+    def test_whitespace_only_is_stripped(self) -> None:
+        """Whitespace-only input is treated as empty after strip."""
+        assert _normalize_gap_task_name("   ") == ""
+
+    def test_slug_with_numbers_is_converted(self) -> None:
+        """Numeric tokens in a slug must be preserved in title case output."""
+        assert _normalize_gap_task_name("setup_player2_controls") == (
+            "Setup Player2 Controls"
+        )
+
+    def test_render_game_board_slug(self) -> None:
+        """Regression: specific slug seen in test2-qwen25-instruct logs."""
+        assert _normalize_gap_task_name("render_game_board") == "Render Game Board"


### PR DESCRIPTION
## Summary

- **Root cause**: Weak local models (Qwen 2.5, small models) occasionally ignore the gap-fill prompt instruction to produce human-readable task names and instead return Python-style slugs like `render_game_board` instead of `"Render Game Board"`. These slugs appear verbatim as task names on the kanban board.
- **Fix**: Add `_normalize_gap_task_name()` that detects the slug pattern (underscores present, no spaces) and converts to Title Case. Wired into all three `Task` construction points in `outcome_coverage.py`.
- **Coverage**: Feature-based and contract-first gap-fill paths both fixed; stub tasks used for the post-fill recheck also normalized.

## Changes

- `src/marcus_mcp/coordinator/outcome_coverage.py`:
  - Added `_normalize_gap_task_name(name: str) -> str` helper
  - Wired into `_make_stub_task_for_coverage`, `_build_feature_gap_fill_task`, `_build_contract_gap_fill_task`
- `tests/unit/coordinator/test_outcome_coverage.py`:
  - Import `_normalize_gap_task_name`
  - Added `TestNormalizeGapTaskName` with 8 tests covering slug conversion, pass-through for readable names, edge cases

## Test plan

- [ ] `pytest -m unit` passes
- [ ] `pytest tests/unit/coordinator/test_outcome_coverage.py::TestNormalizeGapTaskName` — 8 tests green
- [ ] Gap-fill tasks from weak models show readable names on the board

## Heuristic edge cases

| Input | Output | Notes |
|-------|--------|-------|
| `render_game_board` | `Render Game Board` | Classic slug |
| `Render game board` | `Render game board` | Already readable, unchanged |
| `v2_api` | `V2 Api` | Numbers preserved |
| `render` | `render` | Single word, no underscores, not a slug |

## Related

Closes #479

🤖 Generated with [Claude Code](https://claude.com/claude-code)