### PR TITLE
fix(contract-validation): loosen _normalize_type to ignore stylistic noise

### DIFF
--- a/src/integrations/contract_validation.py
+++ b/src/integrations/contract_validation.py
@@ -90,12 +90,34 @@ def _normalize_type(type_str: str) -> str:
     """
     Normalize a type string for cross-file comparison.
 
-    Collapses whitespace, strips markdown formatting, strips common
-    qualifiers (required, optional, nullable), and maps common
-    synonyms to canonical types. Deliberately lenient: catches
-    ``ISO 8601 string`` vs ``Date object`` (a real contradiction)
-    while ignoring ``string`` vs ``string, required`` (stylistic
-    variation on the same type).
+    The goal is to catch real type disagreements (``string`` vs
+    ``number``, ``array of strings`` vs ``array of Foo``) while
+    ignoring stylistic noise that doesn't change the underlying
+    type contract (length constraints, format hints, optionality,
+    JSON Schema synonyms).
+
+    Strategy:
+
+    1. Lowercase, strip markdown, collapse whitespace and union
+       syntax (``or`` → ``|``).
+    2. Drop common qualifier suffixes (required / optional / nullable).
+    3. **Drop everything after the first comma.** Trailing
+       ``, UUID v4``, ``, 0-500 characters``, ``, max 100, default 20``
+       describe constraints on the base type, not the type itself.
+    4. For composite types (``array of X``, ``map of X``), preserve
+       the element type so genuine element-type disagreement is
+       still caught.
+    5. Canonicalize JSON Schema synonyms: ``integer`` → ``number``
+       (integer is a subset of number per JSON Schema; treating them
+       as a contradiction floods recipe-platform-shaped projects
+       with false positives on pagination params like ``limit``).
+
+    Catches: ``string`` vs ``number``, ``array of strings`` vs
+    ``array of Recipe``, ``Date object`` vs ``ISO 8601 string``.
+
+    Ignores: ``string, UUID v4`` vs ``string``, ``number, optional,
+    default 20`` vs ``integer, max 100``, ``string, 0-500 chars`` vs
+    ``string``.
 
     Parameters
     ----------
@@ -126,7 +148,22 @@ def _normalize_type(type_str: str) -> str:
     for qual in qualifiers:
         t = t.replace(qual, "")
 
-    return t.strip()
+    # Drop trailing constraints separated by comma (format hints,
+    # length bounds, default values, etc).  ``string, UUID v4`` →
+    # ``string``; ``number, max 100, default 20`` → ``number``.
+    # Composite types like ``array of X`` don't use commas inside
+    # the ``X`` payload in any of the contract corpora we've seen,
+    # so this is safe.  If that changes, the LLM should emit
+    # ``Array<X>`` style instead.
+    t = t.split(",")[0].strip()
+
+    # JSON Schema synonym: integer is a number subtype.  Treating
+    # them as a contradiction false-positives on pagination params
+    # like ``limit (number)`` vs ``limit (integer)``.
+    if t == "integer":
+        t = "number"
+
+    return t
 
 
 def check_contract_cross_file_consistency(

--- a/src/integrations/contract_validation.py
+++ b/src/integrations/contract_validation.py
@@ -159,8 +159,12 @@ def _normalize_type(type_str: str) -> str:
 
     # JSON Schema synonym: integer is a number subtype.  Treating
     # them as a contradiction false-positives on pagination params
-    # like ``limit (number)`` vs ``limit (integer)``.
-    if t == "integer":
+    # like ``limit (number)`` vs ``limit (integer)``.  Apply per
+    # union member so ``integer | null`` and ``number | null`` also
+    # canonicalize equally (Codex P2 on PR #505).
+    if "|" in t:
+        t = "|".join("number" if part == "integer" else part for part in t.split("|"))
+    elif t == "integer":
         t = "number"
 
     return t

--- a/tests/unit/integrations/test_contract_validation.py
+++ b/tests/unit/integrations/test_contract_validation.py
@@ -251,6 +251,170 @@ class TestCheckContractCrossFileConsistency:
             f"Architecture artifacts should not be cross-checked. " f"Got: {result}"
         )
 
+    def test_string_with_format_hint_matches_plain_string(self):
+        """``string, UUID v4`` and ``string`` are the same base type.
+
+        Regression from recipe-revert-haiku runs: Haiku emits
+        ``userid (string, UUID v4)`` in one contract and ``userid
+        (string, UUID)`` in another (or plain ``string``).  Both
+        describe a UUID-shaped string — not a contradiction.  The
+        normalizer must collapse trailing format hints to the base
+        type token.
+        """
+        contract_artifacts = {
+            "Auth": {
+                "artifacts": [
+                    _make_artifact(
+                        "auth-interface-contracts.md",
+                        "- userid (string, UUID v4) — user identifier\n",
+                    ),
+                ],
+                "decisions": [],
+            },
+            "Recipes": {
+                "artifacts": [
+                    _make_artifact(
+                        "recipes-interface-contracts.md",
+                        "- userid (string, UUID) — owner reference\n",
+                    ),
+                ],
+                "decisions": [],
+            },
+        }
+
+        result = check_contract_cross_file_consistency(contract_artifacts)
+        assert (
+            result["pass"] is True
+        ), f"format-hint variants should not contradict; got {result}"
+
+    def test_string_with_length_constraint_matches_plain_string(self):
+        """``string, 0-500 characters`` is still a string.
+
+        Length / range constraints are not type differences.  Pinned
+        from recipe-revert-haiku: ``description (string)`` vs
+        ``description (string, 0–500 characters, optional)``.
+        """
+        contract_artifacts = {
+            "Domain A": {
+                "artifacts": [
+                    _make_artifact(
+                        "a-interface-contracts.md",
+                        "- description (string) — free text\n",
+                    ),
+                ],
+                "decisions": [],
+            },
+            "Domain B": {
+                "artifacts": [
+                    _make_artifact(
+                        "b-interface-contracts.md",
+                        "- description (string, 0-500 characters, optional)\n",
+                    ),
+                ],
+                "decisions": [],
+            },
+        }
+
+        result = check_contract_cross_file_consistency(contract_artifacts)
+        assert result["pass"] is True
+
+    def test_number_and_integer_are_equivalent(self):
+        """``number`` and ``integer`` describe the same JSON type family.
+
+        Pinned from recipe-revert-haiku: ``limit (number, optional,
+        default 20, max 100)`` vs ``limit (integer, optional, default
+        20, max 100)``.  Per JSON Schema, integer is a subset of number
+        — not a contradiction for cross-contract agreement.
+        """
+        contract_artifacts = {
+            "Domain A": {
+                "artifacts": [
+                    _make_artifact(
+                        "a-interface-contracts.md",
+                        "- limit (number, optional, default 20, max 100)\n",
+                    ),
+                ],
+                "decisions": [],
+            },
+            "Domain B": {
+                "artifacts": [
+                    _make_artifact(
+                        "b-interface-contracts.md",
+                        "- limit (integer, optional, default 20, max 100)\n",
+                    ),
+                ],
+                "decisions": [],
+            },
+        }
+
+        result = check_contract_cross_file_consistency(contract_artifacts)
+        assert result["pass"] is True
+
+    def test_array_of_different_element_types_still_contradicts(self):
+        """Loosening must NOT mask genuine array-element disagreement.
+
+        ``array of strings`` vs ``array of IngredientItem objects``
+        for the same field is a real contradiction the gate must still
+        catch — pinned from recipe-revert-haiku's ``ingredients``
+        field collision.
+        """
+        contract_artifacts = {
+            "Recipes": {
+                "artifacts": [
+                    _make_artifact(
+                        "recipes-interface-contracts.md",
+                        "- ingredients (array of IngredientItem objects)\n",
+                    ),
+                ],
+                "decisions": [],
+            },
+            "Discovery": {
+                "artifacts": [
+                    _make_artifact(
+                        "discovery-interface-contracts.md",
+                        "- ingredients (array of strings) — flat list\n",
+                    ),
+                ],
+                "decisions": [],
+            },
+        }
+
+        result = check_contract_cross_file_consistency(contract_artifacts)
+        assert (
+            result["pass"] is False
+        ), f"array-of-X vs array-of-Y must still contradict; got {result}"
+
+    def test_string_vs_number_still_contradicts(self):
+        """The classic WidgetPosition-shape collision must still fire.
+
+        Loosening trailing constraints is fine; collapsing the base
+        type token (``string`` ↔ ``number``) would defeat the gate's
+        whole purpose.
+        """
+        contract_artifacts = {
+            "Domain A": {
+                "artifacts": [
+                    _make_artifact(
+                        "a-interface-contracts.md",
+                        "- amount (number, max 9999)\n",
+                    ),
+                ],
+                "decisions": [],
+            },
+            "Domain B": {
+                "artifacts": [
+                    _make_artifact(
+                        "b-interface-contracts.md",
+                        "- amount (string, ISO 4217)\n",
+                    ),
+                ],
+                "decisions": [],
+            },
+        }
+
+        result = check_contract_cross_file_consistency(contract_artifacts)
+        assert result["pass"] is False
+
     def test_handles_none_payload_gracefully(self):
         """
         ``_generate_contracts_by_domain`` returns ``None`` for

--- a/tests/unit/integrations/test_contract_validation.py
+++ b/tests/unit/integrations/test_contract_validation.py
@@ -350,6 +350,41 @@ class TestCheckContractCrossFileConsistency:
         result = check_contract_cross_file_consistency(contract_artifacts)
         assert result["pass"] is True
 
+    def test_integer_and_number_inside_union_are_equivalent(self):
+        """``integer | null`` and ``number | null`` describe the same type.
+
+        Codex P2 on PR #505: the integer→number canonicalization only
+        triggered on whole-string equality, so nullable pagination
+        fields like ``limit (integer | null)`` vs ``limit (number | null)``
+        slipped through and still forced contract_first fallback.
+        Canonicalize per union member to fix.
+        """
+        contract_artifacts = {
+            "Domain A": {
+                "artifacts": [
+                    _make_artifact(
+                        "a-interface-contracts.md",
+                        "- cursor (number | null, optional)\n",
+                    ),
+                ],
+                "decisions": [],
+            },
+            "Domain B": {
+                "artifacts": [
+                    _make_artifact(
+                        "b-interface-contracts.md",
+                        "- cursor (integer | null, optional)\n",
+                    ),
+                ],
+                "decisions": [],
+            },
+        }
+
+        result = check_contract_cross_file_consistency(contract_artifacts)
+        assert (
+            result["pass"] is True
+        ), f"integer|null vs number|null should not contradict; got {result}"
+
     def test_array_of_different_element_types_still_contradicts(self):
         """Loosening must NOT mask genuine array-element disagreement.
 


### PR DESCRIPTION
## Summary

The cross-contract type consistency gate at `check_contract_cross_file_consistency` was firing on stylistic LLM phrasing rather than real type disagreements, forcing every Haiku-shaped recipe-platform run from contract_first → feature_based fallback.

## Evidence

Three separate runs in `logs/marcus_20260510_230613.log` (lines 1410, 2805, 7501) all failed with contradictions like:

| Field | Contract A | Contract B | Real? |
|-------|-----------|-----------|-------|
| `userid` | `string, UUID v4` | `string, UUID` | ❌ same |
| `description` | `string` | `string, 0-500 chars, optional` | ❌ same |
| `limit` | `number, optional, default 20` | `integer, optional, default 20` | ❌ same |
| `offset` | `number, optional, default 0` | `integer, optional, default 0` | ❌ same |
| `name` | `string, 1-255 chars` | `string` | ❌ same |

None are type contradictions — format hints, length constraints, and the `number`/`integer` JSON Schema synonym. The old normalizer only stripped `required`/`optional`/`nullable`, leaving the rest to false-positive against strict equality.

## Fix

In `_normalize_type`:

1. After existing qualifier stripping, **drop everything after the first comma**. Trailing constraints describe properties of the base type, not the type itself.
2. **Canonicalize `integer` → `number`** per JSON Schema (integer is a number subtype).

## Must-still-catch (regression-pinned)

- `string` vs `number` (the classic WidgetPosition collision)
- `array of strings` vs `array of IngredientItem objects` (real element-type disagreement)

## Test plan

- [x] 5 new tests: 3 cases that should now pass + 2 that must still fail
- [x] All 11 tests in `test_contract_validation.py` green
- [x] 142 contract-adjacent unit tests across the repo green
- [x] mypy --strict clean

## Follow-ups (separate)

- "Task" prefix prompt fix in `_GAP_FILL_PROMPT_SCHEMA_*`

🤖 Generated with [Claude Code](https://claude.com/claude-code)