### PR TITLE
feat(cost): per-operation drill-down for planner LLM calls (#409)

### DIFF
--- a/src/ai/advanced/prd/advanced_parser.py
+++ b/src/ai/advanced/prd/advanced_parser.py
@@ -605,6 +605,7 @@ class AdvancedPRDParser:
                 prompt=prompt,
                 system_prompt=system_prompt,
                 response_format=response_format,
+                operation="generate_contracts",
             )
         except Exception as e:
             raise RuntimeError(f"Contract decomposition LLM call failed: {e}") from e
@@ -1170,7 +1171,7 @@ Return ONLY the JSON object. Do not include commentary.
 
             # Use the actual LLM to analyze the PRD
             analysis_result = await self.llm_client.analyze(
-                prompt=analysis_prompt, context=context
+                prompt=analysis_prompt, context=context, operation="decompose_prd"
             )
 
             result_len = len(analysis_result) if analysis_result else 0
@@ -1486,7 +1487,9 @@ Provide ONLY valid JSON, no preamble."""
             context = SimpleContext(max_tokens=500)
 
             # Use LLM to discover domains
-            result = await self.llm_client.analyze(prompt, context)
+            result = await self.llm_client.analyze(
+                prompt, context, operation="discover_domains"
+            )
             response_text = str(result) if result else "{}"
 
             # Parse JSON response (handle markdown fences, preamble, etc.)
@@ -2549,7 +2552,9 @@ explanation."""
             context = SimpleContext(max_tokens=200)
 
             # Use LLM to generate task-specific description
-            result = await self.llm_client.analyze(prompt, context)
+            result = await self.llm_client.analyze(
+                prompt, context, operation="generate_task_detail"
+            )
             description: str = str(result) if result else ""
             description = description.strip()
 

--- a/src/ai/advanced/prd/outcome_extractor.py
+++ b/src/ai/advanced/prd/outcome_extractor.py
@@ -215,7 +215,9 @@ async def extract_user_outcomes(
         any individual outcome fails :class:`UserOutcome` validation.
     """
     prompt = _EXTRACTION_PROMPT.format(spec=spec)
-    raw = await llm_client.analyze(prompt, _MaxTokensContext(max_tokens))
+    raw = await llm_client.analyze(
+        prompt, _MaxTokensContext(max_tokens), operation="extract_outcomes"
+    )
     raw_text = str(raw) if raw is not None else ""
 
     try:
@@ -381,7 +383,9 @@ async def filter_to_verifiable_capabilities(
     )
     prompt = _FILTER_PROMPT.format(outcomes_block=outcomes_block)
 
-    raw = await llm_client.analyze(prompt, _MaxTokensContext(max_tokens))
+    raw = await llm_client.analyze(
+        prompt, _MaxTokensContext(max_tokens), operation="filter_outcomes"
+    )
     raw_text = str(raw) if raw is not None else ""
 
     try:

--- a/src/ai/providers/llm_abstraction.py
+++ b/src/ai/providers/llm_abstraction.py
@@ -27,10 +27,11 @@ Examples
 """
 
 import asyncio
+import functools
 import logging
 import os
 from datetime import datetime, timezone
-from typing import Any, Dict, List, Optional
+from typing import Any, Awaitable, Callable, Dict, List, Optional, TypeVar
 
 from src.core.models import Priority, Task, TaskStatus
 
@@ -42,6 +43,55 @@ from .base_provider import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+_T = TypeVar("_T")
+
+
+def _tagged_operation(
+    operation: str,
+) -> Callable[[Callable[..., Awaitable[_T]]], Callable[..., Awaitable[_T]]]:
+    """Wrap an LLMAbstraction method in ``recorder.operation_context``.
+
+    Kaia review on PR #517: the five high-level methods on
+    :class:`LLMAbstraction` (``analyze_task_semantics``,
+    ``infer_dependencies_semantic``, ``generate_enhanced_description``,
+    ``estimate_effort_intelligently``,
+    ``analyze_blocker_and_suggest_solutions``) all needed the same
+    four-line preamble that pushed an ``operation_context`` for the
+    duration of the call. This decorator consolidates the boilerplate.
+
+    Parameters
+    ----------
+    operation : str
+        Operation key from :mod:`src.cost_tracking.operations` to
+        stamp onto ``token_events.operation`` for calls made inside
+        the wrapped method.
+
+    Returns
+    -------
+    Callable
+        A method decorator that wraps the original coroutine in the
+        appropriate ``operation_context``.
+
+    Notes
+    -----
+    The recorder import is performed lazily inside the wrapper so
+    that ``llm_abstraction.py`` can be imported without forcing the
+    cost-tracking module load — keeping startup paths lean.
+    """
+
+    def decorator(fn: Callable[..., Awaitable[_T]]) -> Callable[..., Awaitable[_T]]:
+        @functools.wraps(fn)
+        async def wrapper(self: Any, *args: Any, **kwargs: Any) -> _T:
+            from src.cost_tracking.cost_recorder import get_recorder
+
+            with get_recorder().operation_context(operation):
+                return await fn(self, *args, **kwargs)
+
+        return wrapper
+
+    return decorator
 
 
 class LLMAbstraction:
@@ -290,6 +340,7 @@ class LLMAbstraction:
         self._providers_initialized = True
         logger.info(f"Initialized providers: {list(self.providers.keys())}")
 
+    @_tagged_operation("analyze_task_semantics")
     async def analyze_task_semantics(
         self, task: Task, context: Dict[str, Any]
     ) -> SemanticAnalysis:
@@ -311,19 +362,16 @@ class LLMAbstraction:
         Notes
         -----
         Automatically falls back to alternative providers on failure.
-        Wraps the underlying call in
-        :meth:`CostRecorder.operation_context` so the resulting
-        ``token_events.operation`` row is tagged
-        ``analyze_task_semantics`` instead of the provider's default.
+        Tagged ``analyze_task_semantics`` via :func:`_tagged_operation`
+        so the resulting ``token_events.operation`` row carries that
+        label instead of the provider's default.
         """
-        from src.cost_tracking.cost_recorder import get_recorder
-
-        with get_recorder().operation_context("analyze_task_semantics"):
-            result = await self._execute_with_fallback(
-                "analyze_task", task=task, context=context
-            )
+        result = await self._execute_with_fallback(
+            "analyze_task", task=task, context=context
+        )
         return result  # type: ignore
 
+    @_tagged_operation("infer_dependencies")
     async def infer_dependencies_semantic(
         self, tasks: List[Task]
     ) -> List[SemanticDependency]:
@@ -343,17 +391,13 @@ class LLMAbstraction:
         Notes
         -----
         Complements rule-based dependency detection with semantic
-        understanding. Tagged ``infer_dependencies`` for cost
-        attribution.
+        understanding. Tagged ``infer_dependencies`` via
+        :func:`_tagged_operation`.
         """
-        from src.cost_tracking.cost_recorder import get_recorder
-
-        with get_recorder().operation_context("infer_dependencies"):
-            result = await self._execute_with_fallback(
-                "infer_dependencies", tasks=tasks
-            )
+        result = await self._execute_with_fallback("infer_dependencies", tasks=tasks)
         return result  # type: ignore
 
+    @_tagged_operation("enrich_task")
     async def generate_enhanced_description(
         self, task: Task, context: Dict[str, Any]
     ) -> str:
@@ -372,14 +416,12 @@ class LLMAbstraction:
         str
             Enhanced description with more detail and clarity
         """
-        from src.cost_tracking.cost_recorder import get_recorder
-
-        with get_recorder().operation_context("enrich_task"):
-            result = await self._execute_with_fallback(
-                "generate_enhanced_description", task=task, context=context
-            )
+        result = await self._execute_with_fallback(
+            "generate_enhanced_description", task=task, context=context
+        )
         return result  # type: ignore
 
+    @_tagged_operation("estimate_effort")
     async def estimate_effort_intelligently(
         self, task: Task, context: Dict[str, Any]
     ) -> EffortEstimate:
@@ -398,14 +440,12 @@ class LLMAbstraction:
         EffortEstimate
             AI-powered time estimate with confidence and factors
         """
-        from src.cost_tracking.cost_recorder import get_recorder
-
-        with get_recorder().operation_context("estimate_effort"):
-            result = await self._execute_with_fallback(
-                "estimate_effort", task=task, context=context
-            )
+        result = await self._execute_with_fallback(
+            "estimate_effort", task=task, context=context
+        )
         return result  # type: ignore
 
+    @_tagged_operation("analyze_blocker")
     async def analyze_blocker_and_suggest_solutions(
         self,
         task: Task,
@@ -442,15 +482,12 @@ class LLMAbstraction:
             "agent": agent,
         }
 
-        from src.cost_tracking.cost_recorder import get_recorder
-
-        with get_recorder().operation_context("analyze_blocker"):
-            result = await self._execute_with_fallback(
-                "analyze_blocker",
-                task=task,
-                blocker=blocker_description,
-                context=context,
-            )
+        result = await self._execute_with_fallback(
+            "analyze_blocker",
+            task=task,
+            blocker=blocker_description,
+            context=context,
+        )
         return result  # type: ignore
 
     async def _execute_with_fallback(self, method_name: str, **kwargs: Any) -> Any:

--- a/src/ai/providers/llm_abstraction.py
+++ b/src/ai/providers/llm_abstraction.py
@@ -311,10 +311,17 @@ class LLMAbstraction:
         Notes
         -----
         Automatically falls back to alternative providers on failure.
+        Wraps the underlying call in
+        :meth:`CostRecorder.operation_context` so the resulting
+        ``token_events.operation`` row is tagged
+        ``analyze_task_semantics`` instead of the provider's default.
         """
-        result = await self._execute_with_fallback(
-            "analyze_task", task=task, context=context
-        )
+        from src.cost_tracking.cost_recorder import get_recorder
+
+        with get_recorder().operation_context("analyze_task_semantics"):
+            result = await self._execute_with_fallback(
+                "analyze_task", task=task, context=context
+            )
         return result  # type: ignore
 
     async def infer_dependencies_semantic(
@@ -336,9 +343,15 @@ class LLMAbstraction:
         Notes
         -----
         Complements rule-based dependency detection with semantic
-        understanding.
+        understanding. Tagged ``infer_dependencies`` for cost
+        attribution.
         """
-        result = await self._execute_with_fallback("infer_dependencies", tasks=tasks)
+        from src.cost_tracking.cost_recorder import get_recorder
+
+        with get_recorder().operation_context("infer_dependencies"):
+            result = await self._execute_with_fallback(
+                "infer_dependencies", tasks=tasks
+            )
         return result  # type: ignore
 
     async def generate_enhanced_description(
@@ -359,9 +372,12 @@ class LLMAbstraction:
         str
             Enhanced description with more detail and clarity
         """
-        result = await self._execute_with_fallback(
-            "generate_enhanced_description", task=task, context=context
-        )
+        from src.cost_tracking.cost_recorder import get_recorder
+
+        with get_recorder().operation_context("enrich_task"):
+            result = await self._execute_with_fallback(
+                "generate_enhanced_description", task=task, context=context
+            )
         return result  # type: ignore
 
     async def estimate_effort_intelligently(
@@ -382,9 +398,12 @@ class LLMAbstraction:
         EffortEstimate
             AI-powered time estimate with confidence and factors
         """
-        result = await self._execute_with_fallback(
-            "estimate_effort", task=task, context=context
-        )
+        from src.cost_tracking.cost_recorder import get_recorder
+
+        with get_recorder().operation_context("estimate_effort"):
+            result = await self._execute_with_fallback(
+                "estimate_effort", task=task, context=context
+            )
         return result  # type: ignore
 
     async def analyze_blocker_and_suggest_solutions(
@@ -423,9 +442,15 @@ class LLMAbstraction:
             "agent": agent,
         }
 
-        result = await self._execute_with_fallback(
-            "analyze_blocker", task=task, blocker=blocker_description, context=context
-        )
+        from src.cost_tracking.cost_recorder import get_recorder
+
+        with get_recorder().operation_context("analyze_blocker"):
+            result = await self._execute_with_fallback(
+                "analyze_blocker",
+                task=task,
+                blocker=blocker_description,
+                context=context,
+            )
         return result  # type: ignore
 
     async def _execute_with_fallback(self, method_name: str, **kwargs: Any) -> Any:
@@ -531,18 +556,32 @@ class LLMAbstraction:
 
         raise Exception(error_msg)
 
-    async def analyze(self, prompt: str, context: Any) -> str:
+    async def analyze(
+        self, prompt: str, context: Any, *, operation: Optional[str] = None
+    ) -> str:
         """
         Analyze content using LLM.
 
-        Args
-        ----
-            prompt: The prompt to analyze
-            context: Analysis context
+        Parameters
+        ----------
+        prompt : str
+            The prompt to analyze.
+        context : Any
+            Analysis context (may carry ``max_tokens`` override).
+        operation : str, optional
+            Logical operation label to attach to the cost event. When
+            provided, the recorder's active PlannerContext is shadowed
+            with an ``operation_override`` for the duration of the call,
+            so ``token_events.operation`` records ``operation`` instead
+            of whatever default the provider stamps. Used for per-call
+            drill-down in the Cato cost dashboard. See
+            ``src/cost_tracking/operations.py`` for the canonical
+            taxonomy and human-readable descriptions.
 
         Returns
         -------
-            Analysis result as string
+        str
+            Analysis result as string.
         """
         # Ensure providers are initialized before trying to use them
         self._initialize_providers()
@@ -557,7 +596,16 @@ class LLMAbstraction:
         if hasattr(context, "max_tokens"):
             kwargs["max_tokens"] = context.max_tokens
 
-        result = await self._execute_with_fallback("complete", **kwargs)
+        if operation:
+            # Scope the recorder's active context with operation_override
+            # so the resulting token_events row is tagged correctly. Local
+            # import avoids cost_tracking import at module load.
+            from src.cost_tracking.cost_recorder import get_recorder
+
+            with get_recorder().operation_context(operation):
+                result = await self._execute_with_fallback("complete", **kwargs)
+        else:
+            result = await self._execute_with_fallback("complete", **kwargs)
         return result  # type: ignore
 
     async def switch_provider(self, provider_name: str) -> bool:

--- a/src/ai/providers/openai_provider.py
+++ b/src/ai/providers/openai_provider.py
@@ -25,11 +25,13 @@ Model selection via OPENAI_MODEL environment variable.
 import json
 import logging
 import os
+import time
 from typing import Any, Dict, List
 
 import httpx
 
 from src.core.models import Task
+from src.cost_tracking.cost_recorder import get_recorder
 
 from .base_provider import (
     BaseLLMProvider,
@@ -387,7 +389,14 @@ Provide JSON array of 3-5 specific solutions:
 ["solution1", "solution2", "solution3"]"""
 
     async def _call_openai(self, messages: List[Dict[str, str]]) -> str:
-        """Make API call to OpenAI."""
+        """Make API call to OpenAI.
+
+        Records the token usage to the planner cost store on success
+        (parity with AnthropicProvider / LocalLLMProvider — without
+        this hook every OpenAI fallback during Marcus's decomposition /
+        analysis path silently went uncounted, leaving cost data missing
+        the entire 'planner' role for accounts that aren't on Anthropic).
+        """
         payload = {
             "model": self.model,
             "messages": messages,
@@ -395,6 +404,7 @@ Provide JSON array of 3-5 specific solutions:
             "temperature": self.temperature,
         }
 
+        start = time.monotonic()
         try:
             response = await self.client.post(
                 f"{self.base_url}/chat/completions", json=payload
@@ -402,6 +412,24 @@ Provide JSON array of 3-5 specific solutions:
             response.raise_for_status()
 
             data = response.json()
+            latency_ms = int((time.monotonic() - start) * 1000)
+            # OpenAI-compatible servers return a usage object with
+            # prompt_tokens / completion_tokens. Cache fields are
+            # absent for non-Anthropic backends; record_planner_call
+            # defaults them to 0.
+            usage = data.get("usage") or {}
+            try:
+                get_recorder().record_planner_call(
+                    operation="analyze",
+                    provider="openai",
+                    model=str(data.get("model", self.model)),
+                    input_tokens=int(usage.get("prompt_tokens", 0)),
+                    output_tokens=int(usage.get("completion_tokens", 0)),
+                    latency_ms=latency_ms,
+                    request_id=str(data.get("id")) if data.get("id") else None,
+                )
+            except Exception:  # pragma: no cover - recorder must never raise
+                logger.exception("OpenAI cost recording failed")
             return str(data["choices"][0]["message"]["content"])
 
         except httpx.TimeoutException:

--- a/src/ai/providers/protocols.py
+++ b/src/ai/providers/protocols.py
@@ -1,0 +1,81 @@
+"""
+Structural typing protocols for LLM-client surfaces.
+
+Marcus's :class:`LLMAbstraction` is the concrete implementation, but
+many call sites (and most test doubles) only care about a tiny slice
+of its interface — typically just :py:meth:`analyze`. Defining a
+narrow :class:`typing.Protocol` for that slice lets:
+
+- Production code type-annotate its dependency as ``LLMAnalyzeClient``
+  rather than the whole concrete class, decoupling consumers from
+  the abstraction's full surface area.
+- Tests build mocks (``MagicMock(spec=LLMAnalyzeClient)``) that pin
+  the contract at construction time — when a new kwarg is added to
+  ``analyze``, mypy and pyright flag every offending mock instead of
+  the change quietly slipping past.
+
+Why a separate module
+---------------------
+``llm_abstraction.py`` imports providers (which import HTTP clients,
+config, etc.) at module load. Tests and lightweight consumers
+shouldn't pay that cost just to type-check the call surface. This
+module has no runtime dependencies beyond stdlib so it's safe to
+import from anywhere — including tests that don't have API keys
+configured.
+
+Kaia review on the operation-taxonomy PR flagged the
+``**kwargs``-fan-out fragility we hit when adding the ``operation``
+kwarg to ``analyze``: every test mock needed updating. A Protocol
+fixes that root cause rather than patching individual call sites.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional, Protocol, runtime_checkable
+
+
+@runtime_checkable
+class LLMAnalyzeClient(Protocol):
+    """Minimum surface for callers of ``analyze()``.
+
+    Implementations must provide an awaitable :py:meth:`analyze` that
+    accepts ``(prompt, context)`` positionally and ``operation`` as a
+    keyword-only argument. :class:`LLMAbstraction` is the canonical
+    production implementation; tests can use
+    ``unittest.mock.MagicMock(spec=LLMAnalyzeClient)`` to build a
+    typed double.
+
+    The ``runtime_checkable`` decorator allows ``isinstance(obj,
+    LLMAnalyzeClient)`` checks for defensive code paths, though most
+    callers should rely on the static type checker.
+    """
+
+    async def analyze(
+        self,
+        prompt: str,
+        context: Any,
+        *,
+        operation: Optional[str] = None,
+    ) -> str:
+        """Run the prompt through the active provider and return text.
+
+        Parameters
+        ----------
+        prompt : str
+            Prompt text to send to the LLM.
+        context : Any
+            Arbitrary caller-provided context. Implementations may
+            inspect ``context.max_tokens`` to override the provider's
+            configured default; everything else is opaque.
+        operation : str, optional
+            Operation key from :mod:`src.cost_tracking.operations` so
+            the resulting ``token_events`` row carries a meaningful
+            label for the cost dashboard. ``None`` falls through to
+            whatever default the provider stamps.
+
+        Returns
+        -------
+        str
+            Raw text response from the LLM.
+        """
+        ...

--- a/src/ai/validation/task_completeness_validator.py
+++ b/src/ai/validation/task_completeness_validator.py
@@ -485,6 +485,7 @@ Return only valid JSON."""
                     prompt=prompt,
                     system_prompt="You are a helpful AI assistant. "
                     "Respond with valid JSON only.",
+                    operation="validate_task_completeness",
                 )
             )
             return response_dict

--- a/src/ai/validation/work_analyzer.py
+++ b/src/ai/validation/work_analyzer.py
@@ -1076,7 +1076,7 @@ Focus on FUNCTIONALITY, not understanding. Code must WORK, not just exist.
         # Call dedicated validation LLM with retry support
         logger.debug("Calling AI provider for validation analysis")
         response: str = await self._validation_llm.analyze(
-            prompt=full_prompt, context=context
+            prompt=full_prompt, context=context, operation="validate_work"
         )
         logger.debug("Received AI validation response")
 

--- a/src/analysis/ai_engine.py
+++ b/src/analysis/ai_engine.py
@@ -237,6 +237,7 @@ class AnalysisAIEngine:
             raw_response = await self.llm_client.analyze(
                 prompt=full_prompt,
                 context=request,  # Pass request as context
+                operation=f"post_analysis_{request.analysis_type.value}",
             )
 
             # Parse response

--- a/src/cost_tracking/cost_recorder.py
+++ b/src/cost_tracking/cost_recorder.py
@@ -226,6 +226,23 @@ class CostRecorder:
         if not self.enabled:
             return
         ctx = self.current()
+        # Diagnostic: when a planner LLM call lands without an active
+        # PlannerContext it falls back to 'unassigned'. Logged at DEBUG
+        # so it's quiet by default but still discoverable when chasing
+        # attribution gaps (#409 follow-up — this is how we found the
+        # OpenAI provider missing the recorder hook).
+        if ctx is None:
+            logger.debug(
+                "cost_recorder: NO context for operation=%s provider=%s "
+                "model=%s tokens=%d (call will land in 'unassigned')",
+                operation,
+                provider,
+                model,
+                input_tokens
+                + cache_creation_tokens
+                + cache_read_tokens
+                + output_tokens,
+            )
         if ctx is not None:
             experiment_id = ctx.experiment_id
             project_id = ctx.project_id

--- a/src/cost_tracking/cost_recorder.py
+++ b/src/cost_tracking/cost_recorder.py
@@ -206,26 +206,41 @@ class CostRecorder:
         ``token_events.operation`` regardless of whatever default the
         provider passed.
 
-        If there's no active PlannerContext (e.g., a background loop
-        with no project attribution), this is a no-op — the call still
-        falls through to 'unassigned' with whatever default operation
-        the provider stamps.
+        Even when there's no active PlannerContext (e.g., a background
+        loop with no project attribution, or the standalone
+        post-analysis path that builds ``operation=f"post_analysis_..."``
+        from a request without first pushing a recorder context), this
+        method still pushes a synthetic ``'unassigned'`` child carrying
+        just the operation_override. That way the operation tag still
+        makes it into ``token_events.operation`` — only the project /
+        experiment attribution falls through to ``'unassigned'``. Codex
+        P2 on PR #517 caught this: without the synthetic-parent push,
+        background planner calls silently lost their per-operation
+        drill-down and showed up under the provider's generic
+        ``'analyze'`` bucket.
 
-        Yields the new context (or None when no parent exists) for
-        convenience; most callers ignore the yielded value.
+        Yields the new context for convenience; most callers ignore
+        the yielded value.
         """
         if not operation:
             yield self.current()
             return
-        parent = self.current()
-        if parent is None:
-            yield None
-            return
-        # Replace operation_override on a shallow copy. PlannerContext
-        # is a frozen dataclass; build a new instance with the override.
+        # Replace operation_override on a shallow copy when a parent
+        # context exists. PlannerContext is a frozen dataclass so we
+        # build a new instance with the override via ``replace``.
+        # When there's no parent, synthesize an 'unassigned' child
+        # carrying just the override — see docstring (Codex P2).
         from dataclasses import replace
 
-        child = replace(parent, operation_override=operation)
+        parent = self.current()
+        if parent is None:
+            child = PlannerContext(
+                experiment_id="unassigned",
+                project_id="unassigned",
+                operation_override=operation,
+            )
+        else:
+            child = replace(parent, operation_override=operation)
         stack = list(_context_stack.get())
         stack.append(child)
         token = _context_stack.set(stack)

--- a/src/cost_tracking/cost_recorder.py
+++ b/src/cost_tracking/cost_recorder.py
@@ -185,6 +185,45 @@ class CostRecorder:
         stack = _context_stack.get()
         return stack[-1] if stack else None
 
+    @contextmanager
+    def operation_context(self, operation: str) -> Iterator[Optional[PlannerContext]]:
+        """Push a child context with ``operation_override`` set.
+
+        Used at LLM call sites to label *which* logical operation
+        (decomposition, blocker analysis, dependency inference, etc.)
+        is firing. The :func:`record_planner_call` path reads
+        ``operation_override`` and stamps that label onto
+        ``token_events.operation`` regardless of whatever default the
+        provider passed.
+
+        If there's no active PlannerContext (e.g., a background loop
+        with no project attribution), this is a no-op — the call still
+        falls through to 'unassigned' with whatever default operation
+        the provider stamps.
+
+        Yields the new context (or None when no parent exists) for
+        convenience; most callers ignore the yielded value.
+        """
+        if not operation:
+            yield self.current()
+            return
+        parent = self.current()
+        if parent is None:
+            yield None
+            return
+        # Replace operation_override on a shallow copy. PlannerContext
+        # is a frozen dataclass; build a new instance with the override.
+        from dataclasses import replace
+
+        child = replace(parent, operation_override=operation)
+        stack = list(_context_stack.get())
+        stack.append(child)
+        token = _context_stack.set(stack)
+        try:
+            yield child
+        finally:
+            _context_stack.reset(token)
+
     # -- writes -----------------------------------------------------------
 
     def record_planner_call(

--- a/src/cost_tracking/cost_recorder.py
+++ b/src/cost_tracking/cost_recorder.py
@@ -144,6 +144,16 @@ class CostRecorder:
         # we upsert, and store the new pair. Bounded to ~1k entries
         # (one per project ever seen this process) which is fine.
         self._snapshotted_names: set[tuple[str, str]] = set()
+        # Process-lifetime set of operation keys we've already warned
+        # about. Drift detection: a call site that passes a typo (or a
+        # newly-introduced operation that nobody remembered to
+        # register) silently falls through to the dashboard's
+        # "Unregistered operation" fallback bucket — which defeats
+        # the whole point of the taxonomy. We log a single WARNING
+        # the first time each unknown key shows up so the gap is
+        # visible in dev logs without spamming. Kaia review on the
+        # operation-taxonomy PR.
+        self._unregistered_operations_warned: set[str] = set()
 
     # -- context management -----------------------------------------------
 
@@ -294,6 +304,32 @@ class CostRecorder:
             project_id = "unassigned"
             agent_id = "planner"
             task_id = None
+
+        # Drift detection: warn once per process if the resolved
+        # operation key isn't in the taxonomy catalog. A typo at a
+        # call site (or a new operation that nobody remembered to
+        # register) silently lands in the dashboard's fallback
+        # bucket; this WARNING surfaces it in dev logs without
+        # spamming production. Local import avoids the operations
+        # module at recorder construction time.
+        if operation not in self._unregistered_operations_warned:
+            try:
+                from src.cost_tracking.operations import OPERATIONS
+
+                if operation not in OPERATIONS:
+                    logger.warning(
+                        "cost_recorder: operation '%s' is not registered "
+                        "in src.cost_tracking.operations.OPERATIONS — it "
+                        "will render with the synthesized fallback label "
+                        "on the dashboard. Add it to the catalog for a "
+                        "proper description.",
+                        operation,
+                    )
+                    self._unregistered_operations_warned.add(operation)
+            except Exception:  # pragma: no cover - catalog import failed
+                # Don't break recording if the catalog itself can't load —
+                # the recorder is side-effect-only by contract.
+                pass
 
         event = TokenEvent(
             experiment_id=experiment_id,

--- a/src/cost_tracking/operations.py
+++ b/src/cost_tracking/operations.py
@@ -1,0 +1,374 @@
+"""
+Canonical taxonomy of LLM operations used by Marcus's planner.
+
+Every planner-side LLM call should be tagged with one of the keys in
+:data:`OPERATIONS`. The mapping flows two directions:
+
+- **Producer**: call sites pass the key as ``operation=`` to
+  :meth:`LLMAbstraction.analyze` (or directly through provider hooks).
+  The recorder stamps it onto ``token_events.operation``.
+- **Consumer**: the Cato dashboard fetches this catalog via the
+  ``/api/cost/operations`` endpoint and renders the human label and
+  description next to each operation in the cost breakdown — so users
+  can see *what* the planner spent tokens on, not just *that* it did.
+
+Categories
+----------
+``decomposition``
+    Setup-time LLM work that runs during ``create_project``: parsing the
+    PRD, extracting outcomes, generating contracts, etc. These are the
+    big cache-creation calls.
+``runtime``
+    Per-task LLM work that runs while agents are executing: blocker
+    analysis, dependency inference, task enrichment. Smaller, but more
+    of them.
+``monitoring``
+    LLM work driven by the project monitor loop: health analysis,
+    proactive risk detection.
+``other``
+    Catch-all for ad-hoc analyzers that don't fit the above.
+
+Adding new operations
+---------------------
+1. Add the key to :data:`OPERATIONS` with a ``label``, ``description``,
+   and ``category``.
+2. At the call site, pass ``operation="<your_key>"`` to
+   :meth:`LLMAbstraction.analyze` (or wrap the call in
+   :meth:`CostRecorder.operation_context`).
+3. The dashboard will pick it up automatically on next reload.
+
+If a call lands without an operation key, the recorder falls back to
+whatever default the provider stamps (usually ``'analyze'``). That still
+shows up in the breakdown — just under the generic bucket.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, TypedDict
+
+
+class Operation(TypedDict):
+    """Schema for one entry in :data:`OPERATIONS`."""
+
+    label: str
+    description: str
+    category: str
+
+
+OPERATIONS: Dict[str, Operation] = {
+    # -- decomposition (create_project setup) ------------------------------
+    "decompose_prd": {
+        "label": "Decompose PRD",
+        "description": (
+            "Parses the project requirements document into structured tasks. "
+            "Largest single LLM call per project; benefits heavily from "
+            "prompt caching on retries."
+        ),
+        "category": "decomposition",
+    },
+    "extract_outcomes": {
+        "label": "Extract outcomes",
+        "description": (
+            "Pulls the user-visible outcomes from the PRD (login works, "
+            "checkout completes, etc.) so the task graph can be checked "
+            "against them downstream."
+        ),
+        "category": "decomposition",
+    },
+    "outcome_coverage_check": {
+        "label": "Outcome coverage check",
+        "description": (
+            "Verifies that the decomposed task graph covers every extracted "
+            "outcome. Triggers regeneration of missing tasks when gaps "
+            "appear."
+        ),
+        "category": "decomposition",
+    },
+    "generate_contracts": {
+        "label": "Generate contracts",
+        "description": (
+            "Synthesizes interface contracts (API schemas, data shapes) "
+            "that pre-fork foundation tasks must satisfy, so independent "
+            "agents can fork without coordination drift."
+        ),
+        "category": "decomposition",
+    },
+    "generate_task_detail": {
+        "label": "Generate task detail",
+        "description": (
+            "Expands a high-level task into per-task acceptance criteria, "
+            "scope notes, and artifacts agents will see on the board."
+        ),
+        "category": "decomposition",
+    },
+    "decompose_task": {
+        "label": "Decompose task",
+        "description": (
+            "Breaks a single high-level task into ordered subtasks with "
+            "explicit hard/soft dependencies, file artifacts, and "
+            "provides/requires contracts. Driven by the Marcus "
+            "coordinator on user request."
+        ),
+        "category": "decomposition",
+    },
+    "analyze_task_redundancy": {
+        "label": "Analyze task redundancy",
+        "description": (
+            "Detects duplicate or overlapping tasks in the decomposed "
+            "graph. Used during contract-first decomposition to clean up "
+            "the task list before pre-fork synthesis."
+        ),
+        "category": "decomposition",
+    },
+    "spec_coverage_check": {
+        "label": "Spec coverage check",
+        "description": (
+            "Cross-checks generated task scope against the provided spec "
+            "or contract; flags gaps before tasks are pushed to the board."
+        ),
+        "category": "decomposition",
+    },
+    "extract_spec_features": {
+        "label": "Extract spec features",
+        "description": (
+            "First-pass feature extraction from a raw spec, used by "
+            "``spec_coverage`` to seed the coverage matrix before the "
+            "decomposer runs."
+        ),
+        "category": "decomposition",
+    },
+    "outcome_gap_fill": {
+        "label": "Outcome gap fill",
+        "description": (
+            "Synthesizes replacement or supplementary tasks when "
+            "``outcome_coverage_check`` flags uncovered user outcomes. "
+            "Honors the active contract schema."
+        ),
+        "category": "decomposition",
+    },
+    "filter_outcomes": {
+        "label": "Filter outcomes",
+        "description": (
+            "Filters extracted user outcomes to only those that are "
+            "verifiable from the artifacts an agent can produce, so the "
+            "coverage check has a meaningful ground truth."
+        ),
+        "category": "decomposition",
+    },
+    "discover_domains": {
+        "label": "Discover domains",
+        "description": (
+            "Clusters PRD features into domains (auth, payments, etc.) "
+            "so the decomposer can produce domain-scoped task lists and "
+            "shared contracts."
+        ),
+        "category": "decomposition",
+    },
+    "synthesize_foundation_tasks": {
+        "label": "Synthesize foundation tasks",
+        "description": (
+            "Pre-fork synthesis step: generates the shared foundation "
+            "work (design system, base components, shared contracts) "
+            "that parallel agents need *before* they can safely fork."
+        ),
+        "category": "decomposition",
+    },
+    "generate_design_artifact": {
+        "label": "Generate design artifact",
+        "description": (
+            "Produces a design doc or contract for one domain during "
+            "the design phase. Runs concurrently across domains, gated "
+            "by a semaphore."
+        ),
+        "category": "decomposition",
+    },
+    "generate_design_decisions": {
+        "label": "Generate design decisions",
+        "description": (
+            "Generates the explicit cross-domain decisions log for one "
+            "domain (routing, ownership boundaries) — the prompt that "
+            "implements GH-320 Option A."
+        ),
+        "category": "decomposition",
+    },
+    "generate_project_scaffold": {
+        "label": "Generate project scaffold",
+        "description": (
+            "Produces the initial repo file scaffold (directory layout, "
+            "manifests, README skeleton) that agents check out before "
+            "implementing tasks."
+        ),
+        "category": "decomposition",
+    },
+    "post_analysis": {
+        "label": "Post-project analysis",
+        "description": (
+            "Generic bucket for post-mortem analyzers driven by "
+            "``AnalysisAIEngine`` (requirement divergence, decision "
+            "impact, failure diagnosis, etc.). Sub-type is recorded in "
+            "the analyzer's own logs."
+        ),
+        "category": "monitoring",
+    },
+    "post_analysis_requirement_divergence": {
+        "label": "Post-analysis: requirement divergence",
+        "description": (
+            "Post-project analyzer that compares delivered work against "
+            "the original requirements to detect drift or missing "
+            "scope."
+        ),
+        "category": "monitoring",
+    },
+    "post_analysis_decision_impact": {
+        "label": "Post-analysis: decision impact",
+        "description": (
+            "Post-project analyzer that traces a logged decision "
+            "through to its downstream effects on tasks and outcomes."
+        ),
+        "category": "monitoring",
+    },
+    "post_analysis_instruction_quality": {
+        "label": "Post-analysis: instruction quality",
+        "description": (
+            "Scores the clarity and completeness of generated agent "
+            "instructions against actual completion behavior."
+        ),
+        "category": "monitoring",
+    },
+    "post_analysis_failure_diagnosis": {
+        "label": "Post-analysis: failure diagnosis",
+        "description": (
+            "Diagnoses the root cause of a stalled or failed task by "
+            "cross-referencing agent reports, board state, and prior "
+            "decisions."
+        ),
+        "category": "monitoring",
+    },
+    "post_analysis_task_redundancy": {
+        "label": "Post-analysis: task redundancy",
+        "description": (
+            "Detects duplicate or overlapping tasks across the whole "
+            "decomposed project (post-decomposition audit)."
+        ),
+        "category": "monitoring",
+    },
+    "post_analysis_overall_assessment": {
+        "label": "Post-analysis: overall assessment",
+        "description": (
+            "Cross-analyzer rollup that synthesizes a single overall "
+            "quality verdict from the other post-analysis signals."
+        ),
+        "category": "monitoring",
+    },
+    # -- runtime (per-task agent work) -------------------------------------
+    "analyze_blocker": {
+        "label": "Analyze blocker",
+        "description": (
+            "Reads an agent's blocker report, suggests resolutions, and "
+            "decides whether to re-route or escalate. Fires once per "
+            "``report_blocker`` MCP call."
+        ),
+        "category": "runtime",
+    },
+    "infer_dependencies": {
+        "label": "Infer dependencies",
+        "description": (
+            "Semantic dependency inference beyond rule-based detection. "
+            "Used when the rule engine returns ambiguous edges."
+        ),
+        "category": "runtime",
+    },
+    "enrich_task": {
+        "label": "Enrich task",
+        "description": (
+            "Augments a task with implementation hints, related-artifact "
+            "links, and clarifying context before an agent picks it up."
+        ),
+        "category": "runtime",
+    },
+    "analyze_task_semantics": {
+        "label": "Analyze task semantics",
+        "description": (
+            "Semantic-level analysis of a single task: intent, risks, "
+            "and similar-task matches. Used to refine downstream "
+            "dependency edges."
+        ),
+        "category": "runtime",
+    },
+    "estimate_effort": {
+        "label": "Estimate effort",
+        "description": (
+            "AI-powered effort/hours estimate for a task, blending "
+            "historical performance data with task description."
+        ),
+        "category": "runtime",
+    },
+    # -- monitoring --------------------------------------------------------
+    "analyze_project_health": {
+        "label": "Analyze project health",
+        "description": (
+            "Periodic health check from the monitor loop: detects stalls, "
+            "stuck agents, and risks. Cheaper per-call but runs on a "
+            "schedule."
+        ),
+        "category": "monitoring",
+    },
+    "validate_work": {
+        "label": "Validate agent work",
+        "description": (
+            "Validates that an agent's submitted artifacts satisfy the "
+            "task's acceptance criteria. Runs on ``report_task_progress`` "
+            "completion events."
+        ),
+        "category": "monitoring",
+    },
+    "validate_task_completeness": {
+        "label": "Validate task completeness",
+        "description": (
+            "Pre-board validation that a generated task is well-formed: "
+            "has acceptance criteria, file artifacts, and a coherent "
+            "description. Catches malformed LLM output before it reaches "
+            "agents."
+        ),
+        "category": "decomposition",
+    },
+    # -- other -------------------------------------------------------------
+    "analyze": {
+        "label": "Generic analyze",
+        "description": (
+            "Fallback bucket for LLM calls that didn't pass a specific "
+            "operation tag. If you see meaningful spend here, the call "
+            "site needs an explicit ``operation=`` argument."
+        ),
+        "category": "other",
+    },
+}
+
+
+def get_operation(key: str) -> Operation:
+    """Look up an operation by key, falling back to the generic bucket.
+
+    Parameters
+    ----------
+    key : str
+        Operation key from ``token_events.operation``.
+
+    Returns
+    -------
+    Operation
+        Entry with ``label``, ``description``, ``category``. If ``key``
+        isn't in the catalog, returns a synthesized entry in the
+        ``other`` category so the dashboard can still render it.
+    """
+    if key in OPERATIONS:
+        return OPERATIONS[key]
+    return Operation(
+        label=key.replace("_", " ").title(),
+        description=f"Unregistered operation '{key}'. Add it to OPERATIONS.",
+        category="other",
+    )
+
+
+def all_operations() -> Dict[str, Operation]:
+    """Return a defensive copy of the full catalog."""
+    return dict(OPERATIONS)

--- a/src/integrations/ai_analysis_engine.py
+++ b/src/integrations/ai_analysis_engine.py
@@ -1647,6 +1647,8 @@ Return JSON with this format:
         prompt: str,
         system_prompt: str = "",
         response_format: Optional[Dict[str, Any]] = None,
+        *,
+        operation: Optional[str] = None,
     ) -> Dict[str, Any]:
         """
         Generate a structured JSON response from the AI based on a schema.
@@ -1708,6 +1710,7 @@ explanations, or additional text."""
             response_text = await llm.analyze(
                 full_prompt,
                 context=type("obj", (object,), {"max_tokens": 4096})(),
+                operation=operation,
             )
 
             # Parse JSON response

--- a/src/integrations/nlp_tools.py
+++ b/src/integrations/nlp_tools.py
@@ -4098,6 +4098,86 @@ async def _run_design_phase(
         contract-first Cato retrofit — Phase A skipped when contracts
         are already generated upstream.
     """
+    # Codex P1 on PR #516 — placeholder context leaks into background
+    # design phase. ``create_project`` wraps ``_create_project_inner``
+    # in a ``planner_context`` carrying a synthetic ``pending:<uuid>``
+    # project_id and runs a one-shot ``rebind_project_id`` after the
+    # inner call returns. But this function is spawned via
+    # ``asyncio.ensure_future`` *during* the inner call, so it
+    # inherits the placeholder via the parent task's ContextVar
+    # state copy. After the wrapper's one-shot rebind fires, the
+    # design phase keeps writing rows under the placeholder — those
+    # rows are never rebound and stay hidden as ``pending:*``.
+    #
+    # Fix: as the very first action, push a fresh PlannerContext
+    # carrying the real project_id (resolved from the kanban_client)
+    # so the placeholder is shadowed for the rest of this task's
+    # lifetime. The asyncio task isolation means the main task's
+    # stack is unaffected — the wrapper's rebind still catches the
+    # synchronous rows under the placeholder, and the design
+    # phase's rows are attributed to the real project from the
+    # start.
+    #
+    # If ``kanban_client.project_id`` is unavailable (shouldn't
+    # happen post-board-creation), fall through with the inherited
+    # context — best-effort, no worse than the bug we're fixing.
+    from contextlib import nullcontext as _nullcontext
+
+    from src.cost_tracking.cost_recorder import PlannerContext as _PlannerContext
+    from src.cost_tracking.cost_recorder import (
+        canonical_project_id as _canonical_project_id,
+    )
+    from src.cost_tracking.cost_recorder import get_recorder as _get_recorder
+
+    _raw_pid = getattr(kanban_client, "project_id", None)
+    # Defensive isinstance check: tests often use ``MagicMock``-backed
+    # kanban clients whose ``project_id`` resolves to another
+    # ``MagicMock`` rather than ``None``. Without the check we'd push
+    # a context with a non-string project_id and the recorder would
+    # silently swallow the SQL error.
+    _real_pid = _canonical_project_id(_raw_pid) if isinstance(_raw_pid, str) else None
+    if _real_pid:
+        _design_ctx_cm: Any = _get_recorder().planner_context(
+            _PlannerContext(
+                experiment_id="unassigned",
+                project_id=_real_pid,
+                project_name=project_name,
+            )
+        )
+    else:
+        _design_ctx_cm = _nullcontext()
+
+    with _design_ctx_cm:
+        await _run_design_phase_body(
+            state=state,
+            kanban_client=kanban_client,
+            safe_tasks=safe_tasks,
+            created_tasks=created_tasks,
+            description=description,
+            project_name=project_name,
+            project_root=project_root,
+            pre_generated_content=pre_generated_content,
+        )
+
+
+async def _run_design_phase_body(
+    state: Any,
+    kanban_client: Any,
+    safe_tasks: List[Task],
+    created_tasks: List[Task],
+    description: str,
+    project_name: str,
+    project_root: str,
+    pre_generated_content: Optional[Dict[str, Dict[str, Any]]] = None,
+) -> None:
+    """Body of the background design phase (Phase A + Phase B + DONE + scaffold).
+
+    Split out from :func:`_run_design_phase` so that the wrapper can
+    push a fresh ``PlannerContext`` (Codex P1 on PR #516) without
+    forcing the entire body into an extra indentation level. See
+    :func:`_run_design_phase` for the full documentation of behavior,
+    ordering invariants, and regression history.
+    """
     design_content: Dict[str, Any] = {}
     if pre_generated_content is not None:
         # Contract-first Cato retrofit path. Phase A artifacts and

--- a/src/integrations/nlp_tools.py
+++ b/src/integrations/nlp_tools.py
@@ -148,6 +148,8 @@ async def _bounded_llm_analyze(
     prompt: str,
     context: Any,
     semaphore: asyncio.Semaphore,
+    *,
+    operation: Optional[str] = None,
 ) -> str:
     """Call ``llm.analyze`` under a concurrency cap with retry + backoff.
 
@@ -174,6 +176,10 @@ async def _bounded_llm_analyze(
         Concurrency guard. Must be created inside a running event loop so
         it binds to the correct loop (created per-call in
         :func:`_generate_design_content`).
+    operation : str, optional
+        Operation key forwarded to ``llm.analyze`` for cost-event
+        tagging. See :mod:`src.cost_tracking.operations` for the
+        catalog.
 
     Returns
     -------
@@ -187,7 +193,9 @@ async def _bounded_llm_analyze(
         exhausted.
     """
     async with semaphore:
-        response: str = await llm.analyze(prompt=prompt, context=context)
+        response: str = await llm.analyze(
+            prompt=prompt, context=context, operation=operation
+        )
         return response
 
 
@@ -1132,7 +1140,9 @@ class NaturalLanguageProjectCreator(NaturalLanguageTaskCreator):
 
         try:
             raw = await self.prd_parser.llm_client.analyze(
-                prompt=prompt, context=_Ctx()
+                prompt=prompt,
+                context=_Ctx(),
+                operation="synthesize_foundation_tasks",
             )
         except Exception as exc:
             logger.warning(
@@ -3014,7 +3024,9 @@ async def _generate_single_artifact(
             sibling_domains_block=sibling_domains_block,
         )
 
-    response = await _bounded_llm_analyze(llm, prompt, context, semaphore)
+    response = await _bounded_llm_analyze(
+        llm, prompt, context, semaphore, operation="generate_design_artifact"
+    )
 
     if not response or len(response.strip()) < 20:
         logger.warning(
@@ -3127,7 +3139,9 @@ async def _generate_single_decisions(
         sibling_domains_block=sibling_domains_block,
     )
 
-    dec_response = await _bounded_llm_analyze(llm, dec_prompt, context, semaphore)
+    dec_response = await _bounded_llm_analyze(
+        llm, dec_prompt, context, semaphore, operation="generate_design_decisions"
+    )
 
     if not dec_response:
         return []
@@ -3770,7 +3784,9 @@ async def _generate_project_scaffold(
     )
 
     try:
-        response = await llm.analyze(prompt=prompt, context=_Ctx())
+        response = await llm.analyze(
+            prompt=prompt, context=_Ctx(), operation="generate_project_scaffold"
+        )
 
         if not response:
             logger.warning("[scaffold] Empty LLM response")

--- a/src/integrations/spec_coverage.py
+++ b/src/integrations/spec_coverage.py
@@ -66,7 +66,7 @@ async def _llm_extract_features(description: str) -> str:
         'Return ONLY valid JSON like: ["feature one", "feature two", ...]'
     )
 
-    response = await llm.analyze(prompt, _Ctx())
+    response = await llm.analyze(prompt, _Ctx(), operation="extract_spec_features")
     return str(response)
 
 

--- a/src/marcus_mcp/coordinator/decomposer.py
+++ b/src/marcus_mcp/coordinator/decomposer.py
@@ -305,6 +305,7 @@ async def decompose_task(
                 },
                 "required": ["subtasks", "shared_conventions"],
             },
+            operation="decompose_task",
         )
 
         # Parse response

--- a/src/marcus_mcp/coordinator/dependency_wiring.py
+++ b/src/marcus_mcp/coordinator/dependency_wiring.py
@@ -204,6 +204,7 @@ Determine which (if any) of these candidates should be added as dependencies for
                 },
                 "required": ["dependencies", "reasoning"],
             },
+            operation="infer_dependencies",
         )
 
         # Cast response to Dict[str, Any] for type safety

--- a/src/marcus_mcp/coordinator/outcome_coverage.py
+++ b/src/marcus_mcp/coordinator/outcome_coverage.py
@@ -462,7 +462,9 @@ async def compute_coverage_with_llm(
         outcomes_block=outcomes_block, tasks_block=tasks_block
     )
 
-    raw = await llm_client.analyze(prompt, _MaxTokensContext(max_tokens))
+    raw = await llm_client.analyze(
+        prompt, _MaxTokensContext(max_tokens), operation="outcome_coverage_check"
+    )
     raw_text = str(raw) if raw is not None else ""
 
     try:
@@ -720,7 +722,9 @@ async def fill_gaps(
         + schema_section
     )
 
-    raw = await llm_client.analyze(prompt, _MaxTokensContext(max_tokens))
+    raw = await llm_client.analyze(
+        prompt, _MaxTokensContext(max_tokens), operation="outcome_gap_fill"
+    )
     raw_text = str(raw) if raw is not None else ""
 
     try:

--- a/src/marcus_mcp/handlers.py
+++ b/src/marcus_mcp/handlers.py
@@ -9,7 +9,6 @@ in a centralized location.
 import json
 import logging
 import time
-import uuid
 from contextlib import ExitStack
 from typing import Any, Dict, List, Optional
 
@@ -1337,64 +1336,18 @@ async def handle_tool_call(
             if not description or not project_name:
                 result = {"error": "description and project_name are required"}
             else:
-                # Two-phase cost attribution for project creation:
-                #
-                # Phase 1: push a placeholder PlannerContext so the heavy
-                # decomposition LLM calls land in token_events with an
-                # identifiable project_id. The placeholder is a random
-                # 128-bit hex so two concurrent create_project calls
-                # cannot collide — see docs/issue #514 for the upstream
-                # race in ProjectRegistry itself.
-                #
-                # Phase 2: after create_project returns the real id,
-                # UPDATE token_events to rebind every row from the
-                # placeholder to the new id. If the tool fails before
-                # then, the placeholder rows stay tagged with
-                # ``pending:<hex>`` and the picker hides them — visible
-                # in the Unassigned popover as forensic evidence.
-                _placeholder = f"pending:{uuid.uuid4().hex}"
-                _display_name = f"{project_name} (creating)"
-                with get_recorder().planner_context(
-                    PlannerContext(
-                        experiment_id="unassigned",
-                        project_id=_placeholder,
-                        project_name=_display_name,
-                    )
-                ):
-                    result = await create_project(
-                        description=description,
-                        project_name=project_name,
-                        options=arguments.get("options"),
-                        state=state,
-                    )
-
-                # Phase 2: rebind on success. Failures leave the
-                # placeholder rows for inspection; the dashboard
-                # filters them out of the main project picker.
-                if isinstance(result, dict) and result.get("success"):
-                    _real_id = result.get("project_id")
-                    if _real_id:
-                        from src.cost_tracking.cost_recorder import (
-                            canonical_project_id,
-                        )
-
-                        _canonical = canonical_project_id(str(_real_id))
-                        if _canonical:
-                            try:
-                                state.cost_store.rebind_project_id(
-                                    from_id=_placeholder,
-                                    to_id=_canonical,
-                                )
-                                state.cost_store.upsert_project_name(
-                                    _canonical, project_name
-                                )
-                            except Exception:
-                                logger.exception(
-                                    "cost rebind failed for create_project "
-                                    "placeholder=%s real=%s",
-                                    _placeholder,
-                                    _canonical,
-                                )
+                # Cost attribution (placeholder push + rebind) lives
+                # inside ``nlp.create_project`` so every entry point —
+                # this legacy stdio handler, FastMCP HTTP, or direct
+                # Python callers — gets the same behavior. See the
+                # docstring on ``create_project`` for the two-phase
+                # design.
+                result = await create_project(
+                    description=description,
+                    project_name=project_name,
+                    options=arguments.get("options"),
+                    state=state,
+                )
 
             # Log tool call complete
             state.log_event(

--- a/src/marcus_mcp/tools/nlp.py
+++ b/src/marcus_mcp/tools/nlp.py
@@ -126,8 +126,92 @@ _recent_create_project_calls: Dict[str, tuple[float, Optional[Dict[str, Any]]]] 
 async def create_project(
     description: str, project_name: str, options: Optional[Dict[str, Any]], state: Any
 ) -> Dict[str, Any]:
+    """Public entry point. Wraps the heavy work with cost-attribution.
+
+    Marcus exposes ``create_project`` from two MCP entry points:
+    legacy stdio (``handlers.py:handle_tool_call``) and FastMCP HTTP
+    (``server.py:@app.tool()``). Both ultimately call this function.
+    Putting the placeholder/rebind logic here covers every caller —
+    including future ones — without depending on whichever wrapper
+    happened to fire. Pre-PR-#515 the logic lived only in the legacy
+    handler and never ran for HTTP clients, so all planner cost
+    silently landed in 'unassigned' (#409 followup).
+
+    Two-phase attribution:
+    1. Push a placeholder ``PlannerContext`` (``pending:<uuid_hex>``)
+       so heavy decomposition LLM calls land in ``token_events`` with
+       a real, traceable project_id rather than 'unassigned'.
+    2. After the underlying work returns the real project_id, rebind
+       every placeholder row to it. On failure the rows stay tagged
+       ``pending:*`` for forensic inspection — the picker filters them
+       out and Unassigned surfaces them.
+
+    Concurrency-safe by construction: random UUID per call prevents
+    collisions; ContextVar scopes the push per asyncio task.
+    """
+    import uuid as _uuid
+
+    from src.cost_tracking.cost_recorder import (
+        PlannerContext,
+        canonical_project_id,
+        get_recorder,
+    )
+
+    _placeholder = f"pending:{_uuid.uuid4().hex}"
+    _display_name = f"{project_name} (creating)"
+    logger.debug(
+        "cost_recorder: PUSHING placeholder context for create_project "
+        "name=%s placeholder=%s",
+        project_name,
+        _placeholder,
+    )
+    with get_recorder().planner_context(
+        PlannerContext(
+            experiment_id="unassigned",
+            project_id=_placeholder,
+            project_name=_display_name,
+        )
+    ):
+        result = await _create_project_inner(description, project_name, options, state)
+
+    # Phase 2: rebind on success. Failure leaves the placeholder rows
+    # for inspection; the dashboard hides them from the main picker.
+    if isinstance(result, dict) and result.get("success"):
+        _real_id = result.get("project_id")
+        if _real_id:
+            _canonical = canonical_project_id(str(_real_id))
+            if _canonical and hasattr(state, "cost_store"):
+                try:
+                    n = state.cost_store.rebind_project_id(
+                        from_id=_placeholder,
+                        to_id=_canonical,
+                    )
+                    state.cost_store.upsert_project_name(_canonical, project_name)
+                    logger.info(
+                        "create_project cost: rebound %d events from "
+                        "placeholder to project_id=%s",
+                        n,
+                        _canonical,
+                    )
+                except Exception:
+                    logger.exception(
+                        "cost rebind failed for create_project "
+                        "placeholder=%s real=%s",
+                        _placeholder,
+                        _canonical,
+                    )
+    return result
+
+
+async def _create_project_inner(
+    description: str, project_name: str, options: Optional[Dict[str, Any]], state: Any
+) -> Dict[str, Any]:
     """
     Create a NEW project from natural language description.
+
+    Internal implementation invoked by :func:`create_project`. The
+    public wrapper owns cost attribution; this function does the
+    actual decomposition + persistence work.
 
     This tool ALWAYS creates a new project - it does not search for or reuse
     existing projects. For working with existing projects, use select_project

--- a/tests/unit/ai/test_advanced_prd_parser.py
+++ b/tests/unit/ai/test_advanced_prd_parser.py
@@ -592,7 +592,7 @@ class TestAdvancedPRDParserTaskGeneration:
         )
 
         # Mock the LLM to return task-type-specific descriptions
-        async def mock_analyze(prompt, context):
+        async def mock_analyze(prompt, context, **kwargs):
             # Return different descriptions based on task type in prompt
             if "**DESIGN**" in prompt:
                 return "Design the authentication architecture, API endpoints, and user flow diagrams."

--- a/tests/unit/ai/test_analyze_mock_helper.py
+++ b/tests/unit/ai/test_analyze_mock_helper.py
@@ -1,0 +1,87 @@
+"""
+Unit tests for the ``make_analyze_mock`` test helper.
+
+The helper is meant to insulate tests from future ``analyze()`` kwarg
+additions. These tests pin the contract.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from src.ai.providers.protocols import LLMAnalyzeClient
+from tests.unit.conftest import make_analyze_mock
+
+
+class TestMakeAnalyzeMock:
+    """Verifies the helper's contract.
+
+    The helper has three responsibilities:
+    1. Accept a 2-arg sync ``(prompt, context) -> str`` side effect.
+    2. Accept a 2-arg async side effect, awaiting it transparently.
+    3. Absorb any extra kwargs the production signature adds —
+       ``operation`` today, anything else tomorrow.
+    """
+
+    @pytest.mark.asyncio
+    async def test_sync_side_effect_passthrough(self) -> None:
+        """Sync side_effect runs and its return value bubbles up."""
+        mock = make_analyze_mock(side_effect=lambda p, _c: f"echo:{p}")
+        result = await mock(prompt="hi", context=object())
+        assert result == "echo:hi"
+
+    @pytest.mark.asyncio
+    async def test_async_side_effect_passthrough(self) -> None:
+        """Async side_effect is awaited transparently."""
+
+        async def aio(prompt: str, _ctx: object) -> str:
+            return f"async:{prompt}"
+
+        mock = make_analyze_mock(side_effect=aio)
+        result = await mock(prompt="hi", context=object())
+        assert result == "async:hi"
+
+    @pytest.mark.asyncio
+    async def test_absorbs_operation_kwarg(self) -> None:
+        """``operation`` (and any future kwarg) is silently dropped."""
+        seen: list[tuple[str, object]] = []
+
+        def capture(prompt: str, ctx: object) -> str:
+            seen.append((prompt, ctx))
+            return "ok"
+
+        mock = make_analyze_mock(side_effect=capture)
+        # Simulate Marcus's call: ``operation`` is the new kwarg
+        await mock(prompt="hi", context=object(), operation="decompose_prd")
+        assert seen == [("hi", seen[0][1])]
+
+    @pytest.mark.asyncio
+    async def test_return_value_path(self) -> None:
+        """``return_value`` short-circuits without a side effect."""
+        mock = make_analyze_mock(return_value="canned")
+        result = await mock(prompt="anything", context=None)
+        assert result == "canned"
+
+    def test_rejects_both_side_effect_and_return_value(self) -> None:
+        """Pinning both args is a programming error."""
+        with pytest.raises(ValueError):
+            make_analyze_mock(side_effect=lambda p, c: "", return_value="x")
+
+
+class TestProtocolConformance:
+    """Sanity-check that the mock satisfies the runtime-checkable Protocol."""
+
+    def test_mock_satisfies_protocol_via_runtime_check(self) -> None:
+        """Wrapping the mock in a tiny adapter satisfies ``isinstance``.
+
+        Mocks don't implement Protocol methods directly; this test
+        proves the *production* shape of an adapter (a class that
+        owns an ``analyze`` attribute set to the mock) satisfies the
+        runtime check. That's the realistic test-double pattern.
+        """
+        mock = make_analyze_mock(return_value="ok")
+
+        class _Adapter:
+            analyze = mock
+
+        assert isinstance(_Adapter(), LLMAnalyzeClient)

--- a/tests/unit/ai/test_parallel_task_processing.py
+++ b/tests/unit/ai/test_parallel_task_processing.py
@@ -97,7 +97,7 @@ class TestParallelTaskDescriptionGeneration:
         # Track call times to verify parallel execution
         call_times = []
 
-        async def mock_analyze_with_delay(prompt, context):
+        async def mock_analyze_with_delay(prompt, context, **kwargs):
             call_times.append(asyncio.get_event_loop().time())
             await asyncio.sleep(0.01)  # Simulate AI call delay
             return "Generated task description"
@@ -147,7 +147,7 @@ class TestParallelTaskDescriptionGeneration:
         # Set up mock to fail on specific calls
         call_count = 0
 
-        async def mock_analyze_with_failures(prompt, context):
+        async def mock_analyze_with_failures(prompt, context, **kwargs):
             nonlocal call_count
             call_count += 1
             # Fail every 3rd call
@@ -187,7 +187,7 @@ class TestParallelTaskDescriptionGeneration:
         call_count = 0
 
         # Set up mock to fail some calls
-        async def mock_analyze_with_mixed_results(prompt, context):
+        async def mock_analyze_with_mixed_results(prompt, context, **kwargs):
             nonlocal call_count
             call_count += 1
             # Fail on design tasks (every 3rd call), succeed on others

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -2,8 +2,11 @@
 Common test fixtures for unit tests using real implementations.
 """
 
+import inspect
 import sys
 from pathlib import Path
+from typing import Any, Awaitable, Callable, Optional, Union
+from unittest.mock import AsyncMock
 
 import pytest
 import pytest_asyncio
@@ -13,6 +16,64 @@ sys.path.insert(0, str(Path(__file__).parent.parent.parent))
 
 from src.core.context import Context
 from src.marcus_mcp.server import MarcusServer
+
+
+def make_analyze_mock(
+    side_effect: Optional[Callable[..., Union[str, Awaitable[str]]]] = None,
+    return_value: Optional[str] = None,
+) -> AsyncMock:
+    """Build an AsyncMock that satisfies :class:`LLMAnalyzeClient`.
+
+    The Protocol defined in ``src.ai.providers.protocols`` exposes the
+    ``async def analyze(prompt, context, *, operation)`` signature.
+    Production code may add new keyword arguments to ``analyze`` over
+    time; tests historically broke whenever this happened because each
+    bespoke mock had a pinned signature.
+
+    This helper centralizes the workaround: it returns an AsyncMock
+    whose ``side_effect`` absorbs any extra kwargs (``operation`` and
+    anything added later) and forwards just ``(prompt, context)`` to
+    the caller-provided function. Test authors keep their fakes
+    minimal and don't need to chase signature evolution per-mock.
+
+    Parameters
+    ----------
+    side_effect : callable, optional
+        Sync or async function ``(prompt, context) -> str``. When
+        provided, the mock invokes it (awaiting if needed) and returns
+        the result. Extra kwargs are silently discarded.
+    return_value : str, optional
+        Constant return value. Mutually exclusive with ``side_effect``
+        — pass one or the other.
+
+    Returns
+    -------
+    AsyncMock
+        Configured async mock. Wire onto a fake LLM client with
+        ``client.analyze = make_analyze_mock(side_effect=fn)``.
+
+    Examples
+    --------
+    >>> mock = make_analyze_mock(side_effect=lambda p, c: f"echo:{p}")
+    >>> # Internally Marcus calls: await mock(prompt="hi", context=ctx,
+    >>> #                                       operation="decompose_prd")
+    >>> # The ``operation`` kwarg is dropped before reaching ``side_effect``.
+    """
+    if side_effect is not None and return_value is not None:
+        raise ValueError("Pass either side_effect or return_value, not both")
+
+    if side_effect is not None:
+
+        async def _absorb_kwargs(prompt: Any, context: Any, **_kwargs: Any) -> str:
+            result = side_effect(prompt, context)
+            if inspect.isawaitable(result):
+                return await result
+            return result
+
+        return AsyncMock(side_effect=_absorb_kwargs)
+
+    return AsyncMock(return_value=return_value or "")
+
 
 # Domain-specific fixtures are now imported in the root conftest.py
 

--- a/tests/unit/cost_tracking/test_cost_recorder.py
+++ b/tests/unit/cost_tracking/test_cost_recorder.py
@@ -310,6 +310,77 @@ class TestNameSnapshot:
         assert store.get_project_name("p") is None
 
 
+class TestOperationContext:
+    """``operation_context`` stamps ``operation_override`` on the active context.
+
+    The recorder's ``record_planner_call`` reads ``operation_override``
+    and uses it in place of the operation argument the provider passes,
+    so call sites can label which logical operation they belong to
+    without touching every provider's HTTP path.
+    """
+
+    def test_overrides_operation_when_parent_exists(
+        self, recorder: CostRecorder, store: CostStore
+    ) -> None:
+        """Inside operation_context, the override beats the caller's op."""
+        with recorder.planner_context(
+            PlannerContext(experiment_id="e", project_id="p")
+        ):
+            with recorder.operation_context("decompose_prd"):
+                recorder.record_planner_call(
+                    operation="generic_provider_default",
+                    provider="anthropic",
+                    model="claude-sonnet-4-6",
+                    input_tokens=10,
+                    output_tokens=5,
+                )
+        op = store.conn.execute("SELECT operation FROM token_events").fetchone()[0]
+        assert op == "decompose_prd"
+
+    def test_pops_to_parent_after_exit(
+        self, recorder: CostRecorder, store: CostStore
+    ) -> None:
+        """After exiting operation_context, the parent's op (or caller's) wins."""
+        with recorder.planner_context(
+            PlannerContext(experiment_id="e", project_id="p")
+        ):
+            with recorder.operation_context("decompose_prd"):
+                pass
+            # Outside the operation_context, caller's op is recorded.
+            recorder.record_planner_call(
+                operation="analyze",
+                provider="anthropic",
+                model="claude-sonnet-4-6",
+                input_tokens=1,
+                output_tokens=1,
+            )
+        op = store.conn.execute("SELECT operation FROM token_events").fetchone()[0]
+        assert op == "analyze"
+
+    def test_noop_when_no_parent_context(self, recorder: CostRecorder) -> None:
+        """Without an active PlannerContext, operation_context is a no-op."""
+        with recorder.operation_context("decompose_prd") as ctx:
+            assert ctx is None
+
+    def test_empty_operation_yields_current(
+        self, recorder: CostRecorder, store: CostStore
+    ) -> None:
+        """Empty operation key short-circuits to current() without pushing."""
+        with recorder.planner_context(
+            PlannerContext(experiment_id="e", project_id="p")
+        ):
+            with recorder.operation_context(""):
+                recorder.record_planner_call(
+                    operation="caller_op",
+                    provider="anthropic",
+                    model="claude-sonnet-4-6",
+                    input_tokens=1,
+                    output_tokens=1,
+                )
+        op = store.conn.execute("SELECT operation FROM token_events").fetchone()[0]
+        assert op == "caller_op"
+
+
 class TestSingleton:
     """Module-level get/set helpers."""
 

--- a/tests/unit/cost_tracking/test_cost_recorder.py
+++ b/tests/unit/cost_tracking/test_cost_recorder.py
@@ -381,6 +381,89 @@ class TestOperationContext:
         assert op == "caller_op"
 
 
+class TestUnregisteredOperationWarning:
+    """Drift detection: warn once per unregistered operation key.
+
+    A typo or new-but-uncatalogued operation silently lands in the
+    dashboard's fallback bucket — which defeats the taxonomy. The
+    recorder logs a single WARNING per unknown key so the gap shows
+    up in dev logs without spamming production at every call.
+    """
+
+    def test_warns_once_for_unknown_operation(
+        self, recorder: CostRecorder, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Unknown key triggers exactly one WARNING regardless of repeats."""
+        with caplog.at_level("WARNING", logger="src.cost_tracking.cost_recorder"):
+            with recorder.planner_context(
+                PlannerContext(experiment_id="e", project_id="p")
+            ):
+                for _ in range(5):
+                    recorder.record_planner_call(
+                        operation="totally_typo_op",
+                        provider="anthropic",
+                        model="claude-sonnet-4-6",
+                        input_tokens=1,
+                        output_tokens=1,
+                    )
+        # Exactly one warning, no matter how many calls share the typo
+        warns = [
+            r
+            for r in caplog.records
+            if "totally_typo_op" in r.getMessage() and r.levelname == "WARNING"
+        ]
+        assert len(warns) == 1
+
+    def test_does_not_warn_for_registered_operation(
+        self, recorder: CostRecorder, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Known catalog keys log no drift WARNING."""
+        with caplog.at_level("WARNING", logger="src.cost_tracking.cost_recorder"):
+            with recorder.planner_context(
+                PlannerContext(experiment_id="e", project_id="p")
+            ):
+                recorder.record_planner_call(
+                    operation="decompose_prd",
+                    provider="anthropic",
+                    model="claude-sonnet-4-6",
+                    input_tokens=1,
+                    output_tokens=1,
+                )
+        # No catalog-drift WARNINGs for a known key
+        drift_warns = [
+            r for r in caplog.records if "is not registered" in r.getMessage()
+        ]
+        assert drift_warns == []
+
+    def test_warns_for_operation_override_typo(
+        self, recorder: CostRecorder, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A typo in operation_override (not the caller's op) also warns.
+
+        This is the case the WARNING is specifically designed for:
+        call sites pass a typo through ``operation_context`` and the
+        provider's correctly-spelled default gets shadowed by it.
+        """
+        with caplog.at_level("WARNING", logger="src.cost_tracking.cost_recorder"):
+            with recorder.planner_context(
+                PlannerContext(experiment_id="e", project_id="p")
+            ):
+                with recorder.operation_context("decopmose_prd"):  # typo
+                    recorder.record_planner_call(
+                        operation="decompose_prd",  # correct caller op
+                        provider="anthropic",
+                        model="claude-sonnet-4-6",
+                        input_tokens=1,
+                        output_tokens=1,
+                    )
+        warns = [
+            r
+            for r in caplog.records
+            if "decopmose_prd" in r.getMessage() and r.levelname == "WARNING"
+        ]
+        assert len(warns) == 1
+
+
 class TestSingleton:
     """Module-level get/set helpers."""
 

--- a/tests/unit/cost_tracking/test_cost_recorder.py
+++ b/tests/unit/cost_tracking/test_cost_recorder.py
@@ -357,10 +357,38 @@ class TestOperationContext:
         op = store.conn.execute("SELECT operation FROM token_events").fetchone()[0]
         assert op == "analyze"
 
-    def test_noop_when_no_parent_context(self, recorder: CostRecorder) -> None:
-        """Without an active PlannerContext, operation_context is a no-op."""
+    def test_synthesizes_unassigned_parent_when_no_context(
+        self, recorder: CostRecorder, store: CostStore
+    ) -> None:
+        """Without an active PlannerContext, operation_context still pushes.
+
+        Codex P2 on PR #517: the original implementation yielded
+        ``None`` when no parent existed, which meant ``record_planner_call``
+        never saw the ``operation_override`` and the resulting
+        token_events row recorded the provider's generic ``'analyze'``
+        bucket instead of the call site's intended operation. Fix
+        synthesizes an ``'unassigned'`` PlannerContext carrying just
+        the override, so the operation tag is preserved even when
+        project/experiment attribution falls through.
+        """
         with recorder.operation_context("decompose_prd") as ctx:
-            assert ctx is None
+            assert ctx is not None
+            assert ctx.project_id == "unassigned"
+            assert ctx.experiment_id == "unassigned"
+            assert ctx.operation_override == "decompose_prd"
+            # Recording inside this scope should stamp the override
+            # onto token_events.operation even without a real parent.
+            recorder.record_planner_call(
+                operation="provider_default",
+                provider="anthropic",
+                model="claude-sonnet-4-6",
+                input_tokens=1,
+                output_tokens=1,
+            )
+        row = store.conn.execute(
+            "SELECT operation, project_id FROM token_events"
+        ).fetchone()
+        assert row == ("decompose_prd", "unassigned")
 
     def test_empty_operation_yields_current(
         self, recorder: CostRecorder, store: CostStore

--- a/tests/unit/cost_tracking/test_operations_catalog.py
+++ b/tests/unit/cost_tracking/test_operations_catalog.py
@@ -1,0 +1,111 @@
+"""
+Unit tests for ``src.cost_tracking.operations`` catalog.
+
+Verifies:
+
+- Catalog entries have the required shape.
+- Every operation referenced by call sites in production code resolves
+  to a real catalog entry, so the dashboard tooltip never falls through
+  to the synthesized "Unregistered operation" label.
+- ``get_operation`` gracefully synthesizes a fallback entry for unknown
+  keys.
+"""
+
+from __future__ import annotations
+
+from src.cost_tracking.operations import OPERATIONS, all_operations, get_operation
+
+
+class TestCatalogShape:
+    """Each catalog entry must have label, description, category."""
+
+    def test_every_entry_has_required_fields(self) -> None:
+        """All entries expose label/description/category as non-empty strings."""
+        for key, entry in OPERATIONS.items():
+            assert entry["label"], f"missing label for {key}"
+            assert entry["description"], f"missing description for {key}"
+            assert entry["category"], f"missing category for {key}"
+            assert isinstance(entry["label"], str)
+            assert isinstance(entry["description"], str)
+            assert isinstance(entry["category"], str)
+
+    def test_categories_are_from_known_set(self) -> None:
+        """Categories must come from the documented set so the UI can group."""
+        valid = {"decomposition", "runtime", "monitoring", "other"}
+        for key, entry in OPERATIONS.items():
+            assert (
+                entry["category"] in valid
+            ), f"{key} has unknown category {entry['category']}"
+
+
+class TestGetOperation:
+    """``get_operation`` looks up keys with a graceful fallback."""
+
+    def test_returns_catalog_entry_when_known(self) -> None:
+        """Known keys return the catalog entry verbatim."""
+        entry = get_operation("decompose_prd")
+        assert entry["category"] == "decomposition"
+        assert "PRD" in entry["label"] or "prd" in entry["label"].lower()
+
+    def test_synthesizes_fallback_for_unknown_key(self) -> None:
+        """Unknown keys yield a synthesized entry in the 'other' category."""
+        entry = get_operation("totally_made_up_op")
+        assert entry["category"] == "other"
+        assert "totally_made_up_op" in entry["description"]
+        # Synthesized label should be a human-readable form of the key
+        assert "Totally Made Up Op" in entry["label"]
+
+
+class TestAllOperations:
+    """``all_operations`` returns a defensive copy."""
+
+    def test_returns_copy_not_reference(self) -> None:
+        """Mutating the returned dict must not affect the canonical catalog."""
+        copy = all_operations()
+        copy["bogus_key_for_test"] = {  # type: ignore[typeddict-item]
+            "label": "x",
+            "description": "y",
+            "category": "other",
+        }
+        assert "bogus_key_for_test" not in OPERATIONS
+
+
+class TestCallSitesAreRegistered:
+    """Spot-check that the operation keys used in production resolve.
+
+    Misspellings or removed entries silently fall through to the
+    generic 'analyze' bucket, which defeats the point of per-call
+    drill-down. This test enforces the producer/consumer contract.
+    """
+
+    def test_known_call_site_keys_are_registered(self) -> None:
+        """Every operation key used by ``llm_client.analyze(operation=...)``
+        must be in the catalog.
+        """
+        expected = {
+            "decompose_prd",
+            "extract_outcomes",
+            "outcome_coverage_check",
+            "outcome_gap_fill",
+            "filter_outcomes",
+            "extract_spec_features",
+            "discover_domains",
+            "synthesize_foundation_tasks",
+            "generate_design_artifact",
+            "generate_design_decisions",
+            "generate_project_scaffold",
+            "generate_task_detail",
+            "generate_contracts",
+            "decompose_task",
+            "validate_task_completeness",
+            "validate_work",
+            "analyze_blocker",
+            "infer_dependencies",
+            "enrich_task",
+            "analyze_task_semantics",
+            "estimate_effort",
+            "analyze_project_health",
+            "analyze",
+        }
+        missing = expected - set(OPERATIONS.keys())
+        assert not missing, f"call-site keys missing from catalog: {missing}"

--- a/tests/unit/cost_tracking/test_operations_catalog.py
+++ b/tests/unit/cost_tracking/test_operations_catalog.py
@@ -109,3 +109,30 @@ class TestCallSitesAreRegistered:
         }
         missing = expected - set(OPERATIONS.keys())
         assert not missing, f"call-site keys missing from catalog: {missing}"
+
+
+class TestAnalysisTypeCoverage:
+    """AnalysisType enum ↔ ``post_analysis_*`` catalog keys must agree.
+
+    ``analysis/ai_engine.py:237`` constructs operation keys at runtime
+    as ``f"post_analysis_{request.analysis_type.value}"``. If someone
+    adds a new ``AnalysisType.SOMETHING_NEW`` variant without adding
+    a matching ``post_analysis_something_new`` catalog entry, the
+    dashboard silently falls through to the generic fallback label —
+    which defeats the per-analyzer drill-down. This test catches the
+    drift at PR time. Kaia review on the operation-taxonomy PR.
+    """
+
+    def test_every_analysis_type_has_catalog_entry(self) -> None:
+        """Every AnalysisType.value maps to a ``post_analysis_<value>`` entry."""
+        from src.analysis.ai_engine import AnalysisType
+
+        missing = []
+        for at in AnalysisType:
+            key = f"post_analysis_{at.value}"
+            if key not in OPERATIONS:
+                missing.append(key)
+        assert not missing, (
+            "AnalysisType variants without a catalog entry: "
+            f"{missing}. Add them to src/cost_tracking/operations.py."
+        )

--- a/tests/unit/cost_tracking/test_provider_recording.py
+++ b/tests/unit/cost_tracking/test_provider_recording.py
@@ -133,6 +133,53 @@ class TestLocalProviderRecords:
         assert row == (30, 10, "local")
 
 
+class TestOpenAIProviderRecords:
+    """openai_provider._call_openai must emit one event tagged 'openai'.
+
+    Regression for #409 follow-up: OpenAI was the only provider
+    missing this hook. Without it, every Anthropic→OpenAI fallback
+    silently bypassed cost tracking — which is exactly what was
+    happening on accounts without an Anthropic key, leaving the
+    'planner' role entirely missing from project cost breakdowns.
+    """
+
+    @pytest.mark.asyncio
+    async def test_call_openai_records_event(
+        self, recorder: CostRecorder, store: CostStore
+    ) -> None:
+        """OpenAI completion writes one row with prompt/completion tokens."""
+        from src.ai.providers.openai_provider import OpenAIProvider
+
+        provider = OpenAIProvider.__new__(OpenAIProvider)
+        provider.model = "gpt-3.5-turbo"
+        provider.max_tokens = 100
+        provider.temperature = 0.1
+        provider.base_url = "https://api.openai.com/v1"
+        provider.client = MagicMock()
+        provider.client.post = AsyncMock(
+            return_value=_mock_http_response(
+                {
+                    "id": "cmpl_test",
+                    "model": "gpt-3.5-turbo-0125",
+                    "choices": [{"message": {"content": "ok"}}],
+                    "usage": {"prompt_tokens": 75, "completion_tokens": 40},
+                }
+            )
+        )
+
+        with recorder.planner_context(
+            PlannerContext(experiment_id="e_oa", project_id="p_oa")
+        ):
+            result = await provider._call_openai([{"role": "user", "content": "hi"}])
+
+        assert result == "ok"
+        row = store.conn.execute(
+            "SELECT input_tokens, output_tokens, provider, model, request_id "
+            "FROM token_events"
+        ).fetchone()
+        assert row == (75, 40, "openai", "gpt-3.5-turbo-0125", "cmpl_test")
+
+
 class TestCloudProviderRecords:
     """cloud_provider._call_cloud_llm must emit one event tagged 'cloud'."""
 

--- a/tests/unit/integrations/test_design_autocomplete.py
+++ b/tests/unit/integrations/test_design_autocomplete.py
@@ -1293,3 +1293,146 @@ class TestRunDesignPhasePreGeneratedContent:
             )
 
         mock_gen.assert_called_once()
+
+
+class TestRunDesignPhaseCostAttribution:
+    """Regression tests for Codex P1 on PR #516.
+
+    ``create_project`` wraps ``_create_project_inner`` in a
+    ``planner_context`` carrying a ``pending:<uuid>`` placeholder
+    project_id, and runs a one-shot ``rebind_project_id`` after the
+    inner returns. ``_run_design_phase`` is spawned via
+    ``asyncio.ensure_future`` during the inner call — asyncio copies
+    the parent's ContextVar state into the new task, so the
+    placeholder is inherited. After the wrapper's rebind fires, the
+    background design phase keeps writing rows under the placeholder
+    that never get rebound.
+
+    The fix: ``_run_design_phase`` pushes a fresh ``PlannerContext``
+    carrying the real project_id (resolved from ``kanban_client``) as
+    its very first action. This shadows the inherited placeholder
+    for the design phase's whole lifetime — every LLM call inside
+    records against the real project, not the orphaned placeholder.
+    """
+
+    @pytest.mark.asyncio
+    async def test_pushes_real_project_context_before_running_body(self) -> None:
+        """The design-phase body runs with the real project_id at the top of the stack.
+
+        Sets up a kanban_client whose ``project_id`` is a real
+        canonical string, mocks every downstream LLM/IO call so the
+        body is essentially a no-op, then asserts that during the
+        body the recorder's ``current()`` context reflects the real
+        project_id — not whatever placeholder the caller (or no one)
+        pushed before invoking.
+        """
+        from src.cost_tracking.cost_recorder import (
+            CostRecorder,
+            PlannerContext,
+            set_recorder,
+        )
+        from src.cost_tracking.cost_store import CostStore
+        from src.integrations.nlp_tools import _run_design_phase
+
+        real_pid = "deadbeef" * 4  # 32-char dashless hex
+        store = CostStore(db_path=":memory:")
+        recorder = CostRecorder(store=store, enabled=True)
+        set_recorder(recorder)
+
+        # Capture the active context from inside the body so we can
+        # assert it's the real project_id, not the inherited placeholder.
+        captured: dict = {}
+
+        async def _capture_ctx(**_kwargs) -> dict:
+            ctx = recorder.current()
+            captured["project_id"] = ctx.project_id if ctx else None
+            return {}
+
+        kanban = MagicMock()
+        kanban.project_id = real_pid
+        kanban.update_task = AsyncMock()
+
+        state = MagicMock()
+        state.task_artifacts = {}
+        state.project_tasks = []
+
+        # Simulate the caller-pushed placeholder context (mirrors what
+        # ``create_project`` does in src/marcus_mcp/tools/nlp.py).
+        placeholder = f"pending:{'x' * 32}"
+        with recorder.planner_context(
+            PlannerContext(
+                experiment_id="unassigned",
+                project_id=placeholder,
+                project_name="Placeholder",
+            )
+        ):
+            with (
+                patch(
+                    "src.integrations.nlp_tools._generate_design_content",
+                    new_callable=AsyncMock,
+                    side_effect=_capture_ctx,
+                ),
+                patch(
+                    "src.integrations.nlp_tools._generate_project_scaffold",
+                    new_callable=AsyncMock,
+                ),
+            ):
+                await _run_design_phase(
+                    state=state,
+                    kanban_client=kanban,
+                    safe_tasks=[],
+                    created_tasks=[],
+                    description="x",
+                    project_name="ProjX",
+                    project_root="/var/folders/test",  # nosec B108
+                )
+
+        set_recorder(None)
+        # The body must have seen the REAL project_id, not the placeholder.
+        assert captured["project_id"] == real_pid, (
+            f"Design phase saw {captured['project_id']!r}; expected "
+            f"the real project_id {real_pid!r}. If this is the "
+            f"placeholder {placeholder!r}, the fix has regressed."
+        )
+
+    @pytest.mark.asyncio
+    async def test_falls_through_when_kanban_project_id_missing(self) -> None:
+        """If ``kanban_client.project_id`` is not a string, the wrapper falls through.
+
+        The fix uses ``isinstance(..., str)`` defensively because
+        MagicMock-backed kanban_clients in tests return a MagicMock
+        for any attr access. In that case we don't push a context —
+        we fall through with whatever the caller already has on the
+        stack — and the body still runs without crashing.
+        """
+        from src.integrations.nlp_tools import _run_design_phase
+
+        kanban = MagicMock()  # project_id will be a MagicMock, not str
+        kanban.update_task = AsyncMock()
+
+        state = MagicMock()
+        state.task_artifacts = {}
+        state.project_tasks = []
+
+        with (
+            patch(
+                "src.integrations.nlp_tools._generate_design_content",
+                new_callable=AsyncMock,
+                return_value={},
+            ),
+            patch(
+                "src.integrations.nlp_tools._generate_project_scaffold",
+                new_callable=AsyncMock,
+            ),
+        ):
+            # Should not raise — the isinstance guard prevents the
+            # MagicMock from being used as a project_id.
+            await _run_design_phase(
+                state=state,
+                kanban_client=kanban,
+                safe_tasks=[],
+                created_tasks=[],
+                description="x",
+                project_name="ProjY",
+                project_root="/var/folders/test",  # nosec B108
+            )

--- a/tests/unit/integrations/test_design_autocomplete_parallelism.py
+++ b/tests/unit/integrations/test_design_autocomplete_parallelism.py
@@ -65,7 +65,7 @@ _VALID_DECISIONS_RESPONSE = (
 )
 
 
-def _mock_llm_response(prompt: str, context: Any) -> str:
+def _mock_llm_response(prompt: str, context: Any, **kwargs: Any) -> str:
     """Return a valid response string for artifact or decisions prompts.
 
     Dispatches on prompt content so the same mock can serve both artifact
@@ -94,7 +94,7 @@ class TestDesignAutocompleteParallelism:
         """
         call_times: List[float] = []
 
-        async def slow_analyze(prompt: str, context: Any) -> str:
+        async def slow_analyze(prompt: str, context: Any, **kwargs: Any) -> str:
             call_times.append(time.monotonic())
             await asyncio.sleep(0.1)
             return _mock_llm_response(prompt, context)
@@ -235,7 +235,7 @@ class TestDesignAutocompleteParallelism:
         """
         call_count = {"n": 0}
 
-        async def mixed_analyze(prompt: str, context: Any) -> str:
+        async def mixed_analyze(prompt: str, context: Any, **kwargs: Any) -> str:
             call_count["n"] += 1
             # First artifact call returns garbage, the rest return valid
             if call_count["n"] == 1:
@@ -291,7 +291,7 @@ class TestDesignAutocompleteParallelism:
             "]"
         )
 
-        async def malformed_analyze(prompt: str, context: Any) -> str:
+        async def malformed_analyze(prompt: str, context: Any, **kwargs: Any) -> str:
             if "decision" in prompt.lower() and "json" in prompt.lower():
                 return malformed_decisions
             return _VALID_ARTIFACT_RESPONSE
@@ -336,7 +336,7 @@ class TestDesignAutocompleteParallelism:
         """
         fail_count = {"n": 0}
 
-        async def always_fail(prompt: str, context: Any) -> str:
+        async def always_fail(prompt: str, context: Any, **kwargs: Any) -> str:
             fail_count["n"] += 1
             raise RuntimeError("LLM provider exploded")
 
@@ -411,7 +411,7 @@ class TestDesignAutocompleteParallelism:
         concurrency = {"current": 0, "max": 0}
         lock = asyncio.Lock()
 
-        async def tracked_analyze(prompt: str, context: Any) -> str:
+        async def tracked_analyze(prompt: str, context: Any, **kwargs: Any) -> str:
             async with lock:
                 concurrency["current"] += 1
                 concurrency["max"] = max(concurrency["max"], concurrency["current"])
@@ -607,7 +607,7 @@ class TestGenerateContractsByDomain:
         not processed at all."
         """
 
-        async def empty_analyze(prompt: str, context: Any) -> str:
+        async def empty_analyze(prompt: str, context: Any, **kwargs: Any) -> str:
             return "nope"  # shorter than 20 chars, gets filtered
 
         mock_llm = Mock()
@@ -844,7 +844,7 @@ class TestSiblingBlockPromptIntegration:
         """
         captured_prompts: List[str] = []
 
-        async def capture_analyze(prompt: str, context: Any) -> str:
+        async def capture_analyze(prompt: str, context: Any, **kwargs: Any) -> str:
             captured_prompts.append(prompt)
             return _mock_llm_response(prompt, context)
 
@@ -897,7 +897,7 @@ class TestSiblingBlockPromptIntegration:
         """
         captured_prompts: List[str] = []
 
-        async def capture_analyze(prompt: str, context: Any) -> str:
+        async def capture_analyze(prompt: str, context: Any, **kwargs: Any) -> str:
             captured_prompts.append(prompt)
             return _mock_llm_response(prompt, context)
 
@@ -946,7 +946,7 @@ class TestSiblingBlockPromptIntegration:
         """
         captured_prompts: List[str] = []
 
-        async def capture_analyze(prompt: str, context: Any) -> str:
+        async def capture_analyze(prompt: str, context: Any, **kwargs: Any) -> str:
             captured_prompts.append(prompt)
             return _mock_llm_response(prompt, context)
 


### PR DESCRIPTION
## Summary

Tags every Marcus planner LLM call with a logical operation key (and a human description) so the Cato dashboard renders *what* the planner spent tokens on, not just *that* it did. Fix 2 of the cost-tracking follow-ups after #515 landed the attribution rebind.

Before this PR, the cost dashboard's per-operation breakdown showed `analyze` as the catch-all for ~all planner work. After: 23 distinct operation keys with names, descriptions, and category tags.

Paired Cato PR (renders the data): https://github.com/lwgray/cato/pull/new/feat/marcus-409-operations-taxonomy

## What's in here

**Commit 1 — Initial implementation (`f729ac8a`)**
- New `src/cost_tracking/operations.py` catalog: 32 entries grouped into `decomposition / runtime / monitoring / other`. Each has `{label, description, category}` for the dashboard tooltip.
- New `CostRecorder.operation_context(operation)` context manager that pushes a child `PlannerContext` with `operation_override` set. ContextVar-based so it stays asyncio-safe under concurrent fan-out (e.g., `_bounded_llm_analyze` with the 10-concurrent semaphore).
- `LLMAbstraction.analyze(..., operation=...)` keyword-only kwarg threads the key down to the recorder. High-level methods (`analyze_task_semantics`, `analyze_blocker_and_suggest_solutions`, `estimate_effort_intelligently`, etc.) wrap themselves in the appropriate `operation_context`.
- `AIAnalysisEngine.generate_structured_response(..., operation=...)` also threaded through.
- 18+ call sites tagged: `decompose_prd`, `extract_outcomes`, `outcome_coverage_check`, `outcome_gap_fill`, `filter_outcomes`, `discover_domains`, `synthesize_foundation_tasks`, `generate_design_artifact`, `generate_design_decisions`, `generate_project_scaffold`, `generate_task_detail`, `generate_contracts`, `decompose_task`, `validate_task_completeness`, `validate_work`, `analyze_blocker`, `infer_dependencies`, `enrich_task`, `analyze_task_semantics`, `estimate_effort`, plus `post_analysis_<variant>` for each `AnalysisType` enum value.

**Commit 2 — Kaia review fixes (`7e4f99cd`)**
- **Drift WARNING.** `CostRecorder.record_planner_call` now warns once per process per unregistered operation key. A typo at a call site silently lands in the dashboard's fallback bucket otherwise; this surfaces it in dev logs.
- **AnalysisType ↔ catalog drift test.** `TestAnalysisTypeCoverage` asserts every `AnalysisType` enum variant has a `post_analysis_<value>` catalog entry. Catches new analyzer types added without catalog wiring.
- **`LLMAnalyzeClient` Protocol** in `src/ai/providers/protocols.py` pins the `analyze()` contract: `async def analyze(prompt, context, *, operation: Optional[str] = None) -> str`. Production code can type-annotate against the Protocol; tests use `make_analyze_mock()` in `tests/unit/conftest.py` to build AsyncMocks that absorb future kwargs.

## Multi-Agency compliance

Pure planner-side observability. Doesn't push work to agents, doesn't constrain agent decisions, doesn't open a communication channel. Stays on the right side of the bright line.

## Test plan

- [x] `pytest tests/unit/cost_tracking -q` — 90 passed
- [x] `pytest tests/unit/ai tests/unit/integrations -q` — all passed (4 mock signatures updated to `**kwargs`)
- [x] `pytest -m unit -q` — 1297 passed, 1 skipped
- [x] `mypy src/cost_tracking/ src/ai/providers/protocols.py` — 0 errors
- [x] End-to-end smoke: simulated `decompose_prd + generate_contracts + generate_task_detail + typo` → 3 catalogued ops show as distinct rows, typo lands under category `?` and fires the drift WARNING once
- [ ] Live `create_project` against contract-first decomposition — verify Real-time tab shows the 3 decomposition ops with descriptions on hover (post-merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)