### PR TITLE
feat: runtime smoke gate accepts per-outcome verifications (#523 Slice B)

### DIFF
--- a/src/integrations/integration_verification.py
+++ b/src/integrations/integration_verification.py
@@ -18,10 +18,19 @@ import logging
 import re
 import uuid
 from datetime import datetime, timezone
-from typing import Any, Dict, List, Optional
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
 from src.core.models import Priority, Task, TaskStatus
 from src.integrations.nlp_task_utils import TaskType
+
+if TYPE_CHECKING:
+    # TYPE_CHECKING-only to keep this module decoupled from the
+    # outcome-extractor module at runtime.  ``UserOutcome`` is a plain
+    # dataclass with no heavy imports, but we only ever annotate with
+    # it (never instantiate here), so deferring the import keeps the
+    # integration layer free of upward dependencies on
+    # ``src.ai.advanced.prd``.
+    from src.ai.advanced.prd.outcome_extractor import UserOutcome
 
 logger = logging.getLogger(__name__)
 
@@ -51,6 +60,7 @@ class IntegrationTaskGenerator:
         existing_tasks: List[Task],
         project_name: str = "Project",
         contract_file: Optional[str] = None,
+        outcomes: Optional[List["UserOutcome"]] = None,
     ) -> Optional[Task]:
         """
         Create an integration verification task.
@@ -74,6 +84,27 @@ class IntegrationTaskGenerator:
             integration agent could silently "fix" a mismatch by
             editing the contract, breaking the invariant that made
             contract-first decomposition work in the first place.
+        outcomes : Optional[List[UserOutcome]]
+            Issue #523 Slice B: in-scope user outcomes the integration
+            task must verify.  When provided:
+
+            * Each outcome's ``id`` is stored on
+              ``task.source_context["in_scope_outcome_ids"]`` so the
+              smoke gate's coverage check can require a matching
+              ``VerificationSpec`` per outcome at completion time.
+            * The task description grows a "Verifications required"
+              section listing each outcome's ``id``,
+              ``success_signal``, and ``action`` so the agent knows
+              what to declare in the ``verifications`` field of
+              ``report_task_progress``.
+
+            Out-of-scope outcomes are filtered out — they exist in
+            the extractor output for audit only and must not gate
+            completion.
+
+            When ``None`` or empty after filtering, the integration
+            task behaves like the legacy single-``start_command``
+            contract (no coverage requirement, no description section).
 
         Returns
         -------
@@ -110,8 +141,17 @@ class IntegrationTaskGenerator:
             f"{len(dependencies)} tasks"
         )
 
+        # Filter to in-scope outcomes — out-of-scope outcomes are
+        # retained by the extractor for audit purposes only and must
+        # not gate completion or grow the description.
+        in_scope_outcomes: List["UserOutcome"] = (
+            [o for o in outcomes if o.scope == "in_scope"] if outcomes else []
+        )
+
         description = IntegrationTaskGenerator._generate_integration_description(
-            project_name, contract_file=contract_file
+            project_name,
+            contract_file=contract_file,
+            in_scope_outcomes=in_scope_outcomes,
         )
 
         acceptance_criteria = [
@@ -132,6 +172,18 @@ class IntegrationTaskGenerator:
             "Re-verification passes after fixes",
         ]
 
+        # Slice B: stash the in-scope outcome IDs on source_context so
+        # the smoke gate's coverage check at completion time can verify
+        # the agent declared at least one VerificationSpec per outcome.
+        # Empty list when no outcomes — distinguishes "outcomes wired
+        # but none in scope" from "wiring not present at all," which
+        # matters for the gate's decision to apply the coverage rule.
+        source_context: Optional[Dict[str, Any]] = None
+        if outcomes is not None:
+            source_context = {
+                "in_scope_outcome_ids": [o.id for o in in_scope_outcomes],
+            }
+
         task = Task(
             id=f"integration_verify_{uuid.uuid4().hex[:8]}",
             name=(f"Integration verification for {project_name}"),
@@ -146,6 +198,7 @@ class IntegrationTaskGenerator:
             assigned_to=None,
             due_date=None,
             acceptance_criteria=acceptance_criteria,
+            source_context=source_context,
         )
 
         return task
@@ -232,6 +285,7 @@ class IntegrationTaskGenerator:
     def _generate_integration_description(
         project_name: str,
         contract_file: Optional[str] = None,
+        in_scope_outcomes: Optional[List["UserOutcome"]] = None,
     ) -> str:
         """
         Generate the integration task description.
@@ -249,6 +303,14 @@ class IntegrationTaskGenerator:
             decomposition is active. When set, a contract-authority
             preamble is prepended to the description so the integration
             agent treats the contract as read-only.
+        in_scope_outcomes : Optional[List[UserOutcome]]
+            Issue #523 Slice B: in-scope user outcomes the agent must
+            declare verifications for at completion.  When non-empty,
+            a "Verifications required (#523)" section is appended
+            naming each outcome's ``id``, ``action``, and
+            ``success_signal`` along with a worked example of the
+            ``verifications`` payload to pass to
+            ``report_task_progress``.
 
         Returns
         -------
@@ -276,6 +338,11 @@ class IntegrationTaskGenerator:
                 "contract as your reference when verifying cross-agent "
                 "boundaries in step 9.\n\n---\n\n"
             )
+        outcomes_section = (
+            IntegrationTaskGenerator._render_outcomes_section(in_scope_outcomes)
+            if in_scope_outcomes
+            else ""
+        )
         return preamble + f"""Verify that {project_name} actually builds, starts, \
 and works end-to-end — and FIX any issues you find.
 
@@ -793,6 +860,92 @@ helps Marcus improve task planning over time.
     - If you could not fix all issues after 3 attempts, mark DONE
       anyway but set `overall_pass` to false with details on what
       remains broken and why you couldn't fix it
+""" + outcomes_section
+
+    @staticmethod
+    def _render_outcomes_section(
+        outcomes: List["UserOutcome"],
+    ) -> str:
+        """Render the per-outcome "Verifications required" description block.
+
+        Issue #523 Slice B: when in-scope user outcomes exist, the
+        integration task description ends with this section so the
+        agent knows exactly which outcomes Marcus's smoke gate will
+        require ``VerificationSpec`` entries for at completion time.
+
+        Each outcome is listed with its ``id`` (the ``signal_id`` the
+        agent must reference), the user-facing ``action``, and the
+        observable ``success_signal`` the verification command must
+        prove was satisfied.  A worked ``report_task_progress`` call
+        example shows the structure of the ``verifications`` payload.
+
+        Parameters
+        ----------
+        outcomes
+            In-scope outcomes only (caller has filtered).  Empty list
+            is unexpected here — callers should skip the section.
+
+        Returns
+        -------
+        str
+            Markdown-formatted section appended to the description.
+        """
+        bullets = []
+        for o in outcomes:
+            bullets.append(
+                f"- **`{o.id}`** — {o.action}\n"
+                f"  - Success signal: {o.success_signal}"
+            )
+        bullets_block = "\n".join(bullets)
+
+        first_id = outcomes[0].id
+        return f"""
+
+---
+
+## Verifications required (#523 Slice B)
+
+Marcus's smoke gate at completion time runs every ``VerificationSpec``
+you declare in the ``verifications`` field of ``report_task_progress``,
+and **rejects the completion** if any in-scope user outcome below has
+no matching spec.  You must declare at least one spec per outcome.
+
+**In-scope outcomes for this project:**
+
+{bullets_block}
+
+**Each spec is a shell command** whose exit code reflects whether the
+outcome's ``success_signal`` is observable in the running deliverable.
+Pick the tool that fits the deliverable shape — `curl` for HTTP,
+`npx playwright test` for browser UI, `pytest` for CLI assertions,
+etc.  Marcus does not care which tool you use; only that the command
+exits 0 when the signal is satisfied.
+
+**Worked example** (matching the first outcome above):
+
+```python
+report_task_progress(
+    task_id=task_id,
+    status="completed",
+    progress=100,
+    message="...",
+    verifications=[
+        {{
+            "signal_id": "{first_id}",
+            "command": "<the shell command you wrote>",
+            "description": "<short human label>",
+            # Optional, only when the command is a long-running server:
+            # "readiness_probe": "curl -f http://localhost:5173",
+        }},
+        # ... one entry per in-scope outcome above ...
+    ],
+)
+```
+
+Coverage check: every ``signal_id`` listed above must appear in your
+``verifications`` list, OR the smoke gate will reject your completion
+with a missing-coverage blocker.  See ``report_task_progress``
+documentation for the full schema.
 """
 
 
@@ -802,6 +955,7 @@ def enhance_project_with_integration(
     project_name: str = "Project",
     contract_file: Optional[str] = None,
     functional_requirements: Optional[List[Dict[str, Any]]] = None,
+    outcomes: Optional[List["UserOutcome"]] = None,
 ) -> List[Task]:
     """
     Add integration verification task to project if appropriate.
@@ -832,6 +986,14 @@ def enhance_project_with_integration(
         4 v2 where both agents built clean plumbing but no visible
         UI because the integration agent had no reference back to
         the user's "display weather" ask.
+    outcomes : Optional[List[UserOutcome]]
+        Issue #523 Slice B: extracted ``UserOutcome`` records from
+        the outcome extractor.  Forwarded to
+        :meth:`IntegrationTaskGenerator.create_integration_task` which
+        filters to in-scope, stores ``in_scope_outcome_ids`` on
+        ``Task.source_context``, and appends a "Verifications
+        required" section to the description so the agent knows what
+        the smoke gate's coverage check will demand at completion.
 
     Returns
     -------
@@ -843,7 +1005,7 @@ def enhance_project_with_integration(
         return tasks
 
     task = IntegrationTaskGenerator.create_integration_task(
-        tasks, project_name, contract_file=contract_file
+        tasks, project_name, contract_file=contract_file, outcomes=outcomes
     )
 
     if task:

--- a/src/integrations/nlp_tools.py
+++ b/src/integrations/nlp_tools.py
@@ -917,6 +917,15 @@ class NaturalLanguageProjectCreator(NaturalLanguageTaskCreator):
         # appends them as acceptance_criteria on the integration task.
         self._contract_first_requirements = functional_reqs
 
+        # Issue #523 Slice B: stash the extracted user outcomes
+        # (from ``_analyze_prd_deeply``) alongside the requirements
+        # so the same enhance_project_with_integration call site can
+        # forward them.  Used to grow the integration task description
+        # with a "Verifications required" section and to stash
+        # ``in_scope_outcome_ids`` on the task for the smoke gate's
+        # coverage check at completion.
+        self._contract_first_user_outcomes = list(prd_analysis.user_outcomes or [])
+
         logger.info(
             f"[decomposer] contract_first: synthesized "
             f"{len(ghost_tasks)} design ghost(s) for "
@@ -1458,12 +1467,21 @@ class NaturalLanguageProjectCreator(NaturalLanguageTaskCreator):
                 stashed_requirements = getattr(
                     self, "_contract_first_requirements", None
                 )
+                # Issue #523 Slice B: same stash pattern for the
+                # extracted user outcomes.  The contract-first path
+                # populates them at decomposition time; the
+                # feature-based path leaves the attribute absent
+                # (defaults to None, no outcomes section).  Feature-
+                # based wiring is a follow-up — the snake-game class
+                # of failure ships via contract_first, the default.
+                stashed_outcomes = getattr(self, "_contract_first_user_outcomes", None)
                 safe_tasks = enhance_project_with_integration(
                     safe_tasks,
                     description,
                     project_name,
                     contract_file=contract_file_for_integration,
                     functional_requirements=stashed_requirements,
+                    outcomes=stashed_outcomes,
                 )
                 logger.info(
                     "After integration enhancement: " f"{len(safe_tasks)} tasks"
@@ -1851,6 +1869,9 @@ class NaturalLanguageProjectCreator(NaturalLanguageTaskCreator):
                 # into subsequent feature-based runs).
                 if hasattr(self, "_contract_first_requirements"):
                     delattr(self, "_contract_first_requirements")
+                # Slice B (#523): same cleanup for stashed user outcomes.
+                if hasattr(self, "_contract_first_user_outcomes"):
+                    delattr(self, "_contract_first_user_outcomes")
                 logger.info(
                     "[design_autocomplete] Phase A scheduled as " "background task"
                 )

--- a/src/integrations/product_smoke.py
+++ b/src/integrations/product_smoke.py
@@ -232,6 +232,203 @@ class ProductSmokeResult:
 
 
 # ---------------------------------------------------------------------------
+# Slice B (#523): per-outcome verification specs
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class VerificationSpec:
+    """Agent-declared verification command pinned to a ``UserOutcome``.
+
+    Issue #523 Slice B: integration agents declare one
+    :class:`VerificationSpec` per in-scope user outcome when reporting
+    task completion.  Each spec is a shell command Marcus runs as a
+    subprocess; exit 0 means the outcome's ``success_signal`` was
+    observed in the running deliverable.
+
+    Single-primitive design: Marcus does NOT enumerate verification
+    families (curl, Playwright, pytest, etc.).  The agent picks tooling
+    appropriate to the deliverable shape; Marcus only knows how to run a
+    shell command and check its exit code.  This keeps Marcus a
+    coordination system rather than a tooling registry.
+
+    Attributes
+    ----------
+    signal_id : str
+        The ``UserOutcome.id`` this command verifies (e.g.
+        ``"outcome_play_snake"``).  Used by the smoke gate's coverage
+        check (every in-scope outcome must have at least one spec with
+        a matching ``signal_id``).  Reading the gate's rejection
+        message: when a spec fails, the message names this id so the
+        agent knows which user-observable outcome the failure
+        attributes to.
+    command : str
+        Shell-style command Marcus runs via
+        :func:`verify_deliverable` (same one-shot / server semantics as
+        the legacy ``start_command``).  Examples:
+
+        - ``"curl -fs http://localhost:8765/api/snake | jq -e '.data.snake'"``
+        - ``"npx playwright test verify_snake_render.spec.ts"``
+        - ``"python -m pytest tests/test_visible_output.py -q"``
+    description : str
+        Short human label for audit log, error messages, and downstream
+        telemetry consumers (Cato dashboards).  Empty string is
+        acceptable when the agent omits it; the rejection message
+        falls back to ``signal_id`` in that case.
+    readiness_probe : Optional[str]
+        Optional ``readiness_probe`` for server-mode verifications.
+        Same semantics as the legacy ``readiness_probe`` argument on
+        :func:`verify_deliverable`: when present, the ``command`` is
+        backgrounded and ``readiness_probe`` is polled for up to
+        ``DEFAULT_READINESS_TIMEOUT_SECONDS``.
+    """
+
+    signal_id: str
+    command: str
+    description: str = ""
+    readiness_probe: Optional[str] = None
+
+
+@dataclass
+class VerificationsResult:
+    """Aggregate result of running a list of :class:`VerificationSpec`.
+
+    Attributes
+    ----------
+    success : bool
+        ``True`` iff every spec's underlying :class:`ProductSmokeResult`
+        succeeded.
+    spec_results : list of (VerificationSpec, ProductSmokeResult)
+        Per-spec results in input order.  All specs are always run —
+        a failure mid-list does not short-circuit, so operators see the
+        full diagnostic in one run.
+    failure_summary : Optional[str]
+        One-line description of the first failing spec.  ``None`` on
+        full success.
+    blocker_message : Optional[str]
+        Multi-line, agent-facing actionable description naming the
+        first failing spec.  Renders ``signal_id``, ``description``,
+        ``command``, ``exit_code``, and the tail of the failing
+        step's stderr — the fields the acceptance criteria on #523
+        require.
+    """
+
+    success: bool
+    spec_results: List[Any] = field(default_factory=list)
+    failure_summary: Optional[str] = None
+    blocker_message: Optional[str] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Serialize for logging / telemetry."""
+        return {
+            "success": self.success,
+            "specs": [
+                {
+                    "signal_id": spec.signal_id,
+                    "command": spec.command,
+                    "description": spec.description,
+                    "readiness_probe": spec.readiness_probe,
+                    "result": result.to_dict(),
+                }
+                for spec, result in self.spec_results
+            ],
+            "failure_summary": self.failure_summary,
+        }
+
+
+async def verify_verification_specs(
+    specs: List[VerificationSpec],
+    cwd: Path,
+    one_shot_timeout_seconds: float = DEFAULT_ONE_SHOT_TIMEOUT_SECONDS,
+    readiness_timeout_seconds: float = DEFAULT_READINESS_TIMEOUT_SECONDS,
+) -> VerificationsResult:
+    """Run each :class:`VerificationSpec` via :func:`verify_deliverable`.
+
+    Issue #523 Slice B foundation.  Loops over agent-declared specs
+    using the same subprocess primitive the legacy
+    ``start_command``/``readiness_probe`` pipeline already uses.  All
+    specs are always run (no short-circuit on first failure) so a
+    single integration-task completion produces a complete diagnostic
+    instead of a cascading-rejection retry loop.
+
+    Parameters
+    ----------
+    specs
+        Agent-declared specs.  Empty list is treated as a verification
+        failure with a "no specs declared" blocker — the caller (smoke
+        gate) decides whether the integration task was supposed to
+        carry specs at all and rejects upstream when ``verifications``
+        is required.
+    cwd
+        Working directory for every subprocess.  Typically the kanban-
+        resolved project root.
+    one_shot_timeout_seconds, readiness_timeout_seconds
+        Forwarded verbatim to :func:`verify_deliverable` for each spec.
+        Centralised defaults make per-spec tuning unnecessary at the
+        call site.
+
+    Returns
+    -------
+    VerificationsResult
+        Per-spec breakdown plus aggregate success/failure framing.
+        Never raises on subprocess failure — failures are returned as
+        ``success=False`` with the agent-facing blocker populated.
+    """
+    if not specs:
+        return VerificationsResult(
+            success=False,
+            spec_results=[],
+            failure_summary="no verification specs declared",
+            blocker_message=_render_no_specs_blocker(),
+        )
+
+    spec_results: List[Any] = []
+    for spec in specs:
+        result = await verify_deliverable(
+            start_command=spec.command,
+            readiness_probe=spec.readiness_probe,
+            cwd=cwd,
+            one_shot_timeout_seconds=one_shot_timeout_seconds,
+            readiness_timeout_seconds=readiness_timeout_seconds,
+        )
+        spec_results.append((spec, result))
+
+    success = all(result.success for _, result in spec_results)
+    if success:
+        total_duration = sum(
+            sum(step.duration_seconds for step in result.steps)
+            for _, result in spec_results
+        )
+        logger.info(
+            "verify_verification_specs: all %d spec(s) PASSED in %.1fs",
+            len(specs),
+            total_duration,
+        )
+        return VerificationsResult(success=True, spec_results=spec_results)
+
+    first_failing_spec, first_failing_result = next(
+        (spec, result) for spec, result in spec_results if not result.success
+    )
+    label = first_failing_spec.description or first_failing_spec.signal_id
+    failure_summary = (
+        f"verification {first_failing_spec.signal_id!r} ({label}) failed: "
+        f"{first_failing_result.failure_summary or 'unknown reason'}"
+    )
+    blocker_message = _render_verifications_failure_blocker(
+        failing_spec=first_failing_spec,
+        failing_result=first_failing_result,
+        all_spec_results=spec_results,
+    )
+    logger.warning(f"verify_verification_specs FAILED: {failure_summary}")
+    return VerificationsResult(
+        success=False,
+        spec_results=spec_results,
+        failure_summary=failure_summary,
+        blocker_message=blocker_message,
+    )
+
+
+# ---------------------------------------------------------------------------
 # Subprocess helpers
 # ---------------------------------------------------------------------------
 
@@ -805,6 +1002,116 @@ def _render_missing_blocker() -> str:
         "Marcus will run the command (with a bounded timeout) and "
         "accept the completion only if it exits 0 (one-shot) or the "
         "readiness_probe returns exit 0 within 15s (server mode)."
+    )
+
+
+def _render_no_specs_blocker() -> str:
+    """Blocker for an integration task that declared zero verification specs.
+
+    Issue #523 Slice B: when an integration task has at least one
+    in-scope user outcome, completion must include at least one
+    :class:`VerificationSpec` per outcome.  This blocker fires when
+    the agent declared ``verifications=[]`` explicitly or omitted the
+    field while the task carries outcome metadata.
+    """
+    return (
+        "## Integration task rejected: no verification specs declared\n\n"
+        "Marcus requires integration verification tasks with declared "
+        "user outcomes to include at least one `VerificationSpec` per "
+        "in-scope outcome when marking the task complete.  Each spec is "
+        "a shell command Marcus runs as a subprocess; exit 0 means the "
+        "outcome's `success_signal` was observed in the running "
+        "deliverable.\n\n"
+        "**What to do:**\n\n"
+        "1. Look at the integration task description.  Each listed "
+        "user outcome has an `id` and a `success_signal`.\n"
+        "2. For each outcome, write a shell command whose exit code "
+        "reflects whether the signal is observable.  Pick the tool "
+        "that fits the deliverable shape — `curl` for HTTP, "
+        "`npx playwright test` for browser UI, `pytest` for CLI, etc.\n"
+        "3. Call `report_task_progress` with the `verifications` list:\n\n"
+        "   ```python\n"
+        "   report_task_progress(\n"
+        "       task_id=task_id,\n"
+        "       status='completed',\n"
+        "       progress=100,\n"
+        "       message='...',\n"
+        "       verifications=[\n"
+        "           {\n"
+        "               'signal_id': 'outcome_play_snake',\n"
+        "               'command': 'npx playwright test verify_snake.spec.ts',\n"
+        "               'description': 'snake visibly moves on a board',\n"
+        "           },\n"
+        "       ],\n"
+        "   )\n"
+        "   ```\n\n"
+        "Marcus runs every declared command (one-shot or server+probe) "
+        "and rejects the completion if any exits non-zero or if any "
+        "in-scope outcome has no matching spec."
+    )
+
+
+def _render_verifications_failure_blocker(
+    failing_spec: "VerificationSpec",
+    failing_result: ProductSmokeResult,
+    all_spec_results: List[Any],
+) -> str:
+    """Blocker for the first failing :class:`VerificationSpec`.
+
+    Issue #523 Slice B acceptance criterion: rejection error must
+    name the ``signal_id``, ``description``, ``command``, exit code,
+    and tail of stderr — so the agent knows exactly which
+    user-observable outcome was not produced by the deliverable and
+    what command Marcus ran.
+
+    The list of all-spec outcomes is included so the agent can see
+    which other verifications passed (useful context for diagnosing
+    why one specifically failed).
+    """
+    first_failed_step = next(
+        (step for step in failing_result.steps if not step.success),
+        None,
+    )
+    if first_failed_step is None:
+        exit_code = None
+        cmd = failing_spec.command
+        tail = failing_result.failure_summary or "(no output captured)"
+    else:
+        exit_code = first_failed_step.exit_code
+        cmd = first_failed_step.command or failing_spec.command
+        tail = first_failed_step.stderr or first_failed_step.stdout or "(no output)"
+
+    label = failing_spec.description or "(no description provided)"
+
+    summary_lines = []
+    for spec, result in all_spec_results:
+        marker = "PASS" if result.success else "FAIL"
+        summary_lines.append(
+            f"- [{marker}] `{spec.signal_id}`"
+            + (f" — {spec.description}" if spec.description else "")
+        )
+    summary_block = "\n".join(summary_lines)
+
+    return (
+        "## Verification FAILED\n\n"
+        "Marcus ran each declared verification command.  At least one "
+        "did not observe its claimed user outcome.\n\n"
+        f"**Failing verification**: `{failing_spec.signal_id}` — {label}\n"
+        f"**Command**: `{cmd}`\n"
+        f"**Exit code**: {exit_code}\n\n"
+        f"**Output (tail)**:\n```\n{tail}\n```\n\n"
+        "**All verifications this run:**\n\n"
+        f"{summary_block}\n\n"
+        "**What to do**: Run the failing command locally.  If it "
+        "fails for you, the deliverable does not in fact produce the "
+        "`success_signal` this verification claims to check — fix the "
+        "deliverable (wire missing code, add the rendering layer, "
+        "etc.), re-run, and only mark the integration task complete "
+        "after every declared verification passes.  If it passes for "
+        "you but not for Marcus, check `cwd`, environment variables, "
+        "and any background-process orchestration.  Marcus runs each "
+        "command via `verify_deliverable` (60s one-shot or 15s "
+        "server+probe with `CI=true`)."
     )
 
 

--- a/src/marcus_mcp/server.py
+++ b/src/marcus_mcp/server.py
@@ -1284,14 +1284,18 @@ class MarcusServer:
             message: str = "",
             start_command: Optional[str] = None,
             readiness_probe: Optional[str] = None,
+            verifications: Optional[List[Dict[str, Any]]] = None,
         ) -> Dict[str, Any]:
             """Report progress on a task.
 
             For integration verification tasks (type:integration
-            label), the agent MUST declare ``start_command`` when
-            marking the task complete. Marcus runs the declared
-            command as a subprocess and rejects the completion if
-            it fails. See the report_task_progress docstring in
+            label), the agent MUST declare either ``verifications``
+            (preferred, #523 Slice B) OR ``start_command`` (legacy)
+            when marking the task complete.  Marcus runs each
+            declared command as a subprocess and rejects the
+            completion if any exits non-zero.  ``verifications``
+            takes precedence over ``start_command`` when both are
+            provided.  See the report_task_progress docstring in
             tools/task.py for the full contract and examples.
             """
             from .tools.task import report_task_progress as impl
@@ -1305,6 +1309,7 @@ class MarcusServer:
                 state=server,
                 start_command=start_command,
                 readiness_probe=readiness_probe,
+                verifications=verifications,
             )
 
         @self._fastmcp.tool()  # type: ignore[misc]
@@ -1486,15 +1491,19 @@ class MarcusServer:
                 message: str = "",
                 start_command: Optional[str] = None,
                 readiness_probe: Optional[str] = None,
+                verifications: Optional[List[Dict[str, Any]]] = None,
             ) -> Dict[str, Any]:
                 """Report progress on a task.
 
                 For integration verification tasks (type:integration
-                label), the agent MUST declare ``start_command``
-                when marking the task complete. Marcus runs the
+                label), the agent MUST declare either ``verifications``
+                (preferred, #523 Slice B) OR ``start_command`` (legacy)
+                when marking the task complete.  Marcus runs each
                 declared command as a subprocess and rejects the
-                completion if it fails. See the report_task_progress
-                docstring in tools/task.py for the full contract.
+                completion if any exits non-zero.  ``verifications``
+                takes precedence over ``start_command`` when both are
+                provided.  See the report_task_progress docstring in
+                tools/task.py for the full contract.
                 """
                 from src.logging.mcp_tool_logger import log_mcp_tool_response
 
@@ -1509,6 +1518,7 @@ class MarcusServer:
                     state=server,
                     start_command=start_command,
                     readiness_probe=readiness_probe,
+                    verifications=verifications,
                 )
 
                 # Log MCP tool response
@@ -1522,6 +1532,7 @@ class MarcusServer:
                         "message": message,
                         "start_command": start_command,
                         "readiness_probe": readiness_probe,
+                        "verifications": verifications,
                     },
                     response=result,
                 )

--- a/src/marcus_mcp/tools/task.py
+++ b/src/marcus_mcp/tools/task.py
@@ -243,6 +243,107 @@ def _is_integration_task(task: Task) -> bool:
         return False
 
 
+def _missing_coverage_response(
+    *,
+    task: Task,
+    agent_id: str,
+    required_outcome_ids: List[str],
+    declared_signal_ids: List[str],
+    missing_outcome_ids: List[str],
+) -> Dict[str, Any]:
+    """Build the smoke-gate rejection for missing verification coverage.
+
+    Slice B (#523) acceptance criterion: when an integration task has
+    declared in-scope user outcomes, every outcome must be covered by
+    at least one ``VerificationSpec`` whose ``signal_id`` matches.  The
+    rejection blocker lists which outcomes lacked a matching spec so
+    the agent knows exactly what to add to their next
+    ``report_task_progress`` call — they do not have to re-derive the
+    coverage map themselves.
+
+    The fix is structural, not retry-friendly: re-running the same
+    completion with the same incomplete ``verifications`` list will
+    fail again.  The agent must add the missing entries.
+
+    Parameters
+    ----------
+    task
+        Integration task being completed (for the rejection's
+        ``task_id`` field).
+    agent_id
+        Agent reporting completion (for the rejection's ``agent_id``
+        field).
+    required_outcome_ids
+        All in-scope outcome IDs the task carries on
+        ``source_context["in_scope_outcome_ids"]``.  Listed for the
+        agent's full reference.
+    declared_signal_ids
+        ``signal_id`` values the agent did declare (sorted for stable
+        rendering).  Listed so the agent can see what they HAD
+        provided and diff against the required set.
+    missing_outcome_ids
+        The subset of ``required_outcome_ids`` with no matching
+        ``signal_id`` in the declared list.  Drives the
+        ``failure_summary`` field and is the primary fix target.
+    """
+    blocker = (
+        "## Verification coverage FAILED\n\n"
+        "Marcus rejected this integration-task completion because at "
+        "least one in-scope user outcome has no matching "
+        "``VerificationSpec`` in the ``verifications`` list.  Every "
+        "in-scope outcome must be covered by at least one spec whose "
+        "``signal_id`` matches the outcome's ``id``.\n\n"
+        f"**Missing coverage** ({len(missing_outcome_ids)} outcome(s)):\n\n"
+        + "\n".join(f"- `{oid}`" for oid in missing_outcome_ids)
+        + "\n\n"
+        f"**Required in-scope outcomes** ({len(required_outcome_ids)} "
+        "from the task's source_context):\n\n"
+        + "\n".join(f"- `{oid}`" for oid in required_outcome_ids)
+        + "\n\n"
+        f"**Verifications you declared** "
+        f"({len(declared_signal_ids)} signal_id(s)):\n\n"
+        + (
+            "\n".join(f"- `{sid}`" for sid in declared_signal_ids)
+            if declared_signal_ids
+            else "- (none)"
+        )
+        + "\n\n"
+        "**What to do**: for each missing outcome, look up its "
+        "``action`` and ``success_signal`` in the integration task "
+        "description's *Verifications required* section.  Write a "
+        "shell command whose exit code reflects whether the signal "
+        "is observable in the running deliverable (pick the tool that "
+        "fits — `curl`, `playwright`, `pytest`, etc.).  Add one entry "
+        "per missing outcome to the ``verifications`` list and "
+        "re-call ``report_task_progress`` with the complete set.\n\n"
+        "Retrying with the same incomplete list will fail with the "
+        "same rejection — this is a structural coverage check, not a "
+        "subprocess-level failure."
+    )
+    return {
+        "success": False,
+        "status": "smoke_verification_failed",
+        "error": "verifications_missing_coverage",
+        "agent_id": agent_id,
+        "task_id": task.id,
+        "failure_summary": (
+            f"verifications missing coverage for "
+            f"{len(missing_outcome_ids)} outcome(s): "
+            f"{', '.join(missing_outcome_ids)}"
+        ),
+        "blocker": blocker,
+        "missing_outcome_ids": missing_outcome_ids,
+        "required_outcome_ids": required_outcome_ids,
+        "declared_signal_ids": declared_signal_ids,
+        "message": (
+            "Marcus rejected this integration-task completion: the "
+            "``verifications`` list is missing entries for one or more "
+            "in-scope user outcomes.  See the ``blocker`` field for "
+            "the specific outcome IDs that need coverage."
+        ),
+    }
+
+
 async def _run_product_smoke_gate(
     task: Task,
     agent_id: str,
@@ -394,6 +495,48 @@ async def _run_product_smoke_gate(
             )
             for v in verifications
         ]
+
+        # Slice B (#523) coverage check: when the integration task
+        # was created with ``outcomes`` (commit 228ca479 stores
+        # ``in_scope_outcome_ids`` on ``source_context``), every
+        # declared in-scope outcome must have at least one
+        # ``VerificationSpec`` with a matching ``signal_id``.
+        #
+        # We apply the check ONLY when the source_context carries
+        # the field — legacy integration tasks created without
+        # outcomes have ``source_context is None`` and bypass the
+        # rule.  An empty list means "outcomes were wired but none
+        # were in scope" → coverage trivially satisfied, no check
+        # needed.  The missing-outcome rejection fires BEFORE any
+        # subprocess runs so an agent that forgot a signal_id gets
+        # immediate feedback without paying the verify-deliverable
+        # latency cost.
+        required_outcome_ids: List[str] = list(
+            (task.source_context or {}).get("in_scope_outcome_ids") or []
+        )
+        if required_outcome_ids:
+            declared_signal_ids: set[str] = {
+                spec.signal_id for spec in specs if spec.signal_id
+            }
+            missing_outcome_ids = [
+                oid for oid in required_outcome_ids if oid not in declared_signal_ids
+            ]
+            if missing_outcome_ids:
+                logger.warning(
+                    "PRODUCT SMOKE GATE: Coverage check FAILED for %s. "
+                    "Missing verifications for outcomes: %s. "
+                    "Rejecting completion.",
+                    task.id,
+                    missing_outcome_ids,
+                )
+                return _missing_coverage_response(
+                    task=task,
+                    agent_id=agent_id,
+                    required_outcome_ids=required_outcome_ids,
+                    declared_signal_ids=sorted(declared_signal_ids),
+                    missing_outcome_ids=missing_outcome_ids,
+                )
+
         logger.info(
             "PRODUCT SMOKE GATE: Running %d declared verification(s) for "
             "integration task %s at %s",

--- a/src/marcus_mcp/tools/task.py
+++ b/src/marcus_mcp/tools/task.py
@@ -243,6 +243,92 @@ def _is_integration_task(task: Task) -> bool:
         return False
 
 
+def _missing_verifications_for_required_outcomes_response(
+    *,
+    task: Task,
+    agent_id: str,
+    required_outcome_ids: List[str],
+) -> Dict[str, Any]:
+    """Reject completion when the task has outcomes but agent sent no specs.
+
+    Slice B (#523) escape-hatch closure (Kaia review on PR #525).
+
+    The smoke gate's existing coverage check fires only inside the
+    ``if verifications:`` branch.  Without this preliminary check an
+    agent could send ``verifications=None`` (or empty list) plus a
+    valid legacy ``start_command``, fall through to
+    ``verify_deliverable``, and ship a project whose user-observable
+    outcomes were never verified — the exact failure mode Slice B
+    targets.
+
+    Rejection shape mirrors :func:`_missing_coverage_response` so
+    Cato / log analyzers can treat both as the same "missing
+    coverage" category, distinguished by ``error`` ("verifications_
+    required_but_missing" here vs "verifications_missing_coverage"
+    for partial coverage inside the verifications branch).
+
+    Parameters
+    ----------
+    task
+        Integration task being completed.
+    agent_id
+        Agent reporting completion.
+    required_outcome_ids
+        In-scope outcome IDs the task carries on
+        ``source_context["in_scope_outcome_ids"]``.  Listed in the
+        blocker so the agent knows the full set they must cover.
+    """
+    blocker = (
+        "## Verifications required for this integration task\n\n"
+        "Marcus rejected this completion because the integration task "
+        "was created with in-scope user outcomes, but the agent did "
+        "not declare any ``verifications``.  When user outcomes are "
+        "in scope, the legacy ``start_command`` alone is not "
+        "sufficient — Marcus cannot prove the deliverable produced "
+        "each outcome's ``success_signal`` without per-outcome "
+        "verification commands.\n\n"
+        f"**In-scope outcomes** ({len(required_outcome_ids)}, all "
+        "required):\n\n"
+        + "\n".join(f"- `{oid}`" for oid in required_outcome_ids)
+        + "\n\n"
+        "**What to do**: look up each outcome's ``action`` and "
+        "``success_signal`` in the integration task description's "
+        "*Verifications required* section.  Write a shell command "
+        "whose exit code reflects whether the signal is observable "
+        "in the running deliverable (pick the tool that fits — "
+        "`curl`, `playwright`, `pytest`, etc.).  Call "
+        "``report_task_progress`` again with a ``verifications`` "
+        "list containing one entry per outcome above.\n\n"
+        "Retrying with the same call (omitting ``verifications``) "
+        "will fail with the same rejection — the legacy "
+        "``start_command`` path is closed for tasks that carry "
+        "declared outcomes."
+    )
+    return {
+        "success": False,
+        "status": "smoke_verification_failed",
+        "error": "verifications_required_but_missing",
+        "agent_id": agent_id,
+        "task_id": task.id,
+        "failure_summary": (
+            f"integration task carries {len(required_outcome_ids)} "
+            "in-scope outcome(s) but the agent did not declare a "
+            "verifications list"
+        ),
+        "blocker": blocker,
+        "missing_outcome_ids": list(required_outcome_ids),
+        "required_outcome_ids": list(required_outcome_ids),
+        "declared_signal_ids": [],
+        "message": (
+            "Marcus rejected this integration-task completion: the "
+            "task carries declared in-scope user outcomes and the "
+            "agent did not provide a ``verifications`` list.  See "
+            "the ``blocker`` field for the outcome IDs that need "
+            "coverage."
+        ),
+    }
+
+
 def _missing_coverage_response(
     *,
     task: Task,
@@ -477,12 +563,47 @@ async def _run_product_smoke_gate(
         )
         return _gate_unavailable(f"project_root {project_root!r} is not a directory")
 
+    # Slice B (#523) escape-hatch closure (Kaia review on PR #525):
+    # when the integration task was created with in-scope outcomes,
+    # the agent MUST use the ``verifications`` path — the legacy
+    # ``start_command`` alone cannot prove signal coverage.  Without
+    # this check an agent could send ``verifications=None`` plus a
+    # working ``start_command``, fall through to the legacy path
+    # below, and ship the snake-game class of failure that Slice B
+    # was designed to prevent.
+    #
+    # Defensive ``isinstance``: when a kanban provider rehydrates
+    # ``source_context`` from JSON, malformed values could in theory
+    # come back as a non-list (e.g. a string).  ``list("o_play")``
+    # would silently become ``['o', '_', ...]`` and corrupt the
+    # required-outcome set.  Treat non-list values as "wiring absent"
+    # rather than raising.
+    raw_required = (task.source_context or {}).get("in_scope_outcome_ids")
+    required_outcome_ids_for_task: List[str] = (
+        list(raw_required) if isinstance(raw_required, list) else []
+    )
+    if required_outcome_ids_for_task and not verifications:
+        logger.warning(
+            "PRODUCT SMOKE GATE: Integration task %s has %d in-scope "
+            "outcome(s) but the agent did not declare ``verifications``. "
+            "Rejecting completion — legacy ``start_command`` alone "
+            "cannot prove signal coverage.",
+            task.id,
+            len(required_outcome_ids_for_task),
+        )
+        return _missing_verifications_for_required_outcomes_response(
+            task=task,
+            agent_id=agent_id,
+            required_outcome_ids=required_outcome_ids_for_task,
+        )
+
     # Slice B (#523): if the agent declared a non-empty ``verifications``
     # list, that is the canonical path — run each spec via the
     # multi-spec runner.  ``start_command`` is ignored when
     # ``verifications`` is provided; the legacy single-command path
     # is preserved only as a backward-compat fallback for completions
-    # that omit ``verifications`` entirely.
+    # that omit ``verifications`` entirely AND the task carries no
+    # declared outcomes (escape-hatch closure above).
     if verifications:
         specs = [
             VerificationSpec(
@@ -511,8 +632,14 @@ async def _run_product_smoke_gate(
         # subprocess runs so an agent that forgot a signal_id gets
         # immediate feedback without paying the verify-deliverable
         # latency cost.
-        required_outcome_ids: List[str] = list(
-            (task.source_context or {}).get("in_scope_outcome_ids") or []
+        # Same defensive ``isinstance`` as the escape-hatch check
+        # above — kanban providers that round-trip ``source_context``
+        # through JSON could in theory rehydrate this field as a
+        # non-list; treat malformed values as absent rather than
+        # silently iterating characters of a string.
+        raw_required_inner = (task.source_context or {}).get("in_scope_outcome_ids")
+        required_outcome_ids: List[str] = (
+            list(raw_required_inner) if isinstance(raw_required_inner, list) else []
         )
         if required_outcome_ids:
             declared_signal_ids: set[str] = {

--- a/src/marcus_mcp/tools/task.py
+++ b/src/marcus_mcp/tools/task.py
@@ -249,20 +249,21 @@ async def _run_product_smoke_gate(
     state: Any,
     start_command: Optional[str],
     readiness_probe: Optional[str],
+    verifications: Optional[List[Dict[str, Any]]] = None,
 ) -> Optional[Dict[str, Any]]:
     """Run deliverable verification for a completing integration task.
 
     Resolves the project root from the kanban workspace state, runs
-    the agent-declared start_command (and optional readiness_probe) as
-    subprocess, and returns either ``None`` (verification passed —
-    completion may proceed) or a rejection dict that the caller
-    returns directly to the agent.
+    the agent-declared verification command(s) as subprocess(es), and
+    returns either ``None`` (verification passed — completion may
+    proceed) or a rejection dict that the caller returns directly to
+    the agent.
 
-    **Strict enforcement**: integration tasks MUST declare a
-    start_command. Completions that omit it are rejected with the
-    missing-declaration blocker message, regardless of any other
-    state. This is the explicit design choice locked in Simon decision
-    967555f6 — no fallback auto-detection. Agents own stack knowledge.
+    **Strict enforcement**: integration tasks MUST declare either
+    ``verifications`` OR ``start_command``.  Completions that omit
+    both are rejected with the missing-declaration blocker message.
+    Locked in Simon decision 967555f6 (no fallback auto-detection;
+    agents own stack knowledge) and extended in #523 Slice B.
 
     Parameters
     ----------
@@ -274,20 +275,33 @@ async def _run_product_smoke_gate(
         Marcus server state (provides kanban_client for workspace
         state lookup).
     start_command : Optional[str]
-        Agent-declared shell command that starts the deliverable.
-        Required — missing → rejection.
+        Legacy single-command field.  When ``verifications`` is also
+        provided, ``start_command`` is ignored (the list is canonical).
+        When ``verifications`` is ``None``, ``start_command`` is
+        wrapped as a single legacy :class:`VerificationSpec` and the
+        gate runs in 1:1 backward-compat mode.  Either path produces
+        the same rejection behavior on failure.
     readiness_probe : Optional[str]
-        Agent-declared probe command for long-running servers.
-        Optional — absent means the start_command is treated as a
-        one-shot that must exit 0 within the configured timeout.
+        Companion to legacy ``start_command``.  Ignored when
+        ``verifications`` is provided (each verification carries its
+        own ``readiness_probe`` field).
+    verifications : Optional[List[Dict[str, Any]]]
+        Issue #523 Slice B: agent-declared verifications, one per
+        in-scope user outcome.  Each dict carries ``signal_id``,
+        ``command``, optional ``description``, and optional
+        ``readiness_probe``.  Marcus runs every declared command via
+        the same subprocess primitive ``start_command`` uses — exit 0
+        means the outcome's success_signal was observed.  Empty list
+        is rejected upstream (caller should pass ``None`` for legacy
+        mode); non-empty list takes precedence over ``start_command``.
 
     Returns
     -------
     Optional[Dict[str, Any]]
         ``None`` if verification passed. A rejection dict with
         ``success=False``, ``status="smoke_verification_failed"``,
-        and a ``blocker`` payload if verification failed or the
-        start_command was missing.
+        and a ``blocker`` payload if verification failed or both
+        ``verifications`` and ``start_command`` were missing.
 
     Notes
     -----
@@ -298,7 +312,11 @@ async def _run_product_smoke_gate(
     """
     from pathlib import Path as _Path
 
-    from src.integrations.product_smoke import verify_deliverable
+    from src.integrations.product_smoke import (
+        VerificationSpec,
+        verify_deliverable,
+        verify_verification_specs,
+    )
 
     # Resolve project root via the kanban client's workspace state.
     # This is the same source of truth used by
@@ -358,6 +376,72 @@ async def _run_product_smoke_gate(
         )
         return _gate_unavailable(f"project_root {project_root!r} is not a directory")
 
+    # Slice B (#523): if the agent declared a non-empty ``verifications``
+    # list, that is the canonical path — run each spec via the
+    # multi-spec runner.  ``start_command`` is ignored when
+    # ``verifications`` is provided; the legacy single-command path
+    # is preserved only as a backward-compat fallback for completions
+    # that omit ``verifications`` entirely.
+    if verifications:
+        specs = [
+            VerificationSpec(
+                signal_id=str(v.get("signal_id", "")),
+                command=str(v.get("command", "")),
+                description=str(v.get("description", "") or ""),
+                readiness_probe=(
+                    str(v["readiness_probe"]) if v.get("readiness_probe") else None
+                ),
+            )
+            for v in verifications
+        ]
+        logger.info(
+            "PRODUCT SMOKE GATE: Running %d declared verification(s) for "
+            "integration task %s at %s",
+            len(specs),
+            task.id,
+            project_root_path,
+        )
+        specs_result = await verify_verification_specs(
+            specs=specs, cwd=project_root_path
+        )
+        if specs_result.success:
+            logger.info(
+                "PRODUCT SMOKE GATE: All %d verification(s) passed for %s",
+                len(specs),
+                task.id,
+            )
+            return None
+        logger.warning(
+            "PRODUCT SMOKE GATE: Verification FAILED for %s. "
+            "Failure: %s. Rejecting completion.",
+            task.id,
+            specs_result.failure_summary,
+        )
+        return {
+            "success": False,
+            "status": "smoke_verification_failed",
+            "error": "verifications_failed",
+            "agent_id": agent_id,
+            "task_id": task.id,
+            "failure_summary": specs_result.failure_summary,
+            "blocker": specs_result.blocker_message,
+            "smoke_result": specs_result.to_dict(),
+            "message": (
+                "Marcus rejected this integration-task completion: one "
+                "or more declared verifications did not observe their "
+                "user-outcome success_signal in the running deliverable. "
+                "See the `blocker` field for the failing spec's "
+                "signal_id, command, exit code, and stderr.  Fix the "
+                "deliverable and re-call report_task_progress with the "
+                "same verifications list.  If the product is genuinely "
+                "broken and cannot be fixed, call report_blocker — "
+                "repeated retries without fixing the root cause will "
+                "exhaust your lease."
+            ),
+        }
+
+    # Legacy backward-compat path: no ``verifications`` declared, fall
+    # back to the single ``start_command`` contract.  Removed by v0.4.
     logger.info(
         f"PRODUCT SMOKE GATE: Running deliverable verification for "
         f"integration task {task.id} at {project_root_path}. "
@@ -2184,6 +2268,7 @@ async def report_task_progress(
     state: Any,
     start_command: Optional[str] = None,
     readiness_probe: Optional[str] = None,
+    verifications: Optional[List[Dict[str, Any]]] = None,
 ) -> Dict[str, Any]:
     """
     Agents report their task progress.
@@ -2235,6 +2320,32 @@ async def report_task_progress(
 
         Absent ``readiness_probe``, Marcus treats the start_command as
         a one-shot that must exit 0 within 60s.
+    verifications : Optional[List[Dict[str, Any]]]
+        Issue #523 Slice B: per-outcome verification list.  When
+        completing an integration task with declared user outcomes,
+        pass one entry per in-scope ``UserOutcome`` so Marcus can
+        verify each outcome's ``success_signal`` was observed in the
+        running deliverable.  Each entry is a dict:
+
+        - ``signal_id`` (str, required) — the ``UserOutcome.id`` this
+          command verifies
+        - ``command`` (str, required) — shell command Marcus runs as a
+          subprocess; exit 0 means the signal was observed
+        - ``description`` (str, optional) — short human label
+        - ``readiness_probe`` (str, optional) — per-spec probe for
+          server-mode verifications
+
+        Takes precedence over ``start_command`` when present:
+        Marcus runs every declared verification (in input order) via
+        the same subprocess primitive ``start_command`` uses.  Any
+        non-zero exit rejects the completion; the agent-facing
+        blocker names the failing ``signal_id``, ``description``,
+        ``command``, exit code, and stderr tail.
+
+        Backward compat: when ``verifications`` is ``None`` and only
+        ``start_command`` is provided, the legacy single-command
+        smoke gate runs unchanged.  When both are provided,
+        ``verifications`` wins and ``start_command`` is ignored.
 
     Returns
     -------
@@ -2525,6 +2636,7 @@ async def report_task_progress(
                         state=state,
                         start_command=start_command,
                         readiness_probe=readiness_probe,
+                        verifications=verifications,
                     )
                     if smoke_response is not None:
                         return smoke_response

--- a/tests/unit/integrations/test_integration_verification.py
+++ b/tests/unit/integrations/test_integration_verification.py
@@ -1211,3 +1211,203 @@ class TestStartCommandBuildPipelineRequirement:
                     f"exit 0 for any args). Use the worktree's actual "
                     f"build command instead."
                 )
+
+
+# ---------------------------------------------------------------------------
+# Slice B (#523): outcomes wiring into integration task
+# ---------------------------------------------------------------------------
+
+
+def _user_outcome(
+    out_id: str,
+    action: str = "user can do X",
+    signal: str = "X is observable",
+    scope: str = "in_scope",
+):
+    """Build a UserOutcome for outcome-wiring tests."""
+    from src.ai.advanced.prd.outcome_extractor import UserOutcome
+
+    return UserOutcome(id=out_id, action=action, success_signal=signal, scope=scope)
+
+
+class TestIntegrationTaskOutcomesWiring:
+    """``create_integration_task`` + ``enhance_project_with_integration``
+    accept user outcomes and surface them on the integration task.
+
+    Issue #523 Slice B: in-scope outcomes are stored on
+    ``task.source_context["in_scope_outcome_ids"]`` so the smoke gate
+    can require a matching ``VerificationSpec`` per outcome at
+    completion time, and the description gains a "Verifications
+    required" section so the agent knows what to declare.
+    """
+
+    @pytest.fixture
+    def sample_tasks(self) -> list[Task]:
+        return [
+            create_test_task(
+                "t1",
+                "Implement engine",
+                labels=["contract_first", "implementation"],
+            ),
+            create_test_task(
+                "t2",
+                "Implement renderer",
+                labels=["contract_first", "implementation"],
+            ),
+        ]
+
+    def test_in_scope_outcome_ids_stored_on_source_context(
+        self, sample_tasks: list[Task]
+    ) -> None:
+        from src.integrations.integration_verification import (
+            IntegrationTaskGenerator,
+        )
+
+        outcomes = [
+            _user_outcome("outcome_play", "user can play", "snake moves"),
+            _user_outcome("outcome_score", "user can see score", "score updates"),
+        ]
+        task = IntegrationTaskGenerator.create_integration_task(
+            sample_tasks, project_name="Snake", outcomes=outcomes
+        )
+
+        assert task is not None
+        assert task.source_context is not None
+        ids = task.source_context.get("in_scope_outcome_ids")
+        assert ids == ["outcome_play", "outcome_score"]
+
+    def test_out_of_scope_outcomes_filtered(self, sample_tasks: list[Task]) -> None:
+        """Out-of-scope outcomes don't gate completion or grow description."""
+        from src.integrations.integration_verification import (
+            IntegrationTaskGenerator,
+        )
+
+        outcomes = [
+            _user_outcome("outcome_play", "user can play", "snake moves"),
+            _user_outcome(
+                "outcome_admin",
+                "admin can do X",
+                "admin tools visible",
+                scope="out_of_scope",
+            ),
+        ]
+        task = IntegrationTaskGenerator.create_integration_task(
+            sample_tasks, project_name="Snake", outcomes=outcomes
+        )
+
+        assert task is not None
+        ids = (task.source_context or {}).get("in_scope_outcome_ids")
+        assert ids == ["outcome_play"]
+        # Description names the in-scope outcome but not the out-of-scope.
+        assert "outcome_play" in task.description
+        assert "outcome_admin" not in task.description
+
+    def test_description_grows_verifications_section(
+        self, sample_tasks: list[Task]
+    ) -> None:
+        """The new section names each outcome's id, action, and signal."""
+        from src.integrations.integration_verification import (
+            IntegrationTaskGenerator,
+        )
+
+        outcomes = [
+            _user_outcome(
+                "outcome_play",
+                action="user can play the snake game",
+                signal="snake visibly moves on a board",
+            ),
+        ]
+        task = IntegrationTaskGenerator.create_integration_task(
+            sample_tasks, project_name="Snake", outcomes=outcomes
+        )
+
+        assert task is not None
+        d = task.description
+        assert "Verifications required" in d
+        assert "outcome_play" in d
+        assert "user can play the snake game" in d
+        assert "snake visibly moves on a board" in d
+        # Worked example referencing the same signal_id
+        assert 'signal_id": "outcome_play"' in d or "signal_id" in d
+        # Worked example block points at report_task_progress
+        assert "report_task_progress" in d
+        assert "verifications=[" in d
+
+    def test_no_outcomes_leaves_description_unchanged_default(
+        self, sample_tasks: list[Task]
+    ) -> None:
+        """``outcomes=None`` preserves the legacy description shape.
+
+        Legacy callers (feature-based path until follow-up wiring) get
+        identical behavior — no source_context, no Verifications
+        section.
+        """
+        from src.integrations.integration_verification import (
+            IntegrationTaskGenerator,
+        )
+
+        task = IntegrationTaskGenerator.create_integration_task(
+            sample_tasks, project_name="Snake"
+        )
+        assert task is not None
+        assert task.source_context is None
+        assert "Verifications required" not in task.description
+
+    def test_empty_outcomes_list_stores_empty_list_not_none(
+        self, sample_tasks: list[Task]
+    ) -> None:
+        """``outcomes=[]`` (extractor ran, no outcomes) stores empty list.
+
+        Distinguishes "wiring present, nothing in scope" from "wiring
+        absent" — the smoke gate's coverage check at completion needs
+        this distinction to know whether to apply the rule.
+        """
+        from src.integrations.integration_verification import (
+            IntegrationTaskGenerator,
+        )
+
+        task = IntegrationTaskGenerator.create_integration_task(
+            sample_tasks, project_name="Snake", outcomes=[]
+        )
+        assert task is not None
+        assert task.source_context is not None
+        assert task.source_context.get("in_scope_outcome_ids") == []
+
+    def test_all_outcomes_out_of_scope_stores_empty_list(
+        self, sample_tasks: list[Task]
+    ) -> None:
+        """All-out-of-scope input → empty in_scope_outcome_ids list."""
+        from src.integrations.integration_verification import (
+            IntegrationTaskGenerator,
+        )
+
+        outcomes = [
+            _user_outcome("o_oos", "user does X", "X visible", scope="out_of_scope"),
+        ]
+        task = IntegrationTaskGenerator.create_integration_task(
+            sample_tasks, project_name="Snake", outcomes=outcomes
+        )
+        assert task is not None
+        assert (task.source_context or {}).get("in_scope_outcome_ids") == []
+
+    def test_enhance_project_with_integration_forwards_outcomes(
+        self, sample_tasks: list[Task]
+    ) -> None:
+        """The top-level helper threads outcomes to the generator."""
+        from src.integrations.integration_verification import (
+            enhance_project_with_integration,
+        )
+
+        outcomes = [_user_outcome("outcome_play", "user can play", "snake moves")]
+        result = enhance_project_with_integration(
+            sample_tasks,
+            "Build a snake game",
+            "Snake",
+            outcomes=outcomes,
+        )
+
+        integration_task = next((t for t in result if "integration" in t.labels), None)
+        assert integration_task is not None
+        assert (integration_task.source_context or {}).get("in_scope_outcome_ids") == [
+            "outcome_play"
+        ]

--- a/tests/unit/integrations/test_product_smoke.py
+++ b/tests/unit/integrations/test_product_smoke.py
@@ -705,3 +705,274 @@ class TestRunProbeRealShell:
         exit_code, _, stderr = await _run_probe("   ", tmp_path)
         assert exit_code == -1
         assert "empty" in stderr.lower()
+
+
+# ---------------------------------------------------------------------------
+# Slice B (#523): VerificationSpec + verify_verification_specs
+# ---------------------------------------------------------------------------
+
+
+class TestVerificationSpecDataclass:
+    """Structural invariants of :class:`VerificationSpec`."""
+
+    def test_required_fields(self) -> None:
+        from src.integrations.product_smoke import VerificationSpec
+
+        spec = VerificationSpec(signal_id="o1", command="curl -f /api")
+        assert spec.signal_id == "o1"
+        assert spec.command == "curl -f /api"
+        assert spec.description == ""
+        assert spec.readiness_probe is None
+
+    def test_optional_fields(self) -> None:
+        from src.integrations.product_smoke import VerificationSpec
+
+        spec = VerificationSpec(
+            signal_id="o1",
+            command="npm run dev",
+            description="snake renders",
+            readiness_probe="curl -f localhost:5173",
+        )
+        assert spec.description == "snake renders"
+        assert spec.readiness_probe == "curl -f localhost:5173"
+
+
+class TestVerifyVerificationSpecs:
+    """``verify_verification_specs`` runs each spec via verify_deliverable.
+
+    Each spec ends up calling :func:`verify_deliverable` with the
+    spec's ``command`` as ``start_command`` and the spec's
+    ``readiness_probe`` (or ``None`` for one-shot mode).  Patching at
+    the ``verify_deliverable`` boundary keeps the tests deterministic
+    while exercising the aggregation + failure-rendering logic.
+    """
+
+    @pytest.mark.asyncio
+    async def test_empty_specs_is_failure_with_no_specs_blocker(
+        self, tmp_path: Path
+    ) -> None:
+        """Empty list → structured failure, not a vacuous pass.
+
+        Caller (smoke gate) decides whether verifications are required
+        for the task; the runner refuses to silently succeed on empty
+        input.
+        """
+        from src.integrations.product_smoke import verify_verification_specs
+
+        result = await verify_verification_specs(specs=[], cwd=tmp_path)
+        assert result.success is False
+        assert "no verification specs declared" in (result.failure_summary or "")
+        assert result.blocker_message is not None
+        assert "no verification specs declared" in result.blocker_message
+
+    @pytest.mark.asyncio
+    async def test_all_specs_pass(self, tmp_path: Path) -> None:
+        """All-pass aggregate yields ``success=True`` with per-spec results."""
+        from src.integrations.product_smoke import (
+            VerificationSpec,
+            verify_verification_specs,
+        )
+
+        async def _fake_verify_deliverable(
+            start_command: str, readiness_probe: object, cwd: Path, **_: object
+        ) -> ProductSmokeResult:
+            return ProductSmokeResult(
+                success=True,
+                steps=[_make_step("start_command", command=start_command)],
+            )
+
+        specs = [
+            VerificationSpec(signal_id="o1", command="echo a", description="A"),
+            VerificationSpec(signal_id="o2", command="echo b", description="B"),
+        ]
+
+        with patch(
+            "src.integrations.product_smoke.verify_deliverable",
+            side_effect=_fake_verify_deliverable,
+        ):
+            result = await verify_verification_specs(specs=specs, cwd=tmp_path)
+
+        assert result.success is True
+        assert len(result.spec_results) == 2
+        assert result.failure_summary is None
+        assert result.blocker_message is None
+        # Order preserved
+        assert result.spec_results[0][0].signal_id == "o1"
+        assert result.spec_results[1][0].signal_id == "o2"
+
+    @pytest.mark.asyncio
+    async def test_one_failure_marks_aggregate_failed(self, tmp_path: Path) -> None:
+        """Any single failure → aggregate fails; first failing spec wins
+        rendering."""
+        from src.integrations.product_smoke import (
+            VerificationSpec,
+            verify_verification_specs,
+        )
+
+        async def _fake_verify_deliverable(
+            start_command: str, readiness_probe: object, cwd: Path, **_: object
+        ) -> ProductSmokeResult:
+            if start_command == "false":
+                return ProductSmokeResult(
+                    success=False,
+                    steps=[
+                        _make_step(
+                            "start_command",
+                            command="false",
+                            success=False,
+                            exit_code=1,
+                            stderr="something broke\n",
+                        )
+                    ],
+                    failure_summary="start_command failed (exit=1)",
+                    blocker_message="...",
+                )
+            return ProductSmokeResult(
+                success=True,
+                steps=[_make_step("start_command", command=start_command)],
+            )
+
+        specs = [
+            VerificationSpec(signal_id="o1", command="true", description="A"),
+            VerificationSpec(signal_id="o2", command="false", description="B"),
+            VerificationSpec(signal_id="o3", command="true", description="C"),
+        ]
+
+        with patch(
+            "src.integrations.product_smoke.verify_deliverable",
+            side_effect=_fake_verify_deliverable,
+        ):
+            result = await verify_verification_specs(specs=specs, cwd=tmp_path)
+
+        assert result.success is False
+        # Every spec is still run — no short-circuit.
+        assert len(result.spec_results) == 3
+        # First failing spec drives the failure summary.
+        assert "o2" in (result.failure_summary or "")
+        assert "B" in (result.failure_summary or "")
+        # Blocker mentions signal_id, description, command, exit_code,
+        # and the stderr tail — Slice B acceptance criterion.
+        assert result.blocker_message is not None
+        blocker = result.blocker_message
+        assert "o2" in blocker
+        assert "B" in blocker  # description
+        assert "false" in blocker  # command
+        assert "Exit code" in blocker
+        assert "something broke" in blocker
+        # Pass/fail summary of all specs
+        assert "[PASS] `o1`" in blocker
+        assert "[FAIL] `o2`" in blocker
+        assert "[PASS] `o3`" in blocker
+
+    @pytest.mark.asyncio
+    async def test_readiness_probe_forwarded(self, tmp_path: Path) -> None:
+        """Per-spec readiness_probe reaches verify_deliverable."""
+        from src.integrations.product_smoke import (
+            VerificationSpec,
+            verify_verification_specs,
+        )
+
+        captured: list[tuple[str, object]] = []
+
+        async def _fake_verify_deliverable(
+            start_command: str, readiness_probe: object, cwd: Path, **_: object
+        ) -> ProductSmokeResult:
+            captured.append((start_command, readiness_probe))
+            return ProductSmokeResult(
+                success=True,
+                steps=[_make_step("start_command", command=start_command)],
+            )
+
+        specs = [
+            VerificationSpec(
+                signal_id="o1",
+                command="npm run dev",
+                readiness_probe="curl -f http://localhost:5173",
+            )
+        ]
+
+        with patch(
+            "src.integrations.product_smoke.verify_deliverable",
+            side_effect=_fake_verify_deliverable,
+        ):
+            await verify_verification_specs(specs=specs, cwd=tmp_path)
+
+        assert captured == [("npm run dev", "curl -f http://localhost:5173")]
+
+    @pytest.mark.asyncio
+    async def test_blocker_falls_back_to_signal_id_when_description_empty(
+        self, tmp_path: Path
+    ) -> None:
+        """Empty description is acceptable; the blocker still names the spec."""
+        from src.integrations.product_smoke import (
+            VerificationSpec,
+            verify_verification_specs,
+        )
+
+        async def _fake_verify_deliverable(
+            start_command: str, readiness_probe: object, cwd: Path, **_: object
+        ) -> ProductSmokeResult:
+            return ProductSmokeResult(
+                success=False,
+                steps=[
+                    _make_step(
+                        "start_command",
+                        command=start_command,
+                        success=False,
+                        exit_code=2,
+                        stderr="oops",
+                    )
+                ],
+                failure_summary="failed",
+                blocker_message="...",
+            )
+
+        specs = [VerificationSpec(signal_id="outcome_only_id", command="false")]
+        with patch(
+            "src.integrations.product_smoke.verify_deliverable",
+            side_effect=_fake_verify_deliverable,
+        ):
+            result = await verify_verification_specs(specs=specs, cwd=tmp_path)
+
+        assert result.success is False
+        assert "outcome_only_id" in (result.failure_summary or "")
+        assert "outcome_only_id" in (result.blocker_message or "")
+
+    @pytest.mark.asyncio
+    async def test_to_dict_serialises_for_telemetry(self, tmp_path: Path) -> None:
+        """``VerificationsResult.to_dict`` returns JSON-ready payload."""
+        from src.integrations.product_smoke import (
+            VerificationSpec,
+            verify_verification_specs,
+        )
+
+        async def _fake_verify_deliverable(
+            start_command: str, readiness_probe: object, cwd: Path, **_: object
+        ) -> ProductSmokeResult:
+            return ProductSmokeResult(
+                success=True,
+                steps=[_make_step("start_command", command=start_command)],
+            )
+
+        specs = [
+            VerificationSpec(
+                signal_id="o1",
+                command="echo hi",
+                description="says hi",
+                readiness_probe="curl -f /",
+            )
+        ]
+        with patch(
+            "src.integrations.product_smoke.verify_deliverable",
+            side_effect=_fake_verify_deliverable,
+        ):
+            result = await verify_verification_specs(specs=specs, cwd=tmp_path)
+
+        payload = result.to_dict()
+        assert payload["success"] is True
+        assert payload["specs"][0]["signal_id"] == "o1"
+        assert payload["specs"][0]["command"] == "echo hi"
+        assert payload["specs"][0]["description"] == "says hi"
+        assert payload["specs"][0]["readiness_probe"] == "curl -f /"
+        # Nested ProductSmokeResult serialised too
+        assert payload["specs"][0]["result"]["success"] is True

--- a/tests/unit/marcus_mcp/test_integration_smoke_gate.py
+++ b/tests/unit/marcus_mcp/test_integration_smoke_gate.py
@@ -668,6 +668,191 @@ class TestVerificationsPath:
         assert captured_specs[1].readiness_probe is None
 
     @pytest.mark.asyncio
+    async def test_coverage_satisfied_runs_specs(self, tmp_path: Path) -> None:
+        """When all required outcomes are covered, the gate runs the runner.
+
+        Coverage check is structural — when every in-scope outcome id
+        has at least one matching ``signal_id`` in the declared list,
+        the gate hands off to ``verify_verification_specs`` as normal.
+        """
+        from src.integrations.product_smoke import VerificationsResult
+
+        task = _make_integration_task()
+        # source_context declares two required outcomes
+        task.source_context = {
+            "in_scope_outcome_ids": ["outcome_play", "outcome_score"]
+        }
+        state = _make_state(task, project_root=str(tmp_path))
+
+        passing = VerificationsResult(success=True, spec_results=[])
+        with patch(
+            "src.integrations.product_smoke.verify_verification_specs",
+            new_callable=AsyncMock,
+            return_value=passing,
+        ) as mock_run:
+            response = await _run_product_smoke_gate(
+                task=task,
+                agent_id="agent-001",
+                state=state,
+                start_command=None,
+                readiness_probe=None,
+                verifications=[
+                    {"signal_id": "outcome_play", "command": "true"},
+                    {"signal_id": "outcome_score", "command": "true"},
+                ],
+            )
+
+        assert response is None
+        mock_run.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_coverage_missing_rejects_before_running_subprocess(
+        self, tmp_path: Path
+    ) -> None:
+        """Missing coverage → rejection BEFORE any subprocess runs.
+
+        Slice B (#523) acceptance criterion: every required in-scope
+        outcome must be matched by a declared ``signal_id``.  The
+        rejection's ``failure_summary`` and ``blocker`` name the
+        missing outcome IDs so the agent fixes their next call rather
+        than guessing.
+        """
+        task = _make_integration_task()
+        task.source_context = {
+            "in_scope_outcome_ids": ["outcome_play", "outcome_score"]
+        }
+        state = _make_state(task, project_root=str(tmp_path))
+
+        with patch(
+            "src.integrations.product_smoke.verify_verification_specs",
+            new_callable=AsyncMock,
+        ) as mock_run:
+            response = await _run_product_smoke_gate(
+                task=task,
+                agent_id="agent-001",
+                state=state,
+                start_command=None,
+                readiness_probe=None,
+                verifications=[
+                    # Only outcome_play covered — outcome_score is missing
+                    {"signal_id": "outcome_play", "command": "true"},
+                ],
+            )
+
+        # Rejected without running any spec.
+        mock_run.assert_not_awaited()
+        assert response is not None
+        assert response["success"] is False
+        assert response["status"] == "smoke_verification_failed"
+        assert response["error"] == "verifications_missing_coverage"
+        assert response["missing_outcome_ids"] == ["outcome_score"]
+        assert set(response["declared_signal_ids"]) == {"outcome_play"}
+        assert "outcome_score" in response["failure_summary"]
+        # Blocker names the missing outcome plus the required + declared
+        # sets so the agent can diff and fix in one pass.
+        blocker = response["blocker"]
+        assert "outcome_score" in blocker
+        assert "outcome_play" in blocker
+        assert "Missing coverage" in blocker
+
+    @pytest.mark.asyncio
+    async def test_all_outcomes_missing_lists_them_all(self, tmp_path: Path) -> None:
+        """Empty ``verifications`` payloads (no signal_ids) → reject all."""
+        task = _make_integration_task()
+        task.source_context = {"in_scope_outcome_ids": ["o1", "o2", "o3"]}
+        state = _make_state(task, project_root=str(tmp_path))
+
+        # Each verification has empty signal_id — none match the required
+        # set, so all three required outcomes are missing.
+        with patch(
+            "src.integrations.product_smoke.verify_verification_specs",
+            new_callable=AsyncMock,
+        ) as mock_run:
+            response = await _run_product_smoke_gate(
+                task=task,
+                agent_id="agent-001",
+                state=state,
+                start_command=None,
+                readiness_probe=None,
+                verifications=[{"signal_id": "", "command": "true"}],
+            )
+
+        mock_run.assert_not_awaited()
+        assert response is not None
+        assert response["missing_outcome_ids"] == ["o1", "o2", "o3"]
+
+    @pytest.mark.asyncio
+    async def test_no_required_outcomes_skips_coverage_check(
+        self, tmp_path: Path
+    ) -> None:
+        """Legacy integration tasks (no source_context) bypass coverage.
+
+        Pre-Slice-B integration tasks were created with
+        ``source_context=None``.  Coverage check must NOT fire on
+        them — they are valid via the legacy contract (any verifications
+        the agent declares are sufficient).
+        """
+        from src.integrations.product_smoke import VerificationsResult
+
+        task = _make_integration_task()
+        assert task.source_context is None  # baseline
+        state = _make_state(task, project_root=str(tmp_path))
+
+        passing = VerificationsResult(success=True, spec_results=[])
+        with patch(
+            "src.integrations.product_smoke.verify_verification_specs",
+            new_callable=AsyncMock,
+            return_value=passing,
+        ) as mock_run:
+            response = await _run_product_smoke_gate(
+                task=task,
+                agent_id="agent-001",
+                state=state,
+                start_command=None,
+                readiness_probe=None,
+                verifications=[
+                    {"signal_id": "arbitrary", "command": "true"},
+                ],
+            )
+
+        assert response is None
+        mock_run.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_empty_required_list_is_satisfied(self, tmp_path: Path) -> None:
+        """``in_scope_outcome_ids=[]`` → no required coverage, run specs.
+
+        Distinguishes "outcomes wired, none in scope" from "outcomes
+        not wired at all."  Both bypass the missing-coverage rejection
+        but the former is the explicit-empty case.
+        """
+        from src.integrations.product_smoke import VerificationsResult
+
+        task = _make_integration_task()
+        task.source_context = {"in_scope_outcome_ids": []}
+        state = _make_state(task, project_root=str(tmp_path))
+
+        passing = VerificationsResult(success=True, spec_results=[])
+        with patch(
+            "src.integrations.product_smoke.verify_verification_specs",
+            new_callable=AsyncMock,
+            return_value=passing,
+        ) as mock_run:
+            response = await _run_product_smoke_gate(
+                task=task,
+                agent_id="agent-001",
+                state=state,
+                start_command=None,
+                readiness_probe=None,
+                verifications=[
+                    {"signal_id": "anything", "command": "true"},
+                ],
+            )
+
+        assert response is None
+        mock_run.assert_awaited_once()
+
+    @pytest.mark.asyncio
     async def test_empty_verifications_falls_through_to_legacy_path(
         self, tmp_path: Path
     ) -> None:

--- a/tests/unit/marcus_mcp/test_integration_smoke_gate.py
+++ b/tests/unit/marcus_mcp/test_integration_smoke_gate.py
@@ -463,3 +463,253 @@ class TestReportTaskProgressIntegration:
 
         assert response["success"] is True
         state.kanban_client.update_task.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Slice B (#523): verifications list path
+# ---------------------------------------------------------------------------
+
+
+class TestVerificationsPath:
+    """``_run_product_smoke_gate`` routes through ``verify_verification_specs``
+    when the agent declared a non-empty ``verifications`` list.
+
+    Backward compat is exercised in ``TestProductSmokeGate`` above: a
+    completion that passes only ``start_command`` (no ``verifications``)
+    continues to use the legacy ``verify_deliverable`` path unchanged.
+    """
+
+    @pytest.mark.asyncio
+    async def test_verifications_takes_precedence_over_start_command(
+        self, tmp_path: Path
+    ) -> None:
+        """When both fields are present, ``verifications`` wins.
+
+        The legacy ``verify_deliverable`` must not run at all when the
+        agent declared ``verifications`` — otherwise we double-run
+        commands and conflate two contracts.
+        """
+        from src.integrations.product_smoke import VerificationsResult
+
+        task = _make_integration_task()
+        state = _make_state(task, project_root=str(tmp_path))
+
+        passing = VerificationsResult(success=True, spec_results=[])
+        with (
+            patch(
+                "src.integrations.product_smoke.verify_verification_specs",
+                new_callable=AsyncMock,
+                return_value=passing,
+            ) as mock_specs,
+            patch(
+                "src.integrations.product_smoke.verify_deliverable",
+                new_callable=AsyncMock,
+            ) as mock_legacy,
+        ):
+            response = await _run_product_smoke_gate(
+                task=task,
+                agent_id="agent-001",
+                state=state,
+                start_command="legacy command that must not run",
+                readiness_probe=None,
+                verifications=[
+                    {
+                        "signal_id": "o1",
+                        "command": "echo ok",
+                        "description": "ok",
+                    }
+                ],
+            )
+
+        assert response is None  # passed → no rejection
+        mock_specs.assert_awaited_once()
+        mock_legacy.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_verifications_pass_returns_none(self, tmp_path: Path) -> None:
+        """All specs pass → gate returns None (completion proceeds)."""
+        from src.integrations.product_smoke import VerificationsResult
+
+        task = _make_integration_task()
+        state = _make_state(task, project_root=str(tmp_path))
+
+        passing = VerificationsResult(success=True, spec_results=[])
+        with patch(
+            "src.integrations.product_smoke.verify_verification_specs",
+            new_callable=AsyncMock,
+            return_value=passing,
+        ):
+            response = await _run_product_smoke_gate(
+                task=task,
+                agent_id="agent-001",
+                state=state,
+                start_command=None,
+                readiness_probe=None,
+                verifications=[
+                    {"signal_id": "o1", "command": "true", "description": ""}
+                ],
+            )
+
+        assert response is None
+
+    @pytest.mark.asyncio
+    async def test_verifications_fail_returns_structured_rejection(
+        self, tmp_path: Path
+    ) -> None:
+        """Any failure → rejection dict carrying the runner's blocker.
+
+        Slice B acceptance criterion: rejection includes the failing
+        signal_id, description, command, exit code, and stderr.  Those
+        all live inside the runner's ``blocker_message`` (verified in
+        product_smoke tests); the gate is responsible for passing it
+        through unchanged.
+        """
+        from src.integrations.product_smoke import VerificationsResult
+
+        task = _make_integration_task()
+        state = _make_state(task, project_root=str(tmp_path))
+
+        failing_blocker = (
+            "## Verification FAILED\n\n"
+            "Failing verification: `outcome_play` — snake renders\n"
+            "Command: `false`\n"
+            "Exit code: 1\n"
+        )
+        failing = VerificationsResult(
+            success=False,
+            spec_results=[],
+            failure_summary="verification 'outcome_play' (snake renders) failed",
+            blocker_message=failing_blocker,
+        )
+        with patch(
+            "src.integrations.product_smoke.verify_verification_specs",
+            new_callable=AsyncMock,
+            return_value=failing,
+        ):
+            response = await _run_product_smoke_gate(
+                task=task,
+                agent_id="agent-001",
+                state=state,
+                start_command=None,
+                readiness_probe=None,
+                verifications=[
+                    {
+                        "signal_id": "outcome_play",
+                        "command": "false",
+                        "description": "snake renders",
+                    }
+                ],
+            )
+
+        assert response is not None
+        assert response["success"] is False
+        assert response["status"] == "smoke_verification_failed"
+        assert response["error"] == "verifications_failed"
+        assert response["blocker"] == failing_blocker
+        assert "outcome_play" in response["failure_summary"]
+
+    @pytest.mark.asyncio
+    async def test_spec_dicts_coerced_to_dataclass(self, tmp_path: Path) -> None:
+        """The gate converts JSON dicts to ``VerificationSpec`` instances.
+
+        Agents send dict-shaped payloads through the MCP boundary
+        (FastMCP JSON-schemas everything as dicts).  The gate is
+        responsible for coercing them into typed ``VerificationSpec``
+        records before handing to the runner.  Verify the conversion
+        preserves all fields including the optional ones.
+        """
+        from src.integrations.product_smoke import (
+            VerificationSpec,
+            VerificationsResult,
+        )
+
+        task = _make_integration_task()
+        state = _make_state(task, project_root=str(tmp_path))
+
+        captured_specs: list[VerificationSpec] = []
+
+        async def _capture(specs, cwd, **_):
+            captured_specs.extend(specs)
+            return VerificationsResult(success=True, spec_results=[])
+
+        with patch(
+            "src.integrations.product_smoke.verify_verification_specs",
+            side_effect=_capture,
+        ):
+            await _run_product_smoke_gate(
+                task=task,
+                agent_id="agent-001",
+                state=state,
+                start_command=None,
+                readiness_probe=None,
+                verifications=[
+                    {
+                        "signal_id": "outcome_render",
+                        "command": "npm run dev",
+                        "description": "renders snake",
+                        "readiness_probe": "curl -f http://localhost:5173",
+                    },
+                    {
+                        "signal_id": "outcome_score",
+                        "command": "curl -fs http://localhost:8765/score",
+                    },
+                ],
+            )
+
+        assert len(captured_specs) == 2
+        assert isinstance(captured_specs[0], VerificationSpec)
+        assert captured_specs[0].signal_id == "outcome_render"
+        assert captured_specs[0].command == "npm run dev"
+        assert captured_specs[0].description == "renders snake"
+        assert captured_specs[0].readiness_probe == "curl -f http://localhost:5173"
+        # Second spec exercises the all-defaults path
+        assert captured_specs[1].signal_id == "outcome_score"
+        assert captured_specs[1].description == ""
+        assert captured_specs[1].readiness_probe is None
+
+    @pytest.mark.asyncio
+    async def test_empty_verifications_falls_through_to_legacy_path(
+        self, tmp_path: Path
+    ) -> None:
+        """``verifications=[]`` is treated as absent — legacy path runs.
+
+        Distinguishes "agent explicitly opted out of new path" from
+        "agent provided a non-empty list."  Empty list = no specs
+        declared = legacy start_command path runs with its usual
+        missing-declaration rejection if start_command is also absent.
+        """
+        from src.integrations.product_smoke import ProductSmokeResult
+
+        task = _make_integration_task()
+        state = _make_state(task, project_root=str(tmp_path))
+
+        passing_legacy = ProductSmokeResult(
+            success=True,
+            steps=[
+                VerificationStep(
+                    name="start_command",
+                    command="npm run build",
+                    exit_code=0,
+                    stdout="",
+                    stderr="",
+                    duration_seconds=1.0,
+                    success=True,
+                )
+            ],
+        )
+        with patch(
+            "src.integrations.product_smoke.verify_deliverable",
+            new_callable=AsyncMock,
+            return_value=passing_legacy,
+        ) as mock_legacy:
+            response = await _run_product_smoke_gate(
+                task=task,
+                agent_id="agent-001",
+                state=state,
+                start_command="npm run build",
+                readiness_probe=None,
+                verifications=[],
+            )
+
+        assert response is None
+        mock_legacy.assert_awaited_once()

--- a/tests/unit/marcus_mcp/test_integration_smoke_gate.py
+++ b/tests/unit/marcus_mcp/test_integration_smoke_gate.py
@@ -898,3 +898,241 @@ class TestVerificationsPath:
 
         assert response is None
         mock_legacy.assert_awaited_once()
+
+
+class TestVerificationsRequiredWhenOutcomesDeclared:
+    """Escape-hatch closure (Kaia review on PR #525).
+
+    When the integration task carries declared in-scope outcomes on
+    ``source_context["in_scope_outcome_ids"]``, the agent MUST use
+    the new ``verifications`` path.  ``verifications=None`` or ``[]``
+    plus a legacy ``start_command`` previously slipped through and
+    bypassed the coverage check — the exact failure mode Slice B
+    targets.  The escape-hatch check fires BEFORE either branch
+    decision so neither the verifications runner nor the legacy
+    ``verify_deliverable`` executes.
+
+    Tasks that have NO declared outcomes (``source_context is None``
+    or ``in_scope_outcome_ids`` empty/missing/malformed) are unaffected
+    — backward compat preserved.
+    """
+
+    @pytest.mark.asyncio
+    async def test_outcomes_declared_no_verifications_rejects(
+        self, tmp_path: Path
+    ) -> None:
+        """Outcomes on task + ``verifications=None`` → rejection BEFORE legacy.
+
+        The snake-game class of failure: agent declares
+        ``start_command="python -m src.main"`` (exits 0) without
+        ``verifications``.  Pre-fix this slipped through.  Now rejected.
+        """
+        task = _make_integration_task()
+        task.source_context = {
+            "in_scope_outcome_ids": ["outcome_play", "outcome_score"]
+        }
+        state = _make_state(task, project_root=str(tmp_path))
+
+        with (
+            patch(
+                "src.integrations.product_smoke.verify_verification_specs",
+                new_callable=AsyncMock,
+            ) as mock_specs,
+            patch(
+                "src.integrations.product_smoke.verify_deliverable",
+                new_callable=AsyncMock,
+            ) as mock_legacy,
+        ):
+            response = await _run_product_smoke_gate(
+                task=task,
+                agent_id="agent-001",
+                state=state,
+                start_command="python -m src.main",
+                readiness_probe=None,
+                verifications=None,
+            )
+
+        # Neither path ran — escape hatch closed BEFORE branch decision.
+        mock_specs.assert_not_awaited()
+        mock_legacy.assert_not_awaited()
+        assert response is not None
+        assert response["success"] is False
+        assert response["status"] == "smoke_verification_failed"
+        assert response["error"] == "verifications_required_but_missing"
+        assert response["missing_outcome_ids"] == ["outcome_play", "outcome_score"]
+        assert response["required_outcome_ids"] == ["outcome_play", "outcome_score"]
+        assert response["declared_signal_ids"] == []
+        # Blocker names the outcomes so the agent knows what to add.
+        assert "outcome_play" in response["blocker"]
+        assert "outcome_score" in response["blocker"]
+
+    @pytest.mark.asyncio
+    async def test_outcomes_declared_empty_verifications_rejects(
+        self, tmp_path: Path
+    ) -> None:
+        """``verifications=[]`` is treated the same as ``None`` for the check.
+
+        Both falsy; both bypass the verifications branch.  The
+        escape-hatch check fires above the branch decision and
+        catches them uniformly.
+        """
+        task = _make_integration_task()
+        task.source_context = {"in_scope_outcome_ids": ["outcome_play"]}
+        state = _make_state(task, project_root=str(tmp_path))
+
+        with (
+            patch(
+                "src.integrations.product_smoke.verify_verification_specs",
+                new_callable=AsyncMock,
+            ) as mock_specs,
+            patch(
+                "src.integrations.product_smoke.verify_deliverable",
+                new_callable=AsyncMock,
+            ) as mock_legacy,
+        ):
+            response = await _run_product_smoke_gate(
+                task=task,
+                agent_id="agent-001",
+                state=state,
+                start_command="npm run build",
+                readiness_probe=None,
+                verifications=[],
+            )
+
+        mock_specs.assert_not_awaited()
+        mock_legacy.assert_not_awaited()
+        assert response is not None
+        assert response["error"] == "verifications_required_but_missing"
+
+    @pytest.mark.asyncio
+    async def test_outcomes_declared_with_verifications_proceeds(
+        self, tmp_path: Path
+    ) -> None:
+        """Outcomes + matching verifications → normal flow runs.
+
+        Sanity check that the escape-hatch closure does not
+        accidentally block the happy path.
+        """
+        from src.integrations.product_smoke import VerificationsResult
+
+        task = _make_integration_task()
+        task.source_context = {"in_scope_outcome_ids": ["outcome_play"]}
+        state = _make_state(task, project_root=str(tmp_path))
+
+        passing = VerificationsResult(success=True, spec_results=[])
+        with patch(
+            "src.integrations.product_smoke.verify_verification_specs",
+            new_callable=AsyncMock,
+            return_value=passing,
+        ) as mock_specs:
+            response = await _run_product_smoke_gate(
+                task=task,
+                agent_id="agent-001",
+                state=state,
+                start_command=None,
+                readiness_probe=None,
+                verifications=[{"signal_id": "outcome_play", "command": "true"}],
+            )
+
+        assert response is None
+        mock_specs.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_legacy_task_without_outcomes_bypasses_check(
+        self, tmp_path: Path
+    ) -> None:
+        """``source_context=None`` → escape-hatch check does not fire.
+
+        Backward compat: pre-Slice-B integration tasks were created
+        without outcomes.  They must continue to work with the
+        legacy ``start_command`` contract.
+        """
+        from src.integrations.product_smoke import ProductSmokeResult
+
+        task = _make_integration_task()
+        assert task.source_context is None
+        state = _make_state(task, project_root=str(tmp_path))
+
+        passing = ProductSmokeResult(
+            success=True,
+            steps=[
+                VerificationStep(
+                    name="start_command",
+                    command="npm run build",
+                    exit_code=0,
+                    stdout="",
+                    stderr="",
+                    duration_seconds=1.0,
+                    success=True,
+                )
+            ],
+        )
+        with patch(
+            "src.integrations.product_smoke.verify_deliverable",
+            new_callable=AsyncMock,
+            return_value=passing,
+        ) as mock_legacy:
+            response = await _run_product_smoke_gate(
+                task=task,
+                agent_id="agent-001",
+                state=state,
+                start_command="npm run build",
+                readiness_probe=None,
+                verifications=None,
+            )
+
+        assert response is None
+        mock_legacy.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_malformed_source_context_treated_as_absent(
+        self, tmp_path: Path
+    ) -> None:
+        """Non-list ``in_scope_outcome_ids`` is treated as missing.
+
+        Defensive ``isinstance`` guard: kanban providers that
+        rehydrate ``source_context`` from JSON could in theory return
+        a string here.  ``list("outcome_play")`` would silently
+        iterate characters and corrupt the required set.  Instead
+        we treat malformed values as "wiring absent" and let the
+        legacy path run.
+        """
+        from src.integrations.product_smoke import ProductSmokeResult
+
+        task = _make_integration_task()
+        # Malformed: string instead of list.
+        task.source_context = {"in_scope_outcome_ids": "outcome_play"}
+        state = _make_state(task, project_root=str(tmp_path))
+
+        passing = ProductSmokeResult(
+            success=True,
+            steps=[
+                VerificationStep(
+                    name="start_command",
+                    command="npm run build",
+                    exit_code=0,
+                    stdout="",
+                    stderr="",
+                    duration_seconds=1.0,
+                    success=True,
+                )
+            ],
+        )
+        with patch(
+            "src.integrations.product_smoke.verify_deliverable",
+            new_callable=AsyncMock,
+            return_value=passing,
+        ) as mock_legacy:
+            response = await _run_product_smoke_gate(
+                task=task,
+                agent_id="agent-001",
+                state=state,
+                start_command="npm run build",
+                readiness_probe=None,
+                verifications=None,
+            )
+
+        # Escape-hatch did not fire (string treated as absent).
+        # Legacy path ran successfully.
+        assert response is None
+        mock_legacy.assert_awaited_once()


### PR DESCRIPTION
## Why

Marcus is a system that coordinates AI agents building software from a one-sentence project description. When the agents say "we're done," Marcus runs a final check called the **smoke gate** to verify the deliverable actually starts and works — agents can mark tasks complete from self-report alone, so Marcus needs a machine-level second opinion.

Today the smoke gate only verifies that one agent-declared shell command (`start_command`) exits successfully. That catches "the app crashes on boot," but it does not catch "the app boots but doesn't do what the user asked for." Concrete reproduction (2026-05-11): a user asked for *"a visual snake game,"* and Marcus shipped a project whose `start_command` (`python -m src.main`, a CLI smoke runner) exits 0 — but there is no playable game, the React UI is unwired, and the README admits it.

[Issue #523](https://github.com/lwgray/marcus/issues/523) named this gap and proposed a single-primitive fix: agents declare one **verification command per user outcome**, Marcus runs each as a subprocess, and rejects the completion if any fails or if any outcome lacks a matching verification.

This PR ships **Slice B** of #523 — the runtime layer. Slice A (PR #524) shipped the static layer (the outcome's `success_signal` text in `acceptance_criteria` so the existing `WorkAnalyzer` reads it).

## What changed

Four small commits, each landing one independent piece. Read them in order — each is comprehensible on its own.

### 1. `387e6ca4` — Foundation: `VerificationSpec` + multi-spec runner

`src/integrations/product_smoke.py` gains two new dataclasses and one new async function:

- **`VerificationSpec`** — a `signal_id` (the `UserOutcome.id` this command verifies), a `command` (any shell command), an optional `description` (audit label), and an optional `readiness_probe` (server-mode probe). Single-primitive design: Marcus does NOT enumerate verification families (curl, Playwright, pytest, etc.). The agent picks tooling; Marcus only knows how to run shell commands.
- **`VerificationsResult`** — aggregate result for a list of specs. Carries per-spec pass/fail, the first failing spec's blocker, and a `to_dict()` method for telemetry.
- **`verify_verification_specs(specs, cwd)`** — loops over specs, calling the existing `verify_deliverable` for each. Does NOT short-circuit on failure so operators see the full diagnostic in one run.

### 2. `009095c6` — Smoke gate + MCP surface accept `verifications`

`report_task_progress` (both the impl in `src/marcus_mcp/tools/task.py` and the FastMCP wrappers in `src/marcus_mcp/server.py`) gains a `verifications: Optional[List[Dict[str, Any]]]` parameter. The smoke gate routes through `verify_verification_specs` when the list is non-empty; otherwise the legacy single-`start_command` path runs unchanged.

**Precedence rules:**
- Non-empty `verifications` → multi-spec runner. `start_command` is ignored.
- `verifications` absent or empty list → legacy `verify_deliverable` runs.
- Both absent on an integration task → same missing-declaration rejection as before.

Backward compatible: agents that don't pass `verifications` see identical behavior. The MCP tool exposes the new field so external clients can opt in.

### 3. `228ca479` — Integration task accepts outcomes

`IntegrationTaskGenerator.create_integration_task` (in `src/integrations/integration_verification.py`) accepts an optional `outcomes: List[UserOutcome]` parameter. When provided:

- Filters to in-scope outcomes (out-of-scope outcomes are retained by the extractor for audit only).
- Stores in-scope IDs on `Task.source_context["in_scope_outcome_ids"]` so the smoke gate can read them at completion.
- Appends a *"Verifications required"* section to the description listing each outcome's `id`, `action`, and `success_signal`, with a worked `report_task_progress` example showing the `verifications` payload shape.

`enhance_project_with_integration` accepts and forwards `outcomes`. The contract-first call site in `src/integrations/nlp_tools.py` stashes `prd_analysis.user_outcomes` alongside the existing `_contract_first_requirements` stash and forwards it through.

Feature-based decomposer wiring is deferred to a follow-up; the snake-game class of failure ships via the default `contract_first` decomposer, so wiring the default path closes the original failure case.

### 4. `c9a7f4ef` — Smoke gate rejects on missing coverage

The smoke gate's verifications branch now reads `task.source_context["in_scope_outcome_ids"]` and rejects completion if any required outcome has no matching `VerificationSpec.signal_id`. The check fires **before** any subprocess runs — an agent who forgot a signal_id gets immediate, structural feedback without paying verify-deliverable latency.

**Rejection shape grows** `error="verifications_missing_coverage"` plus three diagnostic fields:
- `missing_outcome_ids` — the subset with no covering spec (the fix target)
- `required_outcome_ids` — the full set the task carries
- `declared_signal_ids` — what the agent had provided (sorted)

The blocker lists all three so the agent can diff and fix in one pass.

**Coverage rule does not fire when** `source_context` is `None` (legacy tasks — backward compat preserved) or `in_scope_outcome_ids` is empty (trivially satisfied).

## Where to look in the code first

| File | Purpose |
|---|---|
| `src/integrations/product_smoke.py` | `VerificationSpec` dataclass + `verify_verification_specs` runner |
| `src/marcus_mcp/tools/task.py` | `_run_product_smoke_gate` (verifications branch + coverage check) and `report_task_progress` (new param) |
| `src/marcus_mcp/server.py` | FastMCP wrappers exposing the `verifications` parameter |
| `src/integrations/integration_verification.py` | `IntegrationTaskGenerator.create_integration_task` accepts outcomes; description grows "Verifications required" section |
| `src/integrations/nlp_tools.py` | Contract-first call site stashes outcomes alongside requirements |
| `src/ai/advanced/prd/outcome_extractor.py` | Unchanged — where `UserOutcome` and `success_signal` live |

## Glossary

| Term | Meaning |
|---|---|
| **kanban board** | The shared task list Marcus uses to coordinate agents. Each task is a card. |
| **integration task** | The final task created for every project. Its job is to inspect the deliverable, run it, and fix anything broken before marking the project complete. Carries the `type:integration` label. |
| **smoke gate** | Marcus's independent subprocess check that runs after the integration agent reports completion. Verifies the agent's self-report against actual subprocess behavior. |
| **`start_command`** | Legacy single-command field on `report_task_progress`. Marcus runs it as a subprocess and rejects completion if it exits non-zero. |
| **`VerificationSpec`** | New per-outcome verification declaration. `signal_id`, `command`, optional `description`, optional `readiness_probe`. |
| **success_signal** | A short text description of observable evidence a user outcome is satisfied (e.g., *"snake visibly moves on a board"*). From `outcome_extractor.py`. |
| **coverage check** | Slice B's new structural rule: every in-scope outcome must have at least one matching `VerificationSpec` at completion time. Catches missing entries before any subprocess runs. |

## Test plan

- [x] `tests/unit/integrations/test_product_smoke.py` — 8 new tests for `VerificationSpec` and `verify_verification_specs` (dataclass fields, empty-input rejection, all-pass aggregation, mixed-result failure, readiness_probe forwarding, signal_id fallback, `to_dict` serialization).
- [x] `tests/unit/marcus_mcp/test_integration_smoke_gate.py` — 10 new tests for the smoke-gate routing and coverage check (precedence over `start_command`, passthrough on success, structured rejection on failure, dict-to-dataclass coercion, empty-list fallthrough; coverage satisfied, missing coverage rejection before subprocess, all-missing case, legacy `source_context=None` bypass, empty `in_scope_outcome_ids` trivial pass).
- [x] `tests/unit/integrations/test_integration_verification.py` — 7 new tests for outcomes wiring (`in_scope_outcome_ids` on `source_context`, out-of-scope filtering, description growth, `outcomes=None` legacy shape, empty list vs None, all-out-of-scope, `enhance_project_with_integration` forwarding).
- [x] **Full unit suite: 3593 passed, 61 skipped, 0 failed** locally on `python -m pytest tests/unit -q`. Existing tests pass unchanged — backward compatibility verified.

### How to verify after merging

1. Run the snake-game spec (`/marcus "build a visual appealing snake game with basic features"`) with `MARCUS_OUTCOME_COVERAGE=true` (default on `v0.3.6.post1+`).
2. Inspect the integration task on the kanban board. It should carry a *"Verifications required"* section in its description listing each in-scope outcome with `id`, `action`, and `success_signal`, plus `in_scope_outcome_ids` on `source_context`.
3. When the integration agent reports completion, watch the smoke-gate log lines:
   - If the agent's `verifications` covers every required outcome and each subprocess exits 0, completion is accepted.
   - If any outcome is missing a `signal_id` in the declared list, the completion is rejected with `error="verifications_missing_coverage"` and the blocker names the missing IDs.
   - If a declared verification subprocess fails, the completion is rejected with `error="verifications_failed"` and the blocker names the failing spec's `signal_id`, `description`, `command`, exit code, and stderr.

## What this does NOT do (out of scope for this PR)

- **Feature-based decomposer wiring.** The contract-first path is wired; the feature-based fallback path still calls `enhance_project_with_integration` without outcomes. Follow-up issue will add equivalent stashing.
- **`success_signal` as a per-implementation-task acceptance criterion.** That's Slice A (already shipped in PR #524).
- **Forcing every project to use `verifications`.** Legacy `start_command` is still a valid declaration. The coverage requirement only activates when the integration task was created with outcomes.

## Related

- Implements Slice B of #523.
- Builds on PR #524 (Slice A, merged).
- Builds on #449 (closed; outcome extraction) and #463 (closed; composition task).
- Orthogonal: #500 (pre-fork human review).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
