### PR TITLE
feat: enable reasoning-capable local LLMs as Marcus planners (strip think blocks + honor max_tokens)

### DIFF
--- a/src/ai/providers/llm_abstraction.py
+++ b/src/ai/providers/llm_abstraction.py
@@ -509,11 +509,17 @@ class LLMAbstraction:
         # Ensure providers are initialized before trying to use them
         self._initialize_providers()
 
-        result = await self._execute_with_fallback(
-            "complete",
-            prompt=prompt,
-            max_tokens=context.max_tokens if hasattr(context, "max_tokens") else 2000,
-        )
+        # Pass max_tokens through ONLY if the caller explicitly attached it
+        # to ``context``.  Otherwise let the provider use its configured
+        # default (sourced from ``config.ai.max_tokens``).  Previously this
+        # method hardcoded 2000, which silently overrode the user's config
+        # — a problem for reasoning-distilled models whose <think> blocks
+        # alone exceed 2000 tokens before any structured output appears.
+        kwargs: Dict[str, Any] = {"prompt": prompt}
+        if hasattr(context, "max_tokens"):
+            kwargs["max_tokens"] = context.max_tokens
+
+        result = await self._execute_with_fallback("complete", **kwargs)
         return result  # type: ignore
 
     async def switch_provider(self, provider_name: str) -> bool:

--- a/src/ai/providers/local_provider.py
+++ b/src/ai/providers/local_provider.py
@@ -343,7 +343,10 @@ Solutions:"""
             return self._get_fallback_solutions()
 
     async def complete(
-        self, prompt: str, max_tokens: int = 2000, temperature: float | None = None
+        self,
+        prompt: str,
+        max_tokens: Optional[int] = None,
+        temperature: float | None = None,
     ) -> str:
         """
         Complete text using local LLM for direct access.
@@ -352,8 +355,12 @@ Solutions:"""
         ----------
         prompt : str
             The prompt to complete
-        max_tokens : int
-            Maximum tokens to generate
+        max_tokens : int, optional
+            Maximum tokens to generate. ``None`` (default) uses
+            ``self.max_tokens`` which is sourced from
+            ``config.ai.max_tokens`` at provider construction. Pass an
+            explicit value only when a single call needs a tighter or
+            looser budget than the project default.
         temperature : float, optional
             Sampling temperature (0.0-1.0). If None, uses config value.
 
@@ -362,6 +369,8 @@ Solutions:"""
         str
             The completion text
         """
+        if max_tokens is None:
+            max_tokens = self.max_tokens
         if temperature is None:
             temperature = self.temperature
         return await self._call_local_llm(prompt, max_tokens, temperature)

--- a/src/ai/providers/local_provider.py
+++ b/src/ai/providers/local_provider.py
@@ -27,6 +27,7 @@ Examples
 import json
 import logging
 import os
+import re
 from typing import Any, Dict, List, Optional
 
 import httpx
@@ -42,6 +43,41 @@ from .base_provider import (
 )
 
 logger = logging.getLogger(__name__)
+
+# Reasoning-distilled models (deepseek-r1, qwq, etc.) emit ``<think>...</think>``
+# blocks before their structured output.  Marcus's downstream parsers expect
+# clean JSON, so we strip the reasoning prefix here.  ``re.DOTALL`` so the
+# pattern spans newlines.
+_THINK_BLOCK = re.compile(r"<think>.*?</think>\s*", re.DOTALL | re.IGNORECASE)
+
+
+def _strip_reasoning_blocks(content: str) -> str:
+    """Remove ``<think>...</think>`` reasoning blocks from a model response.
+
+    Reasoning-distilled models (deepseek-r1 family, qwq, etc.) emit a
+    chain-of-thought reasoning block before their structured output.
+    Marcus's JSON parsers cannot consume that prefix.  This strip removes
+    well-formed blocks; malformed (unclosed) ``<think>`` tags are left
+    untouched so the failure surfaces in parsing rather than being hidden.
+
+    Parameters
+    ----------
+    content : str
+        Raw model response.
+
+    Returns
+    -------
+    str
+        Response with ``<think>...</think>`` blocks removed and surrounding
+        whitespace trimmed.
+    """
+    stripped = _THINK_BLOCK.sub("", content)
+    if stripped != content:
+        logger.debug(
+            "Stripped %d char(s) of <think>...</think> reasoning content",
+            len(content) - len(stripped),
+        )
+    return stripped.strip()
 
 
 class LocalLLMProvider(BaseLLMProvider):
@@ -383,7 +419,7 @@ Solutions:"""
             content = data["choices"][0]["message"]["content"]
             if not isinstance(content, str):
                 raise Exception(f"Expected string response, got {type(content)}")
-            return content
+            return _strip_reasoning_blocks(content)
 
         except httpx.HTTPStatusError as e:
             if e.response.status_code == 404:
@@ -427,7 +463,7 @@ Solutions:"""
             response_text = data["response"]
             if not isinstance(response_text, str):
                 raise Exception(f"Expected string response, got {type(response_text)}")
-            return response_text
+            return _strip_reasoning_blocks(response_text)
 
         except Exception as e:
             logger.error(f"Ollama native API call failed: {e}")

--- a/src/ai/providers/local_provider.py
+++ b/src/ai/providers/local_provider.py
@@ -46,19 +46,32 @@ logger = logging.getLogger(__name__)
 
 # Reasoning-distilled models (deepseek-r1, qwq, etc.) emit ``<think>...</think>``
 # blocks before their structured output.  Marcus's downstream parsers expect
-# clean JSON, so we strip the reasoning prefix here.  ``re.DOTALL`` so the
-# pattern spans newlines.
-_THINK_BLOCK = re.compile(r"<think>.*?</think>\s*", re.DOTALL | re.IGNORECASE)
+# clean JSON, so we strip the leading reasoning prefix here.
+#
+# Anchored to the response prefix only (Codex P2 review on PR #489): a global
+# substitution would corrupt response payloads that legitimately quote the
+# tags inside JSON string values — for example a task description about
+# handling reasoning blocks would otherwise have its content silently
+# removed.  We only strip the reasoning prefix that precedes the structured
+# output, never tags embedded inside it.
+_LEADING_THINK_BLOCK = re.compile(
+    r"\A\s*(?:<think>.*?</think>\s*)+",
+    re.DOTALL | re.IGNORECASE,
+)
 
 
 def _strip_reasoning_blocks(content: str) -> str:
-    """Remove ``<think>...</think>`` reasoning blocks from a model response.
+    """Remove leading ``<think>...</think>`` reasoning prefix from a response.
 
     Reasoning-distilled models (deepseek-r1 family, qwq, etc.) emit a
     chain-of-thought reasoning block before their structured output.
     Marcus's JSON parsers cannot consume that prefix.  This strip removes
-    well-formed blocks; malformed (unclosed) ``<think>`` tags are left
-    untouched so the failure surfaces in parsing rather than being hidden.
+    well-formed reasoning blocks that appear at the start of the response
+    (one or more, possibly separated by whitespace).  Tags that appear
+    inside the structured output — for example inside a JSON string value
+    that legitimately mentions ``<think>...</think>`` — are NOT stripped.
+    Malformed (unclosed) ``<think>`` tags are also left untouched so the
+    failure surfaces in parsing rather than being hidden.
 
     Parameters
     ----------
@@ -68,13 +81,14 @@ def _strip_reasoning_blocks(content: str) -> str:
     Returns
     -------
     str
-        Response with ``<think>...</think>`` blocks removed and surrounding
-        whitespace trimmed.
+        Response with leading ``<think>...</think>`` reasoning prefix
+        removed and surrounding whitespace trimmed.  Embedded tags inside
+        the actual payload are preserved.
     """
-    stripped = _THINK_BLOCK.sub("", content)
+    stripped = _LEADING_THINK_BLOCK.sub("", content)
     if stripped != content:
         logger.debug(
-            "Stripped %d char(s) of <think>...</think> reasoning content",
+            "Stripped %d char(s) of leading <think>...</think> reasoning prefix",
             len(content) - len(stripped),
         )
     return stripped.strip()

--- a/tests/unit/ai/test_local_provider_think_strip.py
+++ b/tests/unit/ai/test_local_provider_think_strip.py
@@ -98,3 +98,83 @@ class TestStripReasoningBlocks:
         """
         content = '[{"id": "t1"}, {"id": "t2"}]'
         assert _strip_reasoning_blocks(content) == content
+
+
+# ---------------------------------------------------------------------------
+# max_tokens propagation
+# ---------------------------------------------------------------------------
+#
+# Before this fix:
+#   - LLMAbstraction.analyze hardcoded max_tokens=2000 when context had no
+#     max_tokens attribute
+#   - LocalLLMProvider.complete defaulted max_tokens=2000
+#   The net effect: ``config.ai.max_tokens`` (default 4096) was silently
+#   ignored on the PRD-parser path, capping every call at 2000 tokens.
+#
+#   For reasoning-distilled models whose ``<think>`` blocks frequently exceed
+#   1500 tokens, this caused mid-reasoning truncation before any JSON could
+#   be emitted.
+#
+# After this fix:
+#   - When the caller does not explicitly supply max_tokens, the provider's
+#     ``self.max_tokens`` (from config) takes effect.
+#   - Explicit caller overrides still work.
+
+
+class TestMaxTokensPropagation:
+    """``self.max_tokens`` from config is the default, not 2000."""
+
+    def test_complete_uses_self_max_tokens_when_not_specified(self) -> None:
+        """``complete(prompt)`` without max_tokens uses ``self.max_tokens``."""
+        from unittest.mock import AsyncMock, patch
+
+        from src.ai.providers.local_provider import LocalLLMProvider
+
+        with patch("src.config.marcus_config.get_config") as mock_cfg:
+            mock_cfg.return_value.ai.local_url = "http://localhost:11434/v1"
+            mock_cfg.return_value.ai.local_key = "none"
+            mock_cfg.return_value.ai.max_tokens = 8192
+            mock_cfg.return_value.ai.temperature = 0.7
+
+            provider = LocalLLMProvider("test-model")
+            assert provider.max_tokens == 8192
+
+            # Spy on _call_local_llm to verify what max_tokens it receives
+            provider._call_local_llm = AsyncMock(return_value="ok")  # type: ignore[method-assign]
+
+            import asyncio
+
+            asyncio.run(provider.complete("prompt"))
+
+            call_kwargs = provider._call_local_llm.call_args
+            # Positional: prompt, max_tokens, temperature
+            passed_max_tokens = call_kwargs.args[1]
+            assert passed_max_tokens == 8192, (
+                f"complete() must propagate self.max_tokens (8192) when no "
+                f"explicit override is given. Got {passed_max_tokens}"
+            )
+
+    def test_complete_respects_explicit_max_tokens(self) -> None:
+        """Explicit ``max_tokens=N`` override is preserved."""
+        from unittest.mock import AsyncMock, patch
+
+        from src.ai.providers.local_provider import LocalLLMProvider
+
+        with patch("src.config.marcus_config.get_config") as mock_cfg:
+            mock_cfg.return_value.ai.local_url = "http://localhost:11434/v1"
+            mock_cfg.return_value.ai.local_key = "none"
+            mock_cfg.return_value.ai.max_tokens = 8192
+            mock_cfg.return_value.ai.temperature = 0.7
+
+            provider = LocalLLMProvider("test-model")
+            provider._call_local_llm = AsyncMock(return_value="ok")  # type: ignore[method-assign]
+
+            import asyncio
+
+            asyncio.run(provider.complete("prompt", max_tokens=500))
+
+            passed_max_tokens = provider._call_local_llm.call_args.args[1]
+            assert passed_max_tokens == 500, (
+                f"Explicit max_tokens override must be preserved. "
+                f"Got {passed_max_tokens}"
+            )

--- a/tests/unit/ai/test_local_provider_think_strip.py
+++ b/tests/unit/ai/test_local_provider_think_strip.py
@@ -1,0 +1,100 @@
+"""
+Unit tests for ``<think>...</think>`` reasoning-block stripping.
+
+Reasoning-distilled models (deepseek-r1, qwq, etc.) emit chain-of-thought
+prefixes that Marcus's JSON parsers cannot consume.  ``_strip_reasoning_blocks``
+removes well-formed blocks before the response is returned to the caller.
+
+Reproducer evidence: trial5-snake-game-deepsekk-r1-q5-mcp run on
+2026-05-07 emitted a 7051-char response starting with ``<think>``; the PRD
+parser failed with "Expected JSON object, got list" and contract_first
+fell back to feature_based.
+"""
+
+import pytest
+
+from src.ai.providers.local_provider import _strip_reasoning_blocks
+
+pytestmark = pytest.mark.unit
+
+
+class TestStripReasoningBlocks:
+    """``_strip_reasoning_blocks`` removes well-formed reasoning prefixes."""
+
+    def test_strips_well_formed_block(self) -> None:
+        """A complete ``<think>...</think>`` followed by JSON is stripped."""
+        content = (
+            "<think>\nOkay, let me analyze this PRD carefully.\n"
+            "Step 1: identify domains.\n</think>\n"
+            '{"tasks": [{"id": "t1", "name": "Setup"}]}'
+        )
+        result = _strip_reasoning_blocks(content)
+        assert result == '{"tasks": [{"id": "t1", "name": "Setup"}]}'
+
+    def test_preserves_response_when_no_think_block(self) -> None:
+        """Plain JSON responses pass through unchanged (after .strip())."""
+        content = '{"tasks": [{"id": "t1", "name": "Setup"}]}'
+        assert _strip_reasoning_blocks(content) == content
+
+    def test_strips_multiple_blocks(self) -> None:
+        """Multiple reasoning blocks are all removed."""
+        content = (
+            "<think>first thought</think>\n"
+            '{"part": 1}\n'
+            "<think>second thought</think>\n"
+            '{"part": 2}'
+        )
+        result = _strip_reasoning_blocks(content)
+        assert "<think>" not in result
+        assert "</think>" not in result
+        assert '"part": 1' in result
+        assert '"part": 2' in result
+
+    def test_strips_block_spanning_many_newlines(self) -> None:
+        """``re.DOTALL`` lets the pattern span newlines (default behavior)."""
+        content = (
+            "<think>\nLine 1\nLine 2\nLine 3\nLine 4\n</think>" '\n{"result": "ok"}'
+        )
+        result = _strip_reasoning_blocks(content)
+        assert result == '{"result": "ok"}'
+
+    def test_leaves_unclosed_think_tag_alone(self) -> None:
+        """
+        Malformed (unclosed) ``<think>`` blocks are NOT stripped.
+
+        We deliberately do not try to recover from a stuck-open think block —
+        better to surface the failure in the parser than silently strip an
+        unbounded prefix that might also contain valid JSON.
+        """
+        content = "<think>\nReasoning never closed and JSON never came..."
+        result = _strip_reasoning_blocks(content)
+        assert result.startswith("<think>")
+
+    def test_handles_case_insensitive_tags(self) -> None:
+        """Some models emit ``<THINK>`` or mixed case — strip those too."""
+        content = "<THINK>thought</THINK>\n{}"
+        result = _strip_reasoning_blocks(content)
+        assert result == "{}"
+
+    def test_strips_surrounding_whitespace(self) -> None:
+        """After stripping the block, leading/trailing whitespace is trimmed."""
+        content = "   <think>x</think>\n\n   {}\n   "
+        result = _strip_reasoning_blocks(content)
+        assert result == "{}"
+
+    def test_handles_empty_think_block(self) -> None:
+        """An empty ``<think></think>`` block is removed cleanly."""
+        content = '<think></think>{"ok": true}'
+        result = _strip_reasoning_blocks(content)
+        assert result == '{"ok": true}'
+
+    def test_preserves_json_array_response(self) -> None:
+        """
+        A response that is a JSON array (no think block) passes through.
+
+        This is the "got list" parser failure case the user observed —
+        the strip should not affect it; the wrapper-shape mismatch is a
+        separate concern handled by the parser layer.
+        """
+        content = '[{"id": "t1"}, {"id": "t2"}]'
+        assert _strip_reasoning_blocks(content) == content

--- a/tests/unit/ai/test_local_provider_think_strip.py
+++ b/tests/unit/ai/test_local_provider_think_strip.py
@@ -36,19 +36,42 @@ class TestStripReasoningBlocks:
         content = '{"tasks": [{"id": "t1", "name": "Setup"}]}'
         assert _strip_reasoning_blocks(content) == content
 
-    def test_strips_multiple_blocks(self) -> None:
-        """Multiple reasoning blocks are all removed."""
+    def test_strips_multiple_leading_blocks(self) -> None:
+        """Consecutive reasoning blocks at the start are all stripped."""
         content = (
             "<think>first thought</think>\n"
-            '{"part": 1}\n'
             "<think>second thought</think>\n"
             '{"part": 2}'
         )
         result = _strip_reasoning_blocks(content)
-        assert "<think>" not in result
-        assert "</think>" not in result
-        assert '"part": 1' in result
-        assert '"part": 2' in result
+        assert result == '{"part": 2}'
+
+    def test_preserves_tags_inside_payload(self) -> None:
+        """
+        Codex P2: tags embedded inside the response payload must NOT be
+        stripped.
+
+        A response like ``<think>reasoning</think>{"task": "handle <think>
+        blocks"}`` would, under a global-substitution strip, lose the
+        legitimate string content "handle ".  Anchoring the regex to the
+        leading prefix preserves embedded tags inside the structured
+        output.
+        """
+        content = (
+            "<think>brief reasoning</think>\n"
+            '{"task": "describe how to parse <think>...</think> blocks"}'
+        )
+        result = _strip_reasoning_blocks(content)
+        # Leading reasoning is gone
+        assert not result.startswith("<think>")
+        # But the payload's quoted tags are preserved
+        assert "<think>...</think>" in result
+        assert "describe how to parse" in result
+
+    def test_preserves_payload_when_no_leading_block(self) -> None:
+        """Embedded tags with no leading reasoning prefix are untouched."""
+        content = '{"description": "model emits <think>X</think> on errors"}'
+        assert _strip_reasoning_blocks(content) == content
 
     def test_strips_block_spanning_many_newlines(self) -> None:
         """``re.DOTALL`` lets the pattern span newlines (default behavior)."""


### PR DESCRIPTION
## Summary

Enables reasoning-distilled local models (deepseek-r1 family, qwq, etc.) to drive Marcus as the planner LLM by fixing two pre-existing local-provider issues that silently broke contract-first decomposition.

## Problem

Trial 5–7 with `deepseek-r1:7b-Q5_K_M` showed contract-first PRD analysis silently falling back to feature_based with non-canonical labels and degraded task graphs (8 tasks vs haiku baseline 20). Two distinct root causes surfaced under investigation:

### Issue 1 — `<think>...</think>` reasoning blocks broke JSON parsing

Reasoning models emit a chain-of-thought block before structured output:

```
<think>
Okay, let me analyze this PRD...
</think>
{
  "functionalRequirements": [...]
}
```

Marcus's parser consumed the raw response and failed with `Failed to parse AI response as JSON: Expected JSON object, got list` (or `No JSON structure found`). Contract-first aborted to feature_based via the loud-fallback path at `nlp_tools.py:256-262`.

**Evidence:** trial5-snake-game-deepsekk-r1-q5-mcp on 2026-05-07 returned a 7051-char response starting with `<think>`; `marcus.log` line 96-105 captures the parse failure and fallback warning.

### Issue 2 — `config.ai.max_tokens` was silently ignored on the PRD-parser path

Two hardcoded `2000`-token defaults capped every PRD-parser LLM call regardless of `config.ai.max_tokens` (default 4096):

- `LLMAbstraction.analyze`, line 515: `max_tokens=context.max_tokens if hasattr(context, "max_tokens") else 2000`
- `LocalLLMProvider.complete`, line 346: `async def complete(self, prompt, max_tokens=2000, ...)`

For reasoning models whose `<think>` blocks routinely exceed 1500 tokens, the 2000-token cap caused mid-reasoning truncation before any JSON could be emitted.

**Evidence:** trial6 raw response dump call 2 — 7224 chars, no `</think>` close tag, ends mid-sentence at "...I have five outcomes: 1." Token-budget exhaustion mid-think.

## Changes

### Strip `<think>...</think>` blocks (commit `cd9ea32d`)

- `_strip_reasoning_blocks()` helper in `local_provider.py`: regex strip with `re.DOTALL | re.IGNORECASE`
- Wired into both response paths: `_call_local_llm` (OpenAI-compat) and `_call_ollama_native`
- **Malformed (unclosed) `<think>` blocks are deliberately left intact** so the failure surfaces in parsing rather than being hidden by an unbounded silent strip
- 9 unit tests covering: well-formed, no-think pass-through, multiple blocks, multi-line, unclosed-tag preservation, case insensitivity, whitespace, empty block, JSON-array passthrough

### Honor `config.ai.max_tokens` on the analyze path (commit `3b79b50e`)

- `LLMAbstraction.analyze`: pass `max_tokens` to provider only when caller explicitly attached it to context; otherwise let provider default take effect
- `LocalLLMProvider.complete`: `max_tokens` defaults to `None`, falls back to `self.max_tokens` (sourced from `config.ai.max_tokens`)
- Explicit per-call overrides still work (e.g., `analyze_blocker_*` paths using 500)
- 2 unit tests verifying config-default propagation and explicit override preservation

## Validation

Ran trial7 (strip + max_tokens fix) against the same prompt as trials 5/6:

| Metric | Trial 5 (no fix) | Trial 6 (no fix) | Trial 7 (this PR) |
|---|---|---|---|
| Total tasks | 8 | 10 | 7 |
| Mode A failures (`<think>` parse) | yes | yes | **none** ✅ |
| Mode B failures (token-budget truncation) | n/a | yes | **none** ✅ |
| `Successfully parsed AI response as JSON` log lines | 0 | 0 | **2** ✅ |

Both pre-existing failure modes are eliminated. The remaining gap (deepseek-r1 still produced 7 tasks vs haiku's 20) is **Mode C** — the model produces structurally-valid JSON with semantically empty content (`functionalRequirements: []`). That's a model-side problem, not Marcus-side, and is being addressed separately with quantization upgrades + modelfile tuning.

## Why this matters

These are prerequisites for *any* reasoning-capable local model — not specific to deepseek-r1. Once a model is selected that can do contract-first planning at the content level, these fixes are required for it to interact with Marcus's parsers correctly.

## Test plan
- [x] `pytest -m unit` — 1252 passed, 1 skipped (+11 new)
- [x] Validated against trial7-snake-game-deepsekk-r1-q5-mcp reproducer
- [x] black, isort, mypy clean on changed files
- [ ] Re-test with q6 quantization + modelfile tuning (separate experiment thread)

🤖 Generated with [Claude Code](https://claude.com/claude-code)