### PR TITLE
feat: add generic cloud LLM provider for OpenAI-compatible APIs

### DIFF
--- a/src/ai/providers/__init__.py
+++ b/src/ai/providers/__init__.py
@@ -6,6 +6,7 @@ from .base_provider import (
     SemanticAnalysis,
     SemanticDependency,
 )
+from .cloud_provider import CloudLLMProvider
 from .llm_abstraction import LLMAbstraction
 
 __all__ = [
@@ -13,5 +14,6 @@ __all__ = [
     "SemanticAnalysis",
     "SemanticDependency",
     "EffortEstimate",
+    "CloudLLMProvider",
     "LLMAbstraction",
 ]

--- a/src/ai/providers/cloud_provider.py
+++ b/src/ai/providers/cloud_provider.py
@@ -1,0 +1,191 @@
+"""
+Cloud LLM Provider for Marcus AI.
+
+Generic OpenAI-compatible cloud provider. Works with any service that
+exposes an OpenAI-style ``/chat/completions`` endpoint — Fireworks AI,
+Groq, Together AI, Mistral, DeepSeek, and others.
+
+Classes
+-------
+CloudLLMProvider
+    Cloud model provider for OpenAI-compatible hosted inference APIs
+
+Examples
+--------
+>>> provider = CloudLLMProvider(
+...     model="accounts/fireworks/models/qwen2p5-coder-7b-instruct",
+...     api_key="fw_abc123",  # pragma: allowlist secret
+...     url="https://api.fireworks.ai/inference/v1",
+... )
+>>> result = await provider.analyze_task(task, context)
+"""
+
+import logging
+from typing import Optional
+
+import httpx
+
+from .local_provider import LocalLLMProvider, _strip_reasoning_blocks
+
+logger = logging.getLogger(__name__)
+
+
+class CloudLLMProvider(LocalLLMProvider):
+    """Generic cloud LLM provider for OpenAI-compatible hosted APIs.
+
+    Inherits all semantic-analysis business logic from ``LocalLLMProvider``
+    and overrides the transport layer only: the HTTP client is pointed at
+    an explicit remote URL with a required API key.  The Ollama native-API
+    fallback present in the parent is intentionally omitted — cloud
+    endpoints do not implement it.
+
+    Parameters
+    ----------
+    model : str
+        Full model identifier as expected by the remote service
+        (e.g. ``"accounts/fireworks/models/qwen2p5-coder-7b-instruct"``).
+    api_key : str
+        Bearer token for the remote service.
+    url : str
+        Base URL of the OpenAI-compatible inference endpoint
+        (e.g. ``"https://api.fireworks.ai/inference/v1"``).
+
+    Raises
+    ------
+    ValueError
+        If ``model``, ``api_key``, or ``url`` is empty.
+    """
+
+    def __init__(self, model: str, api_key: str, url: str) -> None:
+        """Initialize cloud LLM provider.
+
+        Parameters
+        ----------
+        model : str
+            Model identifier for the remote service.
+        api_key : str
+            Bearer token — must not be empty.
+        url : str
+            Base URL for the OpenAI-compatible API — must not be empty.
+        """
+        if not model:
+            raise ValueError("CloudLLMProvider requires a non-empty model name")
+        if not api_key:
+            raise ValueError("CloudLLMProvider requires a non-empty api_key")
+        if not url:
+            raise ValueError("CloudLLMProvider requires a non-empty cloud_url")
+
+        # Pull global settings (temperature, max_tokens) from config; skip
+        # LocalLLMProvider.__init__ entirely because it reads local_model /
+        # local_url / local_key — none of which apply here.
+        from src.config.marcus_config import get_config
+
+        config = get_config()
+
+        self.base_url: str = url
+        self.model: str = model
+        self.max_tokens: int = config.ai.max_tokens
+        self.temperature: float = config.ai.temperature
+        # Cloud APIs respond faster than local inference
+        self.timeout: float = 60.0
+
+        self.client = httpx.AsyncClient(
+            headers={
+                "Content-Type": "application/json",
+                "Authorization": f"Bearer {api_key}",
+            },
+            timeout=self.timeout,
+            base_url=url,
+        )
+
+        logger.info("Cloud LLM provider initialized: model=%s url=%s", model, url)
+
+    async def _call_cloud_llm(
+        self,
+        prompt: str,
+        max_tokens: Optional[int] = None,
+        temperature: Optional[float] = None,
+    ) -> str:
+        """Make a request to the cloud OpenAI-compatible endpoint.
+
+        Unlike ``LocalLLMProvider._call_local_llm``, this method does NOT
+        fall back to the Ollama native API on a 404; cloud services are not
+        Ollama and a 404 is always an error.
+
+        Parameters
+        ----------
+        prompt : str
+            User prompt to send.
+        max_tokens : int, optional
+            Token budget; defaults to ``self.max_tokens`` from config.
+        temperature : float, optional
+            Sampling temperature; defaults to ``self.temperature`` from config.
+
+        Returns
+        -------
+        str
+            Decoded model response with leading ``<think>`` blocks stripped.
+
+        Raises
+        ------
+        Exception
+            On any HTTP or network error.
+        """
+        if max_tokens is None:
+            max_tokens = self.max_tokens
+        if temperature is None:
+            temperature = self.temperature
+
+        request_data = {
+            "model": self.model,
+            "messages": [
+                {
+                    "role": "system",
+                    "content": (
+                        "You are an AI assistant helping with software "
+                        "development task analysis. Provide clear, structured "
+                        "responses focusing on practical implementation details."
+                    ),
+                },
+                {"role": "user", "content": prompt},
+            ],
+            "max_tokens": max_tokens,
+            "temperature": temperature,
+            "stream": False,
+        }
+
+        try:
+            response = await self.client.post("/chat/completions", json=request_data)
+            response.raise_for_status()
+
+            data = response.json()
+            content = data["choices"][0]["message"]["content"]
+            if not isinstance(content, str):
+                raise Exception(f"Expected string response, got {type(content)}")
+            return _strip_reasoning_blocks(content)
+
+        except httpx.HTTPStatusError as e:
+            raise Exception(
+                f"Cloud LLM API error: {e.response.status_code} - " f"{e.response.text}"
+            )
+        except Exception:
+            logger.error("Cloud LLM call failed for model %s", self.model)
+            raise
+
+    # Override the internal dispatch used by all inherited business methods
+    async def _call_local_llm(
+        self,
+        prompt: str,
+        max_tokens: Optional[int] = None,
+        temperature: float = 0.7,
+    ) -> str:
+        """Delegate to ``_call_cloud_llm``.
+
+        ``LocalLLMProvider`` routes all LLM calls through this method.
+        We override it here so every inherited business method
+        (``analyze_task``, ``infer_dependencies``, etc.) transparently uses
+        the cloud endpoint instead of a local server.
+        """
+        return await self._call_cloud_llm(
+            prompt, max_tokens=max_tokens, temperature=temperature
+        )

--- a/src/ai/providers/llm_abstraction.py
+++ b/src/ai/providers/llm_abstraction.py
@@ -206,6 +206,44 @@ class LLMAbstraction:
                 f"(key present: {bool(openai_key)})"
             )
 
+        # Add cloud provider if configured
+        if configured_provider == "cloud":
+            cloud_key = config.ai.cloud_api_key or ""
+            if not cloud_key:
+                cloud_key = os.getenv("MARCUS_CLOUD_LLM_KEY", "").strip()
+
+            cloud_url = config.ai.cloud_url or ""
+            if not cloud_url:
+                cloud_url = os.getenv("MARCUS_CLOUD_LLM_URL", "").strip()
+
+            cloud_model = config.ai.model or ""
+
+            if cloud_key and cloud_url and cloud_model:
+                try:
+                    from .cloud_provider import CloudLLMProvider
+
+                    self.providers["cloud"] = CloudLLMProvider(
+                        model=cloud_model,
+                        api_key=cloud_key,
+                        url=cloud_url,
+                    )
+                    self.fallback_providers.append("cloud")
+                    logger.info(
+                        "Successfully initialized cloud LLM provider: "
+                        "model=%s url=%s",
+                        cloud_model,
+                        cloud_url,
+                    )
+                except Exception as e:
+                    logger.warning("Failed to initialize cloud LLM provider: %s", e)
+            else:
+                logger.debug(
+                    "Skipping cloud provider — missing key=%s url=%s model=%s",
+                    bool(cloud_key),
+                    bool(cloud_url),
+                    bool(cloud_model),
+                )
+
         # Add local provider if configured
         local_model_path = config.ai.local_model or ""
         # Only fall back to env var if no specific provider is configured

--- a/src/config/marcus_config.py
+++ b/src/config/marcus_config.py
@@ -51,7 +51,7 @@ class AISettings:
     Parameters
     ----------
     provider : str
-        AI provider to use: "anthropic", "openai", or "local"
+        AI provider to use: "anthropic", "openai", "local", or "cloud"
     anthropic_api_key : Optional[str]
         Anthropic API key (required if provider="anthropic")
     openai_api_key : Optional[str]
@@ -62,6 +62,10 @@ class AISettings:
         Local LLM API URL (e.g., "http://localhost:11434/v1")
     local_key : Optional[str]
         Local LLM API key (if required)
+    cloud_api_key : Optional[str]
+        API key for generic cloud provider (required if provider="cloud")
+    cloud_url : Optional[str]
+        Base URL for generic cloud provider (required if provider="cloud")
     model : Optional[str]
         Model name (e.g., "claude-3-haiku-20240307")
     temperature : float
@@ -78,6 +82,8 @@ class AISettings:
     local_model: Optional[str] = None
     local_url: Optional[str] = None
     local_key: Optional[str] = None
+    cloud_api_key: Optional[str] = None
+    cloud_url: Optional[str] = None
     model: Optional[str] = "claude-3-haiku-20240307"
     temperature: float = 0.7
     max_tokens: int = 4096
@@ -684,6 +690,19 @@ class MarcusConfig:
                         "AI provider is 'openai' but openai_api_key is not set. "
                         "Set it in config_marcus.json or environment variable "
                         "OPENAI_API_KEY"
+                    )
+            elif self.ai.provider == "cloud":
+                if not self.ai.cloud_api_key:
+                    errors.append(
+                        "AI provider is 'cloud' but cloud_api_key is not set. "
+                        "Set it in config_marcus.json or environment variable "
+                        "MARCUS_CLOUD_LLM_KEY"
+                    )
+                if not self.ai.cloud_url:
+                    errors.append(
+                        "AI provider is 'cloud' but cloud_url is not set. "
+                        "Set it in config_marcus.json or environment variable "
+                        "MARCUS_CLOUD_LLM_URL"
                     )
 
             # Validate temperature

--- a/src/config/marcus_config.py
+++ b/src/config/marcus_config.py
@@ -692,17 +692,36 @@ class MarcusConfig:
                         "OPENAI_API_KEY"
                     )
             elif self.ai.provider == "cloud":
-                if not self.ai.cloud_api_key:
+                # Honor env var fallbacks — LLMAbstraction applies them at
+                # runtime, so validation must check them too or it rejects
+                # valid configs that rely on env-var credentials.
+                effective_key = self.ai.cloud_api_key or os.environ.get(
+                    "MARCUS_CLOUD_LLM_KEY", ""
+                )
+                if not effective_key:
                     errors.append(
                         "AI provider is 'cloud' but cloud_api_key is not set. "
                         "Set it in config_marcus.json or environment variable "
                         "MARCUS_CLOUD_LLM_KEY"
                     )
-                if not self.ai.cloud_url:
+                effective_url = self.ai.cloud_url or os.environ.get(
+                    "MARCUS_CLOUD_LLM_URL", ""
+                )
+                if not effective_url:
                     errors.append(
                         "AI provider is 'cloud' but cloud_url is not set. "
                         "Set it in config_marcus.json or environment variable "
                         "MARCUS_CLOUD_LLM_URL"
+                    )
+                # Catch the common mistake of leaving the Anthropic default
+                # model name when switching to a cloud provider.
+                if self.ai.model and self.ai.model.startswith("claude-"):
+                    errors.append(
+                        f"AI provider is 'cloud' but ai.model is set to an "
+                        f"Anthropic model name ('{self.ai.model}'). "
+                        "Set ai.model to a model available on your cloud "
+                        "endpoint (e.g. "
+                        "'accounts/fireworks/models/qwen2p5-coder-7b-instruct')"
                     )
 
             # Validate temperature

--- a/tests/integration/external/test_cloud_provider_integration.py
+++ b/tests/integration/external/test_cloud_provider_integration.py
@@ -1,0 +1,129 @@
+"""
+Integration tests for CloudLLMProvider against Fireworks AI.
+
+Skipped unless FIREWORKS_API_KEY is set in the environment.
+
+Run with:
+    FIREWORKS_API_KEY=fw_... pytest tests/integration/external/test_cloud_provider_integration.py -v
+
+The model defaults to the Fireworks-hosted Qwen model but can be overridden:
+    FIREWORKS_MODEL=accounts/fireworks/models/llama-v3p1-8b-instruct ...
+"""
+
+import os
+from datetime import datetime, timezone
+
+import pytest
+
+FIREWORKS_API_KEY = os.getenv("FIREWORKS_API_KEY", "")
+FIREWORKS_URL = "https://api.fireworks.ai/inference/v1"
+# Override with FIREWORKS_MODEL env var to point at any accessible model.
+# The default is a private deployment — set FIREWORKS_MODEL to a public
+# Fireworks model ID if using a different API key.
+FIREWORKS_MODEL = os.getenv(
+    "FIREWORKS_MODEL",
+    "accounts/fireworks/models/qwen2p5-coder-7b-instruct",
+)
+
+pytestmark = pytest.mark.skipif(
+    not FIREWORKS_API_KEY,
+    reason="FIREWORKS_API_KEY not set — skipping Fireworks integration tests",
+)
+
+
+@pytest.fixture
+def provider():
+    """Build a real CloudLLMProvider pointed at Fireworks."""
+    from unittest.mock import Mock, patch
+
+    from src.ai.providers.cloud_provider import CloudLLMProvider
+
+    mock_cfg = Mock()
+    mock_cfg.ai.max_tokens = 512
+    mock_cfg.ai.temperature = 0.1
+
+    with patch("src.config.marcus_config.get_config", return_value=mock_cfg):
+        return CloudLLMProvider(
+            model=FIREWORKS_MODEL,
+            api_key=FIREWORKS_API_KEY,
+            url=FIREWORKS_URL,
+        )
+
+
+def _make_task():
+    from src.core.models import Priority, Task, TaskStatus
+
+    return Task(
+        id="fw-int-1",
+        name="Implement user authentication endpoint",
+        description="Add JWT-based login endpoint to the FastAPI app",
+        status=TaskStatus.TODO,
+        priority=Priority.HIGH,
+        assigned_to=None,
+        created_at=datetime.now(timezone.utc),
+        updated_at=datetime.now(timezone.utc),
+        due_date=None,
+        estimated_hours=4.0,
+    )
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_fireworks_complete_returns_string(provider) -> None:
+    """Real call to Fireworks: complete() must return a non-empty string."""
+    result = await provider.complete("Say hello in one word.")
+    assert isinstance(result, str)
+    assert result.strip(), "Expected non-empty response from Fireworks"
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_fireworks_analyze_task_returns_real_analysis(provider) -> None:
+    """Real call to Fireworks: analyze_task must return a genuine response.
+
+    We detect silent fallback by checking task_intent is not the sentinel
+    value 'unknown' that LocalLLMProvider uses when the API call fails.
+    """
+    from src.ai.providers.base_provider import SemanticAnalysis
+
+    result = await provider.analyze_task(_make_task(), {"project_type": "api"})
+
+    assert isinstance(result, SemanticAnalysis)
+    assert result.task_intent not in (
+        "unknown",
+        "parse_error",
+    ), (
+        f"Got fallback sentinel intent '{result.task_intent}' — "
+        "the API call likely failed silently"
+    )
+    assert 0.0 <= result.confidence <= 1.0
+    # A real response should have higher confidence than the 0.1 fallback
+    assert result.confidence > 0.1, (
+        f"Confidence {result.confidence} matches the silent-fallback value "
+        "(0.1) — the API call may have failed"
+    )
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_fireworks_estimate_effort_returns_real_estimate(
+    provider,
+) -> None:
+    """Real call to Fireworks: estimate_effort must return real model output.
+
+    Silent fallback returns exactly estimated_hours=8.0 and confidence=0.3;
+    we check that we got something different.
+    """
+    from src.ai.providers.base_provider import EffortEstimate
+
+    result = await provider.estimate_effort(
+        _make_task(), {"tech_stack": ["python", "fastapi"]}
+    )
+
+    assert isinstance(result, EffortEstimate)
+    assert result.estimated_hours > 0.0
+    assert 0.0 <= result.confidence <= 1.0
+    # Fallback sentinel is confidence=0.3 with factors=["parse_error"]
+    assert (
+        "parse_error" not in result.factors
+    ), "Got parse-error fallback — the API call likely failed silently"

--- a/tests/unit/ai/test_cloud_provider.py
+++ b/tests/unit/ai/test_cloud_provider.py
@@ -290,13 +290,13 @@ class TestAISettingsCloudValidation:
 
     def test_cloud_provider_requires_api_key(self) -> None:
         """Validation must fail when cloud_api_key is missing."""
-        cfg = self._make_config(cloud_url="https://x.com/v1")
+        cfg = self._make_config(cloud_url="https://x.com/v1", model="vendor/model")
         with pytest.raises(ValueError, match="cloud_api_key"):
             cfg.validate()
 
     def test_cloud_provider_requires_url(self) -> None:
         """Validation must fail when cloud_url is missing."""
-        cfg = self._make_config(cloud_api_key="fw_abc123")
+        cfg = self._make_config(cloud_api_key="fw_abc123", model="vendor/model")
         with pytest.raises(ValueError, match="cloud_url"):
             cfg.validate()
 
@@ -305,8 +305,76 @@ class TestAISettingsCloudValidation:
         cfg = self._make_config(
             cloud_api_key="fw_abc123",
             cloud_url="https://api.example.com/v1",
+            model="accounts/fireworks/models/qwen2p5-coder-7b-instruct",
         )
         cfg.validate()  # Must not raise
+
+    def test_cloud_provider_env_var_key_satisfies_validation(self) -> None:
+        """Validation must pass when MARCUS_CLOUD_LLM_KEY is set even if
+        cloud_api_key is absent from config (P2: honor env vars in validate)."""
+        import os
+
+        cfg = self._make_config(
+            cloud_url="https://api.example.com/v1",
+            model="vendor/model",
+        )
+        old = os.environ.pop("MARCUS_CLOUD_LLM_KEY", None)
+        try:
+            os.environ["MARCUS_CLOUD_LLM_KEY"] = "fw_from_env"
+            cfg.validate()  # Must not raise
+        finally:
+            if old is not None:
+                os.environ["MARCUS_CLOUD_LLM_KEY"] = old
+            else:
+                os.environ.pop("MARCUS_CLOUD_LLM_KEY", None)
+
+    def test_cloud_provider_env_var_url_satisfies_validation(self) -> None:
+        """Validation must pass when MARCUS_CLOUD_LLM_URL is set even if
+        cloud_url is absent from config (P2: honor env vars in validate)."""
+        import os
+
+        cfg = self._make_config(
+            cloud_api_key="fw_abc123",
+            model="vendor/model",
+        )
+        old = os.environ.pop("MARCUS_CLOUD_LLM_URL", None)
+        try:
+            os.environ["MARCUS_CLOUD_LLM_URL"] = "https://env.example.com/v1"
+            cfg.validate()  # Must not raise
+        finally:
+            if old is not None:
+                os.environ["MARCUS_CLOUD_LLM_URL"] = old
+            else:
+                os.environ.pop("MARCUS_CLOUD_LLM_URL", None)
+
+    def test_cloud_provider_rejects_anthropic_model_name(self) -> None:
+        """Validation must fail when model looks like an Anthropic model
+        (P2: Anthropic default claude-* names break non-Anthropic endpoints)."""
+        cfg = self._make_config(
+            cloud_api_key="fw_abc123",
+            cloud_url="https://api.example.com/v1",
+            model="claude-3-haiku-20240307",
+        )
+        with pytest.raises(ValueError, match="Anthropic model name"):
+            cfg.validate()
+
+    def test_cloud_provider_default_model_triggers_anthropic_warning(
+        self,
+    ) -> None:
+        """The AISettings default model 'claude-3-haiku-20240307' must be
+        rejected when provider='cloud' so users get a clear error instead of
+        a cryptic API failure from the cloud endpoint."""
+        from src.config.marcus_config import AISettings, MarcusConfig
+
+        # Default model is claude-3-haiku-20240307 — must be caught
+        ai = AISettings(
+            provider="cloud",
+            cloud_api_key="fw_abc123",
+            cloud_url="https://api.example.com/v1",
+        )
+        cfg = MarcusConfig(ai=ai)
+        with pytest.raises(ValueError, match="Anthropic model name"):
+            cfg.validate()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/ai/test_cloud_provider.py
+++ b/tests/unit/ai/test_cloud_provider.py
@@ -1,0 +1,381 @@
+"""
+Unit tests for CloudLLMProvider.
+
+Tests provider initialization, HTTP client configuration, API call
+behaviour, and LLMAbstraction integration — all without network access.
+"""
+
+import os
+from datetime import datetime, timezone
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
+
+import httpx
+import pytest
+
+from src.ai.providers.base_provider import EffortEstimate, SemanticAnalysis
+from src.core.models import Priority, Task, TaskStatus
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_task(name: str = "Test task") -> Task:
+    return Task(
+        id="t1",
+        name=name,
+        description="A test task",
+        status=TaskStatus.TODO,
+        priority=Priority.MEDIUM,
+        assigned_to=None,
+        created_at=datetime.now(timezone.utc),
+        updated_at=datetime.now(timezone.utc),
+        due_date=None,
+        estimated_hours=2.0,
+    )
+
+
+def _mock_config(
+    max_tokens: int = 4096,
+    temperature: float = 0.1,
+) -> Mock:
+    cfg = Mock()
+    cfg.ai.max_tokens = max_tokens
+    cfg.ai.temperature = temperature
+    return cfg
+
+
+def _mock_http_response(content: str) -> Mock:
+    """Build a fake httpx.Response that returns an OpenAI-style payload."""
+    resp = Mock(spec=httpx.Response)
+    resp.status_code = 200
+    resp.json.return_value = {"choices": [{"message": {"content": content}}]}
+    resp.raise_for_status = Mock()
+    return resp
+
+
+# ---------------------------------------------------------------------------
+# Initialization
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestCloudProviderInit:
+    """Test CloudLLMProvider construction."""
+
+    def test_stores_model_url_and_creates_client(self) -> None:
+        """Provider must store model name and configure base_url on client."""
+        from src.ai.providers.cloud_provider import CloudLLMProvider
+
+        cfg = _mock_config()
+        with patch("src.config.marcus_config.get_config", return_value=cfg):
+            p = CloudLLMProvider(
+                model="vendor/my-model",
+                api_key="fw_test123",
+                url="https://api.example.com/v1",
+            )
+
+        assert p.model == "vendor/my-model"
+        assert p.base_url == "https://api.example.com/v1"
+
+    def test_reads_max_tokens_and_temperature_from_config(self) -> None:
+        """Provider must pull max_tokens and temperature from global config."""
+        from src.ai.providers.cloud_provider import CloudLLMProvider
+
+        cfg = _mock_config(max_tokens=2048, temperature=0.3)
+        with patch("src.config.marcus_config.get_config", return_value=cfg):
+            p = CloudLLMProvider(model="m", api_key="k", url="https://x.com/v1")
+
+        assert p.max_tokens == 2048
+        assert p.temperature == 0.3
+
+    def test_bearer_token_set_in_client_headers(self) -> None:
+        """Authorization header must carry the provided API key as Bearer."""
+        from src.ai.providers.cloud_provider import CloudLLMProvider
+
+        cfg = _mock_config()
+        with patch("src.config.marcus_config.get_config", return_value=cfg):
+            p = CloudLLMProvider(
+                model="m", api_key="fw_secret_key", url="https://x.com/v1"
+            )
+
+        auth_header = dict(p.client.headers).get("authorization", "")
+        assert auth_header == "Bearer fw_secret_key"
+
+    def test_empty_url_raises_value_error(self) -> None:
+        """CloudLLMProvider must reject an empty URL immediately."""
+        from src.ai.providers.cloud_provider import CloudLLMProvider
+
+        cfg = _mock_config()
+        with patch("src.config.marcus_config.get_config", return_value=cfg):
+            with pytest.raises(ValueError, match="cloud_url"):
+                CloudLLMProvider(model="m", api_key="k", url="")
+
+    def test_empty_api_key_raises_value_error(self) -> None:
+        """CloudLLMProvider must reject an empty api_key immediately."""
+        from src.ai.providers.cloud_provider import CloudLLMProvider
+
+        cfg = _mock_config()
+        with patch("src.config.marcus_config.get_config", return_value=cfg):
+            with pytest.raises(ValueError, match="api_key"):
+                CloudLLMProvider(model="m", api_key="", url="https://x.com/v1")
+
+    def test_empty_model_raises_value_error(self) -> None:
+        """CloudLLMProvider must reject an empty model name."""
+        from src.ai.providers.cloud_provider import CloudLLMProvider
+
+        cfg = _mock_config()
+        with patch("src.config.marcus_config.get_config", return_value=cfg):
+            with pytest.raises(ValueError, match="model"):
+                CloudLLMProvider(model="", api_key="k", url="https://x.com/v1")
+
+
+# ---------------------------------------------------------------------------
+# _call_cloud_llm (internal HTTP call)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestCloudProviderHTTPCall:
+    """Test the internal _call_cloud_llm method."""
+
+    @pytest.fixture
+    def provider(self) -> Any:
+        from src.ai.providers.cloud_provider import CloudLLMProvider
+
+        cfg = _mock_config()
+        with patch("src.config.marcus_config.get_config", return_value=cfg):
+            return CloudLLMProvider(
+                model="vendor/model",
+                api_key="fw_key",
+                url="https://api.example.com/v1",
+            )
+
+    @pytest.mark.asyncio
+    async def test_posts_to_chat_completions_endpoint(self, provider: Any) -> None:
+        """Must POST to /chat/completions with correct body."""
+        fake_resp = _mock_http_response('{"task_intent": "test"}')
+        provider.client.post = AsyncMock(return_value=fake_resp)
+
+        await provider._call_cloud_llm("hello")
+
+        provider.client.post.assert_called_once()
+        call_kwargs = provider.client.post.call_args
+        assert call_kwargs[0][0] == "/chat/completions"
+        body = call_kwargs[1]["json"]
+        assert body["model"] == "vendor/model"
+        assert body["stream"] is False
+        assert isinstance(body["messages"], list)
+
+    @pytest.mark.asyncio
+    async def test_returns_message_content(self, provider: Any) -> None:
+        """Must return the text from choices[0].message.content."""
+        provider.client.post = AsyncMock(
+            return_value=_mock_http_response("hello world")
+        )
+        result = await provider._call_cloud_llm("prompt")
+        assert result == "hello world"
+
+    @pytest.mark.asyncio
+    async def test_raises_on_http_error(self, provider: Any) -> None:
+        """Must raise Exception (not fall back to Ollama) on 4xx/5xx."""
+        err_resp = Mock(spec=httpx.Response)
+        err_resp.status_code = 401
+        err_resp.text = "Unauthorized"
+        err_resp.raise_for_status.side_effect = httpx.HTTPStatusError(
+            "401", request=Mock(), response=err_resp
+        )
+        provider.client.post = AsyncMock(return_value=err_resp)
+
+        with pytest.raises(Exception, match="Cloud LLM API error"):
+            await provider._call_cloud_llm("prompt")
+
+    @pytest.mark.asyncio
+    async def test_strips_leading_think_blocks(self, provider: Any) -> None:
+        """Must strip <think>...</think> prefix from reasoning models."""
+        raw = "<think>internal reasoning</think>\n{}"
+        provider.client.post = AsyncMock(return_value=_mock_http_response(raw))
+        result = await provider._call_cloud_llm("prompt")
+        assert "<think>" not in result
+        assert result == "{}"
+
+    @pytest.mark.asyncio
+    async def test_uses_config_max_tokens_when_none_passed(self, provider: Any) -> None:
+        """Default max_tokens must come from config, not hardcoded."""
+        provider.max_tokens = 512
+        fake_resp = _mock_http_response("ok")
+        provider.client.post = AsyncMock(return_value=fake_resp)
+
+        await provider._call_cloud_llm("prompt")
+
+        body = provider.client.post.call_args[1]["json"]
+        assert body["max_tokens"] == 512
+
+    @pytest.mark.asyncio
+    async def test_does_not_fall_back_to_ollama_on_404(self, provider: Any) -> None:
+        """Cloud provider must NOT try Ollama native format on 404."""
+        err_resp = Mock(spec=httpx.Response)
+        err_resp.status_code = 404
+        err_resp.text = "Not Found"
+        err_resp.raise_for_status.side_effect = httpx.HTTPStatusError(
+            "404", request=Mock(), response=err_resp
+        )
+        provider.client.post = AsyncMock(return_value=err_resp)
+
+        with pytest.raises(Exception, match="Cloud LLM API error"):
+            await provider._call_cloud_llm("prompt")
+
+        # Must NOT make a second call (Ollama fallback would)
+        assert provider.client.post.call_count == 1
+
+
+# ---------------------------------------------------------------------------
+# High-level methods delegate through _call_cloud_llm
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestCloudProviderMethods:
+    """Verify analyze_task / infer_dependencies use cloud call correctly."""
+
+    @pytest.fixture
+    def provider(self) -> Any:
+        from src.ai.providers.cloud_provider import CloudLLMProvider
+
+        cfg = _mock_config()
+        with patch("src.config.marcus_config.get_config", return_value=cfg):
+            return CloudLLMProvider(model="m", api_key="k", url="https://x.com/v1")
+
+    @pytest.mark.asyncio
+    async def test_analyze_task_returns_semantic_analysis(self, provider: Any) -> None:
+        """analyze_task must return SemanticAnalysis even on parse failure."""
+        provider.client.post = AsyncMock(
+            return_value=_mock_http_response(
+                '{"task_intent":"implement","semantic_dependencies":[],'
+                '"risk_factors":[],"suggestions":[],"confidence":0.8,'
+                '"reasoning":"ok","risk_assessment":{}}'
+            )
+        )
+        result = await provider.analyze_task(_make_task(), {})
+        assert isinstance(result, SemanticAnalysis)
+        assert result.confidence == 0.8
+
+    @pytest.mark.asyncio
+    async def test_analyze_task_returns_fallback_on_api_error(
+        self, provider: Any
+    ) -> None:
+        """analyze_task must return a safe fallback when the API call fails."""
+        provider.client.post = AsyncMock(side_effect=Exception("network error"))
+        result = await provider.analyze_task(_make_task(), {})
+        assert isinstance(result, SemanticAnalysis)
+        assert result.confidence < 0.5
+
+
+# ---------------------------------------------------------------------------
+# Config validation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestAISettingsCloudValidation:
+    """Validate MarcusConfig rejects bad cloud configurations."""
+
+    def _make_config(self, **ai_overrides: Any) -> Any:
+        from src.config.marcus_config import AISettings, MarcusConfig
+
+        ai = AISettings(provider="cloud", **ai_overrides)
+        cfg = MarcusConfig(ai=ai)
+        return cfg
+
+    def test_cloud_provider_requires_api_key(self) -> None:
+        """Validation must fail when cloud_api_key is missing."""
+        cfg = self._make_config(cloud_url="https://x.com/v1")
+        with pytest.raises(ValueError, match="cloud_api_key"):
+            cfg.validate()
+
+    def test_cloud_provider_requires_url(self) -> None:
+        """Validation must fail when cloud_url is missing."""
+        cfg = self._make_config(cloud_api_key="fw_abc123")
+        with pytest.raises(ValueError, match="cloud_url"):
+            cfg.validate()
+
+    def test_cloud_provider_valid_config_passes(self) -> None:
+        """Validation must pass when both cloud_api_key and cloud_url are set."""
+        cfg = self._make_config(
+            cloud_api_key="fw_abc123",
+            cloud_url="https://api.example.com/v1",
+        )
+        cfg.validate()  # Must not raise
+
+
+# ---------------------------------------------------------------------------
+# LLMAbstraction integration
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestLLMAbstractionCloudProvider:
+    """Verify LLMAbstraction initialises cloud provider from config."""
+
+    @pytest.fixture
+    def clean_env(self) -> Any:
+        keys = [
+            "CLAUDE_API_KEY",
+            "OPENAI_API_KEY",
+            "MARCUS_LOCAL_LLM_PATH",
+            "MARCUS_CLOUD_LLM_KEY",
+            "MARCUS_CLOUD_LLM_URL",
+        ]
+        backup = {k: os.environ.pop(k) for k in keys if k in os.environ}
+        yield
+        os.environ.update(backup)
+
+    def test_cloud_provider_initialised_from_config(self, clean_env: Any) -> None:
+        """When provider='cloud' is configured, only the cloud provider starts."""
+        from src.ai.providers.llm_abstraction import LLMAbstraction
+
+        mock_cfg = Mock()
+        mock_cfg.ai.provider = "cloud"
+        mock_cfg.ai.cloud_api_key = "fw_test_key"
+        mock_cfg.ai.cloud_url = "https://api.example.com/v1"
+        mock_cfg.ai.model = "vendor/model"
+        mock_cfg.ai.max_tokens = 4096
+        mock_cfg.ai.temperature = 0.1
+        mock_cfg.ai.anthropic_api_key = None
+        mock_cfg.ai.openai_api_key = None
+        mock_cfg.ai.local_model = None
+
+        with patch("src.config.marcus_config.get_config", return_value=mock_cfg):
+            llm = LLMAbstraction()
+            llm._initialize_providers()
+
+        assert "cloud" in llm.providers
+        assert "anthropic" not in llm.providers
+        assert "openai" not in llm.providers
+        assert "local" not in llm.providers
+        assert llm.current_provider == "cloud"
+
+    def test_cloud_provider_picks_up_env_vars(self, clean_env: Any) -> None:
+        """cloud_api_key and cloud_url can be supplied via env vars."""
+        from src.ai.providers.llm_abstraction import LLMAbstraction
+
+        os.environ["MARCUS_CLOUD_LLM_KEY"] = "fw_from_env"
+        os.environ["MARCUS_CLOUD_LLM_URL"] = "https://env.example.com/v1"
+
+        mock_cfg = Mock()
+        mock_cfg.ai.provider = "cloud"
+        mock_cfg.ai.cloud_api_key = None  # no config key
+        mock_cfg.ai.cloud_url = None  # no config url
+        mock_cfg.ai.model = "vendor/model"
+        mock_cfg.ai.max_tokens = 4096
+        mock_cfg.ai.temperature = 0.1
+        mock_cfg.ai.anthropic_api_key = None
+        mock_cfg.ai.openai_api_key = None
+        mock_cfg.ai.local_model = None
+
+        with patch("src.config.marcus_config.get_config", return_value=mock_cfg):
+            llm = LLMAbstraction()
+            llm._initialize_providers()
+
+        assert "cloud" in llm.providers


### PR DESCRIPTION
## Summary

- Adds `CloudLLMProvider` — a generic transport-layer subclass of `LocalLLMProvider` supporting any OpenAI-compatible cloud inference endpoint (Fireworks AI, Groq, Together AI, Mistral, DeepSeek, and others)
- Minimal config: three fields — `model`, `cloud_api_key`, `cloud_url`
- Adds `cloud_api_key` / `cloud_url` to `AISettings` with validation
- `LLMAbstraction` initialises the cloud provider when `provider="cloud"`; also supports `MARCUS_CLOUD_LLM_KEY` / `MARCUS_CLOUD_LLM_URL` env var overrides

**Config example:**
```json
{
  "ai": {
    "provider": "cloud",
    "model": "accounts/fireworks/models/qwen2p5-coder-7b-instruct",
    "cloud_api_key": "${FIREWORKS_API_KEY}",
    "cloud_url": "https://api.fireworks.ai/inference/v1"
  }
}
```

## Test plan

- [ ] 19 unit tests pass (no network): `pytest tests/unit/ai/test_cloud_provider.py -m unit`
- [ ] Existing provider-selection tests unaffected: `pytest tests/unit/ai/test_llm_provider_selection.py`
- [ ] Integration tests verified against Fireworks AI (real API, 3/3 pass):
  ```
  FIREWORKS_API_KEY=... FIREWORKS_MODEL=... pytest tests/integration/external/test_cloud_provider_integration.py -v
  ```
- [ ] Integration tests auto-skip when `FIREWORKS_API_KEY` is unset

🤖 Generated with [Claude Code](https://claude.com/claude-code)