### PR TITLE
feat(cost-tracking): worker JSONL ingester (#409 phase 4)

### DIFF
--- a/src/cost_tracking/worker_ingester.py
+++ b/src/cost_tracking/worker_ingester.py
@@ -1,0 +1,237 @@
+"""
+Batch ingester for Claude Code worker session JSONL logs.
+
+Spawned worker agents (see ``dev-tools/experiments/runners/spawn_agents.py``)
+each run a Claude Code CLI subprocess that writes a session log to
+``~/.claude/projects/<dir>/<session-id>.jsonl``. Every assistant turn lands
+as a JSON record carrying a ``message.usage`` block with input / cache /
+output token counts. This module ingests those logs into the Marcus cost
+store so the Cato dashboard can display per-agent / per-task / per-turn
+spend alongside the planner-side data captured in
+:mod:`src.cost_tracking.cost_recorder`.
+
+Design choices
+--------------
+- **Batch, not tail.** The ingester reads a file end-to-end on each call.
+  A separate live-tail mode can be layered on later via filesystem
+  watchers; this batch implementation is simpler to test and is enough
+  for post-experiment analysis.
+- **UUID-based dedup.** Each JSONL record has a unique ``uuid`` field.
+  The ingester tracks already-seen UUIDs (per session) in an in-memory
+  set scoped to the ``CostStore`` instance, so re-running ``ingest_file``
+  is idempotent within a single process. Cross-process dedup would
+  require a side table — added later if needed.
+- **Caller supplies binding.** The ingester does not know how to map a
+  session/cwd to an ``agent_id``/``experiment_id``/``project_id``. Callers
+  provide a ``resolve_binding`` callable (typically wired from the spawn
+  registry written by ``spawn_agents.py``).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from collections import defaultdict
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Callable, Dict, Optional, Set
+
+from src.cost_tracking.cost_store import CostStore, TokenEvent
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Types
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class AgentBinding:
+    """Per-event attribution returned by a caller's ``resolve_binding``.
+
+    Parameters
+    ----------
+    agent_id : str
+        Stable agent name as registered with Marcus (e.g.
+        ``'agent_unicorn_1'``).
+    experiment_id : str
+        Marcus experiment ID this session belongs to.
+    project_id : str
+        Marcus project ID — usually the same value the planner uses.
+    parent_agent_id : str, optional
+        For subagents launched by another worker, the parent's
+        ``agent_id``. Plain workers leave this ``None``.
+    task_id : str, optional
+        Active task at the time of the turn, when known. The ingester
+        cannot infer this from the JSONL alone; callers may extract it
+        from MCP tool-call records and pass it in.
+    """
+
+    agent_id: str
+    experiment_id: str
+    project_id: str
+    parent_agent_id: Optional[str] = None
+    task_id: Optional[str] = None
+
+
+# ``resolve_binding`` receives the raw JSONL record and returns either a
+# binding (event will be ingested) or ``None`` (event will be dropped).
+ResolveBinding = Callable[[Dict[str, Any]], Optional[AgentBinding]]
+
+
+# ---------------------------------------------------------------------------
+# Ingester
+# ---------------------------------------------------------------------------
+
+
+class WorkerJSONLIngester:
+    """Reads Claude Code session JSONL files and writes ``token_events`` rows.
+
+    Parameters
+    ----------
+    store : CostStore
+        Backing store for ``token_events`` writes.
+    resolve_binding : callable
+        ``(record: dict) -> AgentBinding | None``. Returning ``None``
+        skips the event. Use this to filter out sessions you don't care
+        about (e.g. project-creator agents that share the same JSONL
+        directory but should not count against worker cost).
+
+    Notes
+    -----
+    Per-session turn indices and seen-UUID sets are kept on the
+    instance, so reusing one ingester across multiple ``ingest_file``
+    calls preserves both counters and dedup state.
+    """
+
+    def __init__(
+        self,
+        *,
+        store: CostStore,
+        resolve_binding: ResolveBinding,
+    ) -> None:
+        self.store = store
+        self.resolve_binding = resolve_binding
+        self._turn_counter: Dict[str, int] = defaultdict(int)
+        self._seen_uuids: Set[str] = set()
+
+    # -- file-level API ---------------------------------------------------
+
+    def ingest_file(self, path: Path) -> int:
+        """Ingest every assistant record in one JSONL file.
+
+        Parameters
+        ----------
+        path : Path
+            Path to a Claude Code session JSONL.
+
+        Returns
+        -------
+        int
+            Number of ``token_events`` rows inserted by this call.
+        """
+        inserted = 0
+        with path.open("r", encoding="utf-8") as fh:
+            for raw in fh:
+                line = raw.strip()
+                if not line:
+                    continue
+                try:
+                    record = json.loads(line)
+                except json.JSONDecodeError:
+                    logger.debug("skipping malformed JSONL line in %s", path)
+                    continue
+                if self._ingest_record(record):
+                    inserted += 1
+        return inserted
+
+    def ingest_directory(self, dir_path: Path) -> int:
+        """Recursively ingest every ``*.jsonl`` file under a directory."""
+        total = 0
+        for jsonl in sorted(dir_path.rglob("*.jsonl")):
+            total += self.ingest_file(jsonl)
+        return total
+
+    # -- record-level helpers --------------------------------------------
+
+    def _ingest_record(self, record: Dict[str, Any]) -> bool:
+        """Insert one token_events row if the record is an assistant turn.
+
+        Returns
+        -------
+        bool
+            True if a row was inserted, False if the record was skipped
+            (wrong type, missing usage, deduped, or binding rejected).
+        """
+        if record.get("type") != "assistant":
+            return False
+        message = record.get("message") or {}
+        usage = message.get("usage") if isinstance(message, dict) else None
+        if not isinstance(usage, dict):
+            return False
+
+        uuid = record.get("uuid")
+        if uuid and uuid in self._seen_uuids:
+            return False
+
+        binding = self.resolve_binding(record)
+        if binding is None:
+            return False
+
+        session_id = record.get("sessionId") or "unknown"
+        self._turn_counter[session_id] += 1
+        turn_index = self._turn_counter[session_id]
+
+        event = TokenEvent(
+            experiment_id=binding.experiment_id,
+            project_id=binding.project_id,
+            agent_id=binding.agent_id,
+            agent_role="worker",
+            parent_agent_id=binding.parent_agent_id,
+            task_id=binding.task_id,
+            operation="turn",
+            provider="anthropic",
+            model=str(message.get("model", "unknown")),
+            input_tokens=int(usage.get("input_tokens", 0)),
+            cache_creation_tokens=int(usage.get("cache_creation_input_tokens", 0)),
+            cache_read_tokens=int(usage.get("cache_read_input_tokens", 0)),
+            output_tokens=int(usage.get("output_tokens", 0)),
+            session_id=session_id,
+            turn_index=turn_index,
+            request_id=record.get("requestId"),
+            timestamp=_parse_timestamp(record.get("timestamp")),
+        )
+        try:
+            self.store.record_event(event)
+        except Exception as exc:  # pragma: no cover
+            logger.warning("ingester swallowed store error: %s", exc)
+            # Do not advance dedup counters on insert failure; let a
+            # retry pick this record up.
+            self._turn_counter[session_id] -= 1
+            return False
+
+        if uuid:
+            self._seen_uuids.add(uuid)
+        return True
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _parse_timestamp(raw: Optional[str]) -> Optional[datetime]:
+    """Parse Claude Code's ISO-Z timestamps into aware datetimes.
+
+    Returns ``None`` when ``raw`` is empty or unparseable, letting the
+    store fall back to its default timestamp expression.
+    """
+    if not raw:
+        return None
+    try:
+        # Python 3.11+ accepts the trailing 'Z' via fromisoformat directly.
+        return datetime.fromisoformat(raw.replace("Z", "+00:00"))
+    except ValueError:
+        return None

--- a/tests/unit/cost_tracking/test_worker_ingester.py
+++ b/tests/unit/cost_tracking/test_worker_ingester.py
@@ -1,0 +1,333 @@
+"""
+Unit tests for src.cost_tracking.worker_ingester.
+
+The ingester reads Claude Code session JSONL files (one per spawned worker
+agent) and inserts a ``token_events`` row for every ``type == "assistant"``
+record that carries a ``message.usage`` block. These tests use synthetic
+fixture JSONL written to ``tmp_path`` so no real Claude Code session is
+required.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+import pytest
+
+from src.cost_tracking.cost_store import CostStore
+from src.cost_tracking.worker_ingester import (
+    AgentBinding,
+    WorkerJSONLIngester,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def store(tmp_path: Path) -> CostStore:
+    """Tmp store seeded with the default Anthropic prices."""
+    s = CostStore(db_path=tmp_path / "costs.db")
+    s.load_seed_prices()
+    return s
+
+
+def _assistant_record(
+    *,
+    session_id: str = "sess_1",
+    uuid: str = "u_1",
+    request_id: str = "req_1",
+    timestamp: str = "2026-05-10T14:00:00.000Z",
+    cwd: str = "/Users/me/exp/agent_1",
+    model: str = "claude-sonnet-4-6",
+    input_tokens: int = 100,
+    cache_creation_input_tokens: int = 200,
+    cache_read_input_tokens: int = 400,
+    output_tokens: int = 50,
+) -> Dict[str, Any]:
+    """Build an ``assistant``-type JSONL record matching the real shape."""
+    return {
+        "type": "assistant",
+        "uuid": uuid,
+        "sessionId": session_id,
+        "requestId": request_id,
+        "timestamp": timestamp,
+        "cwd": cwd,
+        "message": {
+            "model": model,
+            "usage": {
+                "input_tokens": input_tokens,
+                "cache_creation_input_tokens": cache_creation_input_tokens,
+                "cache_read_input_tokens": cache_read_input_tokens,
+                "output_tokens": output_tokens,
+            },
+        },
+    }
+
+
+def _user_record() -> Dict[str, Any]:
+    """Non-assistant record that the ingester must skip."""
+    return {"type": "user", "sessionId": "sess_1", "content": "hi"}
+
+
+def _queue_op_record() -> Dict[str, Any]:
+    """A queue-operation record (no usage block) — must be skipped."""
+    return {"type": "queue-operation", "operation": "enqueue"}
+
+
+def _write_jsonl(path: Path, records: list[Dict[str, Any]]) -> None:
+    """Serialize records as one JSON object per line."""
+    path.write_text("\n".join(json.dumps(r) for r in records) + "\n")
+
+
+def _binding(
+    agent_id: str = "agent_unicorn_1",
+    experiment_id: str = "exp_1",
+    project_id: str = "proj_1",
+) -> AgentBinding:
+    """Convenience binding constructor for tests."""
+    return AgentBinding(
+        agent_id=agent_id, experiment_id=experiment_id, project_id=project_id
+    )
+
+
+# ---------------------------------------------------------------------------
+# ingest_file
+# ---------------------------------------------------------------------------
+
+
+class TestIngestFile:
+    """Single-file batch ingestion."""
+
+    def test_ingests_assistant_records(self, store: CostStore, tmp_path: Path) -> None:
+        """Each assistant record produces one token_events row."""
+        path = tmp_path / "sess.jsonl"
+        _write_jsonl(
+            path,
+            [
+                _assistant_record(uuid="u1"),
+                _assistant_record(uuid="u2", input_tokens=200),
+            ],
+        )
+
+        ingester = WorkerJSONLIngester(
+            store=store, resolve_binding=lambda _r: _binding()
+        )
+        inserted = ingester.ingest_file(path)
+
+        assert inserted == 2
+        rows = store.conn.execute("SELECT COUNT(*) FROM token_events").fetchone()[0]
+        assert rows == 2
+
+    def test_skips_non_assistant_records(
+        self, store: CostStore, tmp_path: Path
+    ) -> None:
+        """user and queue-operation records are filtered out."""
+        path = tmp_path / "sess.jsonl"
+        _write_jsonl(
+            path,
+            [
+                _user_record(),
+                _queue_op_record(),
+                _assistant_record(),
+            ],
+        )
+
+        inserted = WorkerJSONLIngester(
+            store=store, resolve_binding=lambda _r: _binding()
+        ).ingest_file(path)
+
+        assert inserted == 1
+
+    def test_skips_assistant_without_usage(
+        self, store: CostStore, tmp_path: Path
+    ) -> None:
+        """Assistant records lacking ``message.usage`` are skipped."""
+        rec = _assistant_record()
+        del rec["message"]["usage"]
+        path = tmp_path / "sess.jsonl"
+        _write_jsonl(path, [rec])
+
+        inserted = WorkerJSONLIngester(
+            store=store, resolve_binding=lambda _r: _binding()
+        ).ingest_file(path)
+
+        assert inserted == 0
+
+    def test_records_persist_token_fields(
+        self, store: CostStore, tmp_path: Path
+    ) -> None:
+        """All four token counts round-trip through the DB."""
+        path = tmp_path / "sess.jsonl"
+        _write_jsonl(
+            path,
+            [
+                _assistant_record(
+                    input_tokens=100,
+                    cache_creation_input_tokens=200,
+                    cache_read_input_tokens=400,
+                    output_tokens=50,
+                )
+            ],
+        )
+
+        WorkerJSONLIngester(
+            store=store, resolve_binding=lambda _r: _binding()
+        ).ingest_file(path)
+
+        row = store.conn.execute(
+            "SELECT input_tokens, cache_creation_tokens, cache_read_tokens, "
+            "output_tokens, agent_role, provider FROM token_events"
+        ).fetchone()
+        assert row == (100, 200, 400, 50, "worker", "anthropic")
+
+    def test_uses_binding_ids(self, store: CostStore, tmp_path: Path) -> None:
+        """Resolved binding's ids land on the row."""
+        path = tmp_path / "sess.jsonl"
+        _write_jsonl(path, [_assistant_record()])
+
+        binding = _binding(
+            agent_id="agent_42", experiment_id="exp_42", project_id="proj_42"
+        )
+        WorkerJSONLIngester(
+            store=store, resolve_binding=lambda _r: binding
+        ).ingest_file(path)
+
+        row = store.conn.execute(
+            "SELECT agent_id, experiment_id, project_id FROM token_events"
+        ).fetchone()
+        assert row == ("agent_42", "exp_42", "proj_42")
+
+    def test_skips_record_when_resolver_returns_none(
+        self, store: CostStore, tmp_path: Path
+    ) -> None:
+        """If resolve_binding returns None, the event is dropped."""
+        path = tmp_path / "sess.jsonl"
+        _write_jsonl(path, [_assistant_record()])
+
+        inserted = WorkerJSONLIngester(
+            store=store, resolve_binding=lambda _r: None
+        ).ingest_file(path)
+        assert inserted == 0
+
+    def test_skips_malformed_lines(self, store: CostStore, tmp_path: Path) -> None:
+        """Lines that aren't valid JSON are skipped, not fatal."""
+        path = tmp_path / "sess.jsonl"
+        path.write_text(
+            "{not valid json\n"
+            + json.dumps(_assistant_record())
+            + "\n"
+            + "\n"  # blank line
+        )
+
+        inserted = WorkerJSONLIngester(
+            store=store, resolve_binding=lambda _r: _binding()
+        ).ingest_file(path)
+        assert inserted == 1
+
+
+class TestTurnIndex:
+    """Per-session turn counter."""
+
+    def test_assigns_increasing_turn_index_within_session(
+        self, store: CostStore, tmp_path: Path
+    ) -> None:
+        """Three assistant records in one session → turn_index 1, 2, 3."""
+        path = tmp_path / "sess.jsonl"
+        _write_jsonl(
+            path,
+            [
+                _assistant_record(session_id="s_a", uuid="u1"),
+                _assistant_record(session_id="s_a", uuid="u2"),
+                _assistant_record(session_id="s_a", uuid="u3"),
+            ],
+        )
+
+        WorkerJSONLIngester(
+            store=store, resolve_binding=lambda _r: _binding()
+        ).ingest_file(path)
+
+        turns = [
+            r[0]
+            for r in store.conn.execute(
+                "SELECT turn_index FROM token_events ORDER BY event_id"
+            )
+        ]
+        assert turns == [1, 2, 3]
+
+    def test_separate_sessions_have_independent_counters(
+        self, store: CostStore, tmp_path: Path
+    ) -> None:
+        """Each session_id gets its own 1..N counter."""
+        path = tmp_path / "sess.jsonl"
+        _write_jsonl(
+            path,
+            [
+                _assistant_record(session_id="s_a", uuid="u1"),
+                _assistant_record(session_id="s_b", uuid="u2"),
+                _assistant_record(session_id="s_a", uuid="u3"),
+            ],
+        )
+
+        WorkerJSONLIngester(
+            store=store, resolve_binding=lambda _r: _binding()
+        ).ingest_file(path)
+
+        rows = list(
+            store.conn.execute(
+                "SELECT session_id, turn_index FROM token_events ORDER BY event_id"
+            )
+        )
+        assert rows == [("s_a", 1), ("s_b", 1), ("s_a", 2)]
+
+
+class TestIdempotency:
+    """Re-ingesting the same file must not duplicate events."""
+
+    def test_dedups_on_uuid(self, store: CostStore, tmp_path: Path) -> None:
+        """Re-running ingest_file with same records inserts nothing the second time."""
+        path = tmp_path / "sess.jsonl"
+        _write_jsonl(path, [_assistant_record(uuid="u1")])
+
+        ingester = WorkerJSONLIngester(
+            store=store, resolve_binding=lambda _r: _binding()
+        )
+        ingester.ingest_file(path)
+        second = ingester.ingest_file(path)
+
+        assert second == 0
+        count = store.conn.execute("SELECT COUNT(*) FROM token_events").fetchone()[0]
+        assert count == 1
+
+
+class TestIngestDirectory:
+    """Bulk ingest of every .jsonl file in a directory tree."""
+
+    def test_ingests_all_jsonl_files(self, store: CostStore, tmp_path: Path) -> None:
+        """Two files in two subdirs → 4 events total."""
+        d1 = tmp_path / "agent_1"
+        d2 = tmp_path / "agent_2"
+        d1.mkdir()
+        d2.mkdir()
+        _write_jsonl(
+            d1 / "s_a.jsonl",
+            [
+                _assistant_record(session_id="s_a", uuid="u1"),
+                _assistant_record(session_id="s_a", uuid="u2"),
+            ],
+        )
+        _write_jsonl(
+            d2 / "s_b.jsonl",
+            [
+                _assistant_record(session_id="s_b", uuid="u3"),
+                _assistant_record(session_id="s_b", uuid="u4"),
+            ],
+        )
+
+        inserted = WorkerJSONLIngester(
+            store=store, resolve_binding=lambda _r: _binding()
+        ).ingest_directory(tmp_path)
+        assert inserted == 4


### PR DESCRIPTION
## Summary

Adds the second half of #409's data pipeline. Phase 1-3 (PR #497) captures Marcus's own LLM calls; this PR ingests the Claude Code session logs of every spawned worker agent.

\`WorkerJSONLIngester\` reads \`~/.claude/projects/<dir>/<session-id>.jsonl\` files end-to-end and writes one \`token_events\` row per assistant turn. Each turn carries the four token fields from \`message.usage\` (\`input_tokens\`, \`cache_creation_input_tokens\`, \`cache_read_input_tokens\`, \`output_tokens\`), \`session_id\`, \`turn_index\`, \`request_id\`, and \`timestamp\`.

## Design

- **Batch, not tail.** Reads files end-to-end. Live-tail mode can layer on later via a filesystem watcher; this is enough for post-experiment analysis and tests cleanly.
- **Caller supplies binding.** A \`resolve_binding(record) -> AgentBinding | None\` callable maps each record to \`(agent_id, experiment_id, project_id)\`. Returning \`None\` skips the record. Keeps the ingester decoupled from \`spawn_agents.py\`'s specific registry layout.
- **UUID-based dedup.** Each JSONL record has a unique \`uuid\`. Tracked in an in-memory set per ingester instance, so re-ingesting the same file is a no-op.
- **Per-session turn counter.** Independent counters per \`session_id\`.

## Real-data smoke test

Ran the ingester against an actual 549-turn Claude Code session log:

\`\`\`
real-jsonl smoke: ingested=549, events=549,
  in=4,142  cc=604,161  cr=48,900,872  out=271,946
  cost=\$5.6073
\`\`\`

Math checks out for \`claude-haiku-4-5-20251001\` seed prices from PR #497:
- \`4142 × 0.80/1M + 604161 × 1.0/1M + 48900872 × 0.08/1M + 271946 × 4.0/1M = \$5.607\`

## What's not in this PR

- **Wire-up to spawn_agents.py.** A follow-up commit will build the binding map from the spawn registry and run the ingester after experiments complete (or on demand via a \`marcus ingest\` CLI). Kept separate so the ingester can ship independently with a clean blast radius.
- **Live tail mode.** Batch only for now.
- **MCP tool.** Phase 5 will expose \`get_cost_summary\` so agents and Cato can query without direct DB access.

## Test plan

- [x] \`pytest tests/unit/cost_tracking/test_worker_ingester.py\` — 11 passed
- [x] \`pytest tests/unit/cost_tracking/\` — 52 passed (full cost-tracking suite)
- [x] mypy --strict on \`worker_ingester.py\` — clean
- [x] Smoke against real 549-turn session log — ingested correctly, cost arithmetic verified
- [ ] Wire-up commit to \`spawn_agents.py\` (follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)