### PR TITLE
refactor(cost): rename experiments→runs + add path discriminator (#409)

### DIFF
--- a/experiments/spawn_agents.py
+++ b/experiments/spawn_agents.py
@@ -52,6 +52,21 @@ class ExperimentConfig:
         # This tells Marcus where the implementation files will be created
         self.project_options["project_root"] = str(self.implementation_dir)
 
+        # Entry-point discriminator for cost attribution. Marcus's
+        # create_project wrapper reads ``options["path"]`` and stamps
+        # it onto the ``runs.path`` column so the dashboard can break
+        # cost out by *which* entry point produced each run.
+        #
+        # Default to "marcus" since spawn_agents.py is the meta-runner
+        # behind the /marcus skill. Posidonius overrides this in its
+        # config.yaml with ``path: "posidonius"``. Plain MCP callers
+        # get ``"direct"`` for free (the wrapper's default) because
+        # they never hit this code path.
+        #
+        # Honor an explicit override in config — letting users
+        # extend the taxonomy without code changes.
+        self.project_options.setdefault("path", "marcus")
+
         # Project info file (shared between creator and workers)
         self.project_info_file = self.experiment_dir / "project_info.json"
 

--- a/src/cost_tracking/cost_aggregator.py
+++ b/src/cost_tracking/cost_aggregator.py
@@ -50,13 +50,17 @@ class CostAggregator:
 
     # -- public queries ---------------------------------------------------
 
-    def list_experiments(
+    def list_runs(
         self,
         *,
         project_id: Optional[str] = None,
         limit: int = 100,
     ) -> List[Dict[str, Any]]:
-        """List experiments with token + cost totals attached.
+        """List runs with token + cost totals attached.
+
+        Renamed from ``list_experiments`` (Simon ``7ed3074d``); the
+        underlying table is now ``runs`` and the legacy name clashed
+        with MLflow's separate experiment concept.
 
         Parameters
         ----------
@@ -68,38 +72,40 @@ class CostAggregator:
         Returns
         -------
         list of dict
-            Each row carries experiment metadata plus ``total_tokens``
-            and ``total_cost_usd`` aggregated from ``v_event_cost_inclusive``
-            (LEFT-joined to ``model_prices``) so events whose model has no
-            seeded price still count toward token totals.
+            Each row carries run metadata plus ``total_tokens`` and
+            ``total_cost_usd`` aggregated from
+            ``v_event_cost_inclusive`` (LEFT-joined to
+            ``model_prices``) so events whose model has no seeded
+            price still count toward token totals.
         """
         sql = """
             SELECT e.*,
                    COALESCE(SUM(c.total_tokens), 0) AS total_tokens,
                    COALESCE(SUM(c.cost_usd), 0)     AS total_cost_usd
-            FROM experiments e
-            LEFT JOIN v_event_cost_inclusive c USING (experiment_id)
+            FROM runs e
+            LEFT JOIN v_event_cost_inclusive c USING (run_id)
             WHERE (? IS NULL OR e.project_id = ?)
-            GROUP BY e.experiment_id
+            GROUP BY e.run_id
             ORDER BY e.started_at DESC
             LIMIT ?
         """
         return self._rows(sql, (project_id, project_id, limit))
 
-    def experiment_summary(self, experiment_id: str) -> Optional[Dict[str, Any]]:
-        """Full per-experiment summary used by Cato's drill-in view.
+    def run_summary(self, run_id: str) -> Optional[Dict[str, Any]]:
+        """Full per-run summary used by Cato's drill-in view.
+
+        Renamed from ``experiment_summary`` (Simon ``7ed3074d``).
 
         Returns
         -------
         dict or None
             Shaped like the example response in #409 (``summary``,
             ``by_role``, ``by_agent``, ``by_task``, ``by_operation``,
-            ``by_model``). Returns ``None`` if the experiment does not
-            exist.
+            ``by_model``). Returns ``None`` if the run does not exist.
         """
         meta = self._row(
-            "SELECT * FROM experiments WHERE experiment_id = ?",
-            (experiment_id,),
+            "SELECT * FROM runs WHERE run_id = ?",
+            (run_id,),
         )
         if meta is None:
             return None
@@ -116,9 +122,9 @@ class CostAggregator:
                 COALESCE(SUM(output_tokens), 0)             AS output_tokens,
                 COALESCE(SUM(cost_usd), 0)                  AS total_cost_usd
             FROM v_event_cost_inclusive
-            WHERE experiment_id = ?
+            WHERE run_id = ?
             """,
-                (experiment_id,),
+                (run_id,),
             )
             or {}
         )
@@ -140,10 +146,10 @@ class CostAggregator:
                    COALESCE(SUM(total_tokens), 0)    AS tokens,
                    COALESCE(SUM(cost_usd), 0)        AS cost_usd
             FROM v_event_cost_inclusive
-            WHERE experiment_id = ?
+            WHERE run_id = ?
             GROUP BY agent_role
             """,
-            (experiment_id,),
+            (run_id,),
         )
 
         by_agent = self._rows(
@@ -157,11 +163,11 @@ class CostAggregator:
                    COALESCE(SUM(CASE WHEN turn_index IS NOT NULL THEN 1 ELSE 0 END), 0)
                                                               AS turns
             FROM v_event_cost_inclusive
-            WHERE experiment_id = ?
+            WHERE run_id = ?
             GROUP BY agent_id, agent_role
             ORDER BY cost_usd DESC
             """,
-            (experiment_id,),
+            (run_id,),
         )
 
         by_task = self._rows(
@@ -171,11 +177,11 @@ class CostAggregator:
                    COALESCE(SUM(total_tokens), 0)    AS tokens,
                    COALESCE(SUM(cost_usd), 0)        AS cost_usd
             FROM v_event_cost_inclusive
-            WHERE experiment_id = ? AND task_id IS NOT NULL
+            WHERE run_id = ? AND task_id IS NOT NULL
             GROUP BY task_id
             ORDER BY cost_usd DESC
             """,
-            (experiment_id,),
+            (run_id,),
         )
 
         by_operation = self._rows(
@@ -185,11 +191,11 @@ class CostAggregator:
                    COALESCE(SUM(total_tokens), 0)    AS tokens,
                    COALESCE(SUM(cost_usd), 0)        AS cost_usd
             FROM v_event_cost_inclusive
-            WHERE experiment_id = ?
+            WHERE run_id = ?
             GROUP BY operation
             ORDER BY cost_usd DESC
             """,
-            (experiment_id,),
+            (run_id,),
         )
 
         by_model = self._rows(
@@ -199,11 +205,11 @@ class CostAggregator:
                    COALESCE(SUM(total_tokens), 0)    AS tokens,
                    COALESCE(SUM(cost_usd), 0)        AS cost_usd
             FROM v_event_cost_inclusive
-            WHERE experiment_id = ?
+            WHERE run_id = ?
             GROUP BY model, provider
             ORDER BY cost_usd DESC
             """,
-            (experiment_id,),
+            (run_id,),
         )
 
         return {
@@ -232,7 +238,7 @@ class CostAggregator:
             (session_id,),
         )
 
-    def cache_hit_rate_by_agent(self, experiment_id: str) -> List[Dict[str, Any]]:
+    def cache_hit_rate_by_agent(self, run_id: str) -> List[Dict[str, Any]]:
         """Per-agent cache hit rate within one experiment.
 
         Returns
@@ -250,10 +256,10 @@ class CostAggregator:
                      + COALESCE(SUM(cache_read_tokens), 0)         AS cacheable_tokens,
                    COALESCE(SUM(cache_read_tokens), 0)             AS cache_read_tokens
             FROM token_events
-            WHERE experiment_id = ?
+            WHERE run_id = ?
             GROUP BY agent_id
             """,
-            (experiment_id,),
+            (run_id,),
         )
         for r in rows:
             r["cache_hit_rate"] = (
@@ -295,7 +301,7 @@ class CostAggregator:
         # projects will have NULL here.
         #
         # JOIN-safety invariant: this query relies on
-        # ``experiments.experiment_id`` being unique (it's the primary
+        # ``experiments.run_id`` being unique (it's the primary
         # key, see cost_store.SCHEMA_SQL). If a future migration relaxes
         # that — e.g. adds a versioning column — the LEFT JOIN will fan
         # out and inflate every token / cost total. Revisit this query
@@ -312,14 +318,14 @@ class CostAggregator:
             SELECT t.project_id,
                    MAX(e.project_name)                  AS project_name,
                    COUNT(*)                             AS events,
-                   COUNT(DISTINCT t.experiment_id)      AS experiments,
+                   COUNT(DISTINCT t.run_id)      AS runs,
                    COUNT(DISTINCT t.agent_id)           AS agents,
                    COALESCE(SUM(t.total_tokens), 0)     AS total_tokens,
                    COALESCE(SUM(t.cost_usd), 0)         AS total_cost_usd,
                    MIN(t.timestamp)                     AS first_event_at,
                    MAX(t.timestamp)                     AS last_event_at
             FROM v_event_cost_inclusive t
-            LEFT JOIN experiments e USING (experiment_id)
+            LEFT JOIN runs e USING (run_id)
             WHERE t.project_id != 'unassigned'
             GROUP BY t.project_id
             ORDER BY total_cost_usd DESC
@@ -356,7 +362,7 @@ class CostAggregator:
             self._row(
                 """
             SELECT
-                COUNT(DISTINCT experiment_id)        AS experiments,
+                COUNT(DISTINCT run_id)        AS runs,
                 COUNT(*)                             AS events,
                 COALESCE(SUM(total_tokens), 0)       AS total_tokens,
                 COALESCE(SUM(cost_usd), 0)           AS total_cost_usd
@@ -366,7 +372,7 @@ class CostAggregator:
                 (project_id,),
             )
             or {
-                "experiments": 0,
+                "runs": 0,
                 "events": 0,
                 "total_tokens": 0,
                 "total_cost_usd": 0.0,
@@ -376,7 +382,7 @@ class CostAggregator:
     def project_summary(self, project_id: str) -> Optional[Dict[str, Any]]:
         """Full per-project summary used by Cato's drill-in view.
 
-        Mirrors :meth:`experiment_summary` but scoped to ``project_id``,
+        Mirrors :meth:`run_summary` but scoped to ``project_id``,
         because Marcus's coordination model identifies work by project,
         not by MLflow experiment. Most Marcus runs never call
         ``start_experiment`` and therefore have no row in the
@@ -395,7 +401,7 @@ class CostAggregator:
             """
             SELECT
                 COUNT(*)                                    AS total_events,
-                COUNT(DISTINCT experiment_id)               AS experiments,
+                COUNT(DISTINCT run_id)               AS runs,
                 COUNT(DISTINCT agent_id)                    AS agents,
                 COUNT(DISTINCT session_id)                  AS sessions,
                 COALESCE(SUM(total_tokens), 0)              AS total_tokens,

--- a/src/cost_tracking/cost_recorder.py
+++ b/src/cost_tracking/cost_recorder.py
@@ -74,9 +74,12 @@ class PlannerContext:
 
     Parameters
     ----------
-    experiment_id : str
-        Active experiment ID (use ``'unassigned'`` if the call happens
-        outside an experiment lifecycle).
+    run_id : str
+        Active run identifier — joins this event to a row in the
+        ``runs`` table. Use ``'unassigned'`` if the call happens
+        outside any run lifecycle. Renamed from the legacy
+        ``experiment_id`` (see Simon decision ``7ed3074d``); the
+        old name clashed with MLflow's separate experiment concept.
     project_id : str
         Active Marcus project ID. Normalized to dashless hex via
         :func:`canonical_project_id`.
@@ -94,7 +97,7 @@ class PlannerContext:
         Force a specific ``operation`` value regardless of caller.
     """
 
-    experiment_id: str
+    run_id: str
     project_id: str
     project_name: Optional[str] = None
     agent_id: str = "planner"
@@ -235,7 +238,7 @@ class CostRecorder:
         parent = self.current()
         if parent is None:
             child = PlannerContext(
-                experiment_id="unassigned",
+                run_id="unassigned",
                 project_id="unassigned",
                 operation_override=operation,
             )
@@ -308,14 +311,14 @@ class CostRecorder:
                 + output_tokens,
             )
         if ctx is not None:
-            experiment_id = ctx.experiment_id
+            run_id = ctx.run_id
             project_id = ctx.project_id
             agent_id = ctx.agent_id
             task_id = ctx.task_id
             if ctx.operation_override is not None:
                 operation = ctx.operation_override
         else:
-            experiment_id = "unassigned"
+            run_id = "unassigned"
             project_id = "unassigned"
             agent_id = "planner"
             task_id = None
@@ -347,7 +350,7 @@ class CostRecorder:
                 pass
 
         event = TokenEvent(
-            experiment_id=experiment_id,
+            run_id=run_id,
             project_id=project_id,
             agent_id=agent_id,
             agent_role="planner",

--- a/src/cost_tracking/cost_store.py
+++ b/src/cost_tracking/cost_store.py
@@ -8,11 +8,33 @@ never rewrites history.
 
 Schema
 ------
-- ``experiments``    : registry of runs (project, model, totals)
+- ``runs``           : registry of project runs (project, path, totals)
 - ``token_events``   : one row per LLM call (immutable token counts)
 - ``model_prices``   : versioned by ``effective_from``; edited by Cato UI
 - ``v_event_cost``   : view joining events × the price active at each
                       event's timestamp, exposing ``cost_usd``
+
+Terminology note
+----------------
+Marcus's cost-tracking layer talks about **runs** — one row per
+end-to-end traversal of a project (create → decompose → agents work
+→ stop). Each cost ``token_events`` row carries a ``run_id``
+identifying which run produced it.
+
+This concept used to be named ``experiment`` / ``experiment_id``.
+The rename happened because the name clashed with MLflow's
+*operational* experiment concept (the ``start_experiment`` MCP tool
+in ``src/marcus_mcp/tools/experiments.py``), which is unrelated:
+MLflow tracks task assignments, completions, and blockers for
+``/marcus`` and Posidonius runs; the cost-tracking layer tracks
+LLM token spend grouped by run. They share nothing besides a
+historical name collision.
+
+The ``runs.path`` column captures *which entry point produced
+this run*: ``"direct"`` (a human MCP user), ``"marcus"`` (the
+``/marcus`` meta-runner), or ``"posidonius"`` (the automated
+research runner). Defaults to ``"unknown"`` for rows created
+before the discriminator existed.
 
 This module exposes a thin :class:`CostStore` wrapper. Aggregation queries
 live in ``cost_aggregator.py``; this file only handles inserts and schema.
@@ -31,9 +53,15 @@ from typing import Any, Dict, List, Optional
 # ---------------------------------------------------------------------------
 
 SCHEMA_SQL: str = """
-CREATE TABLE IF NOT EXISTS experiments (
-  experiment_id    TEXT PRIMARY KEY,
+CREATE TABLE IF NOT EXISTS runs (
+  run_id           TEXT PRIMARY KEY,
   project_id       TEXT NOT NULL,
+  -- Entry point that produced this run. One of:
+  --   'direct'     - human MCP user (e.g., Claude Code calling create_project)
+  --   'marcus'     - /marcus meta-runner via experiments/spawn_agents.py
+  --   'posidonius' - Posidonius automated research runner via spawn_agents.py
+  --   'unknown'    - legacy rows from before the discriminator existed
+  path             TEXT NOT NULL DEFAULT 'unknown',
   board_id         TEXT,
   project_name     TEXT,
   decomposer       TEXT,
@@ -49,11 +77,12 @@ CREATE TABLE IF NOT EXISTS experiments (
   budget_usd       REAL,
   notes            TEXT
 );
-CREATE INDEX IF NOT EXISTS idx_exp_project ON experiments(project_id);
+CREATE INDEX IF NOT EXISTS idx_runs_project ON runs(project_id);
+CREATE INDEX IF NOT EXISTS idx_runs_path    ON runs(path);
 
 CREATE TABLE IF NOT EXISTS token_events (
   event_id              INTEGER PRIMARY KEY AUTOINCREMENT,
-  experiment_id         TEXT NOT NULL,
+  run_id                TEXT NOT NULL,
   project_id            TEXT NOT NULL,
   agent_id              TEXT NOT NULL,
   agent_role            TEXT NOT NULL,
@@ -85,9 +114,9 @@ CREATE TABLE IF NOT EXISTS token_events (
   timestamp             TIMESTAMP NOT NULL
                         DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
 );
-CREATE INDEX IF NOT EXISTS idx_te_exp       ON token_events(experiment_id);
+CREATE INDEX IF NOT EXISTS idx_te_run       ON token_events(run_id);
 CREATE INDEX IF NOT EXISTS idx_te_project   ON token_events(project_id);
-CREATE INDEX IF NOT EXISTS idx_te_agent     ON token_events(experiment_id, agent_id);
+CREATE INDEX IF NOT EXISTS idx_te_run_agent ON token_events(run_id, agent_id);
 CREATE INDEX IF NOT EXISTS idx_te_task      ON token_events(task_id);
 CREATE INDEX IF NOT EXISTS idx_te_op_model  ON token_events(operation, model);
 CREATE INDEX IF NOT EXISTS idx_te_timestamp ON token_events(timestamp);
@@ -202,8 +231,10 @@ class TokenEvent:
 
     Parameters
     ----------
-    experiment_id : str
-        Marcus experiment ID.
+    run_id : str
+        Run identifier — ties this event to one row in the ``runs``
+        table. See :class:`Run` for the rationale on the rename
+        from the legacy ``experiment_id``.
     project_id : str
         Marcus project ID this event belongs to (denormalized for fast filter).
     agent_id : str
@@ -231,7 +262,7 @@ class TokenEvent:
         in SQLite when not supplied.
     """
 
-    experiment_id: str
+    run_id: str
     project_id: str
     agent_id: str
     agent_role: str
@@ -255,12 +286,23 @@ class TokenEvent:
 
 
 @dataclass
-class Experiment:
-    """Experiment registry row."""
+class Run:
+    """Run registry row — one project traversal end-to-end.
 
-    experiment_id: str
+    Each row in the ``runs`` table represents a single execution of
+    a project from ``create_project`` through agent work. The
+    ``path`` field records which entry point produced the run; see
+    the schema header for the allowed values.
+
+    Renamed from ``Experiment`` (and the table from ``experiments``)
+    to disambiguate from MLflow's separate experiment concept. See
+    Simon decision ``7ed3074d`` for the full rationale.
+    """
+
+    run_id: str
     project_id: str
     started_at: datetime
+    path: str = "unknown"
     board_id: Optional[str] = None
     project_name: Optional[str] = None
     decomposer: Optional[str] = None
@@ -514,14 +556,91 @@ class CostStore:
     def _init_schema(self) -> None:
         """Run schema DDL. Idempotent thanks to IF NOT EXISTS guards.
 
-        Runs a one-shot dedup migration before ``executescript`` so the
-        partial UNIQUE index on ``request_id`` can be created against
-        DBs that accumulated duplicates pre-PR-#511 (Cato's 30s poll
-        re-inserted every event). Without this, ``CREATE UNIQUE INDEX``
-        would raise ``IntegrityError`` and Marcus wouldn't start.
+        Two ordered one-shot migrations run before ``executescript``
+        so that the DDL can assume the new schema:
+
+        1. :meth:`_runs_rename_migration` renames the legacy
+           ``experiments`` table to ``runs`` and the
+           ``experiment_id`` column to ``run_id`` (in both ``runs``
+           and ``token_events``), then adds the new ``path`` column
+           for entry-point discrimination. See the function's
+           docstring for the rationale.
+        2. :meth:`_dedup_pre_index_migration` removes duplicate
+           ``request_id`` rows before the partial UNIQUE index lands.
         """
+        self._runs_rename_migration()
         self._dedup_pre_index_migration()
         self.conn.executescript(SCHEMA_SQL)
+        self.conn.commit()
+
+    def _runs_rename_migration(self) -> None:
+        """One-shot migration: ``experiments`` → ``runs`` + add ``path``.
+
+        Before this rename, the cost-tracking layer used
+        ``experiments`` and ``experiment_id`` as its terminology. That
+        clashed with MLflow's *operational* experiment concept (the
+        ``start_experiment`` MCP tool), causing real architectural
+        confusion — see Simon decision ``7ed3074d``. The rename
+        clarifies that these are two unrelated systems with a
+        historical name collision.
+
+        Operations performed (idempotent):
+
+        1. Detect legacy schema via the presence of the
+           ``experiments`` table and absence of the ``runs`` table.
+        2. ``ALTER TABLE experiments RENAME TO runs``
+        3. ``ALTER TABLE runs RENAME COLUMN experiment_id TO run_id``
+        4. ``ALTER TABLE token_events RENAME COLUMN experiment_id TO run_id``
+        5. Drop the old index names so SCHEMA_SQL's
+           ``CREATE INDEX IF NOT EXISTS`` builds fresh ones with
+           descriptive names (``idx_runs_*`` / ``idx_te_run*``).
+        6. ``ALTER TABLE runs ADD COLUMN path TEXT NOT NULL
+           DEFAULT 'unknown'``.
+
+        Requires SQLite 3.25+ for ``RENAME COLUMN``. Python's bundled
+        sqlite3 module ships with much newer versions; Marcus's
+        supported Python (3.10+) is fine.
+
+        Skipped on three cases:
+
+        - Fresh install (no ``experiments`` table) — SCHEMA_SQL
+          creates the new layout directly.
+        - Already-migrated DB (``runs`` table present) — no-op.
+        - DB with neither table (unreachable in practice, but kept
+          defensive) — no-op.
+        """
+        has_experiments = self.conn.execute(
+            "SELECT 1 FROM sqlite_master " "WHERE type='table' AND name='experiments'"
+        ).fetchone()
+        has_runs = self.conn.execute(
+            "SELECT 1 FROM sqlite_master " "WHERE type='table' AND name='runs'"
+        ).fetchone()
+
+        if has_runs:
+            # Already migrated, or fresh install will create directly.
+            return
+        if not has_experiments:
+            # Fresh install — nothing to rename.
+            return
+
+        # Legacy schema present. Execute the rename.
+        self.conn.execute("ALTER TABLE experiments RENAME TO runs")
+        self.conn.execute("ALTER TABLE runs RENAME COLUMN experiment_id TO run_id")
+        self.conn.execute(
+            "ALTER TABLE token_events RENAME COLUMN experiment_id TO run_id"
+        )
+        # Drop the indices that referenced the old names. SCHEMA_SQL's
+        # ``CREATE INDEX IF NOT EXISTS`` will rebuild them with the
+        # new descriptive names against the renamed columns. SQLite
+        # auto-updates index DDL to track column renames, so the old
+        # indices still work — but we drop them so the index name
+        # vocabulary matches the new schema vocabulary.
+        for old_index in ("idx_exp_project", "idx_te_exp", "idx_te_agent"):
+            self.conn.execute(f"DROP INDEX IF EXISTS {old_index}")
+        # Add the new path column for entry-point discrimination.
+        self.conn.execute(
+            "ALTER TABLE runs ADD COLUMN path TEXT NOT NULL " "DEFAULT 'unknown'"
+        )
         self.conn.commit()
 
     def _dedup_pre_index_migration(self) -> None:
@@ -578,7 +697,7 @@ class CostStore:
         cur = self.conn.execute(
             """
             INSERT OR IGNORE INTO token_events (
-                experiment_id, project_id, agent_id, agent_role,
+                run_id, project_id, agent_id, agent_role,
                 parent_agent_id, task_id, subtask_id, operation,
                 provider, model, input_tokens, cache_creation_tokens,
                 cache_read_tokens, output_tokens, latency_ms, session_id,
@@ -587,7 +706,7 @@ class CostStore:
                       COALESCE(?, strftime('%Y-%m-%dT%H:%M:%fZ', 'now')))
             """,
             (
-                event.experiment_id,
+                event.run_id,
                 event.project_id,
                 event.agent_id,
                 event.agent_role,
@@ -626,17 +745,23 @@ class CostStore:
             raise RuntimeError("sqlite3 did not return lastrowid")
         return event_id
 
-    def record_experiment(self, exp: Experiment) -> None:
-        """Upsert one ``experiments`` row keyed by ``experiment_id``."""
+    def record_run(self, run: Run) -> None:
+        """Upsert one ``runs`` row keyed by ``run_id``.
+
+        Renamed from ``record_experiment`` in the rename of
+        ``experiments`` → ``runs``. See Simon decision ``7ed3074d``.
+        """
         self.conn.execute(
             """
-            INSERT INTO experiments (
-                experiment_id, project_id, board_id, project_name, decomposer,
-                complexity, provider, model, num_agents, started_at, ended_at,
-                total_tasks, completed_tasks, blocked_tasks, budget_usd, notes
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-            ON CONFLICT(experiment_id) DO UPDATE SET
+            INSERT INTO runs (
+                run_id, project_id, path, board_id, project_name,
+                decomposer, complexity, provider, model, num_agents,
+                started_at, ended_at, total_tasks, completed_tasks,
+                blocked_tasks, budget_usd, notes
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT(run_id) DO UPDATE SET
                 project_id=excluded.project_id,
+                path=excluded.path,
                 board_id=excluded.board_id,
                 project_name=excluded.project_name,
                 decomposer=excluded.decomposer,
@@ -653,22 +778,23 @@ class CostStore:
                 notes=excluded.notes
             """,
             (
-                exp.experiment_id,
-                exp.project_id,
-                exp.board_id,
-                exp.project_name,
-                exp.decomposer,
-                exp.complexity,
-                exp.provider,
-                exp.model,
-                exp.num_agents,
-                exp.started_at.isoformat(),
-                exp.ended_at.isoformat() if exp.ended_at else None,
-                exp.total_tasks,
-                exp.completed_tasks,
-                exp.blocked_tasks,
-                exp.budget_usd,
-                exp.notes,
+                run.run_id,
+                run.project_id,
+                run.path,
+                run.board_id,
+                run.project_name,
+                run.decomposer,
+                run.complexity,
+                run.provider,
+                run.model,
+                run.num_agents,
+                run.started_at.isoformat(),
+                run.ended_at.isoformat() if run.ended_at else None,
+                run.total_tasks,
+                run.completed_tasks,
+                run.blocked_tasks,
+                run.budget_usd,
+                run.notes,
             ),
         )
         self.conn.commit()

--- a/src/cost_tracking/worker_ingester.py
+++ b/src/cost_tracking/worker_ingester.py
@@ -22,7 +22,7 @@ Design choices
   is idempotent within a single process. Cross-process dedup would
   require a side table — added later if needed.
 - **Caller supplies binding.** The ingester does not know how to map a
-  session/cwd to an ``agent_id``/``experiment_id``/``project_id``. Callers
+  session/cwd to an ``agent_id``/``run_id``/``project_id``. Callers
   provide a ``resolve_binding`` callable (typically wired from the spawn
   registry written by ``spawn_agents.py``).
 """
@@ -57,8 +57,8 @@ class AgentBinding:
     agent_id : str
         Stable agent name as registered with Marcus (e.g.
         ``'agent_unicorn_1'``).
-    experiment_id : str
-        Marcus experiment ID this session belongs to.
+    run_id : str
+        Marcus run ID this session belongs to (joins to ``runs`` table).
     project_id : str
         Marcus project ID — usually the same value the planner uses.
     parent_agent_id : str, optional
@@ -71,7 +71,7 @@ class AgentBinding:
     """
 
     agent_id: str
-    experiment_id: str
+    run_id: str
     project_id: str
     parent_agent_id: Optional[str] = None
     task_id: Optional[str] = None
@@ -192,7 +192,7 @@ class WorkerJSONLIngester:
         # keeps every token_events row consistent regardless of source.
         canonical_pid = canonical_project_id(binding.project_id)
         event = TokenEvent(
-            experiment_id=binding.experiment_id,
+            run_id=binding.run_id,
             project_id=(
                 canonical_pid if canonical_pid is not None else binding.project_id
             ),

--- a/src/integrations/nlp_tools.py
+++ b/src/integrations/nlp_tools.py
@@ -4155,7 +4155,7 @@ async def _run_design_phase(
     if _real_pid:
         _design_ctx_cm: Any = _get_recorder().planner_context(
             _PlannerContext(
-                experiment_id="unassigned",
+                run_id="unassigned",
                 project_id=_real_pid,
                 project_name=project_name,
             )

--- a/src/marcus_mcp/handlers.py
+++ b/src/marcus_mcp/handlers.py
@@ -1168,7 +1168,7 @@ async def handle_tool_call(
         _cost_stack.enter_context(
             get_recorder().planner_context(
                 PlannerContext(
-                    experiment_id="unassigned",
+                    run_id="unassigned",
                     project_id=_cost_project_id,
                     project_name=_cost_project_name,
                 )
@@ -1304,7 +1304,7 @@ async def handle_tool_call(
         elif name == "get_cost_summary":
             args = arguments or {}
             result = await get_cost_summary(
-                experiment_id=args.get("experiment_id"),
+                run_id=args.get("run_id"),
                 project_id=args.get("project_id"),
                 state=state,
             )

--- a/src/marcus_mcp/tools/cost_tracking.py
+++ b/src/marcus_mcp/tools/cost_tracking.py
@@ -6,6 +6,12 @@ the Cato dashboard) can query the cost store without direct DB access.
 
 The tool dispatches to :class:`src.cost_tracking.cost_aggregator.CostAggregator`
 and returns dicts shaped like the API responses documented in #409.
+
+Terminology
+-----------
+This module talks about **runs** (one project traversal end-to-end),
+not "experiments." The legacy name clashed with MLflow's unrelated
+experiment concept (Simon ``7ed3074d`` for the rationale).
 """
 
 from __future__ import annotations
@@ -18,44 +24,46 @@ from src.cost_tracking.cost_aggregator import CostAggregator
 
 
 async def get_cost_summary(
-    experiment_id: Optional[str] = None,
+    run_id: Optional[str] = None,
     project_id: Optional[str] = None,
     state: Any = None,
 ) -> Dict[str, Any]:
-    """Return a cost summary keyed by experiment or project.
+    """Return a cost summary keyed by run or project.
 
     Parameters
     ----------
-    experiment_id : str, optional
-        Marcus experiment ID. When provided, returns a full per-experiment
-        breakdown (``summary`` + ``by_role`` + ``by_agent`` + ``by_task``
-        + ``by_operation`` + ``by_model``).
+    run_id : str, optional
+        Run identifier. When provided, returns a full per-run
+        breakdown (``summary`` + ``by_role`` + ``by_agent`` +
+        ``by_task`` + ``by_operation`` + ``by_model``).
     project_id : str, optional
-        Marcus project ID. When provided, returns project totals plus a
-        list of experiment summaries belonging to the project. Used by
-        Cato when drilling from a project view into its runs.
+        Marcus project ID. When provided, returns project totals
+        plus a list of run summaries belonging to the project. Used
+        by Cato when drilling from a project view into its runs.
     state : Any
-        Marcus server state. Must expose ``cost_store`` (set up at server
-        init, see :class:`src.marcus_mcp.server.MarcusServer.__init__`).
+        Marcus server state. Must expose ``cost_store`` (set up at
+        server init, see
+        :class:`src.marcus_mcp.server.MarcusServer.__init__`).
 
     Returns
     -------
     dict
-        Either the experiment-summary shape (when ``experiment_id`` is
-        passed), the project-rollup shape (when ``project_id`` is passed),
-        or an error envelope ``{success: False, error: ...}`` if the
-        caller didn't provide either or the store is unavailable.
+        Either the run-summary shape (when ``run_id`` is passed),
+        the project-rollup shape (when ``project_id`` is passed),
+        or an error envelope ``{success: False, error: ...}`` if
+        the caller didn't provide either or the store is
+        unavailable.
 
     Notes
     -----
-    Read-only. Never raises; argument and lookup errors are returned as
-    ``{success: False, error: ...}`` dicts so MCP clients get a friendly
-    payload rather than a stack trace.
+    Read-only. Never raises; argument and lookup errors are returned
+    as ``{success: False, error: ...}`` dicts so MCP clients get a
+    friendly payload rather than a stack trace.
     """
-    if experiment_id is None and project_id is None:
+    if run_id is None and project_id is None:
         return {
             "success": False,
-            "error": "Provide either experiment_id or project_id.",
+            "error": "Provide either run_id or project_id.",
         }
 
     cost_store = getattr(state, "cost_store", None)
@@ -67,12 +75,12 @@ async def get_cost_summary(
 
     aggregator = CostAggregator(store=cost_store)
 
-    if experiment_id is not None:
-        summary = aggregator.experiment_summary(experiment_id)
+    if run_id is not None:
+        summary = aggregator.run_summary(run_id)
         if summary is None:
             return {
                 "success": False,
-                "error": f"Experiment '{experiment_id}' not found.",
+                "error": f"Run '{run_id}' not found.",
             }
         return summary
 
@@ -81,7 +89,7 @@ async def get_cost_summary(
     return {
         "project_id": project_id,
         "totals": aggregator.project_totals(project_id),
-        "experiments": aggregator.list_experiments(project_id=project_id),
+        "runs": aggregator.list_runs(project_id=project_id),
     }
 
 
@@ -89,27 +97,30 @@ async def get_cost_summary(
 COST_SUMMARY_TOOL = Tool(
     name="get_cost_summary",
     description=(
-        "Return per-experiment or per-project token + cost breakdown from "
-        "the Marcus cost store. Pass experiment_id for a full drill-in "
-        "(summary, by_role, by_agent, by_task, by_operation, by_model). "
-        "Pass project_id for project totals plus a list of experiment "
-        "summaries. Read-only."
+        "Return per-run or per-project token + cost breakdown from "
+        "the Marcus cost store. Pass run_id for a full drill-in "
+        "(summary, by_role, by_agent, by_task, by_operation, "
+        "by_model). Pass project_id for project totals plus a list "
+        "of run summaries. Read-only."
     ),
     inputSchema={
         "type": "object",
         "properties": {
-            "experiment_id": {
+            "run_id": {
                 "type": "string",
                 "description": (
-                    "Marcus experiment ID. Returns a full per-experiment "
-                    "breakdown if matched."
+                    "Run identifier. Returns a full per-run "
+                    "breakdown if matched. Renamed from "
+                    "experiment_id; the legacy name clashed with "
+                    "MLflow's separate experiment concept."
                 ),
             },
             "project_id": {
                 "type": "string",
                 "description": (
-                    "Marcus project ID. Returns project totals plus a list "
-                    "of experiment summaries belonging to the project."
+                    "Marcus project ID. Returns project totals plus "
+                    "a list of run summaries belonging to the "
+                    "project."
                 ),
             },
         },

--- a/src/marcus_mcp/tools/nlp.py
+++ b/src/marcus_mcp/tools/nlp.py
@@ -137,68 +137,118 @@ async def create_project(
     handler and never ran for HTTP clients, so all planner cost
     silently landed in 'unassigned' (#409 followup).
 
-    Two-phase attribution:
-    1. Push a placeholder ``PlannerContext`` (``pending:<uuid_hex>``)
+    Two-phase attribution
+    ---------------------
+    1. Push a placeholder ``PlannerContext`` with a freshly-generated
+       ``run_id`` and a placeholder ``project_id`` (``pending:<uuid_hex>``)
        so heavy decomposition LLM calls land in ``token_events`` with
-       a real, traceable project_id rather than 'unassigned'.
-    2. After the underlying work returns the real project_id, rebind
-       every placeholder row to it. On failure the rows stay tagged
-       ``pending:*`` for forensic inspection — the picker filters them
-       out and Unassigned surfaces them.
+       a real, traceable run_id and a recoverable project_id rather
+       than ``'unassigned'``.
+    2. After the underlying work returns the real project_id:
+
+       - Insert the ``runs`` row (``record_run``) carrying the
+         pre-generated run_id, the real project_id, and the
+         ``path`` value from ``options`` (or ``'direct'`` by default).
+       - Rebind every placeholder ``project_id`` row to the canonical
+         project_id. On failure both halves are skipped — the
+         placeholder rows stay tagged ``pending:*`` for forensic
+         inspection and no orphaned run row is created.
+
+    Path discrimination
+    -------------------
+    Reads ``options.get("path", "direct")`` to label which entry
+    point produced this run. Allowed values: ``"direct"`` (a human
+    MCP user — the default), ``"marcus"`` (``/marcus`` meta-runner),
+    ``"posidonius"`` (Posidonius automated trial). ``spawn_agents.py``
+    sets the value in its YAML-driven config; Direct MCP callers
+    don't need to do anything and get ``"direct"`` for free.
+
+    Why the run_id is generated at entry rather than rebound later:
+    rebinding ``run_id`` post-facto would require a new
+    ``rebind_run_id`` method and another UPDATE. Generating the real
+    ID from the start means the only post-success work is inserting
+    the ``runs`` row and the existing ``rebind_project_id`` — same
+    shape as before, one extra INSERT.
 
     Concurrency-safe by construction: random UUID per call prevents
     collisions; ContextVar scopes the push per asyncio task.
     """
     import uuid as _uuid
+    from datetime import datetime, timezone
 
     from src.cost_tracking.cost_recorder import (
         PlannerContext,
         canonical_project_id,
         get_recorder,
     )
+    from src.cost_tracking.cost_store import Run
 
     _placeholder = f"pending:{_uuid.uuid4().hex}"
     _display_name = f"{project_name} (creating)"
+    _run_id = _uuid.uuid4().hex
+    _started_at = datetime.now(timezone.utc)
+    # Path discriminator — see docstring. Defaults to 'direct' so
+    # human MCP callers get the right label without supplying it.
+    _path = (options or {}).get("path", "direct")
     logger.debug(
         "cost_recorder: PUSHING placeholder context for create_project "
-        "name=%s placeholder=%s",
+        "name=%s placeholder=%s run_id=%s path=%s",
         project_name,
         _placeholder,
+        _run_id,
+        _path,
     )
     with get_recorder().planner_context(
         PlannerContext(
-            experiment_id="unassigned",
+            run_id=_run_id,
             project_id=_placeholder,
             project_name=_display_name,
         )
     ):
         result = await _create_project_inner(description, project_name, options, state)
 
-    # Phase 2: rebind on success. Failure leaves the placeholder rows
-    # for inspection; the dashboard hides them from the main picker.
+    # Phase 2: on success, record the runs row (now that we know the
+    # real project_id) and rebind every placeholder project_id row.
+    # Failure leaves both the placeholder rows and the orphaned
+    # run_id behind for forensic inspection; the dashboard's picker
+    # filters placeholder rows out of the main project list.
     if isinstance(result, dict) and result.get("success"):
         _real_id = result.get("project_id")
         if _real_id:
             _canonical = canonical_project_id(str(_real_id))
             if _canonical and hasattr(state, "cost_store"):
                 try:
+                    state.cost_store.record_run(
+                        Run(
+                            run_id=_run_id,
+                            project_id=_canonical,
+                            project_name=project_name,
+                            started_at=_started_at,
+                            path=_path,
+                        )
+                    )
                     n = state.cost_store.rebind_project_id(
                         from_id=_placeholder,
                         to_id=_canonical,
                     )
                     state.cost_store.upsert_project_name(_canonical, project_name)
                     logger.info(
-                        "create_project cost: rebound %d events from "
-                        "placeholder to project_id=%s",
+                        "create_project cost: recorded run_id=%s path=%s "
+                        "and rebound %d events from placeholder to "
+                        "project_id=%s",
+                        _run_id,
+                        _path,
                         n,
                         _canonical,
                     )
                 except Exception:
                     logger.exception(
-                        "cost rebind failed for create_project "
-                        "placeholder=%s real=%s",
+                        "cost rebind/run-record failed for "
+                        "create_project placeholder=%s real=%s "
+                        "run_id=%s",
                         _placeholder,
                         _canonical,
+                        _run_id,
                     )
     return result
 

--- a/src/marcus_mcp/tools/nlp.py
+++ b/src/marcus_mcp/tools/nlp.py
@@ -212,7 +212,16 @@ async def create_project(
     # Failure leaves both the placeholder rows and the orphaned
     # run_id behind for forensic inspection; the dashboard's picker
     # filters placeholder rows out of the main project list.
-    if isinstance(result, dict) and result.get("success"):
+    #
+    # Dedup-cached replays are skipped: the inner function returned a
+    # cached success without doing any planner work, so the placeholder
+    # context never accumulated token_events. Recording would just
+    # insert a phantom zero-cost runs row per retry. Pop the internal
+    # marker before returning so it never leaks to the agent. (Codex P2)
+    _dedup_cached = (
+        isinstance(result, dict) and result.pop("_dedup_cached", False) is True
+    )
+    if isinstance(result, dict) and result.get("success") and not _dedup_cached:
         _real_id = result.get("project_id")
         if _real_id:
             _canonical = canonical_project_id(str(_real_id))
@@ -434,7 +443,16 @@ async def _create_project_inner(
                             f"[create_project dedup] Failed to write "
                             f"project_info.json: {_dedup_write_err}"
                         )
-                return cached_result
+                # Signal to the wrapper that this success is a cached
+                # replay, not fresh work. The wrapper uses this to skip
+                # `record_run` so retries don't pile phantom zero-cost
+                # rows in the `runs` table. Shallow-copy first so the
+                # cache entry stays clean for any subsequent dedup hit
+                # (and so callers don't see the internal flag if the
+                # wrapper somehow forgets to pop it).
+                _replay = dict(cached_result)
+                _replay["_dedup_cached"] = True
+                return _replay
             else:
                 # First call still in-flight — block the duplicate
                 logger.warning(

--- a/src/monitoring/project_monitor.py
+++ b/src/monitoring/project_monitor.py
@@ -604,7 +604,7 @@ class ProjectMonitor:
             stack.enter_context(
                 get_recorder().planner_context(
                     PlannerContext(
-                        experiment_id="unassigned",
+                        run_id="unassigned",
                         project_id=str(project_id),
                         project_name=project_name,
                         agent_id="monitor",

--- a/tests/unit/cost_tracking/test_cost_aggregator.py
+++ b/tests/unit/cost_tracking/test_cost_aggregator.py
@@ -16,8 +16,8 @@ import pytest
 from src.cost_tracking.cost_aggregator import CostAggregator
 from src.cost_tracking.cost_store import (
     CostStore,
-    Experiment,
     ModelPrice,
+    Run,
     TokenEvent,
 )
 
@@ -44,9 +44,9 @@ def store(tmp_path: Path) -> CostStore:
 @pytest.fixture
 def populated_store(store: CostStore) -> CostStore:
     """Store with one experiment + 3 events covering planner + 2 workers."""
-    store.record_experiment(
-        Experiment(
-            experiment_id="exp_1",
+    store.record_run(
+        Run(
+            run_id="exp_1",
             project_id="proj_1",
             project_name="hangman",
             started_at=datetime(2026, 5, 10, tzinfo=timezone.utc),
@@ -56,7 +56,7 @@ def populated_store(store: CostStore) -> CostStore:
         )
     )
     base_kwargs = dict(
-        experiment_id="exp_1",
+        run_id="exp_1",
         project_id="proj_1",
         provider="anthropic",
         model="claude-sonnet-4-6",
@@ -118,8 +118,8 @@ class TestExperimentSummary:
 
     def test_returns_metadata(self, agg: CostAggregator) -> None:
         """Summary includes project_id, name, totals from experiments table."""
-        s = agg.experiment_summary("exp_1")
-        assert s["experiment_id"] == "exp_1"
+        s = agg.run_summary("exp_1")
+        assert s["run_id"] == "exp_1"
         assert s["project_id"] == "proj_1"
         assert s["project_name"] == "hangman"
         assert s["total_tasks"] == 10
@@ -127,34 +127,34 @@ class TestExperimentSummary:
 
     def test_summary_aggregates_token_totals(self, agg: CostAggregator) -> None:
         """summary.total_tokens sums across all event types."""
-        s = agg.experiment_summary("exp_1")
+        s = agg.run_summary("exp_1")
         # 1500 (planner) + 3800 (w1) + 5400 (w2) = 10700
         assert s["summary"]["total_tokens"] == 10700
         assert s["summary"]["total_events"] == 3
 
     def test_summary_breaks_down_by_role(self, agg: CostAggregator) -> None:
         """by_role groups planner vs worker."""
-        s = agg.experiment_summary("exp_1")
+        s = agg.run_summary("exp_1")
         roles = {r["role"]: r for r in s["by_role"]}
         assert roles["planner"]["events"] == 1
         assert roles["worker"]["events"] == 2
 
     def test_summary_breaks_down_by_agent(self, agg: CostAggregator) -> None:
         """by_agent has one row per distinct agent_id."""
-        s = agg.experiment_summary("exp_1")
+        s = agg.run_summary("exp_1")
         agents = {a["agent_id"]: a for a in s["by_agent"]}
         assert set(agents.keys()) == {"planner", "agent_unicorn_1", "agent_unicorn_2"}
         assert agents["agent_unicorn_2"]["turns"] == 1
 
     def test_summary_breaks_down_by_task(self, agg: CostAggregator) -> None:
         """by_task ignores rows with NULL task_id."""
-        s = agg.experiment_summary("exp_1")
+        s = agg.run_summary("exp_1")
         task_ids = {t["task_id"] for t in s["by_task"]}
         assert task_ids == {"t_1", "t_2"}  # planner row excluded
 
     def test_summary_includes_cache_hit_rate(self, agg: CostAggregator) -> None:
         """cache_hit_rate = cache_read / (input + cache_creation + cache_read)."""
-        s = agg.experiment_summary("exp_1")
+        s = agg.run_summary("exp_1")
         # totals: input=6000, cache_creation=1000, cache_read=2500
         # hit_rate = 2500 / 9500 ≈ 0.2632
         assert s["summary"]["cache_hit_rate"] == pytest.approx(2500 / 9500, rel=1e-3)
@@ -163,7 +163,7 @@ class TestExperimentSummary:
         self, agg: CostAggregator
     ) -> None:
         """Querying a non-existent experiment returns None."""
-        assert agg.experiment_summary("nonexistent") is None
+        assert agg.run_summary("nonexistent") is None
 
 
 class TestProjectSummary:
@@ -220,7 +220,7 @@ class TestProjectSummary:
         # Same project, a model that is NOT in the price table.
         populated_store.record_event(
             TokenEvent(
-                experiment_id="exp_1",
+                run_id="exp_1",
                 project_id="proj_1",
                 agent_id="planner",
                 agent_role="planner",
@@ -264,7 +264,7 @@ class TestProjectSummary:
 
         populated_store.record_event(
             TokenEvent(
-                experiment_id="exp_orphan",
+                run_id="exp_orphan",
                 project_id="proj_no_exp",
                 agent_id="planner",
                 agent_role="planner",
@@ -280,7 +280,7 @@ class TestProjectSummary:
         s = CostAggregator(populated_store).project_summary("proj_no_exp")
         assert s is not None
         assert s["summary"]["total_events"] == 1
-        assert s["summary"]["experiments"] == 1  # the exp_id we stamped
+        assert s["summary"]["runs"] == 1  # the run_id we stamped
 
 
 class TestSessionTurns:
@@ -291,7 +291,7 @@ class TestSessionTurns:
         # Add a 2nd turn for s_1
         populated_store.record_event(
             TokenEvent(
-                experiment_id="exp_1",
+                run_id="exp_1",
                 project_id="proj_1",
                 agent_id="agent_unicorn_1",
                 agent_role="worker",
@@ -316,30 +316,30 @@ class TestExperimentList:
     def test_lists_experiments_with_summary(self, populated_store: CostStore) -> None:
         """Each row has totals attached."""
         agg = CostAggregator(store=populated_store)
-        rows = agg.list_experiments()
+        rows = agg.list_runs()
         assert len(rows) == 1
-        assert rows[0]["experiment_id"] == "exp_1"
+        assert rows[0]["run_id"] == "exp_1"
         assert rows[0]["total_tokens"] == 10700
 
     def test_filter_by_project(self, populated_store: CostStore) -> None:
         """project_id filter narrows the set."""
-        populated_store.record_experiment(
-            Experiment(
-                experiment_id="exp_2",
+        populated_store.record_run(
+            Run(
+                run_id="exp_2",
                 project_id="other",
                 started_at=datetime(2026, 5, 11, tzinfo=timezone.utc),
             )
         )
         agg = CostAggregator(store=populated_store)
-        rows = agg.list_experiments(project_id="proj_1")
-        assert {r["experiment_id"] for r in rows} == {"exp_1"}
+        rows = agg.list_runs(project_id="proj_1")
+        assert {r["run_id"] for r in rows} == {"exp_1"}
 
 
 class TestListProjects:
     """list_projects derives project rollups from token_events.project_id.
 
     Project axis is Marcus's actual identity (per CLAUDE.md GH-388 +
-    spawn_agents.py); experiment_id is an MLflow tracking handle and is
+    spawn_agents.py); run_id is an MLflow tracking handle and is
     intentionally not the join key here.
     """
 
@@ -374,7 +374,7 @@ class TestListProjects:
         """
         populated_store.record_event(
             TokenEvent(
-                experiment_id="exp_no_meta",
+                run_id="exp_no_meta",
                 project_id="proj_no_meta",
                 agent_id="planner",
                 agent_role="planner",
@@ -394,7 +394,7 @@ class TestListProjects:
         """Events tagged 'unassigned' do not appear in the project list."""
         populated_store.record_event(
             TokenEvent(
-                experiment_id="unassigned",
+                run_id="unassigned",
                 project_id="unassigned",
                 agent_id="planner",
                 agent_role="planner",
@@ -413,7 +413,7 @@ class TestListProjects:
         """A cheaper project sorts below an expensive one."""
         populated_store.record_event(
             TokenEvent(
-                experiment_id="exp_2",
+                run_id="exp_2",
                 project_id="proj_cheap",
                 agent_id="planner",
                 agent_role="planner",
@@ -442,7 +442,7 @@ class TestUnassignedTotals:
         """Once we add an unassigned event, totals reflect it."""
         populated_store.record_event(
             TokenEvent(
-                experiment_id="unassigned",
+                run_id="unassigned",
                 project_id="unassigned",
                 agent_id="planner",
                 agent_role="planner",

--- a/tests/unit/cost_tracking/test_cost_recorder.py
+++ b/tests/unit/cost_tracking/test_cost_recorder.py
@@ -3,7 +3,7 @@ Unit tests for src.cost_tracking.cost_recorder.
 
 The recorder is a singleton that providers call after each successful LLM
 request. It writes one row to the configured CostStore using the active
-planner context (experiment_id/project_id). These tests verify:
+planner context (run_id/project_id). These tests verify:
 
 - Recorder writes rows when configured with a store.
 - Cache tokens (creation + read) are persisted.
@@ -49,7 +49,7 @@ class TestRecordPlannerCall:
     ) -> None:
         """When a PlannerContext is active, event uses its ids."""
         with recorder.planner_context(
-            PlannerContext(experiment_id="exp_42", project_id="proj_42")
+            PlannerContext(run_id="exp_42", project_id="proj_42")
         ):
             recorder.record_planner_call(
                 operation="parse_prd",
@@ -61,7 +61,7 @@ class TestRecordPlannerCall:
                 output_tokens=50,
             )
         row = store.conn.execute(
-            "SELECT experiment_id, project_id, agent_role, operation, "
+            "SELECT run_id, project_id, agent_role, operation, "
             "input_tokens, cache_creation_tokens, cache_read_tokens, "
             "output_tokens FROM token_events"
         ).fetchone()
@@ -70,7 +70,7 @@ class TestRecordPlannerCall:
     def test_uses_unassigned_fallback_when_no_context(
         self, recorder: CostRecorder, store: CostStore
     ) -> None:
-        """No active context → experiment_id and project_id default to 'unassigned'."""
+        """No active context → run_id and project_id default to 'unassigned'."""
         recorder.record_planner_call(
             operation="parse_prd",
             provider="anthropic",
@@ -79,7 +79,7 @@ class TestRecordPlannerCall:
             output_tokens=5,
         )
         exp, proj = store.conn.execute(
-            "SELECT experiment_id, project_id FROM token_events"
+            "SELECT run_id, project_id FROM token_events"
         ).fetchone()
         assert exp == "unassigned"
         assert proj == "unassigned"
@@ -123,11 +123,9 @@ class TestPlannerContextStack:
         self, recorder: CostRecorder, store: CostStore
     ) -> None:
         """Innermost context's ids are used while it's active."""
-        with recorder.planner_context(
-            PlannerContext(experiment_id="outer", project_id="p")
-        ):
+        with recorder.planner_context(PlannerContext(run_id="outer", project_id="p")):
             with recorder.planner_context(
-                PlannerContext(experiment_id="inner", project_id="p")
+                PlannerContext(run_id="inner", project_id="p")
             ):
                 recorder.record_planner_call(
                     operation="op",
@@ -136,18 +134,16 @@ class TestPlannerContextStack:
                     input_tokens=1,
                     output_tokens=1,
                 )
-        exp = store.conn.execute("SELECT experiment_id FROM token_events").fetchone()[0]
+        exp = store.conn.execute("SELECT run_id FROM token_events").fetchone()[0]
         assert exp == "inner"
 
     def test_context_pops_correctly(
         self, recorder: CostRecorder, store: CostStore
     ) -> None:
         """After leaving inner context, outer is restored."""
-        with recorder.planner_context(
-            PlannerContext(experiment_id="outer", project_id="p")
-        ):
+        with recorder.planner_context(PlannerContext(run_id="outer", project_id="p")):
             with recorder.planner_context(
-                PlannerContext(experiment_id="inner", project_id="p")
+                PlannerContext(run_id="inner", project_id="p")
             ):
                 pass
             recorder.record_planner_call(
@@ -157,7 +153,7 @@ class TestPlannerContextStack:
                 input_tokens=1,
                 output_tokens=1,
             )
-        exp = store.conn.execute("SELECT experiment_id FROM token_events").fetchone()[0]
+        exp = store.conn.execute("SELECT run_id FROM token_events").fetchone()[0]
         assert exp == "outer"
 
 
@@ -195,7 +191,7 @@ class TestCanonicalProjectId:
     def test_planner_context_normalizes_on_construction(self) -> None:
         """PlannerContext stores the dashless form regardless of input."""
         ctx = PlannerContext(
-            experiment_id="e",
+            run_id="e",
             project_id="a18b7050-fe0e-492f-a0cf-008c1be8197d",
         )
         assert ctx.project_id == "a18b7050fe0e492fa0cf008c1be8197d"
@@ -213,7 +209,7 @@ class TestNameSnapshot:
         """A context with project_name upserts into project_names."""
         with recorder.planner_context(
             PlannerContext(
-                experiment_id="e",
+                run_id="e",
                 project_id="proj_snap",
                 project_name="hangman",
             )
@@ -224,7 +220,7 @@ class TestNameSnapshot:
     def test_push_without_name_does_not_snapshot(self, recorder: CostRecorder) -> None:
         """Contexts without project_name leave project_names untouched."""
         with recorder.planner_context(
-            PlannerContext(experiment_id="e", project_id="proj_nameless")
+            PlannerContext(run_id="e", project_id="proj_nameless")
         ):
             pass
         assert recorder.store.get_project_name("proj_nameless") is None
@@ -233,7 +229,7 @@ class TestNameSnapshot:
         """'unassigned' is a sentinel, not a real project — skip the upsert."""
         with recorder.planner_context(
             PlannerContext(
-                experiment_id="e",
+                run_id="e",
                 project_id="unassigned",
                 project_name="should_not_persist",
             )
@@ -261,7 +257,7 @@ class TestNameSnapshot:
         monkeypatch.setattr(recorder.store, "upsert_project_name", counting)
 
         ctx = PlannerContext(
-            experiment_id="e",
+            run_id="e",
             project_id="proj_dedup",
             project_name="dedup-me",
         )
@@ -285,11 +281,11 @@ class TestNameSnapshot:
         monkeypatch.setattr(recorder.store, "upsert_project_name", counting)
 
         with recorder.planner_context(
-            PlannerContext(experiment_id="e", project_id="proj_r", project_name="old")
+            PlannerContext(run_id="e", project_id="proj_r", project_name="old")
         ):
             pass
         with recorder.planner_context(
-            PlannerContext(experiment_id="e", project_id="proj_r", project_name="new")
+            PlannerContext(run_id="e", project_id="proj_r", project_name="new")
         ):
             pass
 
@@ -301,7 +297,7 @@ class TestNameSnapshot:
         r = CostRecorder(store=store, enabled=False)
         with r.planner_context(
             PlannerContext(
-                experiment_id="e",
+                run_id="e",
                 project_id="p",
                 project_name="name",
             )
@@ -323,9 +319,7 @@ class TestOperationContext:
         self, recorder: CostRecorder, store: CostStore
     ) -> None:
         """Inside operation_context, the override beats the caller's op."""
-        with recorder.planner_context(
-            PlannerContext(experiment_id="e", project_id="p")
-        ):
+        with recorder.planner_context(PlannerContext(run_id="e", project_id="p")):
             with recorder.operation_context("decompose_prd"):
                 recorder.record_planner_call(
                     operation="generic_provider_default",
@@ -341,9 +335,7 @@ class TestOperationContext:
         self, recorder: CostRecorder, store: CostStore
     ) -> None:
         """After exiting operation_context, the parent's op (or caller's) wins."""
-        with recorder.planner_context(
-            PlannerContext(experiment_id="e", project_id="p")
-        ):
+        with recorder.planner_context(PlannerContext(run_id="e", project_id="p")):
             with recorder.operation_context("decompose_prd"):
                 pass
             # Outside the operation_context, caller's op is recorded.
@@ -374,7 +366,7 @@ class TestOperationContext:
         with recorder.operation_context("decompose_prd") as ctx:
             assert ctx is not None
             assert ctx.project_id == "unassigned"
-            assert ctx.experiment_id == "unassigned"
+            assert ctx.run_id == "unassigned"
             assert ctx.operation_override == "decompose_prd"
             # Recording inside this scope should stamp the override
             # onto token_events.operation even without a real parent.
@@ -394,9 +386,7 @@ class TestOperationContext:
         self, recorder: CostRecorder, store: CostStore
     ) -> None:
         """Empty operation key short-circuits to current() without pushing."""
-        with recorder.planner_context(
-            PlannerContext(experiment_id="e", project_id="p")
-        ):
+        with recorder.planner_context(PlannerContext(run_id="e", project_id="p")):
             with recorder.operation_context(""):
                 recorder.record_planner_call(
                     operation="caller_op",
@@ -423,9 +413,7 @@ class TestUnregisteredOperationWarning:
     ) -> None:
         """Unknown key triggers exactly one WARNING regardless of repeats."""
         with caplog.at_level("WARNING", logger="src.cost_tracking.cost_recorder"):
-            with recorder.planner_context(
-                PlannerContext(experiment_id="e", project_id="p")
-            ):
+            with recorder.planner_context(PlannerContext(run_id="e", project_id="p")):
                 for _ in range(5):
                     recorder.record_planner_call(
                         operation="totally_typo_op",
@@ -447,9 +435,7 @@ class TestUnregisteredOperationWarning:
     ) -> None:
         """Known catalog keys log no drift WARNING."""
         with caplog.at_level("WARNING", logger="src.cost_tracking.cost_recorder"):
-            with recorder.planner_context(
-                PlannerContext(experiment_id="e", project_id="p")
-            ):
+            with recorder.planner_context(PlannerContext(run_id="e", project_id="p")):
                 recorder.record_planner_call(
                     operation="decompose_prd",
                     provider="anthropic",
@@ -473,9 +459,7 @@ class TestUnregisteredOperationWarning:
         provider's correctly-spelled default gets shadowed by it.
         """
         with caplog.at_level("WARNING", logger="src.cost_tracking.cost_recorder"):
-            with recorder.planner_context(
-                PlannerContext(experiment_id="e", project_id="p")
-            ):
+            with recorder.planner_context(PlannerContext(run_id="e", project_id="p")):
                 with recorder.operation_context("decopmose_prd"):  # typo
                     recorder.record_planner_call(
                         operation="decompose_prd",  # correct caller op

--- a/tests/unit/cost_tracking/test_cost_store.py
+++ b/tests/unit/cost_tracking/test_cost_store.py
@@ -15,8 +15,8 @@ import pytest
 
 from src.cost_tracking.cost_store import (
     CostStore,
-    Experiment,
     ModelPrice,
+    Run,
     TokenEvent,
 )
 
@@ -50,7 +50,7 @@ def seeded_store(store: CostStore) -> CostStore:
 def base_event() -> TokenEvent:
     """Reusable TokenEvent for happy-path tests."""
     return TokenEvent(
-        experiment_id="exp_1",
+        run_id="exp_1",
         project_id="proj_1",
         agent_id="planner",
         agent_role="planner",
@@ -75,7 +75,7 @@ class TestSchemaInitialization:
                 "SELECT name FROM sqlite_master WHERE type IN ('table','view')"
             )
         }
-        assert {"experiments", "token_events", "model_prices", "v_event_cost"} <= names
+        assert {"runs", "token_events", "model_prices", "v_event_cost"} <= names
 
     def test_init_enables_wal_mode(self, store: CostStore) -> None:
         """WAL mode enabled for safe concurrent reads during writes."""
@@ -91,6 +91,182 @@ class TestSchemaInitialization:
             "SELECT total_tokens FROM token_events"
         ).fetchone()
         assert row[0] == 1000 + 2000 + 4000 + 500
+
+
+class TestRunsRenameMigration:
+    """Regression tests for the ``experiments`` → ``runs`` rename.
+
+    Locks in :meth:`CostStore._runs_rename_migration`. Opening a
+    pre-rename DB must transparently:
+
+    - Rename the ``experiments`` table to ``runs``.
+    - Rename the ``experiment_id`` column to ``run_id`` on both
+      ``runs`` and ``token_events``.
+    - Add the new ``path`` column on ``runs`` with default
+      ``'unknown'`` for legacy rows.
+    - Preserve all existing data.
+
+    Without these tests, a future refactor could silently break
+    upgrades for any deployed Marcus that already has cost data.
+    """
+
+    def _build_legacy_db(self, db_path: Path) -> None:
+        """Hand-write a pre-rename schema with one experiment + one event."""
+        conn = sqlite3.connect(str(db_path))
+        conn.executescript("""
+        CREATE TABLE experiments (
+          experiment_id    TEXT PRIMARY KEY,
+          project_id       TEXT NOT NULL,
+          board_id         TEXT,
+          project_name     TEXT,
+          decomposer       TEXT,
+          complexity       TEXT,
+          provider         TEXT,
+          model            TEXT,
+          num_agents       INTEGER,
+          started_at       TIMESTAMP NOT NULL,
+          ended_at         TIMESTAMP,
+          total_tasks      INTEGER,
+          completed_tasks  INTEGER,
+          blocked_tasks    INTEGER,
+          budget_usd       REAL,
+          notes            TEXT
+        );
+        CREATE INDEX idx_exp_project ON experiments(project_id);
+
+        CREATE TABLE token_events (
+          event_id              INTEGER PRIMARY KEY AUTOINCREMENT,
+          experiment_id         TEXT NOT NULL,
+          project_id            TEXT NOT NULL,
+          agent_id              TEXT NOT NULL,
+          agent_role            TEXT NOT NULL,
+          parent_agent_id       TEXT,
+          task_id               TEXT,
+          subtask_id            TEXT,
+          operation             TEXT NOT NULL,
+          provider              TEXT NOT NULL,
+          model                 TEXT NOT NULL,
+          input_tokens          INTEGER NOT NULL DEFAULT 0,
+          cache_creation_tokens INTEGER NOT NULL DEFAULT 0,
+          cache_read_tokens     INTEGER NOT NULL DEFAULT 0,
+          output_tokens         INTEGER NOT NULL DEFAULT 0,
+          total_tokens          INTEGER GENERATED ALWAYS AS
+                                  (input_tokens + cache_creation_tokens
+                                   + cache_read_tokens + output_tokens)
+                                STORED,
+          latency_ms            INTEGER,
+          session_id            TEXT,
+          turn_index            INTEGER,
+          request_id            TEXT,
+          status                TEXT NOT NULL DEFAULT 'ok',
+          error_type            TEXT,
+          timestamp             TIMESTAMP NOT NULL
+                                DEFAULT '2026-05-12T00:00:00.000Z'
+        );
+        CREATE INDEX idx_te_exp     ON token_events(experiment_id);
+        CREATE INDEX idx_te_project ON token_events(project_id);
+        CREATE INDEX idx_te_agent   ON token_events(experiment_id, agent_id);
+        CREATE INDEX idx_te_task    ON token_events(task_id);
+        CREATE UNIQUE INDEX ux_te_request_id
+            ON token_events(request_id) WHERE request_id IS NOT NULL;
+
+        INSERT INTO experiments
+            (experiment_id, project_id, project_name, started_at)
+            VALUES ('e_old', 'p1', 'Legacy Project', '2026-05-11T00:00:00Z');
+        INSERT INTO token_events
+            (experiment_id, project_id, agent_id, agent_role,
+             operation, provider, model, input_tokens)
+            VALUES ('e_old', 'p1', 'planner', 'planner',
+                    'parse_prd', 'anthropic',
+                    'claude-sonnet-4-6', 100);
+        """)
+        conn.commit()
+        conn.close()
+
+    def test_migration_renames_table_and_columns(self, tmp_path: Path) -> None:
+        """After CostStore opens a legacy DB, the new schema is in place."""
+        db = tmp_path / "legacy.db"
+        self._build_legacy_db(db)
+
+        store = CostStore(db_path=db)
+
+        # ``runs`` table exists; ``experiments`` is gone.
+        names = {
+            row[0]
+            for row in store.conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='table'"
+            )
+        }
+        assert "runs" in names
+        assert "experiments" not in names
+
+        # ``runs.run_id`` exists; old ``experiment_id`` is gone.
+        run_cols = {
+            c[1] for c in store.conn.execute("PRAGMA table_info(runs)").fetchall()
+        }
+        assert "run_id" in run_cols
+        assert "experiment_id" not in run_cols
+
+        # ``token_events.run_id`` exists; old ``experiment_id`` is gone.
+        te_cols = {
+            c[1]
+            for c in store.conn.execute("PRAGMA table_info(token_events)").fetchall()
+        }
+        assert "run_id" in te_cols
+        assert "experiment_id" not in te_cols
+
+    def test_migration_adds_path_column_with_unknown_default(
+        self, tmp_path: Path
+    ) -> None:
+        """``runs.path`` is added with 'unknown' for legacy rows."""
+        db = tmp_path / "legacy.db"
+        self._build_legacy_db(db)
+
+        store = CostStore(db_path=db)
+
+        path = store.conn.execute("SELECT path FROM runs").fetchone()[0]
+        assert path == "unknown"
+
+    def test_migration_preserves_data(self, tmp_path: Path) -> None:
+        """Existing experiments + token_events rows survive the rename."""
+        db = tmp_path / "legacy.db"
+        self._build_legacy_db(db)
+
+        store = CostStore(db_path=db)
+
+        run_row = store.conn.execute(
+            "SELECT run_id, project_id, project_name FROM runs"
+        ).fetchone()
+        assert run_row == ("e_old", "p1", "Legacy Project")
+
+        te_row = store.conn.execute(
+            "SELECT run_id, project_id, operation, input_tokens FROM token_events"
+        ).fetchone()
+        assert te_row == ("e_old", "p1", "parse_prd", 100)
+
+    def test_migration_is_idempotent(self, tmp_path: Path) -> None:
+        """Re-opening an already-migrated DB is a no-op (no errors)."""
+        db = tmp_path / "legacy.db"
+        self._build_legacy_db(db)
+
+        # First open triggers the migration
+        store_a = CostStore(db_path=db)
+        path_after_first = store_a.conn.execute("SELECT path FROM runs").fetchone()[0]
+        store_a.conn.close()
+
+        # Second open must succeed without raising and not double-rename
+        store_b = CostStore(db_path=db)
+        path_after_second = store_b.conn.execute("SELECT path FROM runs").fetchone()[0]
+        assert path_after_second == path_after_first
+
+    def test_migration_skipped_on_fresh_install(self, tmp_path: Path) -> None:
+        """A fresh DB (no legacy tables) skips the rename path cleanly."""
+        # Just create with no prep — SCHEMA_SQL builds the new layout
+        # directly and the migration short-circuits.
+        store = CostStore(db_path=tmp_path / "fresh.db")
+        cols = {c[1] for c in store.conn.execute("PRAGMA table_info(runs)").fetchall()}
+        assert "run_id" in cols
+        assert "path" in cols
 
 
 class TestRecordEvent:
@@ -109,7 +285,7 @@ class TestRecordEvent:
         """Every TokenEvent field round-trips through the DB."""
         seeded_store.record_event(base_event)
         row = seeded_store.conn.execute(
-            "SELECT experiment_id, agent_id, agent_role, operation, "
+            "SELECT run_id, agent_id, agent_role, operation, "
             "input_tokens, cache_creation_tokens, cache_read_tokens, "
             "output_tokens FROM token_events"
         ).fetchone()
@@ -169,7 +345,7 @@ class TestRecordEvent:
         conn.executescript("""
             CREATE TABLE token_events (
               event_id     INTEGER PRIMARY KEY AUTOINCREMENT,
-              experiment_id TEXT NOT NULL,
+              run_id TEXT NOT NULL,
               project_id    TEXT NOT NULL,
               agent_id      TEXT NOT NULL,
               agent_role    TEXT NOT NULL,
@@ -198,14 +374,14 @@ class TestRecordEvent:
         for _ in range(3):
             conn.execute(
                 "INSERT INTO token_events "
-                "(experiment_id, project_id, agent_id, agent_role, operation, "
+                "(run_id, project_id, agent_id, agent_role, operation, "
                 " provider, model, request_id) VALUES "
                 "('e','p','a','planner','op','anthropic','m','req_dup')"
             )
         for _ in range(2):
             conn.execute(
                 "INSERT INTO token_events "
-                "(experiment_id, project_id, agent_id, agent_role, operation, "
+                "(run_id, project_id, agent_id, agent_role, operation, "
                 " provider, model, request_id) VALUES "
                 "('e','p','a','planner','op','anthropic','m', NULL)"
             )
@@ -225,7 +401,7 @@ class TestRecordEvent:
         with pytest.raises(sqlite3.IntegrityError):
             store.conn.execute(
                 "INSERT INTO token_events "
-                "(experiment_id, project_id, agent_id, agent_role, operation, "
+                "(run_id, project_id, agent_id, agent_role, operation, "
                 " provider, model, request_id) VALUES "
                 "('e','p','a','planner','op','anthropic','m','req_dup')"
             )
@@ -414,42 +590,38 @@ class TestProjectBudget:
         assert store.get_project_budget("proj_1") is None
 
 
-class TestRecordExperiment:
+class TestRecordRun:
     """experiments table upsert behavior."""
 
     def test_records_new_experiment(self, store: CostStore) -> None:
-        """A fresh experiment_id inserts a row."""
-        store.record_experiment(
-            Experiment(
-                experiment_id="exp_1",
+        """A fresh run_id inserts a row."""
+        store.record_run(
+            Run(
+                run_id="exp_1",
                 project_id="proj_1",
                 started_at=datetime(2026, 5, 10, tzinfo=timezone.utc),
                 project_name="hangman",
             )
         )
-        row = store.conn.execute(
-            "SELECT project_id, project_name FROM experiments"
-        ).fetchone()
+        row = store.conn.execute("SELECT project_id, project_name FROM runs").fetchone()
         assert row == ("proj_1", "hangman")
 
     def test_upserts_existing_experiment(self, store: CostStore) -> None:
-        """Re-recording the same experiment_id updates fields, doesn't duplicate."""
+        """Re-recording the same run_id updates fields, doesn't duplicate."""
         started = datetime(2026, 5, 10, tzinfo=timezone.utc)
-        store.record_experiment(
-            Experiment(experiment_id="exp_1", project_id="p", started_at=started)
-        )
-        store.record_experiment(
-            Experiment(
-                experiment_id="exp_1",
+        store.record_run(Run(run_id="exp_1", project_id="p", started_at=started))
+        store.record_run(
+            Run(
+                run_id="exp_1",
                 project_id="p",
                 started_at=started,
                 completed_tasks=5,
             )
         )
-        rows = store.conn.execute("SELECT COUNT(*) FROM experiments").fetchone()
+        rows = store.conn.execute("SELECT COUNT(*) FROM runs").fetchone()
         assert rows[0] == 1
         completed = store.conn.execute(
-            "SELECT completed_tasks FROM experiments WHERE experiment_id='exp_1'"
+            "SELECT completed_tasks FROM runs WHERE run_id='exp_1'"
         ).fetchone()[0]
         assert completed == 5
 
@@ -551,7 +723,7 @@ class TestEventCostView:
         # Event in mid-2025 should use old price
         store.record_event(
             TokenEvent(
-                experiment_id="e",
+                run_id="e",
                 project_id="proj",
                 agent_id="a",
                 agent_role="planner",
@@ -599,7 +771,7 @@ class TestCodexP1LegacyModelSeeds:
         store.load_seed_prices()
         store.record_event(
             TokenEvent(
-                experiment_id="e",
+                run_id="e",
                 project_id="p",
                 agent_id="planner",
                 agent_role="planner",
@@ -641,7 +813,7 @@ class TestCodexP2TimestampFormat:
         )
         store.record_event(
             TokenEvent(
-                experiment_id="e",
+                run_id="e",
                 project_id="p",
                 agent_id="planner",
                 agent_role="planner",
@@ -662,7 +834,7 @@ class TestCodexP2TimestampFormat:
         store.load_seed_prices()
         store.record_event(
             TokenEvent(
-                experiment_id="e",
+                run_id="e",
                 project_id="p",
                 agent_id="planner",
                 agent_role="planner",

--- a/tests/unit/cost_tracking/test_provider_recording.py
+++ b/tests/unit/cost_tracking/test_provider_recording.py
@@ -81,9 +81,7 @@ class TestAnthropicProviderRecords:
             )
         )
 
-        with recorder.planner_context(
-            PlannerContext(experiment_id="e1", project_id="p1")
-        ):
+        with recorder.planner_context(PlannerContext(run_id="e1", project_id="p1")):
             result = await provider._call_claude("hi", operation="parse_prd")
 
         assert result == "ok"
@@ -121,9 +119,7 @@ class TestLocalProviderRecords:
             )
         )
 
-        with recorder.planner_context(
-            PlannerContext(experiment_id="e2", project_id="p2")
-        ):
+        with recorder.planner_context(PlannerContext(run_id="e2", project_id="p2")):
             result = await provider._call_local_llm("hi")
 
         assert result == "ok"
@@ -167,9 +163,7 @@ class TestOpenAIProviderRecords:
             )
         )
 
-        with recorder.planner_context(
-            PlannerContext(experiment_id="e_oa", project_id="p_oa")
-        ):
+        with recorder.planner_context(PlannerContext(run_id="e_oa", project_id="p_oa")):
             result = await provider._call_openai([{"role": "user", "content": "hi"}])
 
         assert result == "ok"
@@ -205,9 +199,7 @@ class TestCloudProviderRecords:
             )
         )
 
-        with recorder.planner_context(
-            PlannerContext(experiment_id="e3", project_id="p3")
-        ):
+        with recorder.planner_context(PlannerContext(run_id="e3", project_id="p3")):
             result = await provider._call_cloud_llm("hi")
 
         assert result == "ok"

--- a/tests/unit/cost_tracking/test_worker_ingester.py
+++ b/tests/unit/cost_tracking/test_worker_ingester.py
@@ -85,13 +85,11 @@ def _write_jsonl(path: Path, records: list[Dict[str, Any]]) -> None:
 
 def _binding(
     agent_id: str = "agent_unicorn_1",
-    experiment_id: str = "exp_1",
+    run_id: str = "exp_1",
     project_id: str = "proj_1",
 ) -> AgentBinding:
     """Convenience binding constructor for tests."""
-    return AgentBinding(
-        agent_id=agent_id, experiment_id=experiment_id, project_id=project_id
-    )
+    return AgentBinding(agent_id=agent_id, run_id=run_id, project_id=project_id)
 
 
 # ---------------------------------------------------------------------------
@@ -189,15 +187,13 @@ class TestIngestFile:
         path = tmp_path / "sess.jsonl"
         _write_jsonl(path, [_assistant_record()])
 
-        binding = _binding(
-            agent_id="agent_42", experiment_id="exp_42", project_id="proj_42"
-        )
+        binding = _binding(agent_id="agent_42", run_id="exp_42", project_id="proj_42")
         WorkerJSONLIngester(
             store=store, resolve_binding=lambda _r: binding
         ).ingest_file(path)
 
         row = store.conn.execute(
-            "SELECT agent_id, experiment_id, project_id FROM token_events"
+            "SELECT agent_id, run_id, project_id FROM token_events"
         ).fetchone()
         assert row == ("agent_42", "exp_42", "proj_42")
 

--- a/tests/unit/integrations/test_design_autocomplete.py
+++ b/tests/unit/integrations/test_design_autocomplete.py
@@ -1361,7 +1361,7 @@ class TestRunDesignPhaseCostAttribution:
         placeholder = f"pending:{'x' * 32}"
         with recorder.planner_context(
             PlannerContext(
-                experiment_id="unassigned",
+                run_id="unassigned",
                 project_id=placeholder,
                 project_name="Placeholder",
             )

--- a/tests/unit/marcus_mcp/test_cost_tracking_tool.py
+++ b/tests/unit/marcus_mcp/test_cost_tracking_tool.py
@@ -17,8 +17,8 @@ import pytest
 
 from src.cost_tracking.cost_store import (
     CostStore,
-    Experiment,
     ModelPrice,
+    Run,
     TokenEvent,
 )
 from src.marcus_mcp.tools.cost_tracking import (
@@ -47,9 +47,9 @@ def populated_store(tmp_path: Path) -> CostStore:
             source="default",
         )
     )
-    s.record_experiment(
-        Experiment(
-            experiment_id="exp_1",
+    s.record_run(
+        Run(
+            run_id="exp_1",
             project_id="proj_1",
             project_name="hangman",
             started_at=datetime(2026, 5, 10, tzinfo=timezone.utc),
@@ -59,7 +59,7 @@ def populated_store(tmp_path: Path) -> CostStore:
         )
     )
     base = dict(
-        experiment_id="exp_1",
+        run_id="exp_1",
         project_id="proj_1",
         provider="anthropic",
         model="claude-sonnet-4-6",
@@ -116,25 +116,25 @@ class TestToolDefinition:
         assert COST_SUMMARY_TOOL.name == "get_cost_summary"
 
     def test_tool_accepts_either_id(self) -> None:
-        """Schema exposes both experiment_id and project_id parameters."""
+        """Schema exposes both run_id and project_id parameters."""
         props = COST_SUMMARY_TOOL.inputSchema["properties"]
-        assert "experiment_id" in props
+        assert "run_id" in props
         assert "project_id" in props
 
 
 # ---------------------------------------------------------------------------
-# get_cost_summary by experiment_id
+# get_cost_summary by run_id
 # ---------------------------------------------------------------------------
 
 
 class TestGetCostSummaryByExperiment:
-    """Happy path: pass ``experiment_id``."""
+    """Happy path: pass ``run_id``."""
 
     @pytest.mark.asyncio
     async def test_returns_full_breakdown(self, state: Any) -> None:
         """Response carries summary + by_role + by_agent + by_task etc."""
-        result = await get_cost_summary(experiment_id="exp_1", state=state)
-        assert result["experiment_id"] == "exp_1"
+        result = await get_cost_summary(run_id="exp_1", state=state)
+        assert result["run_id"] == "exp_1"
         assert result["project_id"] == "proj_1"
         assert "summary" in result
         assert {"by_role", "by_agent", "by_task", "by_operation", "by_model"} <= set(
@@ -144,14 +144,14 @@ class TestGetCostSummaryByExperiment:
     @pytest.mark.asyncio
     async def test_summary_totals_are_correct(self, state: Any) -> None:
         """summary.total_tokens sums across both events."""
-        result = await get_cost_summary(experiment_id="exp_1", state=state)
+        result = await get_cost_summary(run_id="exp_1", state=state)
         # planner: 1000 + 500 = 1500. worker: 2000 + 500 + 100 = 2600. total: 4100.
         assert result["summary"]["total_tokens"] == 4100
 
     @pytest.mark.asyncio
     async def test_unknown_experiment_returns_error(self, state: Any) -> None:
-        """A missing experiment_id surfaces a friendly error."""
-        result = await get_cost_summary(experiment_id="nope", state=state)
+        """A missing run_id surfaces a friendly error."""
+        result = await get_cost_summary(run_id="nope", state=state)
         assert result.get("success") is False
         assert "not found" in result.get("error", "").lower()
 
@@ -165,14 +165,14 @@ class TestGetCostSummaryByProject:
     """Happy path: pass ``project_id``."""
 
     @pytest.mark.asyncio
-    async def test_returns_project_totals_and_experiments(self, state: Any) -> None:
-        """Response carries totals + per-experiment list."""
+    async def test_returns_project_totals_and_runs(self, state: Any) -> None:
+        """Response carries totals + per-run list."""
         result = await get_cost_summary(project_id="proj_1", state=state)
         assert result["project_id"] == "proj_1"
         assert result["totals"]["events"] == 2
         assert result["totals"]["total_tokens"] == 4100
-        assert len(result["experiments"]) == 1
-        assert result["experiments"][0]["experiment_id"] == "exp_1"
+        assert len(result["runs"]) == 1
+        assert result["runs"][0]["run_id"] == "exp_1"
 
 
 # ---------------------------------------------------------------------------
@@ -202,14 +202,14 @@ class TestArgumentValidation:
 
     @pytest.mark.asyncio
     async def test_missing_both_ids_returns_error(self, state: Any) -> None:
-        """At least one of experiment_id / project_id is required."""
+        """At least one of run_id / project_id is required."""
         result = await get_cost_summary(state=state)
         assert result.get("success") is False
-        assert "experiment_id" in result.get("error", "")
+        assert "run_id" in result.get("error", "")
 
     @pytest.mark.asyncio
     async def test_missing_cost_store_returns_error(self) -> None:
         """If state has no cost_store, surface a clear error."""
-        result = await get_cost_summary(experiment_id="exp_1", state=object())
+        result = await get_cost_summary(run_id="exp_1", state=object())
         assert result.get("success") is False
         assert "cost store" in result.get("error", "").lower()

--- a/tests/unit/marcus_mcp/test_cost_tracking_tool.py
+++ b/tests/unit/marcus_mcp/test_cost_tracking_tool.py
@@ -15,6 +15,8 @@ from typing import Any
 
 import pytest
 
+pytestmark = pytest.mark.unit
+
 from src.cost_tracking.cost_store import (
     CostStore,
     ModelPrice,

--- a/tests/unit/marcus_mcp/test_create_project_run_recording.py
+++ b/tests/unit/marcus_mcp/test_create_project_run_recording.py
@@ -22,11 +22,27 @@ from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 
+pytestmark = pytest.mark.unit
+
 
 @pytest.fixture(autouse=True)
-def _mock_api_key(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Config validation needs CLAUDE_API_KEY set."""
-    monkeypatch.setenv("CLAUDE_API_KEY", "test-key-for-unit-tests")
+def _stub_marcus_config(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Inject a pre-built MarcusConfig stub.
+
+    The wrapper hits ``get_config()`` on the create_project path
+    (kanban provider lookup, snapshot writer). On a fresh checkout
+    without ``config_marcus.json``, ``MarcusConfig.from_file()``
+    falls back to defaults whose ``ai.anthropic_api_key`` is None,
+    and ``validate()`` then raises. Setting ``CLAUDE_API_KEY`` in env
+    is not sufficient — substitution only fires when a config file is
+    actually loaded. Patch the module-level singleton directly so the
+    test is hermetic on any developer machine and in CI. (Codex P1)
+    """
+    from src.config import marcus_config as mc
+
+    stub = mc.MarcusConfig()
+    stub.ai.anthropic_api_key = "test-key-for-unit-tests"
+    monkeypatch.setattr(mc, "_config", stub)
 
 
 @pytest.fixture(autouse=True)
@@ -202,6 +218,64 @@ class TestRunRecording:
         assert run_row is not None and te_row is not None
         assert run_row[0] == te_row[0]
         assert run_row[0] != "unassigned"
+
+
+class TestCodexP2DedupReplay:
+    """Regression: dedup-cached retries must not insert phantom runs rows.
+
+    Codex P2 on PR #522: when ``create_project`` is invoked within the
+    10-minute dedup window after a successful first call, the inner
+    function returns the cached result without doing planner work. The
+    wrapper used to still insert a fresh ``runs`` row on each replay,
+    so dashboards and per-run counts grew zero-cost phantom rows for
+    timeout/retry storms. Verify exactly one row survives N retries.
+    """
+
+    @pytest.mark.asyncio
+    async def test_replay_does_not_create_phantom_run_row(
+        self, cost_store: Any, recorder: Any
+    ) -> None:
+        """Three identical calls in a row → still one row in ``runs``."""
+        from src.marcus_mcp.tools.nlp import create_project
+
+        state = _build_state(cost_store)
+        with patch(
+            "src.integrations.nlp_tools.NaturalLanguageProjectCreator"
+        ) as MockCreator:
+            MockCreator.return_value.create_project_from_description = AsyncMock(
+                return_value=_ok_creator_result()
+            )
+            first = await create_project(
+                description="Build a flight simulator",
+                project_name="Flight Simulator",
+                options={"provider": "planka"},
+                state=state,
+            )
+            # Two retries within the dedup window — both hit the
+            # cached-replay path inside _create_project_inner.
+            second = await create_project(
+                description="Build a flight simulator",
+                project_name="Flight Simulator",
+                options={"provider": "planka"},
+                state=state,
+            )
+            third = await create_project(
+                description="Build a flight simulator",
+                project_name="Flight Simulator",
+                options={"provider": "planka"},
+                state=state,
+            )
+
+        # All three reported success to the agent…
+        assert first["success"] is True
+        assert second["success"] is True
+        assert third["success"] is True
+        # …but only the original work produced a runs row.
+        rows = list(cost_store.conn.execute("SELECT run_id FROM runs"))
+        assert len(rows) == 1, f"expected 1 runs row across replays, got {rows}"
+        # The internal dedup marker must not leak to the agent.
+        assert "_dedup_cached" not in second
+        assert "_dedup_cached" not in third
 
 
 class TestPathDiscriminator:

--- a/tests/unit/marcus_mcp/test_create_project_run_recording.py
+++ b/tests/unit/marcus_mcp/test_create_project_run_recording.py
@@ -1,0 +1,276 @@
+"""
+Tests for ``create_project``'s run + path wiring (Simon ``7ed3074d``).
+
+These tests exercise the two-phase attribution + ``path`` discriminator
+the wrapper in ``src/marcus_mcp/tools/nlp.py`` is responsible for:
+
+- Every successful ``create_project`` records exactly one row in the
+  ``runs`` table.
+- ``runs.run_id`` matches the value cost rows recorded during the
+  wrapper's PlannerContext push.
+- ``runs.path`` reflects the entry point: ``"direct"`` by default,
+  ``"marcus"`` / ``"posidonius"`` when supplied in ``options``.
+- Failure leaves the runs table clean (no half-written rows).
+- Missing ``cost_store`` attribute degrades gracefully.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _mock_api_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Config validation needs CLAUDE_API_KEY set."""
+    monkeypatch.setenv("CLAUDE_API_KEY", "test-key-for-unit-tests")
+
+
+@pytest.fixture(autouse=True)
+def _clear_create_project_dedup_cache() -> Any:
+    """Hermetic tests: clear the module-level dedup cache around each test."""
+    from src.marcus_mcp.tools import nlp as nlp_module
+
+    nlp_module._recent_create_project_calls.clear()
+    yield
+    nlp_module._recent_create_project_calls.clear()
+
+
+def _build_state(cost_store: Any) -> Mock:
+    """Mock state pre-wired with a real CostStore so the wrapper writes to disk."""
+    from src.integrations.kanban_interface import KanbanProvider
+
+    state = Mock()
+    state.log_event = Mock()
+    state.kanban_client = Mock()
+    state.kanban_client.provider = KanbanProvider.PLANKA
+    state.kanban_client.project_id = "1670692878487127607"
+    state.kanban_client.board_id = "1670692878621345337"
+    state.ai_engine = Mock()
+    state.subtask_manager = Mock()
+    state.project_registry = Mock()
+    state.project_manager = Mock()
+    state.cost_store = cost_store
+    state.project_registry.add_project = AsyncMock(return_value="abc-123-def-456")
+    state.project_registry.get_active_project = AsyncMock(return_value=None)
+    state.project_manager.switch_project = AsyncMock()
+    state.project_manager.get_kanban_client = AsyncMock(
+        return_value=state.kanban_client
+    )
+    state._subtasks_migrated = False
+    return state
+
+
+@pytest.fixture
+def cost_store(tmp_path: Path) -> Any:
+    """Real tmp CostStore so we can inspect token_events + runs."""
+    from src.cost_tracking.cost_store import CostStore
+
+    return CostStore(db_path=tmp_path / "costs.db")
+
+
+@pytest.fixture
+def recorder(cost_store: Any) -> Any:
+    """Enabled cost recorder wired to the tmp store."""
+    from src.cost_tracking.cost_recorder import CostRecorder, set_recorder
+
+    rec = CostRecorder(store=cost_store, enabled=True)
+    set_recorder(rec)
+    yield rec
+    set_recorder(None)
+
+
+def _ok_creator_result() -> Dict[str, Any]:
+    """A canned success payload from the underlying creator."""
+    return {
+        "success": True,
+        "project_name": "Flight Simulator",
+        "tasks_created": 29,
+        "task_ids": ["task-1"],
+        "board": {
+            "project_name": "Flight Simulator",
+            "board_name": "Main Board",
+        },
+    }
+
+
+class TestRunRecording:
+    """Direct-MCP ``create_project`` records a ``runs`` row on success."""
+
+    @pytest.mark.asyncio
+    async def test_one_run_row_per_successful_call(
+        self, cost_store: Any, recorder: Any
+    ) -> None:
+        """Exactly one row in ``runs``; path defaults to 'direct'."""
+        from src.marcus_mcp.tools.nlp import create_project
+
+        state = _build_state(cost_store)
+        with patch(
+            "src.integrations.nlp_tools.NaturalLanguageProjectCreator"
+        ) as MockCreator:
+            MockCreator.return_value.create_project_from_description = AsyncMock(
+                return_value=_ok_creator_result()
+            )
+            result = await create_project(
+                description="Build a flight simulator",
+                project_name="Flight Simulator",
+                options={"provider": "planka"},
+                state=state,
+            )
+
+        assert result["success"] is True
+        rows = list(
+            cost_store.conn.execute(
+                "SELECT run_id, project_id, project_name, path FROM runs"
+            )
+        )
+        assert len(rows) == 1, f"expected one runs row, got {rows}"
+        run_id, pid, name, path = rows[0]
+        assert len(run_id) == 32 and all(c in "0123456789abcdef" for c in run_id)
+        assert pid == "abc123def456"  # canonical (dashless)
+        assert name == "Flight Simulator"
+        assert path == "direct", "default path for unmarked options must be 'direct'"
+
+    @pytest.mark.asyncio
+    async def test_no_row_on_failure(self, cost_store: Any, recorder: Any) -> None:
+        """A failed creator leaves the runs table clean."""
+        from src.marcus_mcp.tools.nlp import create_project
+
+        state = _build_state(cost_store)
+        with patch(
+            "src.integrations.nlp_tools.NaturalLanguageProjectCreator"
+        ) as MockCreator:
+            MockCreator.return_value.create_project_from_description = AsyncMock(
+                return_value={"success": False, "error": "decomposer blew up"}
+            )
+            result = await create_project(
+                description="x",
+                project_name="Will Fail",
+                options={"provider": "planka"},
+                state=state,
+            )
+
+        assert result["success"] is False
+        rows = list(cost_store.conn.execute("SELECT * FROM runs"))
+        assert rows == []
+
+    @pytest.mark.asyncio
+    async def test_run_id_matches_token_events(
+        self, cost_store: Any, recorder: Any
+    ) -> None:
+        """The runs.run_id matches what cost rows recorded during the wrapper.
+
+        This is the join the dashboard depends on — if the two don't
+        match, the experiment view returns empty and the fix is dead.
+        """
+        from src.cost_tracking.cost_recorder import get_recorder
+        from src.marcus_mcp.tools.nlp import create_project
+
+        state = _build_state(cost_store)
+
+        async def _emits_cost(*_args: Any, **_kwargs: Any) -> Dict[str, Any]:
+            get_recorder().record_planner_call(
+                operation="decompose_prd",
+                provider="anthropic",
+                model="claude-sonnet-4-6",
+                input_tokens=100,
+                output_tokens=50,
+            )
+            return _ok_creator_result()
+
+        with patch(
+            "src.integrations.nlp_tools.NaturalLanguageProjectCreator"
+        ) as MockCreator:
+            MockCreator.return_value.create_project_from_description = AsyncMock(
+                side_effect=_emits_cost
+            )
+            await create_project(
+                description="x",
+                project_name="Flight Sim",
+                options={"provider": "planka"},
+                state=state,
+            )
+
+        run_row = cost_store.conn.execute("SELECT run_id FROM runs").fetchone()
+        te_row = cost_store.conn.execute(
+            "SELECT DISTINCT run_id FROM token_events "
+            "WHERE operation = 'decompose_prd'"
+        ).fetchone()
+        assert run_row is not None and te_row is not None
+        assert run_row[0] == te_row[0]
+        assert run_row[0] != "unassigned"
+
+
+class TestPathDiscriminator:
+    """``options['path']`` flows into ``runs.path``."""
+
+    @pytest.mark.asyncio
+    async def test_default_path_is_direct(self, cost_store: Any, recorder: Any) -> None:
+        """When options lack a 'path' key, the wrapper stamps 'direct'."""
+        from src.marcus_mcp.tools.nlp import create_project
+
+        state = _build_state(cost_store)
+        with patch(
+            "src.integrations.nlp_tools.NaturalLanguageProjectCreator"
+        ) as MockCreator:
+            MockCreator.return_value.create_project_from_description = AsyncMock(
+                return_value=_ok_creator_result()
+            )
+            await create_project(
+                description="x",
+                project_name="P",
+                # No 'path' in options — must default to 'direct'.
+                options={"provider": "planka"},
+                state=state,
+            )
+        path = cost_store.conn.execute("SELECT path FROM runs").fetchone()[0]
+        assert path == "direct"
+
+    @pytest.mark.asyncio
+    async def test_explicit_marcus_path_flows_through(
+        self, cost_store: Any, recorder: Any
+    ) -> None:
+        """spawn_agents.py's path='marcus' lands in the runs row."""
+        from src.marcus_mcp.tools.nlp import create_project
+
+        state = _build_state(cost_store)
+        with patch(
+            "src.integrations.nlp_tools.NaturalLanguageProjectCreator"
+        ) as MockCreator:
+            MockCreator.return_value.create_project_from_description = AsyncMock(
+                return_value=_ok_creator_result()
+            )
+            await create_project(
+                description="x",
+                project_name="P",
+                options={"provider": "planka", "path": "marcus"},
+                state=state,
+            )
+        path = cost_store.conn.execute("SELECT path FROM runs").fetchone()[0]
+        assert path == "marcus"
+
+    @pytest.mark.asyncio
+    async def test_explicit_posidonius_path_flows_through(
+        self, cost_store: Any, recorder: Any
+    ) -> None:
+        """Posidonius's path='posidonius' lands in the runs row."""
+        from src.marcus_mcp.tools.nlp import create_project
+
+        state = _build_state(cost_store)
+        with patch(
+            "src.integrations.nlp_tools.NaturalLanguageProjectCreator"
+        ) as MockCreator:
+            MockCreator.return_value.create_project_from_description = AsyncMock(
+                return_value=_ok_creator_result()
+            )
+            await create_project(
+                description="x",
+                project_name="P",
+                options={"provider": "planka", "path": "posidonius"},
+                state=state,
+            )
+        path = cost_store.conn.execute("SELECT path FROM runs").fetchone()[0]
+        assert path == "posidonius"


### PR DESCRIPTION
## Summary
- Renames cost-tracking `experiments` table → `runs` (resolving namespace collision with MLflow's separate experiment concept).
- Adds `path` column (`direct` | `marcus` | `posidonius` | `unknown`) so the three entry points are distinguishable in cost analytics.
- One-shot idempotent migration in `_runs_rename_migration()` covers legacy DBs, fresh installs, and already-migrated DBs.
- `create_project` now records one `runs` row per successful call, pre-generating `run_id` at wrapper entry and rebinding on success. Defaults `path="direct"` so unwrapped Direct MCP callers get the correct discriminator without code changes. `experiments/spawn_agents.py` sets `path="marcus"` (Posidonius config overrides to `posidonius`).

## Why
"experiment_id" in cost-tracking was always about *the path through a project* — distinct invocations on a shared `project_id`. MLflow uses the same word for an unrelated namespace, which has caused recurring confusion. This makes the cost-tracking model say what it means and the MLflow tool keep its own namespace cleanly.

## API renames (no compat aliases — pre-public)
- `CostStore.record_experiment` → `record_run`
- `CostAggregator.list_experiments` → `list_runs`; `experiment_summary` → `run_summary`
- `TokenEvent.experiment_id` / `PlannerContext.experiment_id` / `AgentBinding.experiment_id` → `run_id`
- `get_cost_summary` MCP tool: arg `experiment_id` → `run_id`; response key `experiments` → `runs`
- Dataclass `Experiment` → `Run` (with new `path` field)

## Test plan
- [x] `pytest tests/unit/cost_tracking/` (1297 unit tests pass, 1 skipped)
- [x] `pytest tests/unit/marcus_mcp/test_cost_tracking_tool.py tests/unit/marcus_mcp/test_create_project_run_recording.py`
- [x] `mypy src/cost_tracking/ src/marcus_mcp/tools/cost_tracking.py src/marcus_mcp/tools/nlp.py` clean
- [x] Migration smoke test against legacy schema (5 new tests in `TestRunsRenameMigration`)
- [x] Coordinated with Cato PR (lwgray/cato#40)

## Related
- Simon decision: 7ed3074d
- Replaces (closed) PR #521 — folded into this atomic rename
- Kaia reviewed the model: hierarchical project → runs → token_events

🤖 Generated with [Claude Code](https://claude.com/claude-code)