### PR TITLE
fix(cost): plug 100% planner-cost attribution leak (Marcus #409)

### DIFF
--- a/src/ai/providers/openai_provider.py
+++ b/src/ai/providers/openai_provider.py
@@ -25,11 +25,13 @@ Model selection via OPENAI_MODEL environment variable.
 import json
 import logging
 import os
+import time
 from typing import Any, Dict, List
 
 import httpx
 
 from src.core.models import Task
+from src.cost_tracking.cost_recorder import get_recorder
 
 from .base_provider import (
     BaseLLMProvider,
@@ -387,7 +389,14 @@ Provide JSON array of 3-5 specific solutions:
 ["solution1", "solution2", "solution3"]"""
 
     async def _call_openai(self, messages: List[Dict[str, str]]) -> str:
-        """Make API call to OpenAI."""
+        """Make API call to OpenAI.
+
+        Records the token usage to the planner cost store on success
+        (parity with AnthropicProvider / LocalLLMProvider — without
+        this hook every OpenAI fallback during Marcus's decomposition /
+        analysis path silently went uncounted, leaving cost data missing
+        the entire 'planner' role for accounts that aren't on Anthropic).
+        """
         payload = {
             "model": self.model,
             "messages": messages,
@@ -395,6 +404,7 @@ Provide JSON array of 3-5 specific solutions:
             "temperature": self.temperature,
         }
 
+        start = time.monotonic()
         try:
             response = await self.client.post(
                 f"{self.base_url}/chat/completions", json=payload
@@ -402,6 +412,24 @@ Provide JSON array of 3-5 specific solutions:
             response.raise_for_status()
 
             data = response.json()
+            latency_ms = int((time.monotonic() - start) * 1000)
+            # OpenAI-compatible servers return a usage object with
+            # prompt_tokens / completion_tokens. Cache fields are
+            # absent for non-Anthropic backends; record_planner_call
+            # defaults them to 0.
+            usage = data.get("usage") or {}
+            try:
+                get_recorder().record_planner_call(
+                    operation="analyze",
+                    provider="openai",
+                    model=str(data.get("model", self.model)),
+                    input_tokens=int(usage.get("prompt_tokens", 0)),
+                    output_tokens=int(usage.get("completion_tokens", 0)),
+                    latency_ms=latency_ms,
+                    request_id=str(data.get("id")) if data.get("id") else None,
+                )
+            except Exception:  # pragma: no cover - recorder must never raise
+                logger.exception("OpenAI cost recording failed")
             return str(data["choices"][0]["message"]["content"])
 
         except httpx.TimeoutException:

--- a/src/cost_tracking/cost_recorder.py
+++ b/src/cost_tracking/cost_recorder.py
@@ -226,6 +226,23 @@ class CostRecorder:
         if not self.enabled:
             return
         ctx = self.current()
+        # Diagnostic: when a planner LLM call lands without an active
+        # PlannerContext it falls back to 'unassigned'. Logged at DEBUG
+        # so it's quiet by default but still discoverable when chasing
+        # attribution gaps (#409 follow-up — this is how we found the
+        # OpenAI provider missing the recorder hook).
+        if ctx is None:
+            logger.debug(
+                "cost_recorder: NO context for operation=%s provider=%s "
+                "model=%s tokens=%d (call will land in 'unassigned')",
+                operation,
+                provider,
+                model,
+                input_tokens
+                + cache_creation_tokens
+                + cache_read_tokens
+                + output_tokens,
+            )
         if ctx is not None:
             experiment_id = ctx.experiment_id
             project_id = ctx.project_id

--- a/src/integrations/nlp_tools.py
+++ b/src/integrations/nlp_tools.py
@@ -4098,6 +4098,86 @@ async def _run_design_phase(
         contract-first Cato retrofit — Phase A skipped when contracts
         are already generated upstream.
     """
+    # Codex P1 on PR #516 — placeholder context leaks into background
+    # design phase. ``create_project`` wraps ``_create_project_inner``
+    # in a ``planner_context`` carrying a synthetic ``pending:<uuid>``
+    # project_id and runs a one-shot ``rebind_project_id`` after the
+    # inner call returns. But this function is spawned via
+    # ``asyncio.ensure_future`` *during* the inner call, so it
+    # inherits the placeholder via the parent task's ContextVar
+    # state copy. After the wrapper's one-shot rebind fires, the
+    # design phase keeps writing rows under the placeholder — those
+    # rows are never rebound and stay hidden as ``pending:*``.
+    #
+    # Fix: as the very first action, push a fresh PlannerContext
+    # carrying the real project_id (resolved from the kanban_client)
+    # so the placeholder is shadowed for the rest of this task's
+    # lifetime. The asyncio task isolation means the main task's
+    # stack is unaffected — the wrapper's rebind still catches the
+    # synchronous rows under the placeholder, and the design
+    # phase's rows are attributed to the real project from the
+    # start.
+    #
+    # If ``kanban_client.project_id`` is unavailable (shouldn't
+    # happen post-board-creation), fall through with the inherited
+    # context — best-effort, no worse than the bug we're fixing.
+    from contextlib import nullcontext as _nullcontext
+
+    from src.cost_tracking.cost_recorder import PlannerContext as _PlannerContext
+    from src.cost_tracking.cost_recorder import (
+        canonical_project_id as _canonical_project_id,
+    )
+    from src.cost_tracking.cost_recorder import get_recorder as _get_recorder
+
+    _raw_pid = getattr(kanban_client, "project_id", None)
+    # Defensive isinstance check: tests often use ``MagicMock``-backed
+    # kanban clients whose ``project_id`` resolves to another
+    # ``MagicMock`` rather than ``None``. Without the check we'd push
+    # a context with a non-string project_id and the recorder would
+    # silently swallow the SQL error.
+    _real_pid = _canonical_project_id(_raw_pid) if isinstance(_raw_pid, str) else None
+    if _real_pid:
+        _design_ctx_cm: Any = _get_recorder().planner_context(
+            _PlannerContext(
+                experiment_id="unassigned",
+                project_id=_real_pid,
+                project_name=project_name,
+            )
+        )
+    else:
+        _design_ctx_cm = _nullcontext()
+
+    with _design_ctx_cm:
+        await _run_design_phase_body(
+            state=state,
+            kanban_client=kanban_client,
+            safe_tasks=safe_tasks,
+            created_tasks=created_tasks,
+            description=description,
+            project_name=project_name,
+            project_root=project_root,
+            pre_generated_content=pre_generated_content,
+        )
+
+
+async def _run_design_phase_body(
+    state: Any,
+    kanban_client: Any,
+    safe_tasks: List[Task],
+    created_tasks: List[Task],
+    description: str,
+    project_name: str,
+    project_root: str,
+    pre_generated_content: Optional[Dict[str, Dict[str, Any]]] = None,
+) -> None:
+    """Body of the background design phase (Phase A + Phase B + DONE + scaffold).
+
+    Split out from :func:`_run_design_phase` so that the wrapper can
+    push a fresh ``PlannerContext`` (Codex P1 on PR #516) without
+    forcing the entire body into an extra indentation level. See
+    :func:`_run_design_phase` for the full documentation of behavior,
+    ordering invariants, and regression history.
+    """
     design_content: Dict[str, Any] = {}
     if pre_generated_content is not None:
         # Contract-first Cato retrofit path. Phase A artifacts and

--- a/src/marcus_mcp/handlers.py
+++ b/src/marcus_mcp/handlers.py
@@ -9,7 +9,6 @@ in a centralized location.
 import json
 import logging
 import time
-import uuid
 from contextlib import ExitStack
 from typing import Any, Dict, List, Optional
 
@@ -1337,64 +1336,18 @@ async def handle_tool_call(
             if not description or not project_name:
                 result = {"error": "description and project_name are required"}
             else:
-                # Two-phase cost attribution for project creation:
-                #
-                # Phase 1: push a placeholder PlannerContext so the heavy
-                # decomposition LLM calls land in token_events with an
-                # identifiable project_id. The placeholder is a random
-                # 128-bit hex so two concurrent create_project calls
-                # cannot collide — see docs/issue #514 for the upstream
-                # race in ProjectRegistry itself.
-                #
-                # Phase 2: after create_project returns the real id,
-                # UPDATE token_events to rebind every row from the
-                # placeholder to the new id. If the tool fails before
-                # then, the placeholder rows stay tagged with
-                # ``pending:<hex>`` and the picker hides them — visible
-                # in the Unassigned popover as forensic evidence.
-                _placeholder = f"pending:{uuid.uuid4().hex}"
-                _display_name = f"{project_name} (creating)"
-                with get_recorder().planner_context(
-                    PlannerContext(
-                        experiment_id="unassigned",
-                        project_id=_placeholder,
-                        project_name=_display_name,
-                    )
-                ):
-                    result = await create_project(
-                        description=description,
-                        project_name=project_name,
-                        options=arguments.get("options"),
-                        state=state,
-                    )
-
-                # Phase 2: rebind on success. Failures leave the
-                # placeholder rows for inspection; the dashboard
-                # filters them out of the main project picker.
-                if isinstance(result, dict) and result.get("success"):
-                    _real_id = result.get("project_id")
-                    if _real_id:
-                        from src.cost_tracking.cost_recorder import (
-                            canonical_project_id,
-                        )
-
-                        _canonical = canonical_project_id(str(_real_id))
-                        if _canonical:
-                            try:
-                                state.cost_store.rebind_project_id(
-                                    from_id=_placeholder,
-                                    to_id=_canonical,
-                                )
-                                state.cost_store.upsert_project_name(
-                                    _canonical, project_name
-                                )
-                            except Exception:
-                                logger.exception(
-                                    "cost rebind failed for create_project "
-                                    "placeholder=%s real=%s",
-                                    _placeholder,
-                                    _canonical,
-                                )
+                # Cost attribution (placeholder push + rebind) lives
+                # inside ``nlp.create_project`` so every entry point —
+                # this legacy stdio handler, FastMCP HTTP, or direct
+                # Python callers — gets the same behavior. See the
+                # docstring on ``create_project`` for the two-phase
+                # design.
+                result = await create_project(
+                    description=description,
+                    project_name=project_name,
+                    options=arguments.get("options"),
+                    state=state,
+                )
 
             # Log tool call complete
             state.log_event(

--- a/src/marcus_mcp/tools/nlp.py
+++ b/src/marcus_mcp/tools/nlp.py
@@ -126,8 +126,92 @@ _recent_create_project_calls: Dict[str, tuple[float, Optional[Dict[str, Any]]]] 
 async def create_project(
     description: str, project_name: str, options: Optional[Dict[str, Any]], state: Any
 ) -> Dict[str, Any]:
+    """Public entry point. Wraps the heavy work with cost-attribution.
+
+    Marcus exposes ``create_project`` from two MCP entry points:
+    legacy stdio (``handlers.py:handle_tool_call``) and FastMCP HTTP
+    (``server.py:@app.tool()``). Both ultimately call this function.
+    Putting the placeholder/rebind logic here covers every caller —
+    including future ones — without depending on whichever wrapper
+    happened to fire. Pre-PR-#515 the logic lived only in the legacy
+    handler and never ran for HTTP clients, so all planner cost
+    silently landed in 'unassigned' (#409 followup).
+
+    Two-phase attribution:
+    1. Push a placeholder ``PlannerContext`` (``pending:<uuid_hex>``)
+       so heavy decomposition LLM calls land in ``token_events`` with
+       a real, traceable project_id rather than 'unassigned'.
+    2. After the underlying work returns the real project_id, rebind
+       every placeholder row to it. On failure the rows stay tagged
+       ``pending:*`` for forensic inspection — the picker filters them
+       out and Unassigned surfaces them.
+
+    Concurrency-safe by construction: random UUID per call prevents
+    collisions; ContextVar scopes the push per asyncio task.
+    """
+    import uuid as _uuid
+
+    from src.cost_tracking.cost_recorder import (
+        PlannerContext,
+        canonical_project_id,
+        get_recorder,
+    )
+
+    _placeholder = f"pending:{_uuid.uuid4().hex}"
+    _display_name = f"{project_name} (creating)"
+    logger.debug(
+        "cost_recorder: PUSHING placeholder context for create_project "
+        "name=%s placeholder=%s",
+        project_name,
+        _placeholder,
+    )
+    with get_recorder().planner_context(
+        PlannerContext(
+            experiment_id="unassigned",
+            project_id=_placeholder,
+            project_name=_display_name,
+        )
+    ):
+        result = await _create_project_inner(description, project_name, options, state)
+
+    # Phase 2: rebind on success. Failure leaves the placeholder rows
+    # for inspection; the dashboard hides them from the main picker.
+    if isinstance(result, dict) and result.get("success"):
+        _real_id = result.get("project_id")
+        if _real_id:
+            _canonical = canonical_project_id(str(_real_id))
+            if _canonical and hasattr(state, "cost_store"):
+                try:
+                    n = state.cost_store.rebind_project_id(
+                        from_id=_placeholder,
+                        to_id=_canonical,
+                    )
+                    state.cost_store.upsert_project_name(_canonical, project_name)
+                    logger.info(
+                        "create_project cost: rebound %d events from "
+                        "placeholder to project_id=%s",
+                        n,
+                        _canonical,
+                    )
+                except Exception:
+                    logger.exception(
+                        "cost rebind failed for create_project "
+                        "placeholder=%s real=%s",
+                        _placeholder,
+                        _canonical,
+                    )
+    return result
+
+
+async def _create_project_inner(
+    description: str, project_name: str, options: Optional[Dict[str, Any]], state: Any
+) -> Dict[str, Any]:
     """
     Create a NEW project from natural language description.
+
+    Internal implementation invoked by :func:`create_project`. The
+    public wrapper owns cost attribution; this function does the
+    actual decomposition + persistence work.
 
     This tool ALWAYS creates a new project - it does not search for or reuse
     existing projects. For working with existing projects, use select_project

--- a/tests/unit/cost_tracking/test_provider_recording.py
+++ b/tests/unit/cost_tracking/test_provider_recording.py
@@ -133,6 +133,53 @@ class TestLocalProviderRecords:
         assert row == (30, 10, "local")
 
 
+class TestOpenAIProviderRecords:
+    """openai_provider._call_openai must emit one event tagged 'openai'.
+
+    Regression for #409 follow-up: OpenAI was the only provider
+    missing this hook. Without it, every Anthropic→OpenAI fallback
+    silently bypassed cost tracking — which is exactly what was
+    happening on accounts without an Anthropic key, leaving the
+    'planner' role entirely missing from project cost breakdowns.
+    """
+
+    @pytest.mark.asyncio
+    async def test_call_openai_records_event(
+        self, recorder: CostRecorder, store: CostStore
+    ) -> None:
+        """OpenAI completion writes one row with prompt/completion tokens."""
+        from src.ai.providers.openai_provider import OpenAIProvider
+
+        provider = OpenAIProvider.__new__(OpenAIProvider)
+        provider.model = "gpt-3.5-turbo"
+        provider.max_tokens = 100
+        provider.temperature = 0.1
+        provider.base_url = "https://api.openai.com/v1"
+        provider.client = MagicMock()
+        provider.client.post = AsyncMock(
+            return_value=_mock_http_response(
+                {
+                    "id": "cmpl_test",
+                    "model": "gpt-3.5-turbo-0125",
+                    "choices": [{"message": {"content": "ok"}}],
+                    "usage": {"prompt_tokens": 75, "completion_tokens": 40},
+                }
+            )
+        )
+
+        with recorder.planner_context(
+            PlannerContext(experiment_id="e_oa", project_id="p_oa")
+        ):
+            result = await provider._call_openai([{"role": "user", "content": "hi"}])
+
+        assert result == "ok"
+        row = store.conn.execute(
+            "SELECT input_tokens, output_tokens, provider, model, request_id "
+            "FROM token_events"
+        ).fetchone()
+        assert row == (75, 40, "openai", "gpt-3.5-turbo-0125", "cmpl_test")
+
+
 class TestCloudProviderRecords:
     """cloud_provider._call_cloud_llm must emit one event tagged 'cloud'."""
 

--- a/tests/unit/integrations/test_design_autocomplete.py
+++ b/tests/unit/integrations/test_design_autocomplete.py
@@ -1293,3 +1293,146 @@ class TestRunDesignPhasePreGeneratedContent:
             )
 
         mock_gen.assert_called_once()
+
+
+class TestRunDesignPhaseCostAttribution:
+    """Regression tests for Codex P1 on PR #516.
+
+    ``create_project`` wraps ``_create_project_inner`` in a
+    ``planner_context`` carrying a ``pending:<uuid>`` placeholder
+    project_id, and runs a one-shot ``rebind_project_id`` after the
+    inner returns. ``_run_design_phase`` is spawned via
+    ``asyncio.ensure_future`` during the inner call — asyncio copies
+    the parent's ContextVar state into the new task, so the
+    placeholder is inherited. After the wrapper's rebind fires, the
+    background design phase keeps writing rows under the placeholder
+    that never get rebound.
+
+    The fix: ``_run_design_phase`` pushes a fresh ``PlannerContext``
+    carrying the real project_id (resolved from ``kanban_client``) as
+    its very first action. This shadows the inherited placeholder
+    for the design phase's whole lifetime — every LLM call inside
+    records against the real project, not the orphaned placeholder.
+    """
+
+    @pytest.mark.asyncio
+    async def test_pushes_real_project_context_before_running_body(self) -> None:
+        """The design-phase body runs with the real project_id at the top of the stack.
+
+        Sets up a kanban_client whose ``project_id`` is a real
+        canonical string, mocks every downstream LLM/IO call so the
+        body is essentially a no-op, then asserts that during the
+        body the recorder's ``current()`` context reflects the real
+        project_id — not whatever placeholder the caller (or no one)
+        pushed before invoking.
+        """
+        from src.cost_tracking.cost_recorder import (
+            CostRecorder,
+            PlannerContext,
+            set_recorder,
+        )
+        from src.cost_tracking.cost_store import CostStore
+        from src.integrations.nlp_tools import _run_design_phase
+
+        real_pid = "deadbeef" * 4  # 32-char dashless hex
+        store = CostStore(db_path=":memory:")
+        recorder = CostRecorder(store=store, enabled=True)
+        set_recorder(recorder)
+
+        # Capture the active context from inside the body so we can
+        # assert it's the real project_id, not the inherited placeholder.
+        captured: dict = {}
+
+        async def _capture_ctx(**_kwargs) -> dict:
+            ctx = recorder.current()
+            captured["project_id"] = ctx.project_id if ctx else None
+            return {}
+
+        kanban = MagicMock()
+        kanban.project_id = real_pid
+        kanban.update_task = AsyncMock()
+
+        state = MagicMock()
+        state.task_artifacts = {}
+        state.project_tasks = []
+
+        # Simulate the caller-pushed placeholder context (mirrors what
+        # ``create_project`` does in src/marcus_mcp/tools/nlp.py).
+        placeholder = f"pending:{'x' * 32}"
+        with recorder.planner_context(
+            PlannerContext(
+                experiment_id="unassigned",
+                project_id=placeholder,
+                project_name="Placeholder",
+            )
+        ):
+            with (
+                patch(
+                    "src.integrations.nlp_tools._generate_design_content",
+                    new_callable=AsyncMock,
+                    side_effect=_capture_ctx,
+                ),
+                patch(
+                    "src.integrations.nlp_tools._generate_project_scaffold",
+                    new_callable=AsyncMock,
+                ),
+            ):
+                await _run_design_phase(
+                    state=state,
+                    kanban_client=kanban,
+                    safe_tasks=[],
+                    created_tasks=[],
+                    description="x",
+                    project_name="ProjX",
+                    project_root="/var/folders/test",  # nosec B108
+                )
+
+        set_recorder(None)
+        # The body must have seen the REAL project_id, not the placeholder.
+        assert captured["project_id"] == real_pid, (
+            f"Design phase saw {captured['project_id']!r}; expected "
+            f"the real project_id {real_pid!r}. If this is the "
+            f"placeholder {placeholder!r}, the fix has regressed."
+        )
+
+    @pytest.mark.asyncio
+    async def test_falls_through_when_kanban_project_id_missing(self) -> None:
+        """If ``kanban_client.project_id`` is not a string, the wrapper falls through.
+
+        The fix uses ``isinstance(..., str)`` defensively because
+        MagicMock-backed kanban_clients in tests return a MagicMock
+        for any attr access. In that case we don't push a context —
+        we fall through with whatever the caller already has on the
+        stack — and the body still runs without crashing.
+        """
+        from src.integrations.nlp_tools import _run_design_phase
+
+        kanban = MagicMock()  # project_id will be a MagicMock, not str
+        kanban.update_task = AsyncMock()
+
+        state = MagicMock()
+        state.task_artifacts = {}
+        state.project_tasks = []
+
+        with (
+            patch(
+                "src.integrations.nlp_tools._generate_design_content",
+                new_callable=AsyncMock,
+                return_value={},
+            ),
+            patch(
+                "src.integrations.nlp_tools._generate_project_scaffold",
+                new_callable=AsyncMock,
+            ),
+        ):
+            # Should not raise — the isinstance guard prevents the
+            # MagicMock from being used as a project_id.
+            await _run_design_phase(
+                state=state,
+                kanban_client=kanban,
+                safe_tasks=[],
+                created_tasks=[],
+                description="x",
+                project_name="ProjY",
+                project_root="/var/folders/test",  # nosec B108
+            )


### PR DESCRIPTION
## Summary

Live diagnostic against the running HTTP server found that despite #515 wiring the placeholder-context push for \`create_project\`, **every recent planner LLM call still landed in 'unassigned'** (267 events / 932k tokens). Two independent bugs were stacked.

### Bug 1 — FastMCP bypasses the legacy handler

Marcus exposes \`create_project\` from **two** MCP entry points:

- Legacy \`mcp.server.Server\` (stdio) → \`handlers.py:handle_tool_call\`
- **FastMCP HTTP** (port 4298, what users actually run) → \`server.py:1608 @app.tool()\` decorator, which calls \`nlp.create_project\` directly

PR #515 put the placeholder push in handlers.py. That code never ran for HTTP clients. Fix: move the placeholder push + rebind into \`nlp.create_project\` itself, so every caller path (FastMCP, legacy handler, direct Python) gets the same behavior.

### Bug 2 — OpenAIProvider has no recorder hook

Three of the four providers (\`anthropic\`, \`cloud\`, \`local\`) call \`get_recorder().record_planner_call()\` after a successful response. **\`openai_provider._call_openai\` does not.** On accounts without a valid Anthropic key (like this one — we saw 401s), every fallback to OpenAI silently bypassed cost tracking. That's why 'planner' role was missing from project breakdowns even though Marcus was making heavy decomposition calls.

Fix: add the recorder hook to \`_call_openai\` with the same shape as the other providers (operation/provider/model/tokens/latency/request_id). Recorder failures swallowed so a cost-store outage cannot break the provider call path.

## Validation (live)

Three consecutive \`create_project\` runs against the patched server:

| run | events recorded | project_id | unassigned added |
|---|---|---|---|
| diag-1 | 0 (pre-fix1) | n/a | yes |
| diag-2 | 0 (pre-fix2, OpenAI bypass) | n/a | no |
| **diag-3** | **18 events, 21,262 tokens, role=planner** | rebound from placeholder to real id | **0** |

Zero new 'unassigned' rows since the fix landed.

## Test plan
- [x] \`pytest tests/unit/cost_tracking tests/unit/ai tests/unit/mcp\` — 949 pass (1 new asserting OpenAIProvider records)
- [x] Live verification on running HTTP MCP server (above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)