### PR TITLE
feat(cost-tracking): SQLite cost foundation — schema, capture, aggregation (#409 phases 1-3)

### DIFF
--- a/src/ai/providers/anthropic_provider.py
+++ b/src/ai/providers/anthropic_provider.py
@@ -8,11 +8,13 @@ enhancement using Anthropic's Claude models.
 import json
 import logging
 import os
+import time
 from typing import Any, Dict, List
 
 import httpx
 
 from src.core.models import Task
+from src.cost_tracking.cost_recorder import get_recorder
 from src.utils.json_parser import parse_ai_json_response, parse_json_response
 
 from .base_provider import (
@@ -431,17 +433,29 @@ Respond only with valid JSON array."""
         self.max_tokens = max_tokens
         return await self._call_claude(prompt)
 
-    async def _call_claude(self, prompt: str) -> str:
+    async def _call_claude(self, prompt: str, operation: str = "analyze") -> str:
         """
         Make API call to Claude.
 
         Args
         ----
             prompt: Prompt to send to Claude
+            operation: Logical operation name recorded with the cost event
+                (e.g. ``'parse_prd'``, ``'analyze_blocker'``). Defaults to
+                ``'analyze'`` so legacy callers still record something useful.
 
         Returns
         -------
             Claude's response text
+
+        Notes
+        -----
+        After a successful response, this method captures the four token
+        fields from ``data["usage"]`` (``input_tokens``,
+        ``cache_creation_input_tokens``, ``cache_read_input_tokens``,
+        ``output_tokens``) and records a planner-side ``token_events`` row
+        via :func:`src.cost_tracking.cost_recorder.get_recorder`. The
+        recorder is best-effort: it never raises into the caller.
         """
         payload = {
             "model": self.model,
@@ -450,11 +464,25 @@ Respond only with valid JSON array."""
             "messages": [{"role": "user", "content": prompt}],
         }
 
+        start = time.monotonic()
         try:
             response = await self.client.post(f"{self.base_url}/messages", json=payload)
             response.raise_for_status()
 
             data = response.json()
+            latency_ms = int((time.monotonic() - start) * 1000)
+            usage = data.get("usage") or {}
+            get_recorder().record_planner_call(
+                operation=operation,
+                provider="anthropic",
+                model=str(data.get("model", self.model)),
+                input_tokens=int(usage.get("input_tokens", 0)),
+                cache_creation_tokens=int(usage.get("cache_creation_input_tokens", 0)),
+                cache_read_tokens=int(usage.get("cache_read_input_tokens", 0)),
+                output_tokens=int(usage.get("output_tokens", 0)),
+                latency_ms=latency_ms,
+                request_id=str(data.get("id")) if data.get("id") else None,
+            )
             return str(data["content"][0]["text"])
 
         except httpx.TimeoutException:

--- a/src/ai/providers/cloud_provider.py
+++ b/src/ai/providers/cloud_provider.py
@@ -21,9 +21,12 @@ Examples
 """
 
 import logging
+import time
 from typing import Optional
 
 import httpx
+
+from src.cost_tracking.cost_recorder import get_recorder
 
 from .local_provider import LocalLLMProvider, _strip_reasoning_blocks
 
@@ -154,6 +157,7 @@ class CloudLLMProvider(LocalLLMProvider):
             "stream": False,
         }
 
+        start = time.monotonic()
         try:
             response = await self.client.post("/chat/completions", json=request_data)
             response.raise_for_status()
@@ -162,6 +166,16 @@ class CloudLLMProvider(LocalLLMProvider):
             content = data["choices"][0]["message"]["content"]
             if not isinstance(content, str):
                 raise Exception(f"Expected string response, got {type(content)}")
+            usage = data.get("usage") or {}
+            get_recorder().record_planner_call(
+                operation="analyze",
+                provider="cloud",
+                model=self.model,
+                input_tokens=int(usage.get("prompt_tokens", 0)),
+                output_tokens=int(usage.get("completion_tokens", 0)),
+                latency_ms=int((time.monotonic() - start) * 1000),
+                request_id=str(data.get("id")) if data.get("id") else None,
+            )
             return _strip_reasoning_blocks(content)
 
         except httpx.HTTPStatusError as e:
@@ -171,6 +185,14 @@ class CloudLLMProvider(LocalLLMProvider):
         except Exception:
             logger.error("Cloud LLM call failed for model %s", self.model)
             raise
+
+    def _cost_provider_name(self) -> str:
+        """Return ``'cloud'`` as the cost-event provider tag.
+
+        Overrides the parent's ``'local'`` so cost rows from this class
+        attribute correctly to the cloud provider.
+        """
+        return "cloud"
 
     # Override the internal dispatch used by all inherited business methods
     async def _call_local_llm(

--- a/src/ai/providers/local_provider.py
+++ b/src/ai/providers/local_provider.py
@@ -28,11 +28,13 @@ import json
 import logging
 import os
 import re
+import time
 from typing import Any, Dict, List, Optional
 
 import httpx
 
 from src.core.models import Task
+from src.cost_tracking.cost_recorder import get_recorder
 from src.utils.json_parser import parse_ai_json_response
 
 from .base_provider import (
@@ -434,6 +436,7 @@ Solutions:"""
             "stream": False,
         }
 
+        start = time.monotonic()
         try:
             response = await self.client.post("/chat/completions", json=request_data)
             response.raise_for_status()
@@ -442,6 +445,19 @@ Solutions:"""
             content = data["choices"][0]["message"]["content"]
             if not isinstance(content, str):
                 raise Exception(f"Expected string response, got {type(content)}")
+            # OpenAI-compatible servers (incl. local Ollama) usually return
+            # a usage object. Cache fields are absent for non-Anthropic
+            # backends; record_planner_call defaults them to 0.
+            usage = data.get("usage") or {}
+            get_recorder().record_planner_call(
+                operation="analyze",
+                provider=self._cost_provider_name(),
+                model=self.model,
+                input_tokens=int(usage.get("prompt_tokens", 0)),
+                output_tokens=int(usage.get("completion_tokens", 0)),
+                latency_ms=int((time.monotonic() - start) * 1000),
+                request_id=str(data.get("id")) if data.get("id") else None,
+            )
             return _strip_reasoning_blocks(content)
 
         except httpx.HTTPStatusError as e:
@@ -455,6 +471,10 @@ Solutions:"""
         except Exception as e:
             logger.error(f"Local LLM call failed: {e}")
             raise
+
+    def _cost_provider_name(self) -> str:
+        """Return the provider tag for cost events. Subclasses (cloud) override."""
+        return "local"
 
     async def _call_ollama_native(
         self, prompt: str, max_tokens: int, temperature: float

--- a/src/cost_tracking/cost_aggregator.py
+++ b/src/cost_tracking/cost_aggregator.py
@@ -1,0 +1,285 @@
+"""
+Read-only aggregator over the Marcus cost store.
+
+Provides the query helpers that power the Cato ``/api/cost/*`` endpoints
+described in #409. Aggregator never writes; it only reads from
+:class:`src.cost_tracking.cost_store.CostStore` and returns dicts shaped
+like the documented API responses, so the Cato backend can pass them
+through with minimal transformation.
+
+All methods are synchronous (sqlite3 is sync). The aggregator is safe to
+share across threads because it relies on the underlying connection's
+WAL mode for concurrent readers.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from typing import Any, Dict, List, Optional
+
+from src.cost_tracking.cost_store import CostStore
+
+
+class CostAggregator:
+    """Read-only query layer over a :class:`CostStore`.
+
+    Parameters
+    ----------
+    store : CostStore
+        The backing store. Aggregator does not own the connection; the
+        caller is responsible for the store's lifecycle.
+    """
+
+    def __init__(self, store: CostStore) -> None:
+        self.store = store
+        # Allow row access by column name for convenience in helpers.
+        self.store.conn.row_factory = sqlite3.Row
+
+    # -- helpers -----------------------------------------------------------
+
+    def _rows(self, sql: str, params: tuple[Any, ...] = ()) -> List[Dict[str, Any]]:
+        """Run a query and return rows as plain dicts."""
+        cur = self.store.conn.execute(sql, params)
+        return [dict(row) for row in cur.fetchall()]
+
+    def _row(self, sql: str, params: tuple[Any, ...] = ()) -> Optional[Dict[str, Any]]:
+        """Run a query that returns at most one row."""
+        cur = self.store.conn.execute(sql, params)
+        r = cur.fetchone()
+        return dict(r) if r is not None else None
+
+    # -- public queries ---------------------------------------------------
+
+    def list_experiments(
+        self,
+        *,
+        project_id: Optional[str] = None,
+        limit: int = 100,
+    ) -> List[Dict[str, Any]]:
+        """List experiments with token + cost totals attached.
+
+        Parameters
+        ----------
+        project_id : str, optional
+            Restrict to one project.
+        limit : int, default 100
+            Cap result set.
+
+        Returns
+        -------
+        list of dict
+            Each row carries experiment metadata plus ``total_tokens``
+            and ``total_cost_usd`` aggregated from ``v_event_cost``.
+        """
+        sql = """
+            SELECT e.*,
+                   COALESCE(SUM(c.total_tokens), 0) AS total_tokens,
+                   COALESCE(SUM(c.cost_usd), 0)     AS total_cost_usd
+            FROM experiments e
+            LEFT JOIN v_event_cost c USING (experiment_id)
+            WHERE (? IS NULL OR e.project_id = ?)
+            GROUP BY e.experiment_id
+            ORDER BY e.started_at DESC
+            LIMIT ?
+        """
+        return self._rows(sql, (project_id, project_id, limit))
+
+    def experiment_summary(self, experiment_id: str) -> Optional[Dict[str, Any]]:
+        """Full per-experiment summary used by Cato's drill-in view.
+
+        Returns
+        -------
+        dict or None
+            Shaped like the example response in #409 (``summary``,
+            ``by_role``, ``by_agent``, ``by_task``, ``by_operation``,
+            ``by_model``). Returns ``None`` if the experiment does not
+            exist.
+        """
+        meta = self._row(
+            "SELECT * FROM experiments WHERE experiment_id = ?",
+            (experiment_id,),
+        )
+        if meta is None:
+            return None
+
+        totals = (
+            self._row(
+                """
+            SELECT
+                COUNT(*)                                    AS total_events,
+                COALESCE(SUM(total_tokens), 0)              AS total_tokens,
+                COALESCE(SUM(input_tokens), 0)              AS input_tokens,
+                COALESCE(SUM(cache_creation_tokens), 0)     AS cache_creation_tokens,
+                COALESCE(SUM(cache_read_tokens), 0)         AS cache_read_tokens,
+                COALESCE(SUM(output_tokens), 0)             AS output_tokens,
+                COALESCE(SUM(cost_usd), 0)                  AS total_cost_usd
+            FROM v_event_cost
+            WHERE experiment_id = ?
+            """,
+                (experiment_id,),
+            )
+            or {}
+        )
+
+        cacheable = (
+            (totals.get("input_tokens") or 0)
+            + (totals.get("cache_creation_tokens") or 0)
+            + (totals.get("cache_read_tokens") or 0)
+        )
+        hit_rate = (
+            (totals.get("cache_read_tokens") or 0) / cacheable if cacheable > 0 else 0.0
+        )
+        totals["cache_hit_rate"] = hit_rate
+
+        by_role = self._rows(
+            """
+            SELECT agent_role AS role,
+                   COUNT(*)                          AS events,
+                   COALESCE(SUM(total_tokens), 0)    AS tokens,
+                   COALESCE(SUM(cost_usd), 0)        AS cost_usd
+            FROM v_event_cost
+            WHERE experiment_id = ?
+            GROUP BY agent_role
+            """,
+            (experiment_id,),
+        )
+
+        by_agent = self._rows(
+            """
+            SELECT agent_id, agent_role AS role,
+                   COUNT(*)                                   AS events,
+                   COALESCE(SUM(total_tokens), 0)             AS tokens,
+                   COALESCE(SUM(cost_usd), 0)                 AS cost_usd,
+                   COUNT(DISTINCT task_id)                    AS tasks_worked,
+                   COUNT(DISTINCT session_id)                 AS sessions,
+                   COALESCE(SUM(CASE WHEN turn_index IS NOT NULL THEN 1 ELSE 0 END), 0)
+                                                              AS turns
+            FROM v_event_cost
+            WHERE experiment_id = ?
+            GROUP BY agent_id, agent_role
+            ORDER BY cost_usd DESC
+            """,
+            (experiment_id,),
+        )
+
+        by_task = self._rows(
+            """
+            SELECT task_id,
+                   COUNT(*)                          AS events,
+                   COALESCE(SUM(total_tokens), 0)    AS tokens,
+                   COALESCE(SUM(cost_usd), 0)        AS cost_usd
+            FROM v_event_cost
+            WHERE experiment_id = ? AND task_id IS NOT NULL
+            GROUP BY task_id
+            ORDER BY cost_usd DESC
+            """,
+            (experiment_id,),
+        )
+
+        by_operation = self._rows(
+            """
+            SELECT operation,
+                   COUNT(*)                          AS events,
+                   COALESCE(SUM(total_tokens), 0)    AS tokens,
+                   COALESCE(SUM(cost_usd), 0)        AS cost_usd
+            FROM v_event_cost
+            WHERE experiment_id = ?
+            GROUP BY operation
+            ORDER BY cost_usd DESC
+            """,
+            (experiment_id,),
+        )
+
+        by_model = self._rows(
+            """
+            SELECT model, provider,
+                   COUNT(*)                          AS events,
+                   COALESCE(SUM(total_tokens), 0)    AS tokens,
+                   COALESCE(SUM(cost_usd), 0)        AS cost_usd
+            FROM v_event_cost
+            WHERE experiment_id = ?
+            GROUP BY model, provider
+            ORDER BY cost_usd DESC
+            """,
+            (experiment_id,),
+        )
+
+        return {
+            **meta,
+            "summary": totals,
+            "by_role": by_role,
+            "by_agent": by_agent,
+            "by_task": by_task,
+            "by_operation": by_operation,
+            "by_model": by_model,
+        }
+
+    def session_turns(self, session_id: str) -> List[Dict[str, Any]]:
+        """Per-turn cost trajectory for one Claude Code session.
+
+        Used to find runaway loops and visualize cost growth across a
+        single agent session.
+        """
+        return self._rows(
+            """
+            SELECT turn_index, total_tokens, cost_usd, timestamp
+            FROM v_event_cost
+            WHERE session_id = ?
+            ORDER BY turn_index
+            """,
+            (session_id,),
+        )
+
+    def cache_hit_rate_by_agent(self, experiment_id: str) -> List[Dict[str, Any]]:
+        """Per-agent cache hit rate within one experiment.
+
+        Returns
+        -------
+        list of dict
+            Each row: ``{agent_id, cacheable_tokens, cache_read_tokens,
+            cache_hit_rate}``. ``cache_hit_rate`` is 0.0 when no tokens
+            were cacheable.
+        """
+        rows = self._rows(
+            """
+            SELECT agent_id,
+                   COALESCE(SUM(input_tokens), 0)
+                     + COALESCE(SUM(cache_creation_tokens), 0)
+                     + COALESCE(SUM(cache_read_tokens), 0)         AS cacheable_tokens,
+                   COALESCE(SUM(cache_read_tokens), 0)             AS cache_read_tokens
+            FROM token_events
+            WHERE experiment_id = ?
+            GROUP BY agent_id
+            """,
+            (experiment_id,),
+        )
+        for r in rows:
+            r["cache_hit_rate"] = (
+                r["cache_read_tokens"] / r["cacheable_tokens"]
+                if r["cacheable_tokens"] > 0
+                else 0.0
+            )
+        return rows
+
+    def project_totals(self, project_id: str) -> Dict[str, Any]:
+        """Roll up all token and cost data for one project across experiments."""
+        return (
+            self._row(
+                """
+            SELECT
+                COUNT(DISTINCT experiment_id)        AS experiments,
+                COUNT(*)                             AS events,
+                COALESCE(SUM(total_tokens), 0)       AS total_tokens,
+                COALESCE(SUM(cost_usd), 0)           AS total_cost_usd
+            FROM v_event_cost
+            WHERE project_id = ?
+            """,
+                (project_id,),
+            )
+            or {
+                "experiments": 0,
+                "events": 0,
+                "total_tokens": 0,
+                "total_cost_usd": 0.0,
+            }
+        )

--- a/src/cost_tracking/cost_recorder.py
+++ b/src/cost_tracking/cost_recorder.py
@@ -1,0 +1,225 @@
+"""
+Lightweight recording layer between AI providers and the cost store.
+
+Providers call :meth:`CostRecorder.record_planner_call` after every
+successful LLM request. The recorder writes a single ``token_events`` row,
+attaching whichever planner context is currently active (set by Marcus's
+MCP request handlers via :meth:`CostRecorder.planner_context`).
+
+The recorder is intentionally:
+
+- **Side-effect only.** Never raises; provider call paths must not be
+  affected by store failures.
+- **Disable-able.** A no-op mode keeps tests / minimal deployments fast.
+- **Singleton-friendly.** A module-level instance is exposed via
+  :func:`get_recorder` / :func:`set_recorder` so providers don't need
+  dependency injection.
+"""
+
+from __future__ import annotations
+
+import logging
+from contextlib import contextmanager
+from contextvars import ContextVar
+from dataclasses import dataclass
+from typing import Iterator, List, Optional
+
+from src.cost_tracking.cost_store import CostStore, TokenEvent
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Context
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class PlannerContext:
+    """Per-request context used to attribute planner LLM calls.
+
+    Parameters
+    ----------
+    experiment_id : str
+        Active experiment ID (use ``'unassigned'`` if the call happens
+        outside an experiment lifecycle).
+    project_id : str
+        Active Marcus project ID.
+    agent_id : str, default ``'planner'``
+        Logical agent name. Marcus's own LLM calls are attributed to
+        ``'planner'`` by default; specialized callers can override.
+    task_id : str, optional
+        Current task ID, when known.
+    operation_override : str, optional
+        Force a specific ``operation`` value regardless of caller.
+    """
+
+    experiment_id: str
+    project_id: str
+    agent_id: str = "planner"
+    task_id: Optional[str] = None
+    operation_override: Optional[str] = None
+
+
+# Stack of active contexts (innermost wins). ContextVar makes this
+# safe across asyncio tasks and threads.
+_context_stack: ContextVar[List[PlannerContext]] = ContextVar(
+    "_cost_recorder_context_stack", default=[]
+)
+
+
+# ---------------------------------------------------------------------------
+# Recorder
+# ---------------------------------------------------------------------------
+
+
+class CostRecorder:
+    """Side-effect-only recorder of planner-side LLM calls.
+
+    Parameters
+    ----------
+    store : CostStore
+        Backing store for ``token_events`` writes.
+    enabled : bool, default True
+        When False, all ``record_*`` calls are no-ops.
+    """
+
+    def __init__(self, store: CostStore, enabled: bool = True) -> None:
+        self.store = store
+        self.enabled = enabled
+
+    # -- context management -----------------------------------------------
+
+    @contextmanager
+    def planner_context(self, ctx: PlannerContext) -> Iterator[PlannerContext]:
+        """Push a planner context for the duration of the ``with`` block.
+
+        Innermost context wins. ContextVar token returned by ``set`` is
+        used to restore the previous stack on exit, preserving correct
+        nesting under concurrent asyncio tasks.
+        """
+        stack = list(_context_stack.get())
+        stack.append(ctx)
+        token = _context_stack.set(stack)
+        try:
+            yield ctx
+        finally:
+            _context_stack.reset(token)
+
+    def current(self) -> Optional[PlannerContext]:
+        """Return the active context (innermost), or None."""
+        stack = _context_stack.get()
+        return stack[-1] if stack else None
+
+    # -- writes -----------------------------------------------------------
+
+    def record_planner_call(
+        self,
+        *,
+        operation: str,
+        provider: str,
+        model: str,
+        input_tokens: int = 0,
+        cache_creation_tokens: int = 0,
+        cache_read_tokens: int = 0,
+        output_tokens: int = 0,
+        latency_ms: Optional[int] = None,
+        request_id: Optional[str] = None,
+        status: str = "ok",
+        error_type: Optional[str] = None,
+    ) -> None:
+        """Write one ``token_events`` row attributed to the active context.
+
+        Parameters
+        ----------
+        operation : str
+            High-level op name (``'parse_prd'``, ``'analyze_blocker'``,
+            ``'generate_instructions'``, ...). Overridden if the active
+            context sets ``operation_override``.
+        provider, model : str
+            Provider key and model identifier.
+        input_tokens, cache_creation_tokens, cache_read_tokens,
+        output_tokens : int
+            Token counts, all default to 0.
+        latency_ms, request_id, status, error_type : optional
+            Trace metadata.
+
+        Notes
+        -----
+        Never raises. Failures are logged at WARNING and swallowed so
+        that store outages cannot break the provider call path.
+        """
+        if not self.enabled:
+            return
+        ctx = self.current()
+        if ctx is not None:
+            experiment_id = ctx.experiment_id
+            project_id = ctx.project_id
+            agent_id = ctx.agent_id
+            task_id = ctx.task_id
+            if ctx.operation_override is not None:
+                operation = ctx.operation_override
+        else:
+            experiment_id = "unassigned"
+            project_id = "unassigned"
+            agent_id = "planner"
+            task_id = None
+
+        event = TokenEvent(
+            experiment_id=experiment_id,
+            project_id=project_id,
+            agent_id=agent_id,
+            agent_role="planner",
+            task_id=task_id,
+            operation=operation,
+            provider=provider,
+            model=model,
+            input_tokens=input_tokens,
+            cache_creation_tokens=cache_creation_tokens,
+            cache_read_tokens=cache_read_tokens,
+            output_tokens=output_tokens,
+            latency_ms=latency_ms,
+            request_id=request_id,
+            status=status,
+            error_type=error_type,
+        )
+        try:
+            self.store.record_event(event)
+        except Exception as exc:  # pragma: no cover - logged, swallowed
+            logger.warning("cost recorder swallowed store error: %s", exc)
+
+
+# ---------------------------------------------------------------------------
+# Module-level singleton
+# ---------------------------------------------------------------------------
+
+_singleton: Optional[CostRecorder] = None
+
+
+def get_recorder() -> CostRecorder:
+    """Return the module-level recorder, lazily creating a no-op default.
+
+    The default singleton is **disabled** and uses an in-memory store.
+    Marcus's startup wires a real recorder via :func:`set_recorder` once
+    the cost DB path is known.
+    """
+    global _singleton
+    if _singleton is None:
+        from pathlib import Path
+
+        # Default: disabled in-memory store. Real wiring happens at startup.
+        _singleton = CostRecorder(
+            store=CostStore(db_path=Path(":memory:")),
+            enabled=False,
+        )
+    return _singleton
+
+
+def set_recorder(recorder: Optional[CostRecorder]) -> None:
+    """Replace the module-level recorder.
+
+    Pass ``None`` to clear and force the next :func:`get_recorder` call to
+    rebuild a fresh no-op default (used by tests).
+    """
+    global _singleton
+    _singleton = recorder

--- a/src/cost_tracking/cost_store.py
+++ b/src/cost_tracking/cost_store.py
@@ -1,0 +1,475 @@
+"""
+SQLite-backed event store for Marcus token usage and cost data.
+
+Stores one row per LLM call (planner or worker) with full agent/task/model
+attribution. Pricing lives in a versioned ``model_prices`` table and cost is
+computed at query time via the ``v_event_cost`` view, so changing prices
+never rewrites history.
+
+Schema
+------
+- ``experiments``    : registry of runs (project, model, totals)
+- ``token_events``   : one row per LLM call (immutable token counts)
+- ``model_prices``   : versioned by ``effective_from``; edited by Cato UI
+- ``v_event_cost``   : view joining events × the price active at each
+                      event's timestamp, exposing ``cost_usd``
+
+This module exposes a thin :class:`CostStore` wrapper. Aggregation queries
+live in ``cost_aggregator.py``; this file only handles inserts and schema.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import List, Optional
+
+# ---------------------------------------------------------------------------
+# Schema
+# ---------------------------------------------------------------------------
+
+SCHEMA_SQL: str = """
+CREATE TABLE IF NOT EXISTS experiments (
+  experiment_id    TEXT PRIMARY KEY,
+  project_id       TEXT NOT NULL,
+  board_id         TEXT,
+  project_name     TEXT,
+  decomposer       TEXT,
+  complexity       TEXT,
+  provider         TEXT,
+  model            TEXT,
+  num_agents       INTEGER,
+  started_at       TIMESTAMP NOT NULL,
+  ended_at         TIMESTAMP,
+  total_tasks      INTEGER,
+  completed_tasks  INTEGER,
+  blocked_tasks    INTEGER,
+  budget_usd       REAL,
+  notes            TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_exp_project ON experiments(project_id);
+
+CREATE TABLE IF NOT EXISTS token_events (
+  event_id              INTEGER PRIMARY KEY AUTOINCREMENT,
+  experiment_id         TEXT NOT NULL,
+  project_id            TEXT NOT NULL,
+  agent_id              TEXT NOT NULL,
+  agent_role            TEXT NOT NULL,
+  parent_agent_id       TEXT,
+  task_id               TEXT,
+  subtask_id            TEXT,
+  operation             TEXT NOT NULL,
+  provider              TEXT NOT NULL,
+  model                 TEXT NOT NULL,
+  input_tokens          INTEGER NOT NULL DEFAULT 0,
+  cache_creation_tokens INTEGER NOT NULL DEFAULT 0,
+  cache_read_tokens     INTEGER NOT NULL DEFAULT 0,
+  output_tokens         INTEGER NOT NULL DEFAULT 0,
+  total_tokens          INTEGER GENERATED ALWAYS AS
+                          (input_tokens + cache_creation_tokens
+                           + cache_read_tokens + output_tokens) STORED,
+  latency_ms            INTEGER,
+  session_id            TEXT,
+  turn_index            INTEGER,
+  request_id            TEXT,
+  status                TEXT NOT NULL DEFAULT 'ok',
+  error_type            TEXT,
+  timestamp             TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+CREATE INDEX IF NOT EXISTS idx_te_exp       ON token_events(experiment_id);
+CREATE INDEX IF NOT EXISTS idx_te_project   ON token_events(project_id);
+CREATE INDEX IF NOT EXISTS idx_te_agent     ON token_events(experiment_id, agent_id);
+CREATE INDEX IF NOT EXISTS idx_te_task      ON token_events(task_id);
+CREATE INDEX IF NOT EXISTS idx_te_op_model  ON token_events(operation, model);
+CREATE INDEX IF NOT EXISTS idx_te_timestamp ON token_events(timestamp);
+
+CREATE TABLE IF NOT EXISTS model_prices (
+  model                       TEXT NOT NULL,
+  provider                    TEXT NOT NULL,
+  effective_from              TIMESTAMP NOT NULL,
+  input_per_million            REAL NOT NULL,
+  cache_creation_per_million   REAL,
+  cache_read_per_million       REAL,
+  output_per_million           REAL NOT NULL,
+  source                       TEXT,
+  PRIMARY KEY (model, provider, effective_from)
+);
+
+CREATE VIEW IF NOT EXISTS v_event_cost AS
+SELECT t.*,
+       (t.input_tokens          * p.input_per_million          / 1e6
+      + t.cache_creation_tokens * COALESCE(p.cache_creation_per_million, 0) / 1e6
+      + t.cache_read_tokens     * COALESCE(p.cache_read_per_million, 0)     / 1e6
+      + t.output_tokens         * p.output_per_million         / 1e6) AS cost_usd
+FROM token_events t
+JOIN model_prices p
+  ON t.model = p.model AND t.provider = p.provider
+ AND p.effective_from = (
+       SELECT MAX(effective_from) FROM model_prices
+       WHERE model = t.model AND provider = t.provider
+         AND effective_from <= t.timestamp
+     );
+"""
+
+# Default seed prices loaded on first use unless caller provides their own.
+# Values reflect Anthropic / OpenAI public pricing as of 2025-01-01;
+# tweaking these is harmless because Cato can override at runtime.
+DEFAULT_SEED: List["ModelPrice"] = []  # populated below after dataclass def
+
+
+# ---------------------------------------------------------------------------
+# Data classes
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class TokenEvent:
+    """One LLM call (planner or worker).
+
+    Parameters
+    ----------
+    experiment_id : str
+        Marcus experiment ID.
+    project_id : str
+        Marcus project ID this event belongs to (denormalized for fast filter).
+    agent_id : str
+        Stable agent identifier (``'planner'``, ``'agent_unicorn_1'``, etc).
+    agent_role : str
+        One of ``'planner'``, ``'creator'``, ``'worker'``, ``'monitor'``,
+        ``'subagent'``.
+    operation : str
+        High-level operation name (``'parse_prd'``, ``'turn'``, ...).
+    provider : str
+        ``'anthropic'``, ``'cloud'``, ``'local'``, ``'openai'``.
+    model : str
+        Model identifier as reported by the provider.
+    input_tokens : int
+        Non-cached input tokens.
+    cache_creation_tokens : int
+        Tokens written to the prompt cache (priced at 1.25× input).
+    cache_read_tokens : int
+        Tokens served from the prompt cache (priced at 0.10× input).
+    output_tokens : int
+        Generated tokens.
+    parent_agent_id, task_id, subtask_id, latency_ms, session_id,
+    turn_index, request_id, status, error_type, timestamp : optional
+        Drill-down context. ``timestamp`` defaults to ``CURRENT_TIMESTAMP``
+        in SQLite when not supplied.
+    """
+
+    experiment_id: str
+    project_id: str
+    agent_id: str
+    agent_role: str
+    operation: str
+    provider: str
+    model: str
+    input_tokens: int = 0
+    cache_creation_tokens: int = 0
+    cache_read_tokens: int = 0
+    output_tokens: int = 0
+    parent_agent_id: Optional[str] = None
+    task_id: Optional[str] = None
+    subtask_id: Optional[str] = None
+    latency_ms: Optional[int] = None
+    session_id: Optional[str] = None
+    turn_index: Optional[int] = None
+    request_id: Optional[str] = None
+    status: str = "ok"
+    error_type: Optional[str] = None
+    timestamp: Optional[datetime] = None
+
+
+@dataclass
+class Experiment:
+    """Experiment registry row."""
+
+    experiment_id: str
+    project_id: str
+    started_at: datetime
+    board_id: Optional[str] = None
+    project_name: Optional[str] = None
+    decomposer: Optional[str] = None
+    complexity: Optional[str] = None
+    provider: Optional[str] = None
+    model: Optional[str] = None
+    num_agents: Optional[int] = None
+    ended_at: Optional[datetime] = None
+    total_tasks: Optional[int] = None
+    completed_tasks: Optional[int] = None
+    blocked_tasks: Optional[int] = None
+    budget_usd: Optional[float] = None
+    notes: Optional[str] = None
+
+
+@dataclass
+class ModelPrice:
+    """One pricing row (a single (model, provider, effective_from) tuple)."""
+
+    model: str
+    provider: str
+    effective_from: datetime
+    input_per_million: float
+    output_per_million: float
+    cache_creation_per_million: Optional[float] = None
+    cache_read_per_million: Optional[float] = None
+    source: str = "default"
+
+
+# Populate DEFAULT_SEED after the dataclass is defined.
+_SEED_DATE = datetime(2025, 1, 1, tzinfo=timezone.utc)
+DEFAULT_SEED.extend(
+    [
+        ModelPrice(
+            "claude-opus-4-7",
+            "anthropic",
+            _SEED_DATE,
+            15.0,
+            75.0,
+            18.75,
+            1.50,
+            "default",
+        ),
+        ModelPrice(
+            "claude-sonnet-4-6",
+            "anthropic",
+            _SEED_DATE,
+            3.0,
+            15.0,
+            3.75,
+            0.30,
+            "default",
+        ),
+        ModelPrice(
+            "claude-haiku-4-5", "anthropic", _SEED_DATE, 0.80, 4.0, 1.0, 0.08, "default"
+        ),
+        ModelPrice(
+            "claude-haiku-4-5-20251001",
+            "anthropic",
+            _SEED_DATE,
+            0.80,
+            4.0,
+            1.0,
+            0.08,
+            "default",
+        ),
+        ModelPrice("gpt-4o", "openai", _SEED_DATE, 5.0, 15.0, None, None, "default"),
+    ]
+)
+
+
+# ---------------------------------------------------------------------------
+# Store
+# ---------------------------------------------------------------------------
+
+
+class CostStore:
+    """SQLite-backed token-event store.
+
+    Parameters
+    ----------
+    db_path : Path
+        File path for the SQLite database. Parent directory is created if
+        missing. Use ``":memory:"`` (as a Path or str) for ephemeral tests
+        via the alternate ``CostStore.in_memory()`` constructor.
+
+    Notes
+    -----
+    The connection is opened with ``check_same_thread=False`` so background
+    ingesters can write from a different thread than queries. Callers are
+    responsible for serializing writes if multi-threaded access is needed;
+    SQLite's WAL mode gives concurrent readers + one writer for free.
+    """
+
+    def __init__(self, db_path: Path) -> None:
+        self.db_path = db_path
+        if str(db_path) != ":memory:":
+            db_path.parent.mkdir(parents=True, exist_ok=True)
+        self.conn = sqlite3.connect(str(db_path), check_same_thread=False)
+        self.conn.execute("PRAGMA journal_mode=WAL")
+        self.conn.execute("PRAGMA foreign_keys=ON")
+        self._init_schema()
+
+    def _init_schema(self) -> None:
+        """Run schema DDL. Idempotent thanks to IF NOT EXISTS guards."""
+        self.conn.executescript(SCHEMA_SQL)
+        self.conn.commit()
+
+    # -- writes ------------------------------------------------------------
+
+    def record_event(self, event: TokenEvent) -> int:
+        """Insert one ``token_events`` row.
+
+        Parameters
+        ----------
+        event : TokenEvent
+            Event payload. Token counts default to 0 if not supplied.
+
+        Returns
+        -------
+        int
+            The auto-incremented ``event_id``.
+        """
+        cur = self.conn.execute(
+            """
+            INSERT INTO token_events (
+                experiment_id, project_id, agent_id, agent_role,
+                parent_agent_id, task_id, subtask_id, operation,
+                provider, model, input_tokens, cache_creation_tokens,
+                cache_read_tokens, output_tokens, latency_ms, session_id,
+                turn_index, request_id, status, error_type, timestamp
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
+                      COALESCE(?, CURRENT_TIMESTAMP))
+            """,
+            (
+                event.experiment_id,
+                event.project_id,
+                event.agent_id,
+                event.agent_role,
+                event.parent_agent_id,
+                event.task_id,
+                event.subtask_id,
+                event.operation,
+                event.provider,
+                event.model,
+                event.input_tokens,
+                event.cache_creation_tokens,
+                event.cache_read_tokens,
+                event.output_tokens,
+                event.latency_ms,
+                event.session_id,
+                event.turn_index,
+                event.request_id,
+                event.status,
+                event.error_type,
+                event.timestamp.isoformat() if event.timestamp else None,
+            ),
+        )
+        self.conn.commit()
+        event_id = cur.lastrowid
+        if event_id is None:  # pragma: no cover - sqlite3 always returns rowid
+            raise RuntimeError("sqlite3 did not return lastrowid")
+        return event_id
+
+    def record_experiment(self, exp: Experiment) -> None:
+        """Upsert one ``experiments`` row keyed by ``experiment_id``."""
+        self.conn.execute(
+            """
+            INSERT INTO experiments (
+                experiment_id, project_id, board_id, project_name, decomposer,
+                complexity, provider, model, num_agents, started_at, ended_at,
+                total_tasks, completed_tasks, blocked_tasks, budget_usd, notes
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT(experiment_id) DO UPDATE SET
+                project_id=excluded.project_id,
+                board_id=excluded.board_id,
+                project_name=excluded.project_name,
+                decomposer=excluded.decomposer,
+                complexity=excluded.complexity,
+                provider=excluded.provider,
+                model=excluded.model,
+                num_agents=excluded.num_agents,
+                started_at=excluded.started_at,
+                ended_at=excluded.ended_at,
+                total_tasks=excluded.total_tasks,
+                completed_tasks=excluded.completed_tasks,
+                blocked_tasks=excluded.blocked_tasks,
+                budget_usd=excluded.budget_usd,
+                notes=excluded.notes
+            """,
+            (
+                exp.experiment_id,
+                exp.project_id,
+                exp.board_id,
+                exp.project_name,
+                exp.decomposer,
+                exp.complexity,
+                exp.provider,
+                exp.model,
+                exp.num_agents,
+                exp.started_at.isoformat(),
+                exp.ended_at.isoformat() if exp.ended_at else None,
+                exp.total_tasks,
+                exp.completed_tasks,
+                exp.blocked_tasks,
+                exp.budget_usd,
+                exp.notes,
+            ),
+        )
+        self.conn.commit()
+
+    def record_price(self, price: ModelPrice) -> None:
+        """Insert one ``model_prices`` row.
+
+        Raises
+        ------
+        sqlite3.IntegrityError
+            If a row with the same ``(model, provider, effective_from)``
+            already exists. Use a different ``effective_from`` to update.
+        """
+        self.conn.execute(
+            """
+            INSERT INTO model_prices (
+                model, provider, effective_from, input_per_million,
+                cache_creation_per_million, cache_read_per_million,
+                output_per_million, source
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                price.model,
+                price.provider,
+                price.effective_from.isoformat(),
+                price.input_per_million,
+                price.cache_creation_per_million,
+                price.cache_read_per_million,
+                price.output_per_million,
+                price.source,
+            ),
+        )
+        self.conn.commit()
+
+    def load_seed_prices(self, prices: Optional[List[ModelPrice]] = None) -> None:
+        """Insert default pricing rows if not already present.
+
+        Parameters
+        ----------
+        prices : list of ModelPrice, optional
+            Override the built-in defaults. Useful for tests.
+
+        Notes
+        -----
+        Idempotent: rows whose ``(model, provider, effective_from)`` already
+        exist are skipped (``INSERT OR IGNORE``).
+        """
+        rows = prices if prices is not None else DEFAULT_SEED
+        self.conn.executemany(
+            """
+            INSERT OR IGNORE INTO model_prices (
+                model, provider, effective_from, input_per_million,
+                cache_creation_per_million, cache_read_per_million,
+                output_per_million, source
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            [
+                (
+                    p.model,
+                    p.provider,
+                    p.effective_from.isoformat(),
+                    p.input_per_million,
+                    p.cache_creation_per_million,
+                    p.cache_read_per_million,
+                    p.output_per_million,
+                    p.source,
+                )
+                for p in rows
+            ],
+        )
+        self.conn.commit()
+
+    # -- lifecycle ---------------------------------------------------------
+
+    def close(self) -> None:
+        """Close the underlying SQLite connection."""
+        self.conn.close()

--- a/src/cost_tracking/cost_store.py
+++ b/src/cost_tracking/cost_store.py
@@ -76,7 +76,14 @@ CREATE TABLE IF NOT EXISTS token_events (
   request_id            TEXT,
   status                TEXT NOT NULL DEFAULT 'ok',
   error_type            TEXT,
-  timestamp             TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+  -- ISO-8601 with millisecond precision and trailing 'Z' so text
+  -- comparison in v_event_cost matches Python datetime.isoformat() output
+  -- used by record_price(). SQLite's bare CURRENT_TIMESTAMP produces
+  -- 'YYYY-MM-DD HH:MM:SS' (space separator) which sorts BEFORE
+  -- 'YYYY-MM-DDT...' and would silently drop same-day events from cost
+  -- aggregations (Codex P2 on PR #497).
+  timestamp             TIMESTAMP NOT NULL
+                        DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
 );
 CREATE INDEX IF NOT EXISTS idx_te_exp       ON token_events(experiment_id);
 CREATE INDEX IF NOT EXISTS idx_te_project   ON token_events(project_id);
@@ -255,6 +262,61 @@ DEFAULT_SEED.extend(
             0.08,
             "default",
         ),
+        # Legacy Claude 3 family — Marcus's default config still uses
+        # claude-3-haiku-20240307 (anthropic_provider.py:71) and the
+        # historic settings.py default of claude-3-sonnet-20241022. Without
+        # rows here, v_event_cost's INNER JOIN drops out-of-box runs from
+        # all cost aggregations (Codex P1 on PR #497).
+        ModelPrice(
+            "claude-3-haiku-20240307",
+            "anthropic",
+            _SEED_DATE,
+            0.25,
+            1.25,
+            0.30,
+            0.03,
+            "default",
+        ),
+        ModelPrice(
+            "claude-3-5-sonnet-20241022",
+            "anthropic",
+            _SEED_DATE,
+            3.0,
+            15.0,
+            3.75,
+            0.30,
+            "default",
+        ),
+        ModelPrice(
+            "claude-3-sonnet-20241022",
+            "anthropic",
+            _SEED_DATE,
+            3.0,
+            15.0,
+            3.75,
+            0.30,
+            "default",
+        ),
+        ModelPrice(
+            "claude-3-5-haiku-20241022",
+            "anthropic",
+            _SEED_DATE,
+            1.0,
+            5.0,
+            1.25,
+            0.10,
+            "default",
+        ),
+        ModelPrice(
+            "claude-3-opus-20240229",
+            "anthropic",
+            _SEED_DATE,
+            15.0,
+            75.0,
+            18.75,
+            1.50,
+            "default",
+        ),
         ModelPrice("gpt-4o", "openai", _SEED_DATE, 5.0, 15.0, None, None, "default"),
     ]
 )
@@ -321,7 +383,7 @@ class CostStore:
                 cache_read_tokens, output_tokens, latency_ms, session_id,
                 turn_index, request_id, status, error_type, timestamp
             ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
-                      COALESCE(?, CURRENT_TIMESTAMP))
+                      COALESCE(?, strftime('%Y-%m-%dT%H:%M:%fZ', 'now')))
             """,
             (
                 event.experiment_id,

--- a/src/marcus_mcp/server.py
+++ b/src/marcus_mcp/server.py
@@ -58,6 +58,11 @@ from src.core.service_registry import (  # noqa: E402
     unregister_marcus_service,
 )
 from src.cost_tracking.ai_usage_middleware import ai_usage_middleware  # noqa: E402
+from src.cost_tracking.cost_recorder import (  # noqa: E402
+    CostRecorder,
+    set_recorder,
+)
+from src.cost_tracking.cost_store import CostStore  # noqa: E402
 from src.cost_tracking.token_tracker import token_tracker  # noqa: E402
 from src.integrations.ai_analysis_engine import AIAnalysisEngine  # noqa: E402
 from src.integrations.kanban_factory import KanbanFactory  # noqa: E402
@@ -117,6 +122,16 @@ class MarcusServer:
 
         # Token tracking for cost monitoring
         self.token_tracker = token_tracker
+
+        # Cost recorder: writes one row per provider LLM call to SQLite,
+        # capturing input / cache_creation / cache_read / output tokens
+        # for the cost dashboard (#409). Stored at ~/.marcus/costs.db.
+        # Best-effort: any store failure is swallowed by the recorder so
+        # the provider call path can never be broken by cost tracking.
+        self.cost_store = CostStore(db_path=Path.home() / ".marcus" / "costs.db")
+        self.cost_store.load_seed_prices()
+        self.cost_recorder = CostRecorder(store=self.cost_store, enabled=True)
+        set_recorder(self.cost_recorder)
 
         # Code analyzer for GitHub
         self.code_analyzer = None

--- a/tests/unit/cost_tracking/test_cost_aggregator.py
+++ b/tests/unit/cost_tracking/test_cost_aggregator.py
@@ -1,0 +1,230 @@
+"""
+Unit tests for src.cost_tracking.cost_aggregator.
+
+Aggregator is read-only: takes a CostStore, returns dicts shaped like the
+Cato ``/api/cost/*`` response payloads documented in #409. Tests seed the
+store with deterministic events and assert the aggregations are correct.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from src.cost_tracking.cost_aggregator import CostAggregator
+from src.cost_tracking.cost_store import (
+    CostStore,
+    Experiment,
+    ModelPrice,
+    TokenEvent,
+)
+
+
+@pytest.fixture
+def store(tmp_path: Path) -> CostStore:
+    """Tmp store seeded with one default Anthropic price."""
+    s = CostStore(db_path=tmp_path / "costs.db")
+    s.record_price(
+        ModelPrice(
+            model="claude-sonnet-4-6",
+            provider="anthropic",
+            effective_from=datetime(2025, 1, 1, tzinfo=timezone.utc),
+            input_per_million=3.0,
+            cache_creation_per_million=3.75,
+            cache_read_per_million=0.30,
+            output_per_million=15.0,
+            source="default",
+        )
+    )
+    return s
+
+
+@pytest.fixture
+def populated_store(store: CostStore) -> CostStore:
+    """Store with one experiment + 3 events covering planner + 2 workers."""
+    store.record_experiment(
+        Experiment(
+            experiment_id="exp_1",
+            project_id="proj_1",
+            project_name="hangman",
+            started_at=datetime(2026, 5, 10, tzinfo=timezone.utc),
+            num_agents=2,
+            total_tasks=10,
+            completed_tasks=4,
+        )
+    )
+    base_kwargs = dict(
+        experiment_id="exp_1",
+        project_id="proj_1",
+        provider="anthropic",
+        model="claude-sonnet-4-6",
+    )
+    # Planner: parse_prd
+    store.record_event(
+        TokenEvent(
+            agent_id="planner",
+            agent_role="planner",
+            operation="parse_prd",
+            input_tokens=1000,
+            output_tokens=500,
+            **base_kwargs,
+        )
+    )
+    # Worker 1: turn 1
+    store.record_event(
+        TokenEvent(
+            agent_id="agent_unicorn_1",
+            agent_role="worker",
+            operation="turn",
+            task_id="t_1",
+            session_id="s_1",
+            turn_index=1,
+            input_tokens=2000,
+            cache_creation_tokens=1000,
+            cache_read_tokens=500,
+            output_tokens=300,
+            **base_kwargs,
+        )
+    )
+    # Worker 2: turn 1
+    store.record_event(
+        TokenEvent(
+            agent_id="agent_unicorn_2",
+            agent_role="worker",
+            operation="turn",
+            task_id="t_2",
+            session_id="s_2",
+            turn_index=1,
+            input_tokens=3000,
+            cache_creation_tokens=0,
+            cache_read_tokens=2000,
+            output_tokens=400,
+            **base_kwargs,
+        )
+    )
+    return store
+
+
+@pytest.fixture
+def agg(populated_store: CostStore) -> CostAggregator:
+    """Aggregator over the populated store."""
+    return CostAggregator(store=populated_store)
+
+
+class TestExperimentSummary:
+    """Top-level summary used by /api/cost/experiments/{id}."""
+
+    def test_returns_metadata(self, agg: CostAggregator) -> None:
+        """Summary includes project_id, name, totals from experiments table."""
+        s = agg.experiment_summary("exp_1")
+        assert s["experiment_id"] == "exp_1"
+        assert s["project_id"] == "proj_1"
+        assert s["project_name"] == "hangman"
+        assert s["total_tasks"] == 10
+        assert s["completed_tasks"] == 4
+
+    def test_summary_aggregates_token_totals(self, agg: CostAggregator) -> None:
+        """summary.total_tokens sums across all event types."""
+        s = agg.experiment_summary("exp_1")
+        # 1500 (planner) + 3800 (w1) + 5400 (w2) = 10700
+        assert s["summary"]["total_tokens"] == 10700
+        assert s["summary"]["total_events"] == 3
+
+    def test_summary_breaks_down_by_role(self, agg: CostAggregator) -> None:
+        """by_role groups planner vs worker."""
+        s = agg.experiment_summary("exp_1")
+        roles = {r["role"]: r for r in s["by_role"]}
+        assert roles["planner"]["events"] == 1
+        assert roles["worker"]["events"] == 2
+
+    def test_summary_breaks_down_by_agent(self, agg: CostAggregator) -> None:
+        """by_agent has one row per distinct agent_id."""
+        s = agg.experiment_summary("exp_1")
+        agents = {a["agent_id"]: a for a in s["by_agent"]}
+        assert set(agents.keys()) == {"planner", "agent_unicorn_1", "agent_unicorn_2"}
+        assert agents["agent_unicorn_2"]["turns"] == 1
+
+    def test_summary_breaks_down_by_task(self, agg: CostAggregator) -> None:
+        """by_task ignores rows with NULL task_id."""
+        s = agg.experiment_summary("exp_1")
+        task_ids = {t["task_id"] for t in s["by_task"]}
+        assert task_ids == {"t_1", "t_2"}  # planner row excluded
+
+    def test_summary_includes_cache_hit_rate(self, agg: CostAggregator) -> None:
+        """cache_hit_rate = cache_read / (input + cache_creation + cache_read)."""
+        s = agg.experiment_summary("exp_1")
+        # totals: input=6000, cache_creation=1000, cache_read=2500
+        # hit_rate = 2500 / 9500 ≈ 0.2632
+        assert s["summary"]["cache_hit_rate"] == pytest.approx(2500 / 9500, rel=1e-3)
+
+    def test_summary_returns_none_for_unknown_experiment(
+        self, agg: CostAggregator
+    ) -> None:
+        """Querying a non-existent experiment returns None."""
+        assert agg.experiment_summary("nonexistent") is None
+
+
+class TestSessionTurns:
+    """Per-session turn trajectory used by drill-down."""
+
+    def test_returns_turns_in_order(self, populated_store: CostStore) -> None:
+        """session_turns sorts ascending by turn_index."""
+        # Add a 2nd turn for s_1
+        populated_store.record_event(
+            TokenEvent(
+                experiment_id="exp_1",
+                project_id="proj_1",
+                agent_id="agent_unicorn_1",
+                agent_role="worker",
+                operation="turn",
+                session_id="s_1",
+                turn_index=2,
+                provider="anthropic",
+                model="claude-sonnet-4-6",
+                input_tokens=500,
+                output_tokens=100,
+            )
+        )
+        agg = CostAggregator(store=populated_store)
+        turns = agg.session_turns("s_1")
+        assert [t["turn_index"] for t in turns] == [1, 2]
+        assert turns[0]["total_tokens"] == 2000 + 1000 + 500 + 300
+
+
+class TestExperimentList:
+    """List view used by /api/cost/experiments."""
+
+    def test_lists_experiments_with_summary(self, populated_store: CostStore) -> None:
+        """Each row has totals attached."""
+        agg = CostAggregator(store=populated_store)
+        rows = agg.list_experiments()
+        assert len(rows) == 1
+        assert rows[0]["experiment_id"] == "exp_1"
+        assert rows[0]["total_tokens"] == 10700
+
+    def test_filter_by_project(self, populated_store: CostStore) -> None:
+        """project_id filter narrows the set."""
+        populated_store.record_experiment(
+            Experiment(
+                experiment_id="exp_2",
+                project_id="other",
+                started_at=datetime(2026, 5, 11, tzinfo=timezone.utc),
+            )
+        )
+        agg = CostAggregator(store=populated_store)
+        rows = agg.list_experiments(project_id="proj_1")
+        assert {r["experiment_id"] for r in rows} == {"exp_1"}
+
+
+class TestCacheHitRate:
+    """Cache hit rate per agent for a given experiment."""
+
+    def test_per_agent_hit_rate(self, agg: CostAggregator) -> None:
+        """cache_hit_rate is computed per agent independently."""
+        rates = agg.cache_hit_rate_by_agent("exp_1")
+        agent_2 = next(r for r in rates if r["agent_id"] == "agent_unicorn_2")
+        # agent_2: input=3000, cache_creation=0, cache_read=2000
+        # hit_rate = 2000 / 5000 = 0.40
+        assert agent_2["cache_hit_rate"] == pytest.approx(0.40, rel=1e-6)

--- a/tests/unit/cost_tracking/test_cost_recorder.py
+++ b/tests/unit/cost_tracking/test_cost_recorder.py
@@ -1,0 +1,177 @@
+"""
+Unit tests for src.cost_tracking.cost_recorder.
+
+The recorder is a singleton that providers call after each successful LLM
+request. It writes one row to the configured CostStore using the active
+planner context (experiment_id/project_id). These tests verify:
+
+- Recorder writes rows when configured with a store.
+- Cache tokens (creation + read) are persisted.
+- When no context is set, events use the ``'unassigned'`` fallback.
+- Disabling the recorder is a no-op (safe for tests / minimal deployments).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from src.cost_tracking.cost_recorder import (
+    CostRecorder,
+    PlannerContext,
+    get_recorder,
+    set_recorder,
+)
+from src.cost_tracking.cost_store import CostStore
+
+
+@pytest.fixture
+def store(tmp_path: Path) -> CostStore:
+    """Tmp CostStore with default seed prices for cost-view checks."""
+    s = CostStore(db_path=tmp_path / "costs.db")
+    s.load_seed_prices()
+    return s
+
+
+@pytest.fixture
+def recorder(store: CostStore) -> CostRecorder:
+    """Recorder bound to a tmp store."""
+    return CostRecorder(store=store, enabled=True)
+
+
+class TestRecordPlannerCall:
+    """The main provider-side entry point: ``record_planner_call``."""
+
+    def test_writes_event_with_active_context(
+        self, recorder: CostRecorder, store: CostStore
+    ) -> None:
+        """When a PlannerContext is active, event uses its ids."""
+        with recorder.planner_context(
+            PlannerContext(experiment_id="exp_42", project_id="proj_42")
+        ):
+            recorder.record_planner_call(
+                operation="parse_prd",
+                provider="anthropic",
+                model="claude-sonnet-4-6",
+                input_tokens=100,
+                cache_creation_tokens=200,
+                cache_read_tokens=400,
+                output_tokens=50,
+            )
+        row = store.conn.execute(
+            "SELECT experiment_id, project_id, agent_role, operation, "
+            "input_tokens, cache_creation_tokens, cache_read_tokens, "
+            "output_tokens FROM token_events"
+        ).fetchone()
+        assert row == ("exp_42", "proj_42", "planner", "parse_prd", 100, 200, 400, 50)
+
+    def test_uses_unassigned_fallback_when_no_context(
+        self, recorder: CostRecorder, store: CostStore
+    ) -> None:
+        """No active context → experiment_id and project_id default to 'unassigned'."""
+        recorder.record_planner_call(
+            operation="parse_prd",
+            provider="anthropic",
+            model="claude-sonnet-4-6",
+            input_tokens=10,
+            output_tokens=5,
+        )
+        exp, proj = store.conn.execute(
+            "SELECT experiment_id, project_id FROM token_events"
+        ).fetchone()
+        assert exp == "unassigned"
+        assert proj == "unassigned"
+
+    def test_disabled_recorder_is_noop(self, store: CostStore) -> None:
+        """A disabled recorder writes nothing — safe for tests / minimal deploys."""
+        rec = CostRecorder(store=store, enabled=False)
+        rec.record_planner_call(
+            operation="parse_prd",
+            provider="anthropic",
+            model="claude-sonnet-4-6",
+            input_tokens=100,
+            output_tokens=50,
+        )
+        count = store.conn.execute("SELECT COUNT(*) FROM token_events").fetchone()[0]
+        assert count == 0
+
+    def test_swallows_store_errors(
+        self, recorder: CostRecorder, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Recorder must never raise into the provider call path."""
+
+        def boom(_: object) -> None:
+            raise RuntimeError("simulated store failure")
+
+        monkeypatch.setattr(recorder.store, "record_event", boom)
+        # Should not raise
+        recorder.record_planner_call(
+            operation="parse_prd",
+            provider="anthropic",
+            model="claude-sonnet-4-6",
+            input_tokens=10,
+            output_tokens=5,
+        )
+
+
+class TestPlannerContextStack:
+    """Nested contexts behave LIFO (innermost wins)."""
+
+    def test_nested_context_uses_innermost(
+        self, recorder: CostRecorder, store: CostStore
+    ) -> None:
+        """Innermost context's ids are used while it's active."""
+        with recorder.planner_context(
+            PlannerContext(experiment_id="outer", project_id="p")
+        ):
+            with recorder.planner_context(
+                PlannerContext(experiment_id="inner", project_id="p")
+            ):
+                recorder.record_planner_call(
+                    operation="op",
+                    provider="anthropic",
+                    model="claude-sonnet-4-6",
+                    input_tokens=1,
+                    output_tokens=1,
+                )
+        exp = store.conn.execute("SELECT experiment_id FROM token_events").fetchone()[0]
+        assert exp == "inner"
+
+    def test_context_pops_correctly(
+        self, recorder: CostRecorder, store: CostStore
+    ) -> None:
+        """After leaving inner context, outer is restored."""
+        with recorder.planner_context(
+            PlannerContext(experiment_id="outer", project_id="p")
+        ):
+            with recorder.planner_context(
+                PlannerContext(experiment_id="inner", project_id="p")
+            ):
+                pass
+            recorder.record_planner_call(
+                operation="op",
+                provider="anthropic",
+                model="claude-sonnet-4-6",
+                input_tokens=1,
+                output_tokens=1,
+            )
+        exp = store.conn.execute("SELECT experiment_id FROM token_events").fetchone()[0]
+        assert exp == "outer"
+
+
+class TestSingleton:
+    """Module-level get/set helpers."""
+
+    def test_get_recorder_returns_same_instance(self) -> None:
+        """get_recorder is idempotent."""
+        a = get_recorder()
+        b = get_recorder()
+        assert a is b
+
+    def test_set_recorder_replaces_singleton(self, recorder: CostRecorder) -> None:
+        """set_recorder swaps the module-level instance."""
+        set_recorder(recorder)
+        assert get_recorder() is recorder
+        # Reset for downstream tests
+        set_recorder(None)

--- a/tests/unit/cost_tracking/test_cost_store.py
+++ b/tests/unit/cost_tracking/test_cost_store.py
@@ -1,0 +1,317 @@
+"""
+Unit tests for src.cost_tracking.cost_store.
+
+Validates schema creation, seed loading, event/experiment writes, and the
+v_event_cost view's price-versioning behavior.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+from src.cost_tracking.cost_store import (
+    CostStore,
+    Experiment,
+    ModelPrice,
+    TokenEvent,
+)
+
+
+@pytest.fixture
+def store(tmp_path: Path) -> CostStore:
+    """Provide a fresh CostStore backed by a tmp SQLite file."""
+    db = tmp_path / "costs.db"
+    return CostStore(db_path=db)
+
+
+@pytest.fixture
+def seeded_store(store: CostStore) -> CostStore:
+    """CostStore with a single default model_prices row for tests."""
+    store.record_price(
+        ModelPrice(
+            model="claude-sonnet-4-6",
+            provider="anthropic",
+            effective_from=datetime(2025, 1, 1, tzinfo=timezone.utc),
+            input_per_million=3.0,
+            cache_creation_per_million=3.75,
+            cache_read_per_million=0.30,
+            output_per_million=15.0,
+            source="default",
+        )
+    )
+    return store
+
+
+@pytest.fixture
+def base_event() -> TokenEvent:
+    """Reusable TokenEvent for happy-path tests."""
+    return TokenEvent(
+        experiment_id="exp_1",
+        project_id="proj_1",
+        agent_id="planner",
+        agent_role="planner",
+        operation="parse_prd",
+        provider="anthropic",
+        model="claude-sonnet-4-6",
+        input_tokens=1000,
+        cache_creation_tokens=2000,
+        cache_read_tokens=4000,
+        output_tokens=500,
+    )
+
+
+class TestSchemaInitialization:
+    """Schema and view creation."""
+
+    def test_init_creates_all_tables(self, store: CostStore) -> None:
+        """All four schema objects exist after construction."""
+        names = {
+            row[0]
+            for row in store.conn.execute(
+                "SELECT name FROM sqlite_master WHERE type IN ('table','view')"
+            )
+        }
+        assert {"experiments", "token_events", "model_prices", "v_event_cost"} <= names
+
+    def test_init_enables_wal_mode(self, store: CostStore) -> None:
+        """WAL mode enabled for safe concurrent reads during writes."""
+        mode = store.conn.execute("PRAGMA journal_mode").fetchone()[0]
+        assert mode.lower() == "wal"
+
+    def test_token_events_total_tokens_is_generated(
+        self, seeded_store: CostStore, base_event: TokenEvent
+    ) -> None:
+        """total_tokens column auto-sums the four input fields."""
+        seeded_store.record_event(base_event)
+        row = seeded_store.conn.execute(
+            "SELECT total_tokens FROM token_events"
+        ).fetchone()
+        assert row[0] == 1000 + 2000 + 4000 + 500
+
+
+class TestRecordEvent:
+    """token_events insert behavior."""
+
+    def test_records_event_returns_event_id(
+        self, seeded_store: CostStore, base_event: TokenEvent
+    ) -> None:
+        """record_event returns the auto-incremented PK."""
+        event_id = seeded_store.record_event(base_event)
+        assert isinstance(event_id, int) and event_id > 0
+
+    def test_records_event_persists_all_fields(
+        self, seeded_store: CostStore, base_event: TokenEvent
+    ) -> None:
+        """Every TokenEvent field round-trips through the DB."""
+        seeded_store.record_event(base_event)
+        row = seeded_store.conn.execute(
+            "SELECT experiment_id, agent_id, agent_role, operation, "
+            "input_tokens, cache_creation_tokens, cache_read_tokens, "
+            "output_tokens FROM token_events"
+        ).fetchone()
+        assert row == (
+            "exp_1",
+            "planner",
+            "planner",
+            "parse_prd",
+            1000,
+            2000,
+            4000,
+            500,
+        )
+
+    def test_default_status_is_ok(
+        self, seeded_store: CostStore, base_event: TokenEvent
+    ) -> None:
+        """status defaults to 'ok' when not provided."""
+        seeded_store.record_event(base_event)
+        status = seeded_store.conn.execute(
+            "SELECT status FROM token_events"
+        ).fetchone()[0]
+        assert status == "ok"
+
+
+class TestRecordExperiment:
+    """experiments table upsert behavior."""
+
+    def test_records_new_experiment(self, store: CostStore) -> None:
+        """A fresh experiment_id inserts a row."""
+        store.record_experiment(
+            Experiment(
+                experiment_id="exp_1",
+                project_id="proj_1",
+                started_at=datetime(2026, 5, 10, tzinfo=timezone.utc),
+                project_name="hangman",
+            )
+        )
+        row = store.conn.execute(
+            "SELECT project_id, project_name FROM experiments"
+        ).fetchone()
+        assert row == ("proj_1", "hangman")
+
+    def test_upserts_existing_experiment(self, store: CostStore) -> None:
+        """Re-recording the same experiment_id updates fields, doesn't duplicate."""
+        started = datetime(2026, 5, 10, tzinfo=timezone.utc)
+        store.record_experiment(
+            Experiment(experiment_id="exp_1", project_id="p", started_at=started)
+        )
+        store.record_experiment(
+            Experiment(
+                experiment_id="exp_1",
+                project_id="p",
+                started_at=started,
+                completed_tasks=5,
+            )
+        )
+        rows = store.conn.execute("SELECT COUNT(*) FROM experiments").fetchone()
+        assert rows[0] == 1
+        completed = store.conn.execute(
+            "SELECT completed_tasks FROM experiments WHERE experiment_id='exp_1'"
+        ).fetchone()[0]
+        assert completed == 5
+
+
+class TestRecordPrice:
+    """model_prices versioning."""
+
+    def test_records_price(self, store: CostStore) -> None:
+        """A single price row inserts cleanly."""
+        store.record_price(
+            ModelPrice(
+                model="m",
+                provider="p",
+                effective_from=datetime(2025, 1, 1, tzinfo=timezone.utc),
+                input_per_million=1.0,
+                output_per_million=2.0,
+                source="default",
+            )
+        )
+        row = store.conn.execute("SELECT COUNT(*) FROM model_prices").fetchone()
+        assert row[0] == 1
+
+    def test_versioned_prices_coexist(self, store: CostStore) -> None:
+        """Two prices for the same (model, provider) at different effective_from coexist."""
+        for ef in (
+            datetime(2025, 1, 1, tzinfo=timezone.utc),
+            datetime(2026, 1, 1, tzinfo=timezone.utc),
+        ):
+            store.record_price(
+                ModelPrice(
+                    model="m",
+                    provider="p",
+                    effective_from=ef,
+                    input_per_million=1.0,
+                    output_per_million=2.0,
+                    source="default",
+                )
+            )
+        count = store.conn.execute("SELECT COUNT(*) FROM model_prices").fetchone()[0]
+        assert count == 2
+
+    def test_duplicate_effective_from_rejected(self, store: CostStore) -> None:
+        """Same (model, provider, effective_from) twice raises IntegrityError."""
+        ef = datetime(2025, 1, 1, tzinfo=timezone.utc)
+        price = ModelPrice(
+            model="m",
+            provider="p",
+            effective_from=ef,
+            input_per_million=1.0,
+            output_per_million=2.0,
+            source="default",
+        )
+        store.record_price(price)
+        with pytest.raises(sqlite3.IntegrityError):
+            store.record_price(price)
+
+
+class TestEventCostView:
+    """v_event_cost computes cost using the price active at event timestamp."""
+
+    def test_cost_uses_active_price(
+        self, seeded_store: CostStore, base_event: TokenEvent
+    ) -> None:
+        """1000 in + 2000 cache_create + 4000 cache_read + 500 out at default price."""
+        seeded_store.record_event(base_event)
+        cost = seeded_store.conn.execute(
+            "SELECT cost_usd FROM v_event_cost"
+        ).fetchone()[0]
+        # 1000*3/1e6 + 2000*3.75/1e6 + 4000*0.30/1e6 + 500*15/1e6
+        # = 0.003 + 0.0075 + 0.0012 + 0.0075 = 0.0192
+        assert cost == pytest.approx(0.0192, rel=1e-6)
+
+    def test_cost_uses_historical_price_when_event_predates_new_one(
+        self, store: CostStore
+    ) -> None:
+        """Event at t=2025-06 uses 2025-01 price even if 2026-01 price exists."""
+        old = datetime(2025, 1, 1, tzinfo=timezone.utc)
+        new = datetime(2026, 1, 1, tzinfo=timezone.utc)
+        store.record_price(
+            ModelPrice(
+                model="m",
+                provider="p",
+                effective_from=old,
+                input_per_million=1.0,
+                output_per_million=1.0,
+                source="default",
+            )
+        )
+        store.record_price(
+            ModelPrice(
+                model="m",
+                provider="p",
+                effective_from=new,
+                input_per_million=10.0,
+                output_per_million=10.0,
+                source="default",
+            )
+        )
+        # Event in mid-2025 should use old price
+        store.record_event(
+            TokenEvent(
+                experiment_id="e",
+                project_id="proj",
+                agent_id="a",
+                agent_role="planner",
+                operation="op",
+                provider="p",
+                model="m",
+                input_tokens=1_000_000,
+                output_tokens=0,
+                timestamp=datetime(2025, 6, 1, tzinfo=timezone.utc),
+            )
+        )
+        cost = store.conn.execute("SELECT cost_usd FROM v_event_cost").fetchone()[0]
+        assert cost == pytest.approx(1.0, rel=1e-6)
+
+
+class TestSeedLoader:
+    """load_seed_prices idempotency."""
+
+    def test_load_seed_inserts_default_prices(self, store: CostStore) -> None:
+        """Calling load_seed_prices populates the default Anthropic / OpenAI rows."""
+        store.load_seed_prices()
+        models = {
+            row[0]
+            for row in store.conn.execute(
+                "SELECT model FROM model_prices WHERE source='default'"
+            )
+        }
+        # At least the headline Anthropic + OpenAI defaults should be there
+        assert "claude-sonnet-4-6" in models
+        assert "claude-haiku-4-5" in models
+
+    def test_load_seed_idempotent(self, store: CostStore) -> None:
+        """Running load_seed_prices twice doesn't duplicate rows."""
+        store.load_seed_prices()
+        first_count = store.conn.execute(
+            "SELECT COUNT(*) FROM model_prices"
+        ).fetchone()[0]
+        store.load_seed_prices()
+        second_count = store.conn.execute(
+            "SELECT COUNT(*) FROM model_prices"
+        ).fetchone()[0]
+        assert first_count == second_count

--- a/tests/unit/cost_tracking/test_cost_store.py
+++ b/tests/unit/cost_tracking/test_cost_store.py
@@ -288,6 +288,114 @@ class TestEventCostView:
         assert cost == pytest.approx(1.0, rel=1e-6)
 
 
+class TestCodexP1LegacyModelSeeds:
+    """Regression: out-of-box Anthropic models must seed (Codex P1 on PR #497).
+
+    Marcus's default config uses ``claude-3-haiku-20240307`` and the historic
+    settings default ``claude-3-sonnet-20241022``. Without seed rows, the
+    inner join in ``v_event_cost`` drops every event for those models from
+    aggregations.
+    """
+
+    def test_default_anthropic_model_has_seed_price(self, store: CostStore) -> None:
+        """The model anthropic_provider.py defaults to is in DEFAULT_SEED."""
+        store.load_seed_prices()
+        models = {
+            row[0]
+            for row in store.conn.execute(
+                "SELECT model FROM model_prices WHERE provider='anthropic'"
+            )
+        }
+        assert "claude-3-haiku-20240307" in models
+        assert "claude-3-sonnet-20241022" in models
+
+    def test_event_for_legacy_model_appears_in_cost_view(
+        self, store: CostStore
+    ) -> None:
+        """Event for claude-3-haiku-20240307 produces a v_event_cost row."""
+        store.load_seed_prices()
+        store.record_event(
+            TokenEvent(
+                experiment_id="e",
+                project_id="p",
+                agent_id="planner",
+                agent_role="planner",
+                operation="parse_prd",
+                provider="anthropic",
+                model="claude-3-haiku-20240307",
+                input_tokens=1_000_000,
+                output_tokens=0,
+            )
+        )
+        cost = store.conn.execute("SELECT cost_usd FROM v_event_cost").fetchone()
+        assert cost is not None  # would be None if INNER JOIN dropped the event
+        assert cost[0] == pytest.approx(0.25, rel=1e-6)
+
+
+class TestCodexP2TimestampFormat:
+    """Regression: same-day price must apply to events lacking explicit ts.
+
+    Codex P2 on PR #497: SQLite's bare CURRENT_TIMESTAMP defaults to
+    ``YYYY-MM-DD HH:MM:SS`` (space separator) while ``record_price``
+    stores ISO format with a ``T`` separator. Lexical comparison in
+    ``v_event_cost`` would silently drop events whose default timestamp
+    sorts before any price row for the same model.
+    """
+
+    def test_event_with_default_timestamp_joins_iso_priced_row(
+        self, store: CostStore
+    ) -> None:
+        """Insert price first, then event without a timestamp; v_event_cost row exists."""
+        store.record_price(
+            ModelPrice(
+                model="m",
+                provider="p",
+                effective_from=datetime(2025, 1, 1, tzinfo=timezone.utc),
+                input_per_million=1.0,
+                output_per_million=1.0,
+                source="default",
+            )
+        )
+        store.record_event(
+            TokenEvent(
+                experiment_id="e",
+                project_id="p",
+                agent_id="planner",
+                agent_role="planner",
+                operation="op",
+                provider="p",
+                model="m",
+                input_tokens=1_000_000,
+                output_tokens=0,
+                # timestamp deliberately omitted — uses SQLite default
+            )
+        )
+        row = store.conn.execute("SELECT cost_usd FROM v_event_cost").fetchone()
+        assert row is not None, "default timestamp format must allow join"
+        assert row[0] == pytest.approx(1.0, rel=1e-6)
+
+    def test_default_timestamp_uses_iso_t_separator(self, store: CostStore) -> None:
+        """Stored default timestamp has the 'T' separator, not a space."""
+        store.load_seed_prices()
+        store.record_event(
+            TokenEvent(
+                experiment_id="e",
+                project_id="p",
+                agent_id="planner",
+                agent_role="planner",
+                operation="op",
+                provider="anthropic",
+                model="claude-3-haiku-20240307",
+                input_tokens=1,
+                output_tokens=1,
+            )
+        )
+        ts = store.conn.execute("SELECT timestamp FROM token_events").fetchone()[0]
+        assert (
+            "T" in ts and " " not in ts
+        ), f"expected ISO format with T separator, got {ts!r}"
+
+
 class TestSeedLoader:
     """load_seed_prices idempotency."""
 

--- a/tests/unit/cost_tracking/test_provider_recording.py
+++ b/tests/unit/cost_tracking/test_provider_recording.py
@@ -1,0 +1,170 @@
+"""
+Unit tests verifying provider HTTP paths emit ``token_events`` rows.
+
+Mocks the HTTP client on each provider so no network calls happen, then
+asserts that a successful ``_call_*`` produces exactly one row in the
+backing CostStore with the expected token counts.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from src.cost_tracking.cost_recorder import (
+    CostRecorder,
+    PlannerContext,
+    set_recorder,
+)
+from src.cost_tracking.cost_store import CostStore
+
+
+@pytest.fixture
+def store(tmp_path: Path) -> CostStore:
+    """Tmp store with default seed prices."""
+    s = CostStore(db_path=tmp_path / "costs.db")
+    s.load_seed_prices()
+    return s
+
+
+@pytest.fixture
+def recorder(store: CostStore) -> CostRecorder:
+    """Bind a fresh enabled recorder to the module singleton."""
+    rec = CostRecorder(store=store, enabled=True)
+    set_recorder(rec)
+    yield rec
+    # Reset for downstream tests
+    set_recorder(None)
+
+
+def _mock_http_response(json_payload: dict[str, Any]) -> MagicMock:
+    """Build a MagicMock that mimics httpx.Response.json() + raise_for_status()."""
+    resp = MagicMock()
+    resp.raise_for_status = MagicMock()
+    resp.json = MagicMock(return_value=json_payload)
+    resp.status_code = 200
+    return resp
+
+
+class TestAnthropicProviderRecords:
+    """anthropic_provider._call_claude must emit one event with cache fields."""
+
+    @pytest.mark.asyncio
+    async def test_call_claude_records_event(
+        self, recorder: CostRecorder, store: CostStore
+    ) -> None:
+        """Successful Claude call writes one row with all four token fields."""
+        from src.ai.providers.anthropic_provider import AnthropicProvider
+
+        provider = AnthropicProvider.__new__(AnthropicProvider)
+        provider.model = "claude-sonnet-4-6"
+        provider.max_tokens = 100
+        provider.temperature = 0.1
+        provider.base_url = "https://api.anthropic.com/v1"
+        provider.client = MagicMock()
+        provider.client.post = AsyncMock(
+            return_value=_mock_http_response(
+                {
+                    "id": "msg_test",
+                    "model": "claude-sonnet-4-6",
+                    "content": [{"text": "ok"}],
+                    "usage": {
+                        "input_tokens": 100,
+                        "cache_creation_input_tokens": 200,
+                        "cache_read_input_tokens": 400,
+                        "output_tokens": 50,
+                    },
+                }
+            )
+        )
+
+        with recorder.planner_context(
+            PlannerContext(experiment_id="e1", project_id="p1")
+        ):
+            result = await provider._call_claude("hi", operation="parse_prd")
+
+        assert result == "ok"
+        row = store.conn.execute(
+            "SELECT input_tokens, cache_creation_tokens, cache_read_tokens, "
+            "output_tokens, operation, provider, request_id "
+            "FROM token_events"
+        ).fetchone()
+        assert row == (100, 200, 400, 50, "parse_prd", "anthropic", "msg_test")
+
+
+class TestLocalProviderRecords:
+    """local_provider._call_local_llm must emit one event tagged 'local'."""
+
+    @pytest.mark.asyncio
+    async def test_call_local_llm_records_event(
+        self, recorder: CostRecorder, store: CostStore
+    ) -> None:
+        """OpenAI-compatible response → one row with prompt_tokens / completion_tokens."""
+        from src.ai.providers.local_provider import LocalLLMProvider
+
+        provider = LocalLLMProvider.__new__(LocalLLMProvider)
+        provider.model = "qwen-25-coder-q5"
+        provider.max_tokens = 100
+        provider.temperature = 0.1
+        provider.base_url = "http://localhost:11434/v1"
+        provider.client = MagicMock()
+        provider.client.post = AsyncMock(
+            return_value=_mock_http_response(
+                {
+                    "id": "cmpl_test",
+                    "choices": [{"message": {"content": "ok"}}],
+                    "usage": {"prompt_tokens": 30, "completion_tokens": 10},
+                }
+            )
+        )
+
+        with recorder.planner_context(
+            PlannerContext(experiment_id="e2", project_id="p2")
+        ):
+            result = await provider._call_local_llm("hi")
+
+        assert result == "ok"
+        row = store.conn.execute(
+            "SELECT input_tokens, output_tokens, provider FROM token_events"
+        ).fetchone()
+        assert row == (30, 10, "local")
+
+
+class TestCloudProviderRecords:
+    """cloud_provider._call_cloud_llm must emit one event tagged 'cloud'."""
+
+    @pytest.mark.asyncio
+    async def test_call_cloud_llm_records_event(
+        self, recorder: CostRecorder, store: CostStore
+    ) -> None:
+        """OpenAI-compatible response on cloud endpoint → 'cloud' provider tag."""
+        from src.ai.providers.cloud_provider import CloudLLMProvider
+
+        provider = CloudLLMProvider.__new__(CloudLLMProvider)
+        provider.model = "deepseek-coder"
+        provider.max_tokens = 100
+        provider.temperature = 0.1
+        provider.client = MagicMock()
+        provider.client.post = AsyncMock(
+            return_value=_mock_http_response(
+                {
+                    "id": "cmpl_cloud",
+                    "choices": [{"message": {"content": "ok"}}],
+                    "usage": {"prompt_tokens": 50, "completion_tokens": 25},
+                }
+            )
+        )
+
+        with recorder.planner_context(
+            PlannerContext(experiment_id="e3", project_id="p3")
+        ):
+            result = await provider._call_cloud_llm("hi")
+
+        assert result == "ok"
+        row = store.conn.execute(
+            "SELECT input_tokens, output_tokens, provider FROM token_events"
+        ).fetchone()
+        assert row == (50, 25, "cloud")


### PR DESCRIPTION
## Summary

Foundation for the unified cost dashboard described in #409. Marcus now records every planner-side LLM call (Anthropic, Cloud, Local) to a SQLite store at \`~/.marcus/costs.db\`, including the cache-token fields the legacy middleware was dropping. A read-only aggregator returns API-shaped dicts ready for Cato's \`/api/cost/*\` endpoints in the next PR.

## Architecture

\`\`\`
[Provider call] → AnthropicProvider._call_claude / *_call_cloud_llm / _call_local_llm
              → get_recorder().record_planner_call(...)
              → CostStore.record_event() → ~/.marcus/costs.db
                                                ↑
                                      CostAggregator queries here,
                                      returns API-shaped dicts
\`\`\`

Tokens are truth (immutable). Cost is derived (prices change). The price-versioned \`v_event_cost\` view computes \`cost_usd\` at query time, so old experiments keep their original cost when prices change.

## What's in this PR

### Phase 1 — Schema + writer (commit \`81f8158c\`)
- \`src/cost_tracking/cost_store.py\` — \`CostStore\` with three tables (\`experiments\`, \`token_events\`, \`model_prices\`) and one view (\`v_event_cost\`).
- WAL mode for safe concurrent reads during writes.
- Versioned pricing — \`effective_from\` makes historical cost stable across price edits.
- Default seed prices for current Anthropic / OpenAI models; loaded idempotently.

### Phase 2 — Planner-side capture (commit \`3ec597d7\`)
- \`src/cost_tracking/cost_recorder.py\` — side-effect-only recorder with a \`ContextVar\`-based \`PlannerContext\` stack. Failures are swallowed so the recorder cannot break a provider call path.
- \`anthropic_provider._call_claude\` captures all four token fields including \`cache_creation_input_tokens\` / \`cache_read_input_tokens\` (previously dropped).
- \`local_provider._call_local_llm\` and \`cloud_provider._call_cloud_llm\` capture \`prompt_tokens\` / \`completion_tokens\`. Provider tag distinguished via \`_cost_provider_name\` hook (\`'local'\` vs \`'cloud'\`).

### Phase 3 — Aggregator (commit \`233efc4d\`)
- \`src/cost_tracking/cost_aggregator.py\` — read-only query layer.
- Methods: \`list_experiments\`, \`experiment_summary\` (full per-experiment breakdown by role/agent/task/operation/model), \`session_turns\` (per-turn trajectory for runaway-loop detection), \`cache_hit_rate_by_agent\`, \`project_totals\`.
- All return dicts shaped like the API responses in #409.

### Phase 4 — Activation (commit \`38775508\`)
- \`MarcusServer.__init__\` opens the store, seeds prices, registers the recorder. Planner data starts landing immediately.

## Behavior change

- New file written: \`~/.marcus/costs.db\`. Created on first server start.
- One row appended per AnthropicProvider/CloudLLM/LocalLLM call.
- No effect on responses; recorder is purely a side effect.
- Without an active \`PlannerContext\` (set by MCP request handlers in a follow-up PR), events use \`'unassigned'\` ids. They still record correctly.

## Test coverage

| File | Tests | Coverage |
|---|---|---|
| \`cost_store.py\` | 15 | 98.89% |
| \`cost_recorder.py\` | 8 | 98.25% |
| \`cost_aggregator.py\` | 11 | 97.56% |
| Provider integration | 3 | (covers all 3 providers) |
| **Total new** | **37** | — |

- mypy \`--strict\` clean on all new files.
- All 573 existing AI provider tests pass.
- All 84 \`marcus_mcp\` tests pass.

## Test plan

- [x] \`pytest tests/unit/cost_tracking/\` — 37 passed
- [x] \`pytest tests/unit/ai/\` — 573 passed
- [x] \`pytest tests/unit/marcus_mcp/\` — 84 passed
- [x] mypy --strict on \`src/cost_tracking/*.py\` and patched providers — clean
- [x] End-to-end smoke: \`record_planner_call\` → row in \`v_event_cost\` with correct \`cost_usd\`
- [ ] Run a real experiment, verify rows land in \`~/.marcus/costs.db\`

## What's next (separate PRs)

- **Phase 5** — Worker JSONL ingester (tails \`~/.claude/projects/*/<session>.jsonl\` per spawned agent, ingests \`usage\` blocks per turn).
- **Phase 6** — MCP tool \`get_cost_summary\` so agents and Cato can query without direct DB access.
- **Phase 7** — \`MCP request handler\` push of \`PlannerContext\` so events attribute to the correct \`experiment_id\` / \`project_id\` instead of \`'unassigned'\`.
- **Phase 8** — Cato side: \`/api/cost/*\` endpoints + \`/cost\` dashboard route with 4 tabs (real-time, historical, budget, pricing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)