### PR TITLE
feat(experiments): drop duplicated agent prompt embed in worker stdin

### DIFF
--- a/dev-tools/experiments/runners/spawn_agents.py
+++ b/dev-tools/experiments/runners/spawn_agents.py
@@ -508,10 +508,6 @@ CRITICAL INSTRUCTIONS:
         str
             Prompt for worker agent
         """
-        # Read the base agent prompt template
-        with open(self.agent_prompt_template, "r") as f:
-            base_prompt = f.read()
-
         agent_id = agent["id"]
         agent_name = agent["name"]
         agent_role = agent["role"]
@@ -593,12 +589,6 @@ STARTUP SEQUENCE:
    terminal — the project should not stall waiting for it. Your only
    job is to read the lifecycle fields and act on them. You do not
    compute completion yourself.
-
----
-
-{base_prompt}
-
----
 
 CRITICAL REMINDERS:
 - Work directory: {work_dir}


### PR DESCRIPTION
## Summary
- Removes the redundant `{base_prompt}` embed in `create_worker_prompt()` (`dev-tools/experiments/runners/spawn_agents.py`).
- The agent prompt template was being shipped to each worker twice: once as CLAUDE.md (auto-loaded by Claude Code into the cacheable system prompt block) and again as a `--- {base_prompt} ---` block inside the worker's stdin prompt.
- ~5,859 tokens off every worker's first turn. Smaller cached prefix → smaller cache-read bill on every subsequent turn (~586 tokens / turn at Anthropic cache pricing of 0.10× input).

## What changed
- Deleted lines that read the agent prompt template inside `create_worker_prompt`.
- Deleted the `--- {base_prompt} ---` separator block embedded in the worker stdin.
- Kept the startup sequence (steps 1-6, register/request_next_task/etc.) — that's experiment-specific bootstrap and doesn't belong in CLAUDE.md.

## Why this is safe
- Agents still see the full operating instructions — Claude Code loads CLAUDE.md at session start and keeps it in the system prompt.
- `copy_agent_workflow_to_implementation()` (line 901) is unchanged, so CLAUDE.md still lands in every agent's working directory.
- All 44 unit tests in `tests/unit/experiments/test_spawn_agents.py` pass.

## Test plan
- [x] `pytest tests/unit/experiments/test_spawn_agents.py` — 44 passed
- [ ] Run a small experiment (e.g. hangman) and verify in agent JSONL session logs that `cache_creation_input_tokens` on turn 1 is reduced by ~5,859 vs `develop`
- [ ] Confirm agents still register, request tasks, report progress correctly

## Related
- Sets up the cache-effectiveness measurement use case in #409 (we'll be able to quantify this saving once the cost dashboard ships).

🤖 Generated with [Claude Code](https://claude.com/claude-code)