### PR TITLE
feat(cost): plumb project_name through list_projects (Marcus #409)

### DIFF
--- a/src/cost_tracking/cost_aggregator.py
+++ b/src/cost_tracking/cost_aggregator.py
@@ -264,11 +264,16 @@ class CostAggregator:
     def list_projects(self, limit: int = 100) -> List[Dict[str, Any]]:
         """List every project_id that has cost events, sorted by spend desc.
 
-        Source of truth is ``token_events.project_id`` — derived purely from
-        recorded events, no dependence on the ``experiments`` table. Each
-        row carries event count, token total, cost, and (best-effort)
-        first/last activity timestamps so the dashboard can show "active
-        in the last hour" without a second query.
+        The primary source of truth is ``token_events.project_id`` — every
+        row is derived from recorded events. The query then enriches each
+        project row with a human-readable ``project_name`` from the
+        ``experiments`` table as a best-effort label; this is NULL for
+        projects whose runs never called ``start_experiment``, and the
+        dashboard falls back to the raw ``project_id`` in that case.
+
+        Each row carries event count, token total, cost, and first/last
+        activity timestamps so the dashboard can show "active in the last
+        hour" without a second query.
 
         Parameters
         ----------
@@ -285,10 +290,21 @@ class CostAggregator:
         # LEFT JOIN to experiments to pull a human-readable project_name
         # when one exists. The experiments table is only populated when a
         # run opts into MLflow tracking (start_experiment), so many
-        # projects will have NULL here — the dashboard falls back to the
-        # raw project_id in that case. We pick MAX(project_name) just to
-        # avoid GROUP BY non-determinism when the same project has
-        # multiple experiments with different names (rare but possible).
+        # projects will have NULL here.
+        #
+        # JOIN-safety invariant: this query relies on
+        # ``experiments.experiment_id`` being unique (it's the primary
+        # key, see cost_store.SCHEMA_SQL). If a future migration relaxes
+        # that — e.g. adds a versioning column — the LEFT JOIN will fan
+        # out and inflate every token / cost total. Revisit this query
+        # if the experiments PK ever changes.
+        #
+        # MAX(project_name) picks the lexically latest name to keep the
+        # GROUP BY deterministic when the same project_id has multiple
+        # experiments with conflicting names. This is masking-not-fixing
+        # behavior: a name conflict usually means data drift (rename,
+        # spawn registry bug). Intentional drift detection is a separate
+        # follow-up; today we just stay deterministic.
         return self._rows(
             """
             SELECT t.project_id,

--- a/src/cost_tracking/cost_aggregator.py
+++ b/src/cost_tracking/cost_aggregator.py
@@ -282,19 +282,28 @@ class CostAggregator:
             it's surfaced separately via ``unassigned_totals`` so it
             doesn't get mistaken for a real project.
         """
+        # LEFT JOIN to experiments to pull a human-readable project_name
+        # when one exists. The experiments table is only populated when a
+        # run opts into MLflow tracking (start_experiment), so many
+        # projects will have NULL here — the dashboard falls back to the
+        # raw project_id in that case. We pick MAX(project_name) just to
+        # avoid GROUP BY non-determinism when the same project has
+        # multiple experiments with different names (rare but possible).
         return self._rows(
             """
-            SELECT project_id,
+            SELECT t.project_id,
+                   MAX(e.project_name)                  AS project_name,
                    COUNT(*)                             AS events,
-                   COUNT(DISTINCT experiment_id)        AS experiments,
-                   COUNT(DISTINCT agent_id)             AS agents,
-                   COALESCE(SUM(total_tokens), 0)       AS total_tokens,
-                   COALESCE(SUM(cost_usd), 0)           AS total_cost_usd,
-                   MIN(timestamp)                       AS first_event_at,
-                   MAX(timestamp)                       AS last_event_at
-            FROM v_event_cost
-            WHERE project_id != 'unassigned'
-            GROUP BY project_id
+                   COUNT(DISTINCT t.experiment_id)      AS experiments,
+                   COUNT(DISTINCT t.agent_id)           AS agents,
+                   COALESCE(SUM(t.total_tokens), 0)     AS total_tokens,
+                   COALESCE(SUM(t.cost_usd), 0)         AS total_cost_usd,
+                   MIN(t.timestamp)                     AS first_event_at,
+                   MAX(t.timestamp)                     AS last_event_at
+            FROM v_event_cost t
+            LEFT JOIN experiments e USING (experiment_id)
+            WHERE t.project_id != 'unassigned'
+            GROUP BY t.project_id
             ORDER BY total_cost_usd DESC
             LIMIT ?
             """,

--- a/tests/unit/cost_tracking/test_cost_aggregator.py
+++ b/tests/unit/cost_tracking/test_cost_aggregator.py
@@ -234,6 +234,45 @@ class TestListProjects:
         assert rows[0]["events"] == 3
         assert rows[0]["total_tokens"] == 10700
 
+    def test_attaches_project_name_when_experiment_exists(
+        self, agg: CostAggregator
+    ) -> None:
+        """Kaia PR #33 review: project_name should plumb through the JOIN.
+
+        The fixture experiment ``exp_1`` registered ``project_name='hangman'``;
+        the project rollup should surface that label instead of leaving it
+        for the dashboard to fall back to a truncated project_id.
+        """
+        rows = agg.list_projects()
+        assert rows[0]["project_name"] == "hangman"
+
+    def test_project_name_null_when_no_experiment_registered(
+        self, populated_store: CostStore
+    ) -> None:
+        """A project with events but no MLflow run leaves project_name NULL.
+
+        Many runs never call start_experiment, so the dashboard MUST handle
+        NULL gracefully. This test pins the contract: NULL means "no name
+        available, fall back to project_id".
+        """
+        populated_store.record_event(
+            TokenEvent(
+                experiment_id="exp_no_meta",
+                project_id="proj_no_meta",
+                agent_id="planner",
+                agent_role="planner",
+                operation="parse_prd",
+                provider="anthropic",
+                model="claude-sonnet-4-6",
+                input_tokens=1,
+                output_tokens=1,
+            )
+        )
+        agg = CostAggregator(store=populated_store)
+        rows = agg.list_projects()
+        nameless = next(r for r in rows if r["project_id"] == "proj_no_meta")
+        assert nameless["project_name"] is None
+
     def test_excludes_unassigned_bucket(self, populated_store: CostStore) -> None:
         """Events tagged 'unassigned' do not appear in the project list."""
         populated_store.record_event(


### PR DESCRIPTION
## Summary

Kaia review of [Cato PR #33](https://github.com/lwgray/cato/pull/33) caught that the project picker in the dashboard shows \`project_id.slice(0, 12)\`. Marcus project IDs are 19-digit numbers (\`1555318548920796226\`), so two runs from the same day become indistinguishable in the dropdown. Fix: surface \`project_name\` from the experiments table so the dashboard can show a real label when one exists.

## Change

\`list_projects()\` now \`LEFT JOIN\`s \`experiments\` on \`experiment_id\` and returns \`MAX(project_name)\` per project. NULL when no MLflow run was ever registered (the common case for runs that don't opt into tracking). Cato will fall back to the truncated id when name is NULL.

- \`MAX(project_name)\` keeps the GROUP BY deterministic when a project has multiple experiments with different names.
- \`LEFT JOIN\` (not INNER) preserves the existing "projects with events but no run" surface.

## Test plan

- [x] 2 new regression tests in \`TestListProjects\`:
  - \`test_attaches_project_name_when_experiment_exists\`
  - \`test_project_name_null_when_no_experiment_registered\`
- [x] All 18 aggregator tests pass
- [x] mypy --strict clean

## Cato follow-up

A matching Cato change will update \`CostDashboard.tsx\` to render \`project_name ?? project_id.slice(...)\`. Goes in a separate PR so this Marcus piece can merge independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)