### PR TITLE
feat(cost): wire experiment_id for Direct MCP create_project (#409)

### DIFF
--- a/src/marcus_mcp/tools/nlp.py
+++ b/src/marcus_mcp/tools/nlp.py
@@ -150,55 +150,100 @@ async def create_project(
     collisions; ContextVar scopes the push per asyncio task.
     """
     import uuid as _uuid
+    from datetime import datetime, timezone
 
     from src.cost_tracking.cost_recorder import (
         PlannerContext,
         canonical_project_id,
         get_recorder,
     )
+    from src.cost_tracking.cost_store import Experiment
 
     _placeholder = f"pending:{_uuid.uuid4().hex}"
     _display_name = f"{project_name} (creating)"
+    # Pre-generate the experiment_id at wrapper entry so every cost
+    # row from ``_create_project_inner`` carries a real value from
+    # the start. Direct-MCP creates have no caller-supplied
+    # ``start_experiment`` call (only ``spawn_agents.py``-driven
+    # paths do), so without this every direct cost row would record
+    # ``experiment_id="unassigned"`` — leaving the experiments
+    # table empty and the experiments dimension of the dashboard
+    # useless for the most common entry point. The actual
+    # ``experiments`` row is inserted *after* ``_create_project_inner``
+    # succeeds, when we know the real project_id; until then the
+    # cost rows reference an experiment_id that has no row in the
+    # experiments table (FK is informal — schema doesn't enforce
+    # it). The view ``v_event_cost`` and aggregator joins use a
+    # LEFT JOIN against ``experiments``, so the temporary
+    # mismatch is harmless.
+    _experiment_id = _uuid.uuid4().hex
+    _started_at = datetime.now(timezone.utc)
     logger.debug(
         "cost_recorder: PUSHING placeholder context for create_project "
-        "name=%s placeholder=%s",
+        "name=%s placeholder=%s experiment_id=%s",
         project_name,
         _placeholder,
+        _experiment_id,
     )
     with get_recorder().planner_context(
         PlannerContext(
-            experiment_id="unassigned",
+            experiment_id=_experiment_id,
             project_id=_placeholder,
             project_name=_display_name,
         )
     ):
         result = await _create_project_inner(description, project_name, options, state)
 
-    # Phase 2: rebind on success. Failure leaves the placeholder rows
-    # for inspection; the dashboard hides them from the main picker.
+    # Phase 2: on success, record the experiments row (now that we
+    # have the real project_id) and rebind every placeholder
+    # project_id row. Failure leaves both the placeholder rows and
+    # the orphaned experiment_id for forensic inspection; the
+    # dashboard's picker filters placeholder rows out of the main
+    # project list.
     if isinstance(result, dict) and result.get("success"):
         _real_id = result.get("project_id")
         if _real_id:
             _canonical = canonical_project_id(str(_real_id))
             if _canonical and hasattr(state, "cost_store"):
                 try:
+                    # Insert the experiments row first. ``record_experiment``
+                    # is an upsert keyed by experiment_id, so a retry
+                    # under the same wrapper invocation is idempotent.
+                    # Decomposer / complexity / provider / model fields
+                    # are left blank here — they're harder to derive at
+                    # the wrapper layer and aren't critical for the
+                    # MVP. Issue #520 (entry_point) adds the source
+                    # discriminator and is where richer metadata can
+                    # be backfilled.
+                    state.cost_store.record_experiment(
+                        Experiment(
+                            experiment_id=_experiment_id,
+                            project_id=_canonical,
+                            project_name=project_name,
+                            started_at=_started_at,
+                        )
+                    )
                     n = state.cost_store.rebind_project_id(
                         from_id=_placeholder,
                         to_id=_canonical,
                     )
                     state.cost_store.upsert_project_name(_canonical, project_name)
                     logger.info(
-                        "create_project cost: rebound %d events from "
-                        "placeholder to project_id=%s",
+                        "create_project cost: recorded experiment_id=%s "
+                        "and rebound %d events from placeholder to "
+                        "project_id=%s",
+                        _experiment_id,
                         n,
                         _canonical,
                     )
                 except Exception:
                     logger.exception(
-                        "cost rebind failed for create_project "
-                        "placeholder=%s real=%s",
+                        "cost rebind/experiment-record failed for "
+                        "create_project placeholder=%s real=%s "
+                        "experiment_id=%s",
                         _placeholder,
                         _canonical,
+                        _experiment_id,
                     )
     return result
 

--- a/tests/unit/marcus_mcp/test_create_project_experiment_recording.py
+++ b/tests/unit/marcus_mcp/test_create_project_experiment_recording.py
@@ -1,0 +1,320 @@
+"""
+Tests for create_project's experiment_id wiring (Simon ``b74d5e1c``).
+
+Before this work, direct-MCP create_project produced cost rows with
+``experiment_id="unassigned"`` because no caller invoked the
+``start_experiment`` MCP tool — only the ``spawn_agents.py`` paths
+(``/marcus`` and Posidonius) did. The ``experiments`` table stayed
+empty for the most common entry point, leaving the experiments
+dimension of the cost data unusable for direct-MCP users.
+
+These tests lock in the fix:
+
+- Every successful ``create_project`` records exactly one row in the
+  ``experiments`` table.
+- The recorded ``experiment_id`` matches what cost rows recorded
+  during the wrapper's PlannerContext push.
+- The recorded row references the real (canonical) ``project_id``,
+  not the wrapper's placeholder.
+- Failure / missing-registry paths do not crash and do not leave
+  half-written experiment rows.
+
+See also: GitHub issue #520 for the follow-up that adds an
+``entry_point`` column so direct / ``/marcus`` / Posidonius
+experiments can be distinguished at the row level.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _mock_api_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Ensure CLAUDE_API_KEY is set so config validation passes."""
+    monkeypatch.setenv("CLAUDE_API_KEY", "test-key-for-unit-tests")
+
+
+@pytest.fixture(autouse=True)
+def _clear_create_project_dedup_cache() -> Any:
+    """Clear the module-level dedup cache between tests."""
+    from src.marcus_mcp.tools import nlp as nlp_module
+
+    nlp_module._recent_create_project_calls.clear()
+    yield
+    nlp_module._recent_create_project_calls.clear()
+
+
+def _build_state(cost_store: Any) -> Mock:
+    """Construct the minimum-viable ``state`` for the create_project wrapper.
+
+    Returns a Mock pre-wired with the kanban_client, ProjectRegistry,
+    project_manager, ai_engine, subtask_manager, and (importantly)
+    the real CostStore so the wrapper's
+    ``state.cost_store.record_experiment`` / ``rebind_project_id``
+    calls hit a real database.
+    """
+    from src.integrations.kanban_interface import KanbanProvider
+
+    state = Mock()
+    state.log_event = Mock()
+    state.kanban_client = Mock()
+    state.kanban_client.provider = KanbanProvider.PLANKA
+    state.kanban_client.project_id = "1670692878487127607"
+    state.kanban_client.board_id = "1670692878621345337"
+    state.ai_engine = Mock()
+    state.subtask_manager = Mock()
+    state.project_registry = Mock()
+    state.project_manager = Mock()
+    state.cost_store = cost_store
+    state.project_registry.add_project = AsyncMock(return_value="abc-123-def-456")
+    state.project_registry.get_active_project = AsyncMock(return_value=None)
+    state.project_manager.switch_project = AsyncMock()
+    state.project_manager.get_kanban_client = AsyncMock(
+        return_value=state.kanban_client
+    )
+    state._subtasks_migrated = False
+    return state
+
+
+@pytest.fixture
+def cost_store(tmp_path: Path) -> Any:
+    """Real tmp CostStore so we can read back token_events + experiments."""
+    from src.cost_tracking.cost_store import CostStore
+
+    return CostStore(db_path=tmp_path / "costs.db")
+
+
+@pytest.fixture
+def recorder(cost_store: Any) -> Any:
+    """Enabled cost recorder wired to the tmp store."""
+    from src.cost_tracking.cost_recorder import CostRecorder, set_recorder
+
+    rec = CostRecorder(store=cost_store, enabled=True)
+    set_recorder(rec)
+    yield rec
+    set_recorder(None)
+
+
+class TestCreateProjectRecordsExperiment:
+    """Direct-MCP ``create_project`` must record an experiments row."""
+
+    @pytest.mark.asyncio
+    async def test_records_exactly_one_experiment_per_successful_call(
+        self, cost_store: Any, recorder: Any
+    ) -> None:
+        """One successful create_project → exactly one experiments row."""
+        from src.marcus_mcp.tools.nlp import create_project
+
+        state = _build_state(cost_store)
+        marcus_project_id = "abc-123-def-456"
+        canonical_pid = marcus_project_id.replace("-", "")
+
+        mock_creator_result: Dict[str, Any] = {
+            "success": True,
+            "project_name": "Flight Simulator",
+            "tasks_created": 29,
+            "task_ids": ["task-1"],
+            "board": {
+                "project_name": "Flight Simulator",
+                "board_name": "Main Board",
+            },
+        }
+
+        with patch(
+            "src.integrations.nlp_tools.NaturalLanguageProjectCreator"
+        ) as MockCreator:
+            mock_creator = MockCreator.return_value
+            mock_creator.create_project_from_description = AsyncMock(
+                return_value=mock_creator_result
+            )
+            result = await create_project(
+                description="Build a flight simulator",
+                project_name="Flight Simulator",
+                options={"provider": "planka"},
+                state=state,
+            )
+
+        assert result["success"] is True
+        rows = list(
+            cost_store.conn.execute(
+                "SELECT experiment_id, project_id, project_name FROM experiments"
+            )
+        )
+        assert len(rows) == 1, f"expected one experiments row, got {rows}"
+        exp_id, pid, name = rows[0]
+        # experiment_id is a 32-char hex (uuid4().hex)
+        assert len(exp_id) == 32 and all(c in "0123456789abcdef" for c in exp_id)
+        assert pid == canonical_pid
+        assert name == "Flight Simulator"
+
+    @pytest.mark.asyncio
+    async def test_no_experiment_row_on_failure(
+        self, cost_store: Any, recorder: Any
+    ) -> None:
+        """Failed creator → no experiments row written.
+
+        The wrapper's recording is gated on ``result.get("success")``,
+        so a failure path leaves the experiments table clean. This
+        prevents a flood of orphaned experiment rows when the
+        decomposer is misbehaving.
+        """
+        from src.marcus_mcp.tools.nlp import create_project
+
+        state = _build_state(cost_store)
+        mock_creator_result: Dict[str, Any] = {
+            "success": False,
+            "error": "decomposer blew up",
+        }
+        with patch(
+            "src.integrations.nlp_tools.NaturalLanguageProjectCreator"
+        ) as MockCreator:
+            mock_creator = MockCreator.return_value
+            mock_creator.create_project_from_description = AsyncMock(
+                return_value=mock_creator_result
+            )
+            result = await create_project(
+                description="Build something",
+                project_name="Will Fail",
+                options={"provider": "planka"},
+                state=state,
+            )
+
+        assert result["success"] is False
+        rows = list(cost_store.conn.execute("SELECT * FROM experiments"))
+        assert rows == [], f"expected zero experiments rows, got {rows}"
+
+    @pytest.mark.asyncio
+    async def test_handles_missing_cost_store_gracefully(self) -> None:
+        """If ``state`` has no ``cost_store``, the wrapper still returns success.
+
+        Older tests / minimal deployments may construct a state Mock
+        without a cost_store attribute. The wrapper must skip the
+        experiment-record / rebind path without crashing.
+        """
+        from src.integrations.kanban_interface import KanbanProvider
+        from src.marcus_mcp.tools.nlp import create_project
+
+        # state without cost_store (spec excludes the attribute)
+        state = Mock(
+            spec=[
+                "log_event",
+                "kanban_client",
+                "ai_engine",
+                "subtask_manager",
+                "project_registry",
+                "project_manager",
+                "_subtasks_migrated",
+            ]
+        )
+        state.log_event = Mock()
+        state.kanban_client = Mock()
+        state.kanban_client.provider = KanbanProvider.PLANKA
+        state.kanban_client.project_id = "1670692878487127607"
+        state.kanban_client.board_id = "1670692878621345337"
+        state.ai_engine = Mock()
+        state.subtask_manager = Mock()
+        state.project_registry = Mock()
+        state.project_manager = Mock()
+        state.project_registry.add_project = AsyncMock(return_value="abc-123")
+        state.project_registry.get_active_project = AsyncMock(return_value=None)
+        state.project_manager.switch_project = AsyncMock()
+        state.project_manager.get_kanban_client = AsyncMock(
+            return_value=state.kanban_client
+        )
+        state._subtasks_migrated = False
+
+        mock_creator_result: Dict[str, Any] = {
+            "success": True,
+            "project_name": "Tiny Project",
+            "tasks_created": 1,
+        }
+        with patch(
+            "src.integrations.nlp_tools.NaturalLanguageProjectCreator"
+        ) as MockCreator:
+            mock_creator = MockCreator.return_value
+            mock_creator.create_project_from_description = AsyncMock(
+                return_value=mock_creator_result
+            )
+            result = await create_project(
+                description="Tiny",
+                project_name="Tiny Project",
+                options={"provider": "planka"},
+                state=state,
+            )
+
+        assert result["success"] is True
+
+    @pytest.mark.asyncio
+    async def test_experiment_id_matches_token_event_rows(
+        self, cost_store: Any, recorder: Any
+    ) -> None:
+        """Cost rows emitted during the wrapper carry the experiment_id we recorded.
+
+        This is the property that lets the dashboard's experiment view
+        actually display anything for direct-MCP projects. If the
+        token_events.experiment_id and experiments.experiment_id don't
+        match, the dashboard's join returns empty and the fix is
+        useless even though the experiments row exists.
+        """
+        from src.cost_tracking.cost_recorder import get_recorder
+        from src.marcus_mcp.tools.nlp import create_project
+
+        state = _build_state(cost_store)
+
+        # Simulate a planner LLM call landing during the wrapper's
+        # scope by having the mocked creator's
+        # ``create_project_from_description`` emit a cost row before
+        # returning. This mirrors how the real decomposer's LLM calls
+        # land inside the wrapper.
+        async def _creator_emits_cost(*_args: Any, **_kwargs: Any) -> Dict[str, Any]:
+            get_recorder().record_planner_call(
+                operation="decompose_prd",
+                provider="anthropic",
+                model="claude-sonnet-4-6",
+                input_tokens=100,
+                output_tokens=50,
+            )
+            return {
+                "success": True,
+                "project_name": "Flight Sim",
+                "tasks_created": 3,
+            }
+
+        with patch(
+            "src.integrations.nlp_tools.NaturalLanguageProjectCreator"
+        ) as MockCreator:
+            mock_creator = MockCreator.return_value
+            mock_creator.create_project_from_description = AsyncMock(
+                side_effect=_creator_emits_cost
+            )
+            await create_project(
+                description="Build a flight simulator",
+                project_name="Flight Sim",
+                options={"provider": "planka"},
+                state=state,
+            )
+
+        # Both tables must reference the same experiment_id
+        exp_row = cost_store.conn.execute(
+            "SELECT experiment_id FROM experiments"
+        ).fetchone()
+        te_row = cost_store.conn.execute(
+            "SELECT DISTINCT experiment_id FROM token_events "
+            "WHERE operation = 'decompose_prd'"
+        ).fetchone()
+        assert exp_row is not None
+        assert te_row is not None
+        assert exp_row[0] == te_row[0], (
+            f"experiment_id mismatch — experiments has {exp_row[0]!r} but "
+            f"token_events has {te_row[0]!r}. The dashboard's join "
+            f"would return empty."
+        )
+        # And critically — neither side recorded the legacy 'unassigned'
+        # sentinel that the pre-fix wrapper used.
+        assert exp_row[0] != "unassigned"
+        assert te_row[0] != "unassigned"


### PR DESCRIPTION
## Summary

Closes the experiment-attribution gap for the **Direct MCP entry point** — the most common way users invoke Marcus.

Before this PR, every cost row from a direct ``mcp__marcus__create_project`` call recorded ``experiment_id="unassigned"`` because no caller invoked the ``start_experiment`` MCP tool. Only the ``spawn_agents.py``-driven paths (``/marcus`` and Posidonius) did. The ``experiments`` table stayed empty for the entry point most users actually hit, making the experiments dimension of the cost data unusable for them.

Resolves Simon thought ``b74d5e1c``.

## The schema relationship that motivates this

``experiments`` is a child of ``project`` — each experiment has a NOT NULL ``project_id`` FK. Direct MCP creates a project but never opens an experiment, so the hierarchy was half-populated. Now every project has at least one experiment (the wrapper-created "primary" one).

## What changed

In ``src/marcus_mcp/tools/nlp.py``'s ``create_project`` wrapper:

1. Pre-generate ``_experiment_id = uuid4().hex`` at wrapper entry alongside the existing placeholder project_id.
2. The PlannerContext push now carries the real experiment_id from the start — so every cost row inside the wrapper's scope is attributed to it.
3. On success (once we have the real project_id): insert the ``experiments`` row via ``record_experiment(...)`` then run the existing ``rebind_project_id``.
4. On failure: leave the orphaned experiment_id behind for forensic inspection. The dashboard's LEFT JOIN against ``experiments`` keeps stray rows harmless.

### Why generate the experiment_id at entry rather than rebind later

Rebinding ``experiment_id`` post-facto would require a new ``rebind_experiment_id`` method and another UPDATE. Using the real ID from the start means the only post-success work is inserting the ``experiments`` row and the existing ``rebind_project_id`` — same shape as before, one extra ``INSERT``.

## Follow-up issue #520

The richer entry-point discrimination (``direct`` vs ``marcus`` vs ``posidonius``) is filed as issue #520. This PR is the prerequisite — uniform experiment_id attribution must exist before we can tag *which* entry point produced each experiment.

## Test plan

- [x] ``pytest tests/unit/marcus_mcp/test_create_project_experiment_recording.py`` — 4 new tests pass
- [x] ``pytest tests/unit/marcus_mcp/test_project_registration_on_create.py`` — existing tests still pass (no behavior regression)
- [x] ``pytest tests/unit/cost_tracking -q`` — 90 cost-tracking tests pass

The 4 new tests cover:
- One ``experiments`` row per successful call
- No row on failure (gated on ``result["success"]``)
- Missing ``cost_store`` attribute degrades gracefully (no crash)
- ``experiments.experiment_id`` matches the value cost rows recorded during the wrapper — proves the join the dashboard relies on

🤖 Generated with [Claude Code](https://claude.com/claude-code)