### PR TITLE
fix(cost): close runs rows on completion (#537)

### DIFF
--- a/scripts/backfill_run_close_state.py
+++ b/scripts/backfill_run_close_state.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""
+One-shot backfill of ``runs.ended_at`` from ``token_events.timestamp``.
+
+The ``runs`` table has lifecycle columns (``ended_at``, ``total_tasks``,
+``completed_tasks``, etc.) that the schema clearly anticipates, but
+until Marcus #537 no Python code ever wrote them. Every row in ``runs``
+has been "open" since insertion. This blocks any dashboard query
+filtering on ``ended_at IS NOT NULL`` and prevents wall-clock-time
+analysis (cost-per-minute, coordination tax rate, run duration).
+
+Going forward, ``end_experiment`` closes runs live for the
+``path=marcus`` and ``path=posidonius`` flows. This backfill closes
+the rest: historical runs that pre-date the fix, and runs from
+``path=direct`` usage where the user never invokes ``end_experiment``.
+
+Heuristic
+---------
+For each ``runs`` row where ``ended_at IS NULL``, set ``ended_at`` to
+``MAX(timestamp) FROM token_events WHERE run_id = ?`` — the timestamp
+of the last LLM call attributed to that run. That's the best on-disk
+approximation we have for unattended close. Runs with zero token
+events are left open (genuinely empty runs are ambiguous and likely
+indicate the run died before any LLM call).
+
+Idempotent: re-runnable. Rows with ``ended_at`` already set are
+skipped (the CostStore's UPDATE only fills NULL fields).
+
+Usage
+-----
+.. code-block:: console
+
+    $ python scripts/backfill_run_close_state.py
+    Closed 23 runs (10 had zero events and were skipped).
+
+Pass ``--costs-db PATH`` to override the cost-store path (defaults
+to ``~/.marcus/costs.db``).
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+from typing import Tuple
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_REPO_ROOT))
+
+from src.cost_tracking.cost_store import CostStore  # noqa: E402
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
+    parser.add_argument(
+        "--costs-db",
+        type=Path,
+        default=Path.home() / ".marcus" / "costs.db",
+        help="Path to costs.db (default: ~/.marcus/costs.db).",
+    )
+    return parser.parse_args()
+
+
+def backfill(costs_db: Path) -> Tuple[int, int]:
+    """Close every open run whose token_events have a max timestamp.
+
+    Returns
+    -------
+    (closed, skipped) : tuple of int
+        Counts for runs successfully closed and runs left open
+        because they had zero token_events.
+    """
+    store = CostStore(db_path=costs_db)
+
+    open_rows = store.conn.execute(
+        "SELECT run_id FROM runs WHERE ended_at IS NULL"
+    ).fetchall()
+
+    closed = 0
+    skipped = 0
+    for (run_id,) in open_rows:
+        # ``close_run`` returns False when there are no events to
+        # derive ended_at from — those runs stay open.
+        if store.close_run(run_id):
+            closed += 1
+        else:
+            skipped += 1
+    return closed, skipped
+
+
+def main() -> int:
+    """Parse CLI args, run the backfill, and print a summary."""
+    args = _parse_args()
+    closed, skipped = backfill(args.costs_db)
+    print(
+        f"Closed {closed} runs"
+        + (f" ({skipped} had zero events and were skipped)." if skipped > 0 else ".")
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/cost_tracking/cost_aggregator.py
+++ b/src/cost_tracking/cost_aggregator.py
@@ -361,6 +361,12 @@ class CostAggregator:
         or ``agent_id``. A healthy audit shows ``reconciles=True`` and
         zero ``worker_events_without_task_id``.
 
+        Also reports run-lifecycle status (Marcus #537): ``run_open``
+        is True when the run's ``ended_at`` is NULL — i.e. the row
+        was written at create_project time but never closed. A
+        complete audit cares about both token reconciliation AND
+        lifecycle closure.
+
         Returns
         -------
         dict
@@ -368,17 +374,46 @@ class CostAggregator:
             ``reconciles`` (bool), ``tokens_outside_known_roles``,
             ``planner_events``, ``worker_events``,
             ``worker_events_without_task_id``,
-            ``worker_events_without_agent_id``.
+            ``worker_events_without_agent_id``, ``run_open`` (bool).
         """
-        return self._audit_query("run_id = ?", (run_id,))
+        audit = self._audit_query("run_id = ?", (run_id,))
+        row = self._row("SELECT ended_at FROM runs WHERE run_id = ?", (run_id,))
+        # ``run_open`` is True only when a run exists and has no
+        # ended_at. An unknown run_id yields False to avoid noise.
+        audit["run_open"] = row is not None and row.get("ended_at") is None
+        return audit
 
     def project_audit(self, project_id: str) -> Dict[str, Any]:
         """Token-attribution audit for one project (Marcus #527).
 
         Like :meth:`run_audit` but scoped to all runs for one
-        ``project_id``. Same return shape — see that docstring.
+        ``project_id``. Reports the same token-attribution fields plus
+        project-level lifecycle counts (Marcus #537): ``runs_total``
+        and ``runs_open`` for the runs attributed to this project.
+
+        Returns
+        -------
+        dict
+            All fields from :meth:`run_audit` minus ``run_open``, plus
+            ``runs_total`` and ``runs_open``.
         """
-        return self._audit_query("project_id = ?", (project_id,))
+        audit = self._audit_query("project_id = ?", (project_id,))
+        row = (
+            self._row(
+                """
+            SELECT COUNT(*) AS total,
+                   COALESCE(SUM(CASE WHEN ended_at IS NULL THEN 1 ELSE 0 END), 0)
+                                                                AS open_count
+            FROM runs
+            WHERE project_id = ?
+            """,
+                (project_id,),
+            )
+            or {"total": 0, "open_count": 0}
+        )
+        audit["runs_total"] = int(row.get("total", 0) or 0)
+        audit["runs_open"] = int(row.get("open_count", 0) or 0)
+        return audit
 
     def cache_hit_rate_by_agent(self, run_id: str) -> List[Dict[str, Any]]:
         """Per-agent cache hit rate within one experiment.

--- a/src/cost_tracking/cost_store.py
+++ b/src/cost_tracking/cost_store.py
@@ -1009,14 +1009,25 @@ class CostStore:
         live-close hook from ``end_experiment``, where we know the
         monitor's project_id but not the cost-tracking run_id.
 
+        The incoming ``project_id`` is normalized via
+        :func:`src.cost_tracking.cost_recorder.canonical_project_id`
+        so callers can pass either dashed UUID form (ProjectRegistry)
+        or dashless hex form (SQLiteKanban auto-discovery) — both
+        resolve to the dashless form actually stored in ``runs``.
+        Without this, the live close from ``end_experiment`` silently
+        no-ops whenever the monitor was handed a dashed project_id.
+
         Returns
         -------
         int
             Number of runs closed.
         """
+        from src.cost_tracking.cost_recorder import canonical_project_id
+
+        normalized = canonical_project_id(project_id) or project_id
         rows = self.conn.execute(
             "SELECT run_id FROM runs WHERE project_id = ? AND ended_at IS NULL",
-            (project_id,),
+            (normalized,),
         ).fetchall()
         closed = 0
         for (run_id,) in rows:

--- a/src/cost_tracking/cost_store.py
+++ b/src/cost_tracking/cost_store.py
@@ -992,7 +992,7 @@ class CostStore:
         self.conn.commit()
         return cur.rowcount > 0
 
-    def close_open_runs_for_project(
+    def close_latest_open_run_for_project(
         self,
         project_id: str,
         *,
@@ -1001,46 +1001,59 @@ class CostStore:
         completed_tasks: Optional[int] = None,
         blocked_tasks: Optional[int] = None,
         num_agents: Optional[int] = None,
-    ) -> int:
-        """Close every open run attributed to one project (Marcus #537).
+    ) -> Optional[str]:
+        """Close the most recently started open run for a project (#537).
 
-        Wraps :meth:`close_run` over every ``runs`` row where
-        ``project_id`` matches and ``ended_at IS NULL``. Used as the
-        live-close hook from ``end_experiment``, where we know the
-        monitor's project_id but not the cost-tracking run_id.
+        Live-close hook for ``end_experiment``. The schema allows
+        multiple ``runs`` rows per ``project_id`` (retries, repeated
+        traversals), so a bulk close would stamp every historical
+        open row with the just-finished experiment's
+        ``ended_at`` / counters — corrupting older runs.
+
+        Scope the close to the latest open run, identified by
+        ``MAX(started_at)``. Older open rows for the same project are
+        left to the periodic ``backfill_run_close_state.py``, which
+        derives ``ended_at`` from each row's own
+        ``MAX(token_events.timestamp)``.
 
         The incoming ``project_id`` is normalized via
         :func:`src.cost_tracking.cost_recorder.canonical_project_id`
         so callers can pass either dashed UUID form (ProjectRegistry)
         or dashless hex form (SQLiteKanban auto-discovery) — both
         resolve to the dashless form actually stored in ``runs``.
-        Without this, the live close from ``end_experiment`` silently
-        no-ops whenever the monitor was handed a dashed project_id.
+        Without this, the live close silently no-ops whenever the
+        monitor was handed a dashed project_id.
 
         Returns
         -------
-        int
-            Number of runs closed.
+        Optional[str]
+            The closed ``run_id``, or ``None`` if the project had no
+            open runs.
         """
         from src.cost_tracking.cost_recorder import canonical_project_id
 
         normalized = canonical_project_id(project_id) or project_id
-        rows = self.conn.execute(
-            "SELECT run_id FROM runs WHERE project_id = ? AND ended_at IS NULL",
+        row = self.conn.execute(
+            """
+            SELECT run_id FROM runs
+             WHERE project_id = ? AND ended_at IS NULL
+             ORDER BY started_at DESC
+             LIMIT 1
+            """,
             (normalized,),
-        ).fetchall()
-        closed = 0
-        for (run_id,) in rows:
-            if self.close_run(
-                run_id,
-                ended_at=ended_at,
-                total_tasks=total_tasks,
-                completed_tasks=completed_tasks,
-                blocked_tasks=blocked_tasks,
-                num_agents=num_agents,
-            ):
-                closed += 1
-        return closed
+        ).fetchone()
+        if row is None:
+            return None
+        (run_id,) = row
+        closed = self.close_run(
+            run_id,
+            ended_at=ended_at,
+            total_tasks=total_tasks,
+            completed_tasks=completed_tasks,
+            blocked_tasks=blocked_tasks,
+            num_agents=num_agents,
+        )
+        return run_id if closed else None
 
     def record_price(self, price: ModelPrice) -> None:
         """Insert one ``model_prices`` row.

--- a/src/cost_tracking/cost_store.py
+++ b/src/cost_tracking/cost_store.py
@@ -905,6 +905,132 @@ class CostStore:
         )
         self.conn.commit()
 
+    def close_run(
+        self,
+        run_id: str,
+        *,
+        ended_at: Optional[datetime] = None,
+        total_tasks: Optional[int] = None,
+        completed_tasks: Optional[int] = None,
+        blocked_tasks: Optional[int] = None,
+        num_agents: Optional[int] = None,
+    ) -> bool:
+        """Stamp final-state lifecycle fields on a run (Marcus #537).
+
+        Closes the data-quality gap where every ``runs`` row stayed
+        open forever because the only writer
+        (``create_project`` → ``record_run``) only wrote the open
+        state. The dataclass and UPSERT have always supported the
+        close fields; this method is the missing caller.
+
+        When ``ended_at`` is ``None``, falls back to the timestamp of
+        the most recent ``token_events`` row attributed to this run —
+        the best on-disk approximation for unattended close
+        (``path=direct`` usage where the user never calls
+        ``end_experiment``). When no events exist for the run, the
+        method returns False without updating, since "closed with no
+        activity" is ambiguous and likely indicates the run died
+        before any LLM call.
+
+        Uses a targeted UPDATE rather than the upsert path so passing
+        ``None`` for a field leaves the existing column value
+        untouched (COALESCE-guarded). Safe to re-run; idempotent on
+        already-closed rows.
+
+        Parameters
+        ----------
+        run_id : str
+            The run to close.
+        ended_at : datetime, optional
+            Wall-clock end time. When None, derives from the run's
+            last event timestamp.
+        total_tasks, completed_tasks, blocked_tasks, num_agents : int, optional
+            Final lifecycle counts. None leaves the existing value.
+
+        Returns
+        -------
+        bool
+            True if a row was updated, False if the run_id was
+            unknown or had no events to back into ``ended_at``.
+        """
+        # Resolve ended_at via the last event timestamp when the
+        # caller didn't supply one. This is the unattended-close path
+        # — backfill scripts and direct-MCP runs land here.
+        resolved_ended_at_iso: Optional[str]
+        if ended_at is not None:
+            resolved_ended_at_iso = ended_at.isoformat()
+        else:
+            row = self.conn.execute(
+                "SELECT MAX(timestamp) FROM token_events WHERE run_id = ?",
+                (run_id,),
+            ).fetchone()
+            if row is None or row[0] is None:
+                # No events for this run — can't infer ended_at.
+                # Caller should pass an explicit value or skip.
+                return False
+            resolved_ended_at_iso = str(row[0])
+
+        cur = self.conn.execute(
+            """
+            UPDATE runs
+               SET ended_at        = COALESCE(?, ended_at),
+                   total_tasks     = COALESCE(?, total_tasks),
+                   completed_tasks = COALESCE(?, completed_tasks),
+                   blocked_tasks   = COALESCE(?, blocked_tasks),
+                   num_agents      = COALESCE(?, num_agents)
+             WHERE run_id = ?
+            """,
+            (
+                resolved_ended_at_iso,
+                total_tasks,
+                completed_tasks,
+                blocked_tasks,
+                num_agents,
+                run_id,
+            ),
+        )
+        self.conn.commit()
+        return cur.rowcount > 0
+
+    def close_open_runs_for_project(
+        self,
+        project_id: str,
+        *,
+        ended_at: Optional[datetime] = None,
+        total_tasks: Optional[int] = None,
+        completed_tasks: Optional[int] = None,
+        blocked_tasks: Optional[int] = None,
+        num_agents: Optional[int] = None,
+    ) -> int:
+        """Close every open run attributed to one project (Marcus #537).
+
+        Wraps :meth:`close_run` over every ``runs`` row where
+        ``project_id`` matches and ``ended_at IS NULL``. Used as the
+        live-close hook from ``end_experiment``, where we know the
+        monitor's project_id but not the cost-tracking run_id.
+
+        Returns
+        -------
+        int
+            Number of runs closed.
+        """
+        rows = self.conn.execute(
+            "SELECT run_id FROM runs WHERE project_id = ? AND ended_at IS NULL",
+            (project_id,),
+        ).fetchall()
+        closed = 0
+        for (run_id,) in rows:
+            if self.close_run(
+                run_id,
+                ended_at=ended_at,
+                total_tasks=total_tasks,
+                completed_tasks=completed_tasks,
+                blocked_tasks=blocked_tasks,
+                num_agents=num_agents,
+            ):
+                closed += 1
+        return closed
+
     def record_price(self, price: ModelPrice) -> None:
         """Insert one ``model_prices`` row.
 

--- a/src/marcus_mcp/coordinator/subtask_assignment.py
+++ b/src/marcus_mcp/coordinator/subtask_assignment.py
@@ -328,6 +328,39 @@ async def check_and_complete_parent_task(
         # task to the agent that drove it to completion (Bug 3 fix).
         # Without this, the parent appears as a ghost completion with no
         # agent record — invisible in experiment analytics.
+        #
+        # DELIBERATELY NOT WRITING task_outcomes HERE — see contract below.
+        #
+        # Auto-completion contract (do not change without an ADR):
+        #
+        #   Parents-with-subtasks are coordination containers. The work data
+        #   (started_at, completed_at, actual_hours, agent_id) lives on the
+        #   subtask outcomes — which are real per-agent records written via
+        #   Memory.record_task_completion when each subtask finishes.
+        #
+        #   Writing a synthetic parent outcome here would corrupt agent
+        #   learning:
+        #     * Memory._update_agent_profile (memory.py) ticks
+        #       total_tasks + skill_success_rates EMA per outcome row;
+        #       a parent row attributed to completing_agent_id would
+        #       double-count their work.
+        #     * analysis.aggregator._build_agent_histories sums
+        #       outcome.actual_hours into total_hours, also double-counting.
+        #     * Scheduler tests (test_scheduler_prototype_mode.py) already
+        #       assert "parent with subtasks is a container — should be
+        #       excluded" from CPM. Outcome accounting must match that.
+        #
+        #   Contrast with About/design auto-completion in nlp_tools.py:
+        #   those write task_outcomes with agent_id="system" or "Marcus",
+        #   synthetic IDs that don't correspond to a real worker and so
+        #   don't pollute learning. Those tasks are LEAVES with no
+        #   subtasks — the outcome write is the only place their data
+        #   lives. Subtask-driven parents are DERIVATIVE — the data
+        #   already lives on the subtasks.
+        #
+        #   Downstream observers (Cato) aggregate subtask data for parent
+        #   display rather than relying on a parent outcome row. See
+        #   cato_src/core/aggregator._apply_subtask_rollup.
         if completing_agent_id and state and hasattr(state, "log_event"):
             state.log_event(
                 "task_assignment",

--- a/src/marcus_mcp/tools/experiments.py
+++ b/src/marcus_mcp/tools/experiments.py
@@ -252,7 +252,7 @@ async def end_experiment() -> Dict[str, Any]:
 
                 _cost_store = get_recorder().store
                 final = result.get("final_metrics", {}) or {}
-                closed = _cost_store.close_open_runs_for_project(
+                closed_run_id = _cost_store.close_latest_open_run_for_project(
                     project_id=project_id,
                     ended_at=datetime.now(timezone.utc),
                     total_tasks=final.get("total_tasks"),
@@ -260,10 +260,10 @@ async def end_experiment() -> Dict[str, Any]:
                     blocked_tasks=final.get("total_blockers"),
                     num_agents=final.get("total_registered_agents"),
                 )
-                if closed > 0:
+                if closed_run_id:
                     logger.info(
-                        "Closed %d open run(s) for project %s on end_experiment",
-                        closed,
+                        "Closed run %s for project %s on end_experiment",
+                        closed_run_id,
                         project_id,
                     )
             except Exception as _close_err:  # pragma: no cover

--- a/src/marcus_mcp/tools/experiments.py
+++ b/src/marcus_mcp/tools/experiments.py
@@ -223,8 +223,11 @@ async def end_experiment() -> Dict[str, Any]:
         return {"success": False, "error": "No experiment is currently running"}
 
     try:
-        # Grab run_dir before clearing the monitor
+        # Grab run_dir + project_id before clearing the monitor.
+        # project_id is the bridge to the cost-tracking ``runs`` table,
+        # whose rows would otherwise stay open forever (Marcus #537).
         run_dir = getattr(monitor, "run_dir", None)
+        project_id = getattr(monitor, "project_id", None)
 
         result = await monitor.stop()
 
@@ -232,6 +235,46 @@ async def end_experiment() -> Dict[str, Any]:
         set_active_monitor(None)
 
         logger.info(f"Stopped experiment: {result['run_name']}")
+
+        # Close any open ``runs`` rows for this project (Marcus #537).
+        # The runs table has lifecycle fields (ended_at, total_tasks,
+        # completed_tasks, ...) that were never written before this
+        # hook landed — every run stayed open forever. Wire the close
+        # here because ``end_experiment`` is the natural lifecycle
+        # signal for ``path=marcus`` and ``path=posidonius`` runs.
+        # ``path=direct`` runs (no runner) close via the periodic
+        # backfill script instead.
+        if project_id:
+            try:
+                from datetime import datetime, timezone
+
+                from src.cost_tracking.cost_recorder import get_recorder
+
+                _cost_store = get_recorder().store
+                final = result.get("final_metrics", {}) or {}
+                closed = _cost_store.close_open_runs_for_project(
+                    project_id=project_id,
+                    ended_at=datetime.now(timezone.utc),
+                    total_tasks=final.get("total_tasks"),
+                    completed_tasks=final.get("total_task_completions"),
+                    blocked_tasks=final.get("total_blockers"),
+                    num_agents=final.get("total_registered_agents"),
+                )
+                if closed > 0:
+                    logger.info(
+                        "Closed %d open run(s) for project %s on end_experiment",
+                        closed,
+                        project_id,
+                    )
+            except Exception as _close_err:  # pragma: no cover
+                # Cost-tracking close is not allowed to fail the
+                # experiment-stop path. The backfill script is the
+                # safety net.
+                logger.debug(
+                    "Failed to close runs for project %s on end_experiment: %s",
+                    project_id,
+                    _close_err,
+                )
 
         # Write experiment_complete.json so Posidonius auto-advance
         # can detect that this run is finished.

--- a/tests/unit/cost_tracking/test_cost_aggregator.py
+++ b/tests/unit/cost_tracking/test_cost_aggregator.py
@@ -696,3 +696,46 @@ class TestTaskNamesJoin:
         assert result is not None
         rows = {r["task_id"]: r for r in result["by_task"]}
         assert rows["t_1"]["task_name"] == "Implement scoring logic"
+
+
+class TestRunAuditOpenStatus:
+    """``run_audit`` reports run-lifecycle status (Marcus #537)."""
+
+    def test_run_open_true_when_ended_at_is_null(
+        self, populated_store: CostStore
+    ) -> None:
+        """Fixture run has no ended_at → audit reports run_open=True."""
+        audit = CostAggregator(store=populated_store).run_audit("exp_1")
+        assert audit["run_open"] is True
+
+    def test_run_open_false_after_close(self, populated_store: CostStore) -> None:
+        """Closing the run flips run_open to False."""
+        populated_store.close_run(
+            "exp_1", ended_at=datetime(2026, 5, 13, tzinfo=timezone.utc)
+        )
+        audit = CostAggregator(store=populated_store).run_audit("exp_1")
+        assert audit["run_open"] is False
+
+    def test_run_open_false_for_unknown_run(self, populated_store: CostStore) -> None:
+        """Querying a nonexistent run reports run_open=False (not noise)."""
+        audit = CostAggregator(store=populated_store).run_audit("nope")
+        assert audit["run_open"] is False
+
+
+class TestProjectAuditRunCounts:
+    """``project_audit`` reports runs_total / runs_open (Marcus #537)."""
+
+    def test_one_open_run_counted(self, populated_store: CostStore) -> None:
+        """Fixture has one open run for proj_1."""
+        audit = CostAggregator(store=populated_store).project_audit("proj_1")
+        assert audit["runs_total"] == 1
+        assert audit["runs_open"] == 1
+
+    def test_closed_runs_lower_open_count(self, populated_store: CostStore) -> None:
+        """Closing the run reduces runs_open without changing runs_total."""
+        populated_store.close_run(
+            "exp_1", ended_at=datetime(2026, 5, 13, tzinfo=timezone.utc)
+        )
+        audit = CostAggregator(store=populated_store).project_audit("proj_1")
+        assert audit["runs_total"] == 1
+        assert audit["runs_open"] == 0

--- a/tests/unit/cost_tracking/test_cost_store.py
+++ b/tests/unit/cost_tracking/test_cost_store.py
@@ -1076,3 +1076,37 @@ class TestCloseOpenRunsForProject:
         assert rows["r1"] == end.isoformat()
         assert rows["r2"] == end.isoformat()
         assert rows["r3"] is None
+
+    def test_dashed_project_id_canonicalizes_to_dashless(
+        self, store: CostStore
+    ) -> None:
+        """Dashed UUID from caller matches dashless row in ``runs``.
+
+        Regression for the silent no-op bug Kaia caught on PR #538:
+        ``record_run`` stores dashless via ``canonical_project_id``,
+        but ``end_experiment`` passes ``monitor.project_id`` straight
+        through. Without canonicalization here, the dashed form never
+        matches the dashless row and the live close silently closes
+        zero runs.
+        """
+        dashless = "4cca814b47024489a914a9868da9e4fc"
+        dashed = "4cca814b-4702-4489-a914-a9868da9e4fc"
+
+        store.record_run(
+            Run(
+                run_id="r_canon",
+                project_id=dashless,
+                project_name="canon",
+                started_at=datetime(2026, 5, 13, 10, tzinfo=timezone.utc),
+            )
+        )
+
+        end = datetime(2026, 5, 13, 12, tzinfo=timezone.utc)
+        # Caller hands in the dashed form — must still close the row.
+        closed = store.close_open_runs_for_project(dashed, ended_at=end)
+        assert closed == 1
+
+        row = store.conn.execute(
+            "SELECT ended_at FROM runs WHERE run_id = ?", ("r_canon",)
+        ).fetchone()
+        assert row[0] == end.isoformat()

--- a/tests/unit/cost_tracking/test_cost_store.py
+++ b/tests/unit/cost_tracking/test_cost_store.py
@@ -1034,14 +1034,21 @@ class TestCloseRun:
         assert row[0] == 15  # original value preserved
 
 
-class TestCloseOpenRunsForProject:
-    """``close_open_runs_for_project`` is the bulk-close helper (#537)."""
+class TestCloseLatestOpenRunForProject:
+    """``close_latest_open_run_for_project`` is the live-close helper (#537)."""
 
-    def test_closes_all_open_runs_for_project(self, store: CostStore) -> None:
-        """Two open runs for proj_x both get closed; closed runs are untouched."""
+    def test_closes_only_latest_open_run(self, store: CostStore) -> None:
+        """Older open run is preserved; only MAX(started_at) is stamped.
+
+        Regression for Codex P2 on PR #538: the schema allows multiple
+        open runs per project (retries, repeated traversals). A bulk
+        close would stamp historical rows with the just-finished
+        experiment's ended_at + counters, corrupting them. The live
+        hook must scope to one row.
+        """
         store.record_run(
             Run(
-                run_id="r1",
+                run_id="r_old",
                 project_id="proj_x",
                 project_name="x",
                 started_at=datetime(2026, 5, 13, 10, tzinfo=timezone.utc),
@@ -1049,7 +1056,7 @@ class TestCloseOpenRunsForProject:
         )
         store.record_run(
             Run(
-                run_id="r2",
+                run_id="r_new",
                 project_id="proj_x",
                 project_name="x",
                 started_at=datetime(2026, 5, 13, 11, tzinfo=timezone.utc),
@@ -1058,7 +1065,7 @@ class TestCloseOpenRunsForProject:
         # Different project — must NOT be touched.
         store.record_run(
             Run(
-                run_id="r3",
+                run_id="r_other",
                 project_id="other",
                 project_name="o",
                 started_at=datetime(2026, 5, 13, 10, tzinfo=timezone.utc),
@@ -1066,16 +1073,41 @@ class TestCloseOpenRunsForProject:
         )
 
         end = datetime(2026, 5, 13, 12, tzinfo=timezone.utc)
-        closed = store.close_open_runs_for_project("proj_x", ended_at=end)
-        assert closed == 2
-
-        # proj_x's runs are closed; other's stays open.
-        rows = dict(
-            store.conn.execute("SELECT run_id, ended_at FROM runs ORDER BY run_id")
+        closed_id = store.close_latest_open_run_for_project(
+            "proj_x", ended_at=end, total_tasks=8
         )
-        assert rows["r1"] == end.isoformat()
-        assert rows["r2"] == end.isoformat()
-        assert rows["r3"] is None
+        assert closed_id == "r_new"
+
+        rows = {
+            run_id: (ended_at, total_tasks)
+            for run_id, ended_at, total_tasks in store.conn.execute(
+                "SELECT run_id, ended_at, total_tasks FROM runs ORDER BY run_id"
+            )
+        }
+        # Latest stamped with the experiment's counters.
+        assert rows["r_new"] == (end.isoformat(), 8)
+        # Older row left untouched for the periodic backfill.
+        assert rows["r_old"] == (None, None)
+        # Different project untouched.
+        assert rows["r_other"] == (None, None)
+
+    def test_returns_none_when_no_open_runs(self, store: CostStore) -> None:
+        """Empty / fully-closed project returns None — caller treats as no-op."""
+        end = datetime(2026, 5, 13, 12, tzinfo=timezone.utc)
+        # Project never recorded.
+        assert store.close_latest_open_run_for_project("ghost", ended_at=end) is None
+
+        # Project with a row that's already closed.
+        store.record_run(
+            Run(
+                run_id="r_done",
+                project_id="proj_y",
+                project_name="y",
+                started_at=datetime(2026, 5, 13, 10, tzinfo=timezone.utc),
+                ended_at=datetime(2026, 5, 13, 11, tzinfo=timezone.utc),
+            )
+        )
+        assert store.close_latest_open_run_for_project("proj_y", ended_at=end) is None
 
     def test_dashed_project_id_canonicalizes_to_dashless(
         self, store: CostStore
@@ -1103,8 +1135,8 @@ class TestCloseOpenRunsForProject:
 
         end = datetime(2026, 5, 13, 12, tzinfo=timezone.utc)
         # Caller hands in the dashed form — must still close the row.
-        closed = store.close_open_runs_for_project(dashed, ended_at=end)
-        assert closed == 1
+        closed_id = store.close_latest_open_run_for_project(dashed, ended_at=end)
+        assert closed_id == "r_canon"
 
         row = store.conn.execute(
             "SELECT ended_at FROM runs WHERE run_id = ?", ("r_canon",)

--- a/tests/unit/cost_tracking/test_cost_store.py
+++ b/tests/unit/cost_tracking/test_cost_store.py
@@ -909,3 +909,170 @@ class TestTaskNamesSnapshot:
         """get_task_name on an unrecorded id returns None, not an error."""
         s = CostStore(db_path=tmp_path / "costs.db")
         assert s.get_task_name("never_recorded") is None
+
+
+class TestCloseRun:
+    """``close_run`` stamps lifecycle fields on a previously-open row (#537)."""
+
+    def test_explicit_ended_at_writes_to_row(self, store: CostStore) -> None:
+        """Pass ended_at directly; UPDATE writes it to the row."""
+        store.record_run(
+            Run(
+                run_id="r1",
+                project_id="p1",
+                project_name="x",
+                started_at=datetime(2026, 5, 13, 10, 0, tzinfo=timezone.utc),
+            )
+        )
+        end = datetime(2026, 5, 13, 10, 30, tzinfo=timezone.utc)
+        ok = store.close_run(
+            "r1",
+            ended_at=end,
+            total_tasks=10,
+            completed_tasks=8,
+            blocked_tasks=1,
+            num_agents=3,
+        )
+        assert ok is True
+        row = store.conn.execute(
+            "SELECT ended_at, total_tasks, completed_tasks, blocked_tasks, "
+            "num_agents FROM runs WHERE run_id = 'r1'"
+        ).fetchone()
+        assert row[0] == end.isoformat()
+        assert row[1:] == (10, 8, 1, 3)
+
+    def test_ended_at_falls_back_to_last_event_timestamp(
+        self, store: CostStore
+    ) -> None:
+        """No ended_at supplied → use MAX(token_events.timestamp)."""
+        store.record_run(
+            Run(
+                run_id="r1",
+                project_id="p1",
+                project_name="x",
+                started_at=datetime(2026, 5, 13, 10, 0, tzinfo=timezone.utc),
+            )
+        )
+        store.record_price(
+            ModelPrice(
+                model="claude-sonnet-4-6",
+                provider="anthropic",
+                effective_from=datetime(2025, 1, 1, tzinfo=timezone.utc),
+                input_per_million=3.0,
+                output_per_million=15.0,
+                source="test",
+            )
+        )
+        last_ts = datetime(2026, 5, 13, 10, 25, tzinfo=timezone.utc)
+        store.record_event(
+            TokenEvent(
+                run_id="r1",
+                project_id="p1",
+                agent_id="a1",
+                agent_role="worker",
+                operation="turn",
+                provider="anthropic",
+                model="claude-sonnet-4-6",
+                request_id="req_1",
+                timestamp=last_ts,
+                input_tokens=100,
+            )
+        )
+        ok = store.close_run("r1")
+        assert ok is True
+        row = store.conn.execute(
+            "SELECT ended_at FROM runs WHERE run_id = 'r1'"
+        ).fetchone()
+        assert row[0] == last_ts.isoformat()
+
+    def test_returns_false_when_no_events_and_no_ended_at(
+        self, store: CostStore
+    ) -> None:
+        """Run with no events + no explicit ended_at: leave open, return False."""
+        store.record_run(
+            Run(
+                run_id="empty",
+                project_id="p1",
+                project_name="x",
+                started_at=datetime(2026, 5, 13, 10, 0, tzinfo=timezone.utc),
+            )
+        )
+        ok = store.close_run("empty")
+        assert ok is False
+        row = store.conn.execute(
+            "SELECT ended_at FROM runs WHERE run_id = 'empty'"
+        ).fetchone()
+        assert row[0] is None
+
+    def test_returns_false_when_run_id_unknown(self, store: CostStore) -> None:
+        """Unknown run_id returns False, no error."""
+        ok = store.close_run(
+            "nope",
+            ended_at=datetime(2026, 5, 13, tzinfo=timezone.utc),
+        )
+        assert ok is False
+
+    def test_none_fields_preserve_existing_values(self, store: CostStore) -> None:
+        """COALESCE-guarded UPDATE: None args don't overwrite existing data."""
+        store.record_run(
+            Run(
+                run_id="r1",
+                project_id="p1",
+                project_name="x",
+                started_at=datetime(2026, 5, 13, 10, 0, tzinfo=timezone.utc),
+                total_tasks=15,  # pre-set
+            )
+        )
+        store.close_run(
+            "r1",
+            ended_at=datetime(2026, 5, 13, 11, tzinfo=timezone.utc),
+            # total_tasks deliberately not passed
+        )
+        row = store.conn.execute(
+            "SELECT total_tasks FROM runs WHERE run_id = 'r1'"
+        ).fetchone()
+        assert row[0] == 15  # original value preserved
+
+
+class TestCloseOpenRunsForProject:
+    """``close_open_runs_for_project`` is the bulk-close helper (#537)."""
+
+    def test_closes_all_open_runs_for_project(self, store: CostStore) -> None:
+        """Two open runs for proj_x both get closed; closed runs are untouched."""
+        store.record_run(
+            Run(
+                run_id="r1",
+                project_id="proj_x",
+                project_name="x",
+                started_at=datetime(2026, 5, 13, 10, tzinfo=timezone.utc),
+            )
+        )
+        store.record_run(
+            Run(
+                run_id="r2",
+                project_id="proj_x",
+                project_name="x",
+                started_at=datetime(2026, 5, 13, 11, tzinfo=timezone.utc),
+            )
+        )
+        # Different project — must NOT be touched.
+        store.record_run(
+            Run(
+                run_id="r3",
+                project_id="other",
+                project_name="o",
+                started_at=datetime(2026, 5, 13, 10, tzinfo=timezone.utc),
+            )
+        )
+
+        end = datetime(2026, 5, 13, 12, tzinfo=timezone.utc)
+        closed = store.close_open_runs_for_project("proj_x", ended_at=end)
+        assert closed == 2
+
+        # proj_x's runs are closed; other's stays open.
+        rows = dict(
+            store.conn.execute("SELECT run_id, ended_at FROM runs ORDER BY run_id")
+        )
+        assert rows["r1"] == end.isoformat()
+        assert rows["r2"] == end.isoformat()
+        assert rows["r3"] is None


### PR DESCRIPTION
## What is this, briefly

Marcus is a coordinator that runs multi-agent software-engineering experiments. Every experiment is a *run*, and each run gets one row in the ``runs`` table inside ``~/.marcus/costs.db`` (the dedicated SQLite database that tracks LLM cost and token attribution). The schema for ``runs`` includes lifecycle columns — ``ended_at``, ``total_tasks``, ``completed_tasks``, ``blocked_tasks``, ``num_agents`` — that record what happened when the experiment finished.

## Why

Until now, **no Python code ever wrote those lifecycle columns**. The ``record_run`` method in ``CostStore`` only inserted a row with ``started_at``; nothing closed it. Every row in ``runs`` has been "open" (``ended_at IS NULL``) since insertion.

User-visible impact:

- Any dashboard query filtering on ``ended_at IS NOT NULL`` returns nothing.
- Wall-clock-time analyses are impossible — you cannot compute run duration, cost-per-minute, or coordination-tax rate from rows that never close.
- The token-audit work in #528 confirms tokens line up, but it never asserts lifecycle closure, so the gap stayed silent.

## What changed

| Change | File |
| --- | --- |
| New ``CostStore.close_run`` — stamp ``ended_at`` + counters with a COALESCE-guarded UPDATE | ``src/cost_tracking/cost_store.py`` |
| New ``CostStore.close_open_runs_for_project`` — bulk close for end-of-experiment | ``src/cost_tracking/cost_store.py`` |
| Wire ``close_open_runs_for_project`` into ``end_experiment`` after ``monitor.stop()`` | ``src/marcus_mcp/tools/experiments.py`` |
| Extend ``run_audit`` with ``run_open`` and ``project_audit`` with ``runs_total`` / ``runs_open`` so the audit catches future drift | ``src/cost_tracking/cost_aggregator.py`` |
| One-shot backfill: walks every open row, derives ``ended_at`` from ``MAX(token_events.timestamp)`` | ``scripts/backfill_run_close_state.py`` |

### Heuristic for the backfill

For historical rows, we cannot know the exact wall-clock close time. The script uses ``MAX(token_events.timestamp) WHERE run_id = ?`` — the timestamp of the last LLM call attributed to that run. That is the best on-disk approximation for unattended close. Runs with zero events are left open (ambiguous; the run likely died before any LLM call).

The backfill is **idempotent** — rows already closed are not touched (the UPDATE uses COALESCE).

## Worked example

Before:

    sqlite> SELECT run_id, started_at, ended_at FROM runs LIMIT 1;
    abc123|2026-05-12T14:22:01+00:00|

After backfill:

    sqlite> SELECT run_id, started_at, ended_at FROM runs LIMIT 1;
    abc123|2026-05-12T14:22:01+00:00|2026-05-12T14:38:47+00:00

For *new* runs (path=marcus/posidonius), ``end_experiment`` closes the row live with the actual final-state counters from ``monitor.stop()``:

    sqlite> SELECT ended_at, total_tasks, completed_tasks, num_agents FROM runs WHERE run_id = ?;
    2026-05-13T09:14:33+00:00|12|11|3

## Where to look in the code first

| File | Purpose |
| --- | --- |
| ``src/cost_tracking/cost_store.py`` | ``close_run``, ``close_open_runs_for_project`` |
| ``src/marcus_mcp/tools/experiments.py`` | ``end_experiment`` wiring (calls bulk close after monitor stops) |
| ``src/cost_tracking/cost_aggregator.py`` | ``run_audit`` / ``project_audit`` lifecycle reporting |
| ``scripts/backfill_run_close_state.py`` | Historical rows + ``path=direct`` users |

## Glossary

| Term | Meaning |
| --- | --- |
| ``runs`` table | Per-experiment row in ``~/.marcus/costs.db`` |
| ``token_events`` table | One row per LLM call, with ``run_id`` foreign key + ``timestamp`` |
| ``end_experiment`` | The MCP tool agents call when they're done with an experiment |
| ``path`` | Which entry path created the run — ``marcus``, ``posidonius``, or ``direct`` |
| ``monitor.stop()`` | Returns final-state metrics: total_tasks, total_task_completions, total_blockers, total_registered_agents |
| COALESCE-guarded UPDATE | ``SET ended_at = COALESCE(?, ended_at)`` — passing NULL preserves the existing value |

## Real-data validation

Ran against the user's actual ``~/.marcus/costs.db`` (already used by the previous summary as ground truth):

    $ python scripts/backfill_run_close_state.py
    Closed 1 runs.
    $ sqlite3 ~/.marcus/costs.db \
        "SELECT COUNT(*), SUM(ended_at IS NULL) FROM runs;"
    1|0

After the backfill, zero rows remain open.

## How to verify

1. Check out the branch and install nothing new (no schema changes).
2. ``pytest tests/unit/cost_tracking/`` — expect 95 passed (11 are new for #537).
3. Apply the backfill against your own DB:
       ``python scripts/backfill_run_close_state.py``
       Expected: ``Closed N runs.`` or ``Closed N runs (M had zero events and were skipped).``
4. Re-run; should print ``Closed 0 runs.`` (idempotent).
5. Run a fresh experiment via ``mcp__marcus__start_experiment`` → ``mcp__marcus__end_experiment``. Confirm the new row has non-NULL ``ended_at`` and final counters.
6. Call ``project_audit(project_id)`` and confirm ``runs_open == 0`` after end_experiment.

## Test plan

- [x] ``pytest tests/unit/cost_tracking/`` — 95 passed (11 new)
- [x] ``mypy src/cost_tracking/cost_store.py src/cost_tracking/cost_aggregator.py`` — clean
- [x] Backfill ran end-to-end against real ``~/.marcus/costs.db`` — closed 1 of 1 open rows
- [ ] Reviewer: run a fresh experiment and confirm new row closes live

## Related

- Closes #537
- Follows #522 (added ``record_run`` without a close path)
- Follows #528 (audited tokens but not lifecycle — this PR adds ``runs_open`` to the audit so future drift surfaces)

🤖 Generated with [Claude Code](https://claude.com/claude-code)