### PR TITLE
feat(cost): project-axis aggregation + automatic PlannerContext push (#409)

### DIFF
--- a/src/cost_tracking/cost_aggregator.py
+++ b/src/cost_tracking/cost_aggregator.py
@@ -261,6 +261,68 @@ class CostAggregator:
             )
         return rows
 
+    def list_projects(self, limit: int = 100) -> List[Dict[str, Any]]:
+        """List every project_id that has cost events, sorted by spend desc.
+
+        Source of truth is ``token_events.project_id`` — derived purely from
+        recorded events, no dependence on the ``experiments`` table. Each
+        row carries event count, token total, cost, and (best-effort)
+        first/last activity timestamps so the dashboard can show "active
+        in the last hour" without a second query.
+
+        Parameters
+        ----------
+        limit : int
+            Cap result set. Default 100.
+
+        Returns
+        -------
+        list of dict
+            One row per project_id. Excludes the ``'unassigned'`` bucket;
+            it's surfaced separately via ``unassigned_totals`` so it
+            doesn't get mistaken for a real project.
+        """
+        return self._rows(
+            """
+            SELECT project_id,
+                   COUNT(*)                             AS events,
+                   COUNT(DISTINCT experiment_id)        AS experiments,
+                   COUNT(DISTINCT agent_id)             AS agents,
+                   COALESCE(SUM(total_tokens), 0)       AS total_tokens,
+                   COALESCE(SUM(cost_usd), 0)           AS total_cost_usd,
+                   MIN(timestamp)                       AS first_event_at,
+                   MAX(timestamp)                       AS last_event_at
+            FROM v_event_cost
+            WHERE project_id != 'unassigned'
+            GROUP BY project_id
+            ORDER BY total_cost_usd DESC
+            LIMIT ?
+            """,
+            (limit,),
+        )
+
+    def unassigned_totals(self) -> Dict[str, Any]:
+        """Cost of LLM calls made without an active PlannerContext.
+
+        These are events Marcus recorded before ``project_id`` was known —
+        usually because a code path makes an LLM call outside the MCP
+        request lifecycle. Surfacing them separately keeps the project
+        list clean while making the gap visible so we can fix the
+        upstream caller.
+        """
+        return (
+            self._row(
+                """
+            SELECT COUNT(*)                             AS events,
+                   COALESCE(SUM(total_tokens), 0)       AS total_tokens,
+                   COALESCE(SUM(cost_usd), 0)           AS total_cost_usd
+            FROM v_event_cost
+            WHERE project_id = 'unassigned'
+            """,
+            )
+            or {"events": 0, "total_tokens": 0, "total_cost_usd": 0.0}
+        )
+
     def project_totals(self, project_id: str) -> Dict[str, Any]:
         """Roll up all token and cost data for one project across experiments."""
         return (

--- a/src/marcus_mcp/handlers.py
+++ b/src/marcus_mcp/handlers.py
@@ -8,10 +8,12 @@ in a centralized location.
 
 import json
 import time
+from contextlib import ExitStack
 from typing import Any, Dict, List, Optional
 
 import mcp.types as types
 
+from src.cost_tracking.cost_recorder import PlannerContext, get_recorder
 from src.logging.mcp_tool_logger import log_mcp_tool_response
 
 from .audit import get_audit_logger
@@ -976,6 +978,38 @@ def get_tool_definitions(role: str = "agent") -> List[types.Tool]:
     return human_tools
 
 
+def _resolve_project_for_cost(arguments: Dict[str, Any], state: Any) -> Optional[str]:
+    """Pick the most specific project_id available for cost attribution.
+
+    Marcus's identity (per CLAUDE.md GH-388 and spawn_agents.py) is
+    ``project_id``, so every planner LLM call made while servicing an
+    MCP request should be tagged with the project that request belongs
+    to. This helper checks, in order:
+
+    1. ``project_id`` explicitly in the tool arguments.
+    2. ``agent_id`` → ``state.agent_project_map`` (set by register_agent).
+    3. ``state.selected_project_id`` (the active project on the server).
+
+    Returns ``None`` when none of those resolve, in which case the
+    recorder falls back to its ``'unassigned'`` bucket — visible in
+    the dashboard as a separate row so the gap is observable.
+    """
+    pid = arguments.get("project_id")
+    if pid:
+        return str(pid)
+    agent_id = arguments.get("agent_id")
+    if agent_id:
+        mapped = getattr(state, "agent_project_map", {}).get(agent_id)
+        if mapped:
+            return str(mapped)
+    selected = getattr(state, "selected_project_id", None) or getattr(
+        state, "current_project_id", None
+    )
+    if selected:
+        return str(selected)
+    return None
+
+
 async def handle_tool_call(
     name: str, arguments: Optional[Dict[str, Any]], state: Any
 ) -> List[types.TextContent | types.ImageContent | types.EmbeddedResource]:
@@ -1041,6 +1075,23 @@ async def handle_tool_call(
                 ),
             )
         ]
+
+    # Push a PlannerContext for the duration of this tool call so any
+    # planner-side LLM calls Marcus makes while servicing it get tagged
+    # with the right project_id (the dashboard's join key). If no
+    # project resolves, the recorder falls back to 'unassigned' and the
+    # gap shows up in the dashboard's unassigned bucket. (#409)
+    _cost_project_id = _resolve_project_for_cost(arguments, state)
+    _cost_stack = ExitStack()
+    if _cost_project_id is not None:
+        _cost_stack.enter_context(
+            get_recorder().planner_context(
+                PlannerContext(
+                    experiment_id="unassigned",
+                    project_id=_cost_project_id,
+                )
+            )
+        )
 
     try:
         # Initialize result variable with proper type
@@ -1550,3 +1601,7 @@ async def handle_tool_call(
         sys.stderr.flush()
 
         return error_response
+    finally:
+        # Pop the PlannerContext pushed at the top of this call so events
+        # made by subsequent handlers don't inherit a stale project_id.
+        _cost_stack.close()

--- a/tests/unit/cost_tracking/test_cost_aggregator.py
+++ b/tests/unit/cost_tracking/test_cost_aggregator.py
@@ -218,6 +218,91 @@ class TestExperimentList:
         assert {r["experiment_id"] for r in rows} == {"exp_1"}
 
 
+class TestListProjects:
+    """list_projects derives project rollups from token_events.project_id.
+
+    Project axis is Marcus's actual identity (per CLAUDE.md GH-388 +
+    spawn_agents.py); experiment_id is an MLflow tracking handle and is
+    intentionally not the join key here.
+    """
+
+    def test_lists_projects_with_totals(self, agg: CostAggregator) -> None:
+        """One row per distinct project_id with token + cost rollups."""
+        rows = agg.list_projects()
+        assert len(rows) == 1
+        assert rows[0]["project_id"] == "proj_1"
+        assert rows[0]["events"] == 3
+        assert rows[0]["total_tokens"] == 10700
+
+    def test_excludes_unassigned_bucket(self, populated_store: CostStore) -> None:
+        """Events tagged 'unassigned' do not appear in the project list."""
+        populated_store.record_event(
+            TokenEvent(
+                experiment_id="unassigned",
+                project_id="unassigned",
+                agent_id="planner",
+                agent_role="planner",
+                operation="parse_prd",
+                provider="anthropic",
+                model="claude-sonnet-4-6",
+                input_tokens=10,
+                output_tokens=10,
+            )
+        )
+        agg = CostAggregator(store=populated_store)
+        rows = agg.list_projects()
+        assert all(r["project_id"] != "unassigned" for r in rows)
+
+    def test_orders_by_cost_desc(self, populated_store: CostStore) -> None:
+        """A cheaper project sorts below an expensive one."""
+        populated_store.record_event(
+            TokenEvent(
+                experiment_id="exp_2",
+                project_id="proj_cheap",
+                agent_id="planner",
+                agent_role="planner",
+                operation="parse_prd",
+                provider="anthropic",
+                model="claude-sonnet-4-6",
+                input_tokens=1,
+                output_tokens=1,
+            )
+        )
+        rows = CostAggregator(store=populated_store).list_projects()
+        assert rows[0]["project_id"] == "proj_1"
+        assert rows[1]["project_id"] == "proj_cheap"
+
+
+class TestUnassignedTotals:
+    """unassigned_totals surfaces the 'no PlannerContext' gap."""
+
+    def test_returns_zeros_when_no_unassigned_events(self, agg: CostAggregator) -> None:
+        """Clean state: nothing to report."""
+        totals = agg.unassigned_totals()
+        assert totals["events"] == 0
+        assert totals["total_cost_usd"] == 0.0
+
+    def test_sums_unassigned_events(self, populated_store: CostStore) -> None:
+        """Once we add an unassigned event, totals reflect it."""
+        populated_store.record_event(
+            TokenEvent(
+                experiment_id="unassigned",
+                project_id="unassigned",
+                agent_id="planner",
+                agent_role="planner",
+                operation="parse_prd",
+                provider="anthropic",
+                model="claude-sonnet-4-6",
+                input_tokens=1_000_000,
+                output_tokens=0,
+            )
+        )
+        totals = CostAggregator(store=populated_store).unassigned_totals()
+        assert totals["events"] == 1
+        # 1M input * $3/M = $3
+        assert totals["total_cost_usd"] == pytest.approx(3.0, rel=1e-6)
+
+
 class TestCacheHitRate:
     """Cache hit rate per agent for a given experiment."""
 

--- a/tests/unit/marcus_mcp/test_project_context_resolver.py
+++ b/tests/unit/marcus_mcp/test_project_context_resolver.py
@@ -1,0 +1,74 @@
+"""
+Unit tests for ``_resolve_project_for_cost`` in marcus_mcp.handlers.
+
+The resolver is what makes the cost dashboard's project axis actually
+work. Marcus's identity is ``project_id`` (per CLAUDE.md GH-388 and
+spawn_agents.py), so every planner LLM call made while servicing an
+MCP request needs to land in the right project bucket.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from src.marcus_mcp.handlers import _resolve_project_for_cost
+
+
+class _State:
+    """Lightweight stand-in for MarcusServer state."""
+
+    def __init__(
+        self,
+        agent_project_map: dict[str, str] | None = None,
+        selected_project_id: str | None = None,
+    ) -> None:
+        self.agent_project_map: dict[str, str] = agent_project_map or {}
+        self.selected_project_id: str | None = selected_project_id
+
+
+class TestResolveProjectForCost:
+    """Resolver checks args → agent map → server state, in that order."""
+
+    def test_explicit_project_id_wins(self) -> None:
+        """An explicit project_id arg overrides everything else."""
+        state = _State(
+            agent_project_map={"a1": "from-map"},
+            selected_project_id="from-state",
+        )
+        assert (
+            _resolve_project_for_cost(
+                {"project_id": "explicit", "agent_id": "a1"}, state
+            )
+            == "explicit"
+        )
+
+    def test_falls_back_to_agent_project_map(self) -> None:
+        """When no project_id arg, look up agent_id in the map."""
+        state = _State(agent_project_map={"agent_1": "p_via_agent"})
+        assert (
+            _resolve_project_for_cost({"agent_id": "agent_1"}, state) == "p_via_agent"
+        )
+
+    def test_falls_back_to_selected_project_id(self) -> None:
+        """If neither args nor agent map have it, use the selected project."""
+        state = _State(selected_project_id="p_selected")
+        assert _resolve_project_for_cost({}, state) == "p_selected"
+
+    def test_falls_back_to_current_project_id(self) -> None:
+        """current_project_id is accepted as an alt attribute name."""
+        state: Any = type("S", (), {})()
+        state.current_project_id = "p_current"
+        assert _resolve_project_for_cost({}, state) == "p_current"
+
+    def test_returns_none_when_nothing_resolves(self) -> None:
+        """Resolver returns None so the caller can fall back to 'unassigned'."""
+        state = _State()
+        assert _resolve_project_for_cost({}, state) is None
+
+    def test_unknown_agent_falls_through(self) -> None:
+        """agent_id not in the map → keep looking at selected_project_id."""
+        state = _State(
+            agent_project_map={"a1": "p_a1"},
+            selected_project_id="p_selected",
+        )
+        assert _resolve_project_for_cost({"agent_id": "unknown"}, state) == "p_selected"


### PR DESCRIPTION
## Summary

After a Kaia review of the phase 8 dashboard, I had the data model wrong. Marcus's identity is \`project_id\` (CLAUDE.md GH-388 + \`spawn_agents.py\`) — \`experiment_id\` is an MLflow tracking handle, not a join key. This PR refactors the cost layer to lead with \`project_id\` without removing anything that already worked.

## What changed

**\`CostAggregator\` gains two methods:**
- \`list_projects(limit=100)\` — one row per distinct \`project_id\` from \`token_events\`, sorted by spend desc. Carries event count, experiment count, agent count, tokens, cost, and first/last activity timestamps. Excludes the \`'unassigned'\` bucket.
- \`unassigned_totals()\` — surfaces LLM calls made without an active \`PlannerContext\` as its own row, so the gap is observable rather than silent.

**\`marcus_mcp/handlers.py\` pushes a \`PlannerContext\` around every tool dispatch:**

\`\`\`python
_cost_project_id = _resolve_project_for_cost(arguments, state)
_cost_stack = ExitStack()
if _cost_project_id is not None:
    _cost_stack.enter_context(
        get_recorder().planner_context(
            PlannerContext(experiment_id="unassigned", project_id=_cost_project_id)
        )
    )
try:
    # existing dispatch
finally:
    _cost_stack.close()
\`\`\`

The \`_resolve_project_for_cost\` helper picks the most specific source available:
1. Explicit \`project_id\` in arguments
2. \`agent_id\` in arguments → \`state.agent_project_map\` (set by \`register_agent\`)
3. \`state.selected_project_id\` / \`current_project_id\`

If none resolve, the recorder falls back to \`'unassigned'\` — visible on the dashboard via the new \`unassigned_totals\` row.

## Why the \`experiments\` table sticks around

Kept for now (cheap, doesn't hurt), but it's no longer the primary axis. The dashboard refactor in the next Cato PR removes the \`experiments\` table from the query path entirely — project becomes the primary picker, experiments become an optional sub-filter for runs that opt into MLflow tracking.

## Test plan

- [x] 10 new tests: 4 aggregator (list_projects, unassigned_totals, ordering, exclusion), 6 resolver (4-tier lookup chain)
- [x] All 156 existing cost-tracking + marcus_mcp unit tests pass
- [x] mypy --strict clean on \`cost_aggregator.py\` and \`handlers.py\`
- [ ] Manual: run a small experiment end-to-end, verify \`sqlite3 ~/.marcus/costs.db "SELECT project_id, COUNT(*) FROM token_events GROUP BY project_id"\` returns the real project ID (not \`'unassigned'\`)

## Follow-up: Cato dashboard refactor

Separate PR will:
- Add \`GET /api/cost/projects\` endpoint (calls \`list_projects\`)
- Make \`CostDashboard\` lead with a project picker (not experiment picker)
- \`RealTimeTab\` takes \`project_id\` instead of \`experiment_id\`
- Pricing tab unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)