### PR TITLE
fix(kanban): handle dataclass / pydantic objects in JSON columns (#502)

### DIFF
--- a/src/integrations/providers/sqlite_kanban.py
+++ b/src/integrations/providers/sqlite_kanban.py
@@ -14,11 +14,12 @@ SQLiteKanban
 import asyncio
 import base64
 import dataclasses
+import enum
 import json
 import logging
 import sqlite3
 import uuid
-from datetime import datetime, timezone
+from datetime import date, datetime, timezone
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, TypeVar, Union
 
@@ -42,12 +43,22 @@ def _json_default(obj: Any) -> Any:
     failure where Implement/Test tasks vanish while Design/foundation
     tasks (carrying plain dicts) make it through.
 
-    Supports, in order of preference:
+    Handles, in order of preference:
 
-    1. Dataclass instances → ``dataclasses.asdict``
-    2. Pydantic v2 models → ``model_dump``
-    3. Pydantic v1 / objects exposing a callable ``dict`` method
-    4. Objects with ``__dict__`` (last resort, shallow attribute dump)
+    1. Pydantic v2 models → ``model_dump(mode="json")`` so nested
+       ``datetime`` / ``UUID`` / ``Path`` / ``Enum`` values are emitted
+       as JSON-safe primitives in one pass.  Without ``mode="json"``,
+       ``model_dump`` returns native Python objects that re-trigger the
+       same ``TypeError`` (Codex P2 on PR #504).
+    2. Pydantic v1 / objects exposing a callable ``dict`` method.
+    3. Dataclass instances → ``dataclasses.asdict``.  Nested non-JSON
+       primitives (e.g. ``datetime`` fields) get a second pass through
+       this same default function via ``json.dumps``'s recursive
+       encoding, hitting the stdlib branches below.
+    4. Common stdlib non-JSON-native types: ``datetime`` / ``date``
+       (ISO 8601), ``UUID`` (string), ``Path`` (string), ``Enum``
+       (``.value``), ``set`` / ``frozenset`` (list).
+    5. Objects with ``__dict__`` (last resort, shallow attribute dump).
 
     Raises
     ------
@@ -56,17 +67,46 @@ def _json_default(obj: Any) -> Any:
         Lets ``json.dumps`` surface a clear error rather than silently
         producing partial state.
     """
-    if dataclasses.is_dataclass(obj) and not isinstance(obj, type):
-        return dataclasses.asdict(obj)
+    # Pydantic v2 — JSON mode handles nested datetime/UUID/Path/Enum
+    # in a single recursive pass.
     model_dump = getattr(obj, "model_dump", None)
     if callable(model_dump):
-        return model_dump()
+        try:
+            return model_dump(mode="json")
+        except TypeError:
+            # Pydantic v1 / older signature without ``mode`` kwarg.
+            try:
+                return model_dump()
+            except Exception:  # pragma: no cover - defensive
+                pass
+
+    # Pydantic v1 / arbitrary objects with a ``dict`` accessor.
     obj_dict_method = getattr(obj, "dict", None)
     if callable(obj_dict_method):
         try:
             return obj_dict_method()
         except TypeError:
             pass
+
+    # Dataclasses.  ``asdict`` returns nested Python objects; non-JSON
+    # primitives recurse back into this function on the next pass.
+    if dataclasses.is_dataclass(obj) and not isinstance(obj, type):
+        return dataclasses.asdict(obj)
+
+    # Common stdlib non-JSON-native types.
+    if isinstance(obj, (datetime, date)):
+        return obj.isoformat()
+    if isinstance(obj, uuid.UUID):
+        return str(obj)
+    if isinstance(obj, Path):
+        return str(obj)
+    if isinstance(obj, enum.Enum):
+        return obj.value
+    if isinstance(obj, (set, frozenset)):
+        return list(obj)
+    if isinstance(obj, bytes):
+        return base64.b64encode(obj).decode("ascii")
+
     if hasattr(obj, "__dict__"):
         return vars(obj)
     raise TypeError(f"Object of type {obj.__class__.__name__} is not JSON serializable")

--- a/src/integrations/providers/sqlite_kanban.py
+++ b/src/integrations/providers/sqlite_kanban.py
@@ -13,6 +13,7 @@ SQLiteKanban
 
 import asyncio
 import base64
+import dataclasses
 import json
 import logging
 import sqlite3
@@ -27,6 +28,49 @@ from src.integrations.kanban_interface import KanbanInterface, KanbanProvider
 logger = logging.getLogger(__name__)
 
 T = TypeVar("T")
+
+
+def _json_default(obj: Any) -> Any:
+    """JSON encoder fallback for objects ``json.dumps`` can't natively handle.
+
+    The kanban writer persists ``source_context``, ``completion_criteria``,
+    and ``acceptance_criteria`` as JSON columns.  Upstream task generators
+    (notably the outcome-coverage pipeline introduced in #449) attach
+    dataclass instances such as ``UserOutcome`` to these fields.  Without
+    a custom encoder, ``json.dumps`` raises ``TypeError`` and the kanban
+    write silently drops the task — producing the recipe-revert-haiku
+    failure where Implement/Test tasks vanish while Design/foundation
+    tasks (carrying plain dicts) make it through.
+
+    Supports, in order of preference:
+
+    1. Dataclass instances → ``dataclasses.asdict``
+    2. Pydantic v2 models → ``model_dump``
+    3. Pydantic v1 / objects exposing a callable ``dict`` method
+    4. Objects with ``__dict__`` (last resort, shallow attribute dump)
+
+    Raises
+    ------
+    TypeError
+        When the object exposes no recognized serialization protocol.
+        Lets ``json.dumps`` surface a clear error rather than silently
+        producing partial state.
+    """
+    if dataclasses.is_dataclass(obj) and not isinstance(obj, type):
+        return dataclasses.asdict(obj)
+    model_dump = getattr(obj, "model_dump", None)
+    if callable(model_dump):
+        return model_dump()
+    obj_dict_method = getattr(obj, "dict", None)
+    if callable(obj_dict_method):
+        try:
+            return obj_dict_method()
+        except TypeError:
+            pass
+    if hasattr(obj, "__dict__"):
+        return vars(obj)
+    raise TypeError(f"Object of type {obj.__class__.__name__} is not JSON serializable")
+
 
 # Column name → TaskStatus mapping (case-insensitive)
 _COLUMN_TO_STATUS: Dict[str, TaskStatus] = {
@@ -374,17 +418,26 @@ class SQLiteKanban(KanbanInterface):
                         task_data.get("subtask_index"),
                         task_data.get("source_type"),
                         (
-                            json.dumps(task_data["source_context"])
+                            json.dumps(
+                                task_data["source_context"],
+                                default=_json_default,
+                            )
                             if task_data.get("source_context")
                             else None
                         ),
                         (
-                            json.dumps(task_data["completion_criteria"])
+                            json.dumps(
+                                task_data["completion_criteria"],
+                                default=_json_default,
+                            )
                             if task_data.get("completion_criteria")
                             else None
                         ),
                         (
-                            json.dumps(task_data["acceptance_criteria"])
+                            json.dumps(
+                                task_data["acceptance_criteria"],
+                                default=_json_default,
+                            )
                             if task_data.get("acceptance_criteria")
                             else None
                         ),

--- a/tests/unit/integrations/test_sqlite_kanban.py
+++ b/tests/unit/integrations/test_sqlite_kanban.py
@@ -351,6 +351,82 @@ class TestSQLiteKanbanCreateTask:
 
         assert task.id is not None
 
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_create_task_serializes_nested_non_json_primitives(
+        self, connected_kanban: SQLiteKanban
+    ) -> None:
+        """Nested datetime/UUID/Path/Enum values must serialize.
+
+        Codex P2 on PR #504: ``model_dump()`` and ``dataclasses.asdict()``
+        return Python objects unchanged for non-JSON-native types
+        (``datetime``, ``UUID``, ``Path``, ``Enum``).  Without explicit
+        handling for those types in ``_json_default``, the encoder
+        recursively invokes itself on a ``datetime`` value, has no
+        protocol match, and raises — same silent task-drop symptom as
+        the original bug, just one level deeper.
+
+        Pins coverage for the common stdlib types embedded inside
+        dataclass / Pydantic-model fields.
+        """
+        from dataclasses import dataclass
+        from datetime import datetime, timezone
+        from enum import Enum
+        from pathlib import Path
+        from uuid import uuid4
+
+        class Severity(Enum):
+            HIGH = "high"
+
+        @dataclass
+        class Diagnostic:
+            id_: object
+            created_at: datetime
+            workspace: Path
+            severity: Severity
+
+        task = await connected_kanban.create_task(
+            _sample_task_data(
+                source_context={
+                    "diagnostic": Diagnostic(
+                        id_=uuid4(),
+                        created_at=datetime.now(timezone.utc),
+                        workspace=Path(__file__).parent,
+                        severity=Severity.HIGH,
+                    )
+                },
+            )
+        )
+
+        assert task.id is not None
+
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_create_task_handles_broken_dict_method(
+        self, connected_kanban: SQLiteKanban
+    ) -> None:
+        """Objects whose ``.dict()`` raises must fall through to other paths.
+
+        Pydantic-shaped objects (and arbitrary user code) may expose a
+        callable ``dict`` attribute that raises when invoked without
+        args — e.g. a stub method or a class whose ``dict`` shadows the
+        builtin.  The encoder must catch and fall through to dataclass /
+        stdlib / ``__dict__`` branches rather than propagating.
+        """
+
+        class Wrapper:
+            def __init__(self, value: str) -> None:
+                self.value = value
+
+            def dict(self) -> Any:  # noqa: D401, A003
+                raise TypeError("intentional break")
+
+        task = await connected_kanban.create_task(
+            _sample_task_data(source_context={"wrapped": Wrapper("ok")}),
+        )
+
+        assert task.id is not None
+
 
 class TestSQLiteKanbanGetTasks:
     """Test task retrieval methods."""

--- a/tests/unit/integrations/test_sqlite_kanban.py
+++ b/tests/unit/integrations/test_sqlite_kanban.py
@@ -290,6 +290,67 @@ class TestSQLiteKanbanCreateTask:
         assert task.project_id == "proj-123"
         assert task.project_name == "My Project"
 
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_create_task_serializes_dataclass_in_source_context(
+        self, connected_kanban: SQLiteKanban
+    ) -> None:
+        """Dataclass objects nested in source_context must serialize.
+
+        Regression test for the recipe-revert-haiku failure: per-feature
+        Implement and Test tasks carry UserOutcome dataclass instances
+        in their source_context to support outcome-coverage tracking.
+        The SQLite kanban writer used plain ``json.dumps`` which raised
+        ``TypeError: Object of type UserOutcome is not JSON serializable``,
+        causing every Implement/Test task to be silently dropped while
+        Design/foundation tasks (which carry plain dicts) made it to
+        the board.
+
+        The fix wires a default encoder that handles dataclasses,
+        Pydantic models, and other objects exposing ``model_dump`` /
+        ``dict`` / ``__dict__``.
+        """
+        from dataclasses import dataclass
+
+        @dataclass
+        class FakeOutcome:
+            id: str
+            action: str
+
+        outcome = FakeOutcome(id="outcome_login", action="user can log in")
+
+        task = await connected_kanban.create_task(
+            _sample_task_data(
+                source_type="feature_based",
+                source_context={"covers_outcomes": [outcome], "domain": "auth"},
+            )
+        )
+
+        assert task.id is not None
+
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_create_task_serializes_dataclass_in_completion_criteria(
+        self, connected_kanban: SQLiteKanban
+    ) -> None:
+        """Dataclasses in completion_criteria also must serialize."""
+        from dataclasses import dataclass
+
+        @dataclass
+        class Criterion:
+            description: str
+            verifier: str
+
+        task = await connected_kanban.create_task(
+            _sample_task_data(
+                completion_criteria=[
+                    Criterion(description="login works", verifier="curl")
+                ],
+            )
+        )
+
+        assert task.id is not None
+
 
 class TestSQLiteKanbanGetTasks:
     """Test task retrieval methods."""


### PR DESCRIPTION
## Summary

Per-feature `Implement X` and `Test X` tasks were silently dropped during SQLite kanban writes because their `source_context` carries `UserOutcome` dataclass instances (attached by the outcome-coverage pipeline from #449). `json.dumps` raised `TypeError`, the kanban write failed per-task, and the symptom surfaced as *\"recipe-scale projects have zero Implement parents on the board\"* while Design / foundation tasks (carrying plain dicts) survived.

Fixes #502.

## Root cause

Three sites in `sqlite_kanban.py` called `json.dumps` on task fields with no `default` encoder:
- `source_context` (line 377)
- `completion_criteria` (line 382)
- `acceptance_criteria` (line 387)

When upstream attached dataclass instances, all three raised. Per-task exception bubbled up to `create_tasks_on_board`, was logged as a Medium-severity Marcus error, and the task never reached the board.

## Evidence

`logs/marcus_20260510_215120.log` recipe-revert-haiku run:

```
L1970 INFO  Successfully generated all 15 tasks in parallel
L1993 INFO  process_natural_language returned 19 tasks
            breakdown: {'infrastructure': 1, 'implementation': 9,
                        'design': 4, 'testing': 5}
L2037 ERROR Task creation failed for 'Implement User Authentication':
            TypeError: Object of type UserOutcome is not JSON serializable
            File \"sqlite_kanban.py\", line 377
              json.dumps(task_data[\"source_context\"])
```

9 implementation tasks generated → 0 reached kanban.

## Fix

Adds module-level `_json_default` encoder covering dataclasses, Pydantic v1/v2 models, and `__dict__`-bearing objects. Wires it into all three `json.dumps` sites.

## Test plan

- [x] Two new regression tests pin both `source_context` and `completion_criteria` against a synthetic dataclass — fail before fix, pass after
- [x] Full file suite: 98 / 98 passed
- [x] mypy --strict clean
- [ ] Manual: re-run recipe-revert-haiku at standard complexity → verify `Implement X` parents appear on board

## Follow-ups (separate PRs)

1. Revert-the-revert of #490 (the outcome-coverage prompt tightening, currently reverted on `revert/490-outcome-coverage-prompt`) — with this fix in, gap-fill returns to safety-net role and #490's false-positive fix is a legitimate improvement.
2. New issue: contract-first gap-fill LLM (Haiku) emits names prefixed with literal \"Task\" (e.g. `Task Signup Form`). Tighten `_GAP_FILL_PROMPT_SCHEMA_*` and harden `_normalize_gap_task_name`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)