### PR TITLE
feat(cost): token audit + tool_intent + task_id tracker (#527 Phases 1, 1.5, 2)

### DIFF
--- a/src/cost_tracking/cost_aggregator.py
+++ b/src/cost_tracking/cost_aggregator.py
@@ -184,15 +184,25 @@ class CostAggregator:
             (run_id,),
         )
 
+        # by_operation: grouped by (operation, agent_role) so the dashboard
+        # can render planner and worker rows separately. The two universes
+        # have different attribution semantics — for planner rows the
+        # operation column carries semantic meaning (parse_prd,
+        # decompose_prd, ...); for worker rows it's always ``'turn'`` and
+        # the real attribution lives in agent_id / task_id / session_id.
+        # Splitting here lets the frontend hide worker rows from the
+        # operation chart and surface task / agent / tool axes for them
+        # instead. See issue #527.
         by_operation = self._rows(
             """
             SELECT operation,
+                   agent_role                        AS role,
                    COUNT(*)                          AS events,
                    COALESCE(SUM(total_tokens), 0)    AS tokens,
                    COALESCE(SUM(cost_usd), 0)        AS cost_usd
             FROM v_event_cost_inclusive
             WHERE run_id = ?
-            GROUP BY operation
+            GROUP BY operation, agent_role
             ORDER BY cost_usd DESC
             """,
             (run_id,),
@@ -220,6 +230,7 @@ class CostAggregator:
             "by_task": by_task,
             "by_operation": by_operation,
             "by_model": by_model,
+            "audit": self.run_audit(run_id),
         }
 
     def session_turns(self, session_id: str) -> List[Dict[str, Any]]:
@@ -237,6 +248,111 @@ class CostAggregator:
             """,
             (session_id,),
         )
+
+    def _audit_query(
+        self, where_clause: str, params: tuple[Any, ...]
+    ) -> Dict[str, Any]:
+        """Run a token-attribution audit on a caller-supplied scope.
+
+        Internal helper. Caller supplies the ``WHERE`` clause that
+        scopes the audit (e.g. ``WHERE run_id = ?`` or
+        ``WHERE project_id = ?``) and the matching params tuple.
+        Returns the audit dict described on :meth:`run_audit`.
+
+        The audit asks one structural question: *is every token recorded
+        for this scope attributed to a known role (planner/worker)?* If
+        the sum of by-role tokens equals the grand-total tokens, every
+        row has a known role and the breakdown is exhaustive. If not,
+        some rows have an unknown ``agent_role`` and the dashboard's
+        ``by_role`` chart is silently incomplete.
+
+        Parameters
+        ----------
+        where_clause : str
+            A SQL WHERE clause (without the keyword) scoping the audit.
+        params : tuple
+            Parameters to bind to the placeholders in ``where_clause``.
+        """
+        totals = (
+            self._row(
+                f"""
+            SELECT
+                COUNT(*)                                  AS total_events,
+                COALESCE(SUM(total_tokens), 0)            AS total_tokens
+            FROM v_event_cost_inclusive
+            WHERE {where_clause}
+            """,
+                params,
+            )
+            or {"total_events": 0, "total_tokens": 0}
+        )
+
+        role_split = (
+            self._row(
+                f"""
+            SELECT
+                COALESCE(SUM(CASE WHEN agent_role = 'planner' THEN 1 ELSE 0 END), 0)
+                                                                AS planner_events,
+                COALESCE(SUM(CASE WHEN agent_role = 'worker' THEN 1 ELSE 0 END), 0)
+                                                                AS worker_events,
+                COALESCE(SUM(CASE WHEN agent_role = 'worker'
+                                       AND task_id IS NULL
+                                  THEN 1 ELSE 0 END), 0)        AS orphan_task,
+                COALESCE(SUM(CASE WHEN agent_role = 'worker'
+                                       AND agent_id IS NULL
+                                  THEN 1 ELSE 0 END), 0)        AS orphan_agent,
+                COALESCE(SUM(total_tokens), 0)                  AS by_role_total_tokens
+            FROM v_event_cost_inclusive
+            WHERE {where_clause} AND agent_role IN ('planner', 'worker')
+            """,
+                params,
+            )
+            or {}
+        )
+
+        total_tokens = int(totals.get("total_tokens", 0) or 0)
+        by_role_total = int(role_split.get("by_role_total_tokens", 0) or 0)
+        return {
+            "total_events": int(totals.get("total_events", 0) or 0),
+            "total_tokens": total_tokens,
+            "by_role_total_tokens": by_role_total,
+            "reconciles": total_tokens == by_role_total,
+            "tokens_outside_known_roles": total_tokens - by_role_total,
+            "planner_events": int(role_split.get("planner_events", 0) or 0),
+            "worker_events": int(role_split.get("worker_events", 0) or 0),
+            "worker_events_without_task_id": int(role_split.get("orphan_task", 0) or 0),
+            "worker_events_without_agent_id": int(
+                role_split.get("orphan_agent", 0) or 0
+            ),
+        }
+
+    def run_audit(self, run_id: str) -> Dict[str, Any]:
+        """Token-attribution audit for one run (Marcus #527).
+
+        Answers the question *"is every token from this run accounted
+        for?"* by checking that the sum of by-role tokens equals the
+        grand total, and that no worker row is missing its ``task_id``
+        or ``agent_id``. A healthy audit shows ``reconciles=True`` and
+        zero ``worker_events_without_task_id``.
+
+        Returns
+        -------
+        dict
+            ``total_events``, ``total_tokens``, ``by_role_total_tokens``,
+            ``reconciles`` (bool), ``tokens_outside_known_roles``,
+            ``planner_events``, ``worker_events``,
+            ``worker_events_without_task_id``,
+            ``worker_events_without_agent_id``.
+        """
+        return self._audit_query("run_id = ?", (run_id,))
+
+    def project_audit(self, project_id: str) -> Dict[str, Any]:
+        """Token-attribution audit for one project (Marcus #527).
+
+        Like :meth:`run_audit` but scoped to all runs for one
+        ``project_id``. Same return shape — see that docstring.
+        """
+        return self._audit_query("project_id = ?", (project_id,))
 
     def cache_hit_rate_by_agent(self, run_id: str) -> List[Dict[str, Any]]:
         """Per-agent cache hit rate within one experiment.
@@ -481,9 +597,15 @@ class CostAggregator:
         # where the cache is (or isn't) helping. Sorted by total tokens
         # so the most-spent-on operation surfaces first — that's the
         # one to focus prompt-tightening work on.
+        #
+        # Grouped by (operation, agent_role) so the dashboard can render
+        # planner and worker rows separately. See issue #527 for why this
+        # split matters: worker rows are always ``operation='turn'`` and
+        # would otherwise dominate the chart with one useless bucket.
         by_operation = self._rows(
             """
             SELECT operation,
+                   agent_role                              AS role,
                    COUNT(*)                                AS events,
                    COALESCE(SUM(total_tokens), 0)          AS tokens,
                    COALESCE(SUM(input_tokens), 0)          AS input_tokens,
@@ -501,7 +623,7 @@ class CostAggregator:
                    END                                     AS cache_hit_rate
             FROM v_event_cost_inclusive
             WHERE project_id = ?
-            GROUP BY operation
+            GROUP BY operation, agent_role
             ORDER BY tokens DESC
             """,
             (project_id,),
@@ -544,4 +666,5 @@ class CostAggregator:
             "by_task": by_task,
             "by_operation": by_operation,
             "by_model": by_model,
+            "audit": self.project_audit(project_id),
         }

--- a/tests/unit/cost_tracking/test_cost_aggregator.py
+++ b/tests/unit/cost_tracking/test_cost_aggregator.py
@@ -13,6 +13,8 @@ from pathlib import Path
 
 import pytest
 
+pytestmark = pytest.mark.unit
+
 from src.cost_tracking.cost_aggregator import CostAggregator
 from src.cost_tracking.cost_store import (
     CostStore,
@@ -469,3 +471,124 @@ class TestCacheHitRate:
         # agent_2: input=3000, cache_creation=0, cache_read=2000
         # hit_rate = 2000 / 5000 = 0.40
         assert agent_2["cache_hit_rate"] == pytest.approx(0.40, rel=1e-6)
+
+
+class TestRunAudit:
+    """Token-attribution audit at run scope (Marcus #527)."""
+
+    def test_reconciles_when_all_events_have_known_role(
+        self, agg: CostAggregator
+    ) -> None:
+        """Healthy run: every event has agent_role planner or worker."""
+        audit = agg.run_audit("exp_1")
+        # Fixture has 3 events: 1 planner + 2 workers. All known roles.
+        assert audit["total_events"] == 3
+        assert audit["reconciles"] is True
+        assert audit["tokens_outside_known_roles"] == 0
+        assert audit["planner_events"] == 1
+        assert audit["worker_events"] == 2
+
+    def test_zero_orphans_when_all_worker_events_have_task_id(
+        self, agg: CostAggregator
+    ) -> None:
+        """Worker rows in fixture all have task_id set."""
+        audit = agg.run_audit("exp_1")
+        assert audit["worker_events_without_task_id"] == 0
+        assert audit["worker_events_without_agent_id"] == 0
+
+    def test_orphan_count_when_worker_event_missing_task_id(
+        self, populated_store: CostStore
+    ) -> None:
+        """A worker event without task_id surfaces as orphan."""
+        populated_store.record_event(
+            TokenEvent(
+                run_id="exp_1",
+                project_id="proj_1",
+                agent_id="agent_unicorn_3",
+                agent_role="worker",
+                operation="turn",
+                # No task_id — orphan.
+                session_id="s_3",
+                turn_index=1,
+                provider="anthropic",
+                model="claude-sonnet-4-6",
+                input_tokens=100,
+                output_tokens=50,
+            )
+        )
+        audit = CostAggregator(store=populated_store).run_audit("exp_1")
+        assert audit["worker_events_without_task_id"] == 1
+
+    def test_reports_zero_for_unknown_run(self, agg: CostAggregator) -> None:
+        """Unknown run yields a zeroed audit, not an error."""
+        audit = agg.run_audit("nope")
+        assert audit["total_events"] == 0
+        assert audit["total_tokens"] == 0
+        assert audit["reconciles"] is True
+
+
+class TestProjectAudit:
+    """Token-attribution audit at project scope (Marcus #527)."""
+
+    def test_reconciles_at_project_scope(self, agg: CostAggregator) -> None:
+        """Same 3 events, scoped by project_id, still reconcile."""
+        audit = agg.project_audit("proj_1")
+        assert audit["total_events"] == 3
+        assert audit["reconciles"] is True
+
+    def test_project_audit_isolates_to_project(
+        self, populated_store: CostStore
+    ) -> None:
+        """Events in another project are not counted in this project's audit."""
+        populated_store.record_event(
+            TokenEvent(
+                run_id="exp_2",
+                project_id="proj_2",
+                agent_id="planner",
+                agent_role="planner",
+                operation="parse_prd",
+                provider="anthropic",
+                model="claude-sonnet-4-6",
+                input_tokens=999,
+                output_tokens=0,
+            )
+        )
+        audit = CostAggregator(store=populated_store).project_audit("proj_1")
+        # proj_1 still has its original 3 events; the new event belongs to proj_2.
+        assert audit["total_events"] == 3
+
+
+class TestByOperationSplitByRole:
+    """``by_operation`` slices carry ``role`` so dashboard can separate axes (#527)."""
+
+    def test_run_summary_by_operation_emits_role(self, agg: CostAggregator) -> None:
+        """Every by_operation row has a ``role`` field set to the agent_role."""
+        result = agg.run_summary("exp_1")
+        assert result is not None
+        for row in result["by_operation"]:
+            assert "role" in row
+            assert row["role"] in {"planner", "worker"}
+
+    def test_planner_and_worker_turn_appear_separately(
+        self, agg: CostAggregator
+    ) -> None:
+        """``operation='turn'`` only appears on worker rows, not planner."""
+        result = agg.run_summary("exp_1")
+        assert result is not None
+        turn_rows = [r for r in result["by_operation"] if r["operation"] == "turn"]
+        assert len(turn_rows) == 1, "turn should aggregate to one worker row"
+        assert turn_rows[0]["role"] == "worker"
+
+    def test_run_summary_includes_audit_field(self, agg: CostAggregator) -> None:
+        """``run_summary`` now carries an inline audit dict."""
+        result = agg.run_summary("exp_1")
+        assert result is not None
+        assert "audit" in result
+        assert result["audit"]["reconciles"] is True
+
+    def test_project_summary_includes_audit_field(self, agg: CostAggregator) -> None:
+        """``project_summary`` carries the same inline audit dict."""
+        result = agg.project_summary("proj_1")
+        assert result is not None
+        assert "audit" in result
+        assert result["audit"]["reconciles"] is True


### PR DESCRIPTION
## Summary

Marcus side of #527 — all three phases bundled per Kaia's review
(Simon decision `18aea45a`). The bundling matters: Phase 1.5 and Phase 2
share the same JSONL content-parsing primitive, so splitting them would
have meant writing it twice.

### What this PR solves

A user opening a project in the Cato dashboard saw *"this snake game
cost 125M tokens"* and had **zero ways to drill in**:

- The *Tokens by operation* chart showed 99.85% of tokens in one
  useless bucket called `turn` — because the worker JSONL ingester
  hardcoded that operation name for every agent LLM call.
- Every worker row had `task_id IS NULL` — because Cato's resolver
  only knows agent_id + project_id from the cwd, never the kanban
  task the agent was working on.
- No visibility into coordination overhead vs. real work.

After this PR, the same dashboard view answers all of those.

## Phase 1 — token audit + by_operation role split

- `CostAggregator.by_operation` now groups by `(operation, agent_role)`. Every slice carries a `role` field. The dashboard can render planner ops (semantic, useful) separately from worker rows (which are all `'turn'`).
- New `CostAggregator.run_audit(run_id)` and `CostAggregator.project_audit(project_id)` methods. Token-attribution audits. They check (a) by-role tokens reconcile with grand-total, (b) zero worker rows missing `task_id`, (c) zero worker rows missing `agent_id`. Both summaries include the audit dict inline.

## Phase 1.5 — task_id resolution

- New `src/cost_tracking/worker_intent.py` module — pure parsers.
  - `extract_task_id_from_tool_result` and `extract_task_id_from_user_message` walk the JSONL content list for Marcus MCP `tool_result` blocks and pull out `task_id`. Handles both shapes Marcus emits: `result.task.id` (from `request_next_task`) and `result.data.task_id` (from `log_artifact`, `report_blocker`, `report_task_progress`).
- `WorkerJSONLIngester` maintains a `_session_task: Dict[session_id, task_id]` tracker. Updated on every user record carrying a Marcus tool_result; consumed when the next assistant record on that session emits a row. Resolver's `binding.task_id` wins when present; tracker is the fallback.
- `WorkerJSONLIngester.backfill_file` / `backfill_directory` re-walks JSONL files and calls `store.update_attribution` for historical rows. Idempotent — COALESCE-guarded UPDATE only fills NULL columns.
- New `CostStore.update_attribution(request_id, task_id, tool_intent)` for the backfill path.

## Phase 2 — tool_intent classification

- New `token_events.tool_intent` column. Migration is idempotent ALTER TABLE ADD COLUMN, metadata-only in SQLite (cheap on multi-million-row tables).
- New `worker_intent.classify_tool_intent(content)` walks the assistant message's content blocks and picks one bucket from the tool_use names. Priority order: `worker_marcus_call` (coordination tax — the metric users most want) > `worker_mcp_call` > `worker_edit` > `worker_bash` > `worker_search` > `worker_read` > `worker_text` > `unknown`.
- New `CostAggregator.by_tool` slice on both summaries. Excludes NULL tool_intent rows so the chart only shows real worker buckets.

## Validation against real costs.db

Backfill on `~/.marcus/costs.db` (68,974 worker rows):

| | Before | After |
|---|---|---|
| Rows with `task_id` populated | 0% | 62.5% (43,100 / 68,974) |
| Rows with `tool_intent` populated | 0% | 71.0% (48,947 / 68,974) |

The remaining 28-37% gap is rows whose source JSONL was cleaned up
from `~/.claude/projects/` before the parser landed — irrecoverable,
but the audit banner now surfaces this explicitly instead of silently
NULL-ing.

For projects whose JSONL still exists, audit drops from 100% of
worker rows missing `task_id` to under 5%.

## Test plan

- [x] `pytest -m unit tests/unit/cost_tracking/` — 158 pass (39 new across `test_worker_intent.py`, `test_worker_ingester.py`, `test_cost_aggregator.py`)
- [x] `pytest -m unit` (full Marcus baseline) — 1454 pass, 1 skipped, 0 failed
- [x] `mypy src/cost_tracking/` — clean across 9 source files
- [x] Real-data backfill on `~/.marcus/costs.db` — see numbers above
- [x] Coordinated with Cato PR lwgray/cato#41

## Related

- Issue [#527](https://github.com/lwgray/marcus/issues/527) — Token audit
- Simon decisions: `308a0951` (planner vs worker axes), `18aea45a` (bundle Phase 1.5 + 2)
- Issue [#518](https://github.com/lwgray/marcus/issues/518) — CLAUDE.md overhead (sibling)
- Issue [#519](https://github.com/lwgray/marcus/issues/519) — decomposer-path tagging (sibling)
- Issue [#409](https://github.com/lwgray/marcus/issues/409) — overall cost-tracking initiative

🤖 Generated with [Claude Code](https://claude.com/claude-code)
