### PR TITLE
feat(cost-tracking): MCP tool get_cost_summary (#409 phase 5)

### DIFF
--- a/src/marcus_mcp/handlers.py
+++ b/src/marcus_mcp/handlers.py
@@ -58,6 +58,10 @@ from .tools.code_metrics import (  # Code metrics tools
 from .tools.context import (  # Context tools
     log_decision,
 )
+from .tools.cost_tracking import (
+    COST_SUMMARY_TOOL,
+    get_cost_summary,
+)
 
 # Pattern learning tools disabled - only accessible via visualization UI API
 # from .tools.pattern_learning import (  # Pattern learning tools
@@ -108,6 +112,7 @@ def get_all_tool_definitions() -> Dict[str, types.Tool]:
     # Add auth and audit tools
     all_tools["authenticate"] = AUTHENTICATE_TOOL
     all_tools["get_usage_report"] = USAGE_REPORT_TOOL
+    all_tools["get_cost_summary"] = COST_SUMMARY_TOOL
 
     return all_tools
 
@@ -964,6 +969,8 @@ def get_tool_definitions(role: str = "agent") -> List[types.Tool]:
         # Pattern Learning Tools removed - only accessible via visualization UI API
         # Audit and analytics tools
         USAGE_REPORT_TOOL,
+        # Cost tracking dashboard (#409)
+        COST_SUMMARY_TOOL,
     ]
 
     return human_tools
@@ -1160,6 +1167,14 @@ async def handle_tool_call(
         elif name == "get_usage_report":
             days = arguments.get("days", 7) if arguments else 7
             result = await get_usage_report(days=days, state=state)
+
+        elif name == "get_cost_summary":
+            args = arguments or {}
+            result = await get_cost_summary(
+                experiment_id=args.get("experiment_id"),
+                project_id=args.get("project_id"),
+                state=state,
+            )
 
         elif name == "check_board_health":
             result = await check_board_health(state=state)

--- a/src/marcus_mcp/tools/auth.py
+++ b/src/marcus_mcp/tools/auth.py
@@ -36,6 +36,7 @@ ROLE_TOOLS = {
         "check_assignment_health",  # Debug assignments
         # Audit and usage analytics
         "get_usage_report",  # Usage statistics
+        "get_cost_summary",  # Per-experiment / per-project cost (#409)
         # Prediction and AI intelligence tools
         "predict_completion_time",  # Project completion predictions
         "predict_task_outcome",  # Task success probability

--- a/src/marcus_mcp/tools/cost_tracking.py
+++ b/src/marcus_mcp/tools/cost_tracking.py
@@ -1,0 +1,117 @@
+"""
+MCP tools for the Marcus cost tracking dashboard (#409).
+
+Exposes :func:`get_cost_summary` so agents and external clients (notably
+the Cato dashboard) can query the cost store without direct DB access.
+
+The tool dispatches to :class:`src.cost_tracking.cost_aggregator.CostAggregator`
+and returns dicts shaped like the API responses documented in #409.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+from mcp.types import Tool
+
+from src.cost_tracking.cost_aggregator import CostAggregator
+
+
+async def get_cost_summary(
+    experiment_id: Optional[str] = None,
+    project_id: Optional[str] = None,
+    state: Any = None,
+) -> Dict[str, Any]:
+    """Return a cost summary keyed by experiment or project.
+
+    Parameters
+    ----------
+    experiment_id : str, optional
+        Marcus experiment ID. When provided, returns a full per-experiment
+        breakdown (``summary`` + ``by_role`` + ``by_agent`` + ``by_task``
+        + ``by_operation`` + ``by_model``).
+    project_id : str, optional
+        Marcus project ID. When provided, returns project totals plus a
+        list of experiment summaries belonging to the project. Used by
+        Cato when drilling from a project view into its runs.
+    state : Any
+        Marcus server state. Must expose ``cost_store`` (set up at server
+        init, see :class:`src.marcus_mcp.server.MarcusServer.__init__`).
+
+    Returns
+    -------
+    dict
+        Either the experiment-summary shape (when ``experiment_id`` is
+        passed), the project-rollup shape (when ``project_id`` is passed),
+        or an error envelope ``{success: False, error: ...}`` if the
+        caller didn't provide either or the store is unavailable.
+
+    Notes
+    -----
+    Read-only. Never raises; argument and lookup errors are returned as
+    ``{success: False, error: ...}`` dicts so MCP clients get a friendly
+    payload rather than a stack trace.
+    """
+    if experiment_id is None and project_id is None:
+        return {
+            "success": False,
+            "error": "Provide either experiment_id or project_id.",
+        }
+
+    cost_store = getattr(state, "cost_store", None)
+    if cost_store is None:
+        return {
+            "success": False,
+            "error": "Cost store not available on server state.",
+        }
+
+    aggregator = CostAggregator(store=cost_store)
+
+    if experiment_id is not None:
+        summary = aggregator.experiment_summary(experiment_id)
+        if summary is None:
+            return {
+                "success": False,
+                "error": f"Experiment '{experiment_id}' not found.",
+            }
+        return summary
+
+    # project_id was provided
+    assert project_id is not None  # for mypy
+    return {
+        "project_id": project_id,
+        "totals": aggregator.project_totals(project_id),
+        "experiments": aggregator.list_experiments(project_id=project_id),
+    }
+
+
+# Tool definition registered in handlers.py.
+COST_SUMMARY_TOOL = Tool(
+    name="get_cost_summary",
+    description=(
+        "Return per-experiment or per-project token + cost breakdown from "
+        "the Marcus cost store. Pass experiment_id for a full drill-in "
+        "(summary, by_role, by_agent, by_task, by_operation, by_model). "
+        "Pass project_id for project totals plus a list of experiment "
+        "summaries. Read-only."
+    ),
+    inputSchema={
+        "type": "object",
+        "properties": {
+            "experiment_id": {
+                "type": "string",
+                "description": (
+                    "Marcus experiment ID. Returns a full per-experiment "
+                    "breakdown if matched."
+                ),
+            },
+            "project_id": {
+                "type": "string",
+                "description": (
+                    "Marcus project ID. Returns project totals plus a list "
+                    "of experiment summaries belonging to the project."
+                ),
+            },
+        },
+    },
+)

--- a/tests/unit/marcus_mcp/test_cost_tracking_tool.py
+++ b/tests/unit/marcus_mcp/test_cost_tracking_tool.py
@@ -180,6 +180,23 @@ class TestGetCostSummaryByProject:
 # ---------------------------------------------------------------------------
 
 
+class TestCodexP1ObserverAccess:
+    """Regression: get_cost_summary must be in observer ROLE_TOOLS.
+
+    Codex P1 on PR #499: registering the tool in handlers.py is necessary
+    but not sufficient. ``handle_tool_call`` filters through
+    ``get_client_tools()`` / ROLE_TOOLS in ``auth.py`` before dispatch,
+    so an observer client (e.g. Cato) would otherwise see the tool
+    omitted from list_tools and get an access-denied error.
+    """
+
+    def test_observer_role_includes_get_cost_summary(self) -> None:
+        """The Cato/observer role must list this tool."""
+        from src.marcus_mcp.tools.auth import ROLE_TOOLS
+
+        assert "get_cost_summary" in ROLE_TOOLS["observer"]
+
+
 class TestArgumentValidation:
     """Caller errors are returned, never raised."""
 

--- a/tests/unit/marcus_mcp/test_cost_tracking_tool.py
+++ b/tests/unit/marcus_mcp/test_cost_tracking_tool.py
@@ -1,0 +1,198 @@
+"""
+Unit tests for the ``get_cost_summary`` MCP tool.
+
+Validates the tool's argument handling, dispatch to ``CostAggregator``,
+and the shape of the returned payload. Uses a fake state object that
+exposes the real :class:`CostStore` from ``src.cost_tracking`` populated
+with deterministic test data.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from src.cost_tracking.cost_store import (
+    CostStore,
+    Experiment,
+    ModelPrice,
+    TokenEvent,
+)
+from src.marcus_mcp.tools.cost_tracking import (
+    COST_SUMMARY_TOOL,
+    get_cost_summary,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def populated_store(tmp_path: Path) -> CostStore:
+    """Store with one experiment + a planner event + a worker turn."""
+    s = CostStore(db_path=tmp_path / "costs.db")
+    s.record_price(
+        ModelPrice(
+            model="claude-sonnet-4-6",
+            provider="anthropic",
+            effective_from=datetime(2025, 1, 1, tzinfo=timezone.utc),
+            input_per_million=3.0,
+            cache_creation_per_million=3.75,
+            cache_read_per_million=0.30,
+            output_per_million=15.0,
+            source="default",
+        )
+    )
+    s.record_experiment(
+        Experiment(
+            experiment_id="exp_1",
+            project_id="proj_1",
+            project_name="hangman",
+            started_at=datetime(2026, 5, 10, tzinfo=timezone.utc),
+            num_agents=1,
+            total_tasks=4,
+            completed_tasks=2,
+        )
+    )
+    base = dict(
+        experiment_id="exp_1",
+        project_id="proj_1",
+        provider="anthropic",
+        model="claude-sonnet-4-6",
+    )
+    s.record_event(
+        TokenEvent(
+            agent_id="planner",
+            agent_role="planner",
+            operation="parse_prd",
+            input_tokens=1000,
+            output_tokens=500,
+            **base,
+        )
+    )
+    s.record_event(
+        TokenEvent(
+            agent_id="agent_1",
+            agent_role="worker",
+            operation="turn",
+            task_id="t_1",
+            session_id="s_1",
+            turn_index=1,
+            input_tokens=2000,
+            cache_read_tokens=500,
+            output_tokens=100,
+            **base,
+        )
+    )
+    return s
+
+
+@pytest.fixture
+def state(populated_store: CostStore) -> Any:
+    """Minimal state stub exposing ``cost_store`` like MarcusServer does."""
+
+    class _State:
+        pass
+
+    s = _State()
+    s.cost_store = populated_store
+    return s
+
+
+# ---------------------------------------------------------------------------
+# Tool definition
+# ---------------------------------------------------------------------------
+
+
+class TestToolDefinition:
+    """Static checks on the MCP Tool descriptor."""
+
+    def test_tool_name(self) -> None:
+        """Tool registers under the documented name."""
+        assert COST_SUMMARY_TOOL.name == "get_cost_summary"
+
+    def test_tool_accepts_either_id(self) -> None:
+        """Schema exposes both experiment_id and project_id parameters."""
+        props = COST_SUMMARY_TOOL.inputSchema["properties"]
+        assert "experiment_id" in props
+        assert "project_id" in props
+
+
+# ---------------------------------------------------------------------------
+# get_cost_summary by experiment_id
+# ---------------------------------------------------------------------------
+
+
+class TestGetCostSummaryByExperiment:
+    """Happy path: pass ``experiment_id``."""
+
+    @pytest.mark.asyncio
+    async def test_returns_full_breakdown(self, state: Any) -> None:
+        """Response carries summary + by_role + by_agent + by_task etc."""
+        result = await get_cost_summary(experiment_id="exp_1", state=state)
+        assert result["experiment_id"] == "exp_1"
+        assert result["project_id"] == "proj_1"
+        assert "summary" in result
+        assert {"by_role", "by_agent", "by_task", "by_operation", "by_model"} <= set(
+            result.keys()
+        )
+
+    @pytest.mark.asyncio
+    async def test_summary_totals_are_correct(self, state: Any) -> None:
+        """summary.total_tokens sums across both events."""
+        result = await get_cost_summary(experiment_id="exp_1", state=state)
+        # planner: 1000 + 500 = 1500. worker: 2000 + 500 + 100 = 2600. total: 4100.
+        assert result["summary"]["total_tokens"] == 4100
+
+    @pytest.mark.asyncio
+    async def test_unknown_experiment_returns_error(self, state: Any) -> None:
+        """A missing experiment_id surfaces a friendly error."""
+        result = await get_cost_summary(experiment_id="nope", state=state)
+        assert result.get("success") is False
+        assert "not found" in result.get("error", "").lower()
+
+
+# ---------------------------------------------------------------------------
+# get_cost_summary by project_id
+# ---------------------------------------------------------------------------
+
+
+class TestGetCostSummaryByProject:
+    """Happy path: pass ``project_id``."""
+
+    @pytest.mark.asyncio
+    async def test_returns_project_totals_and_experiments(self, state: Any) -> None:
+        """Response carries totals + per-experiment list."""
+        result = await get_cost_summary(project_id="proj_1", state=state)
+        assert result["project_id"] == "proj_1"
+        assert result["totals"]["events"] == 2
+        assert result["totals"]["total_tokens"] == 4100
+        assert len(result["experiments"]) == 1
+        assert result["experiments"][0]["experiment_id"] == "exp_1"
+
+
+# ---------------------------------------------------------------------------
+# Argument validation
+# ---------------------------------------------------------------------------
+
+
+class TestArgumentValidation:
+    """Caller errors are returned, never raised."""
+
+    @pytest.mark.asyncio
+    async def test_missing_both_ids_returns_error(self, state: Any) -> None:
+        """At least one of experiment_id / project_id is required."""
+        result = await get_cost_summary(state=state)
+        assert result.get("success") is False
+        assert "experiment_id" in result.get("error", "")
+
+    @pytest.mark.asyncio
+    async def test_missing_cost_store_returns_error(self) -> None:
+        """If state has no cost_store, surface a clear error."""
+        result = await get_cost_summary(experiment_id="exp_1", state=object())
+        assert result.get("success") is False
+        assert "cost store" in result.get("error", "").lower()


### PR DESCRIPTION
## Summary

Exposes the cost store via MCP so agents, Cato, and any MCP-aware client can query token + cost data without poking at SQLite directly.

\`\`\`
get_cost_summary(experiment_id="exp_1") →
  {
    "experiment_id": "exp_1",
    "project_id": "...",
    "summary": {total_tokens, total_cost_usd, cache_hit_rate, ...},
    "by_role":      [{role, events, tokens, cost_usd}, ...],
    "by_agent":     [{agent_id, role, tokens, cost_usd, tasks_worked, sessions, turns}, ...],
    "by_task":      [...],
    "by_operation": [...],
    "by_model":     [...]
  }

get_cost_summary(project_id="proj_1") →
  {
    "project_id": "proj_1",
    "totals": {experiments, events, total_tokens, total_cost_usd},
    "experiments": [<list of experiment summaries>]
  }
\`\`\`

Both shapes match the API responses documented in #409, ready for Cato's \`/api/cost/*\` endpoints in the next PR.

## Behavior

- Read-only. No writes.
- Argument and lookup errors return \`{success: False, error: ...}\` envelopes rather than raising — friendlier for MCP clients than tracebacks.
- Dispatches to the existing \`CostAggregator\` from #497, so query logic lives in one place.

## Wiring

\`src/marcus_mcp/handlers.py\`:
- Imports \`COST_SUMMARY_TOOL\` + \`get_cost_summary\`
- Registered in \`get_all_tool_definitions\`
- Listed in \`human_tools\`
- Dispatch case in \`handle_tool_call\`

\`MarcusServer.cost_store\` (set up in #497) is the data source.

## Test plan

- [x] \`pytest tests/unit/marcus_mcp/test_cost_tracking_tool.py\` — 8 passed
- [x] \`pytest tests/unit/marcus_mcp/\` — 92 passed (84 prior + 8 new), 0 regressions
- [x] mypy --strict on the new module — clean
- [ ] Smoke via real MCP call once a session has populated \`~/.marcus/costs.db\`

## What's next

- **Phase 6** — Cato backend \`/api/cost/*\` endpoints. Will call this MCP tool through the existing Cato → Marcus bridge so the dashboard never reads SQLite directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)