### PR TITLE
fix(cost): make dedup migration truly no-op + busy_timeout (#511 followup)

### DIFF
--- a/src/cost_tracking/cost_store.py
+++ b/src/cost_tracking/cost_store.py
@@ -450,6 +450,11 @@ class CostStore:
         self.conn = sqlite3.connect(str(db_path), check_same_thread=False)
         self.conn.execute("PRAGMA journal_mode=WAL")
         self.conn.execute("PRAGMA foreign_keys=ON")
+        # Wait up to 5s for the lock on startup DDL / contended writes
+        # before raising OperationalError. Cato polls run_ingest every
+        # 30s; bare 0ms timeout caused Marcus startup to die immediately
+        # when Cato held the WAL.
+        self.conn.execute("PRAGMA busy_timeout=5000")
         self._init_schema()
 
     def _init_schema(self) -> None:
@@ -470,13 +475,25 @@ class CostStore:
 
         Keeps the lowest ``event_id`` per ``request_id``. Duplicates are
         byte-identical re-inserts of the same payload, so any winner is
-        correct; ``MIN(event_id)`` is just a stable choice. No-op on
-        fresh installs (table absent) and on already-clean DBs.
+        correct; ``MIN(event_id)`` is just a stable choice.
+
+        Skipped on three cases:
+        - Fresh install (token_events absent) — nothing to dedup.
+        - Already-migrated DB (ux_te_request_id present) — by construction
+          there are no duplicates, and the DELETE would still take a write
+          lock that conflicts with concurrent Cato polling. This makes the
+          migration truly no-op on every Marcus restart after the first.
         """
         table_exists = self.conn.execute(
             "SELECT 1 FROM sqlite_master " "WHERE type='table' AND name='token_events'"
         ).fetchone()
         if not table_exists:
+            return
+        index_exists = self.conn.execute(
+            "SELECT 1 FROM sqlite_master "
+            "WHERE type='index' AND name='ux_te_request_id'"
+        ).fetchone()
+        if index_exists:
             return
         self.conn.execute("""
             DELETE FROM token_events

--- a/tests/unit/cost_tracking/test_cost_store.py
+++ b/tests/unit/cost_tracking/test_cost_store.py
@@ -230,6 +230,43 @@ class TestRecordEvent:
                 "('e','p','a','planner','op','anthropic','m','req_dup')"
             )
 
+    def test_dedup_migration_skipped_when_index_already_exists(
+        self, tmp_path: Path
+    ) -> None:
+        """Subsequent CostStore opens must not run the DELETE.
+
+        Once ``ux_te_request_id`` exists the DB has no duplicates by
+        construction. The migration must short-circuit so it doesn't
+        take a write lock on every startup — that's what caused
+        ``OperationalError: database is locked`` against a concurrently-
+        polled Cato. Uses ``set_trace_callback`` to capture every SQL
+        statement issued during init and asserts none of them is the
+        dedup DELETE.
+        """
+        db = tmp_path / "x.db"
+        # First open creates the index.
+        CostStore(db_path=db).conn.close()
+
+        # Second open: spy on all SQL via trace callback before init runs.
+        seen: list[str] = []
+        original_connect = sqlite3.connect
+
+        def tracing_connect(*args: object, **kwargs: object) -> sqlite3.Connection:
+            conn = original_connect(*args, **kwargs)  # type: ignore[arg-type]
+            conn.set_trace_callback(seen.append)
+            return conn
+
+        import unittest.mock as mock
+
+        with mock.patch(
+            "src.cost_tracking.cost_store.sqlite3.connect", tracing_connect
+        ):
+            CostStore(db_path=db)
+
+        assert not any(
+            "DELETE FROM token_events" in s for s in seen
+        ), f"dedup DELETE issued despite existing index; statements: {seen}"
+
     def test_null_request_id_allows_multiple_rows(
         self, seeded_store: CostStore, base_event: TokenEvent
     ) -> None:


### PR DESCRIPTION
## Summary
After #511 merged, restarting Marcus while Cato was polling caused \`OperationalError: database is locked\` on startup. Two root causes:

1. \`_dedup_pre_index_migration\` ran a write-locking \`DELETE\` on every startup, even when the unique index already existed. Now short-circuits: index present ⇒ zero duplicates by construction ⇒ skip the DELETE entirely.

2. \`sqlite3.connect()\` defaults to \`busy_timeout=0\`, so any concurrent writer (Cato's 30s \`run_ingest\`) made startup DDL fail immediately. Set \`PRAGMA busy_timeout=5000\`.

## Test plan
- [x] \`pytest tests/unit/cost_tracking/\` — 62 pass
- [x] Restarted live Marcus with Cato historically polling — clean startup, no lock errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)