### PR TITLE
Resilient structured-LLM calls: safe_structured_call helper + truncation retry

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,869 +1,168 @@
 # Contributing to Marcus
 
-Welcome to Marcus! We're excited you're interested in contributing. This guide will help you get started, whether you're fixing a typo or building a major feature.
-
-## 💰 Zero-Cost Development (No API Keys Needed!)
-
-**You can contribute to Marcus 100% FREE** - no paid API keys required!
-
-Marcus supports local AI models through Ollama. The recommended free setup:
-
-```bash
-# 1. Install Ollama (one-time, 2 minutes)
-curl -fsSL https://ollama.com/install.sh | sh
-
-# 2. Pull Qwen2.5-Coder (best free coding model, ~5GB download)
-ollama pull qwen2.5-coder:7b
-
-# 3. Use the free development config
-cp .env.dev.example .env
-
-# 4. Start developing!
-./marcus start
-```
-
-**Why Qwen2.5-Coder?**
-- ✅ **Free & Open Source** - No costs, ever
-- ✅ **Excellent Code Quality** - Rivals GPT-4 for coding tasks
-- ✅ **Runs Locally** - Works on 8GB RAM, no internet needed
-- ✅ **Fast Responses** - No API latency
-- ✅ **Privacy First** - Your code never leaves your machine
-
-📖 **Full guide:** [Setup Local LLM](docs/source/getting-started/setup-local-llm.md)
-
-**Alternative free models:**
-- `deepseek-coder:6.7b` - Excellent code understanding
-- `codellama:7b` - Fast responses
-- `mistral:7b` - Good general purpose
-
-> **💡 Tip:** All Marcus features work identically with local or cloud models!
-
-## 🔀 Branching Strategy
-
-**Important:** Marcus uses a `develop` branch workflow to manage contributions efficiently.
-
-- **`main`**: Production-ready code. Protected - no direct pushes allowed.
-- **`develop`**: Primary development branch. All PRs should target this branch.
-- **Feature branches**: Work in your fork's feature branches, created from `develop`.
-
-**Why this approach?**
-- ✅ Reduces merge conflicts by keeping all development synchronized
-- ✅ Allows testing before production release
-- ✅ Keeps your fork clean and organized
-- ✅ Makes it easy to stay up-to-date with latest changes
-
-**Quick workflow:**
-1. Fork the Marcus repository
-2. Clone your fork and add upstream remote
-3. Always branch from `develop`
-4. Submit PRs targeting `develop`
-
-## 🌟 First Time Contributing?
-
-New to open source? Marcus is a great place to start! Here's how:
-
-### Quick Start for First-Timers
-
-1. **Find a Good First Issue**
-   - Look for issues labeled [`good first issue`](https://github.com/lwgray/marcus/labels/good%20first%20issue)
-   - These are specifically chosen to be approachable for newcomers
-   - Don't see one you like? Ask in discussions - we'll help you find something!
-
-2. **Set Up Your Environment** (15 minutes)
-
-   📖 **See the complete guide:** [Local Development Setup](docs/source/developer/local-development.md)
-
-   **Quick overview:**
-   ```bash
-   # 1. Fork the repo on GitHub (click the Fork button)
-   # Then clone your fork and kanban-mcp as sibling directories:
-   cd ~/projects  # or wherever you prefer
-   git clone https://github.com/YOUR_USERNAME/marcus.git
-   git clone https://github.com/lwgray/kanban-mcp.git
-
-   # 2. Build kanban-mcp
-   cd kanban-mcp
-   npm install && npm run build
-
-   # 3. Set up Marcus
-   cd ../marcus
-   pip install -r requirements.txt
-   pip install -r requirements-dev.txt
-   pre-commit install
-
-   # 4. Start Planka (in Docker)
-   docker compose up -d postgres planka
-
-   # 5. Configure Marcus
-   cp config_marcus.example.json config_marcus.json
-   # Edit with your Planka project/board IDs and API key
-
-   # 6. Run tests to verify setup
-   pytest tests/
-   ```
-
-3. **Make Your First Contribution**
-   - Start small: fix a typo, improve an error message, or add a test
-   - Even tiny improvements are valuable!
-   - Your first PR doesn't need to be perfect - we'll help you improve it
-
-### Your First Pull Request Checklist
-
-- [ ] I've read the [Local Development Setup](docs/source/developer/local-development.md)
-- [ ] I've set up my development environment
-- [ ] I've found an issue to work on (or created one)
-- [ ] I've made my changes in a new branch
-- [ ] I've tested my changes work
-- [ ] I've opened a Pull Request
-- [ ] I'm ready to learn from feedback!
-
-## 🤝 Code of Conduct
-
-We're committed to providing a welcoming and inspiring community for all. Before participating, please read our code of conduct:
-
-- **Be Respectful**: Value each other's ideas, styles, and viewpoints
-- **Be Supportive**: Be kind to newcomers and help them learn
-- **Be Collaborative**: Work together to solve problems
-- **Be Inclusive**: Welcome people of all backgrounds and identities
-- **Be Professional**: Disagreement is fine, but stay constructive
-
-## 🛠️ Ways to Contribute
-
-### Not Just Code!
-
-Marcus needs more than just code contributions:
-
-- 📝 **Documentation**: Help others understand Marcus better
-- 🎨 **Design**: Improve UI/UX, create diagrams, or design assets
-- 🧪 **Testing**: Write tests, find bugs, or improve test coverage
-- 💬 **Community**: Answer questions, write tutorials, or give talks
-- 🌐 **Translation**: Help make Marcus accessible globally
-- 💡 **Ideas**: Suggest features, improvements, or use cases
-
-### Code Contributions
-
-#### Reporting Bugs
-
-Found a bug? Help us fix it:
-
-1. **Check Existing Issues**: Maybe someone already reported it
-2. **Create a Bug Report**: Use our bug report template
-3. **Include Details**:
-   - What you expected to happen
-   - What actually happened
-   - Steps to reproduce
-   - Your environment (OS, Python version, Docker version, etc.)
-   - Error messages and logs
-
-#### Suggesting Features
-
-Have an idea? We'd love to hear it:
-
-1. **Check the Roadmap**: See [docs/source/roadmap/](docs/source/roadmap/) if it's already planned
-2. **Open a Discussion**: Get community feedback first
-3. **Create a Feature Request**: Use our template
-4. **Explain the Why**: Help us understand the problem it solves
-
-#### Submitting Code
-
-Ready to code? Follow these steps:
-
-1. **Claim an Issue**: Comment "I'll work on this" to avoid duplicate work
-2. **Fork and Branch**: Create a feature branch from `develop` in your fork
-3. **Write Code**: Follow our style guide (see below)
-4. **Add Tests**: New features need tests (80% coverage target)
-5. **Update Docs**: If you changed behavior, update the docs
-6. **Keep Updated**: Regularly sync with `upstream/develop` to avoid conflicts
-7. **Submit PR**: Use our PR template and target the `develop` branch
-
-## 💻 Development Setup
-
-### Prerequisites
-
-- Python 3.11 or higher
-- Docker and Docker Compose (for running Planka)
-- Git
-- Node.js 16+ (for kanban-mcp)
-- AI Model (choose one):
-  - **FREE:** Ollama with Qwen2.5-Coder (recommended for contributors, see above ⬆️)
-  - **Paid:** Anthropic or OpenAI API key
-
-### Detailed Setup
-
-📖 **Complete guide:** [Local Development Setup](docs/source/developer/local-development.md)
-
-**Quick setup:**
-
-```bash
-# 1. Clone Marcus and kanban-mcp as sibling directories
-cd ~/projects
-git clone https://github.com/YOUR_USERNAME/marcus.git
-git clone https://github.com/lwgray/kanban-mcp.git
-
-# 2. Add upstream remote and checkout develop
-cd marcus
-git remote add upstream https://github.com/lwgray/marcus.git
-git checkout develop
-
-# 3. Build kanban-mcp
-cd ../kanban-mcp
-npm install && npm run build
-
-# 4. Set up Marcus virtual environment
-cd ../marcus
-python -m venv venv
-source venv/bin/activate  # On Windows: venv\Scripts\activate
-
-# 5. Install dependencies
-pip install -r requirements.txt
-pip install -r requirements-dev.txt
-
-# 6. Install pre-commit hooks (required for code quality)
-pre-commit install
-
-# 7. Start Planka
-docker compose up -d postgres planka
-
-# 8. Configure Marcus
-cp config_marcus.example.json config_marcus.json
-# Edit config_marcus.json with your Planka project/board IDs and API key
-
-# 9. Run tests to verify setup
-pytest tests/
-```
-
-### Development Workflow
-
-📖 **Complete guide:** [Development Workflow](docs/source/developer/development-workflow.md)
-
-**Important:** Marcus uses a `develop` branch workflow. All contributions should be made against `develop`, not `main`.
-
-```bash
-# 1. Set up upstream remote (one-time setup)
-git remote add upstream https://github.com/lwgray/marcus.git
-
-# 2. Update your fork's develop branch
-git checkout develop
-git pull upstream develop
-git push origin develop
-
-# 3. Create feature branch from develop (in your fork)
-git checkout -b feature/your-feature-name
-
-# 4. Make changes and test
-# ... edit files ...
-pytest tests/                    # Run tests
-mypy src/                        # Type checking
-pre-commit run --all-files       # Run all quality checks
-
-# 5. Commit with conventional commits
-git add .
-git commit -m "feat(worker): add task retry logic"
-
-# 6. Keep your branch updated with develop
-git fetch upstream
-git rebase upstream/develop
-
-# 7. Push to your fork and create PR
-git push origin feature/your-feature-name
-# Open PR on GitHub targeting the 'develop' branch
-```
-
-**Branching Best Practices:**
-- ✅ Always branch from `develop`, not `main`
-- ✅ Work in your fork's feature branches
-- ✅ Keep feature branches focused and short-lived
-- ✅ Regularly sync with `upstream/develop` to avoid conflicts
-- ✅ Target your PRs to the `develop` branch
-
-### Running Marcus Locally vs Docker
-
-📖 **See:** [Development Workflow - Testing Workflow](docs/source/developer/development-workflow.md#testing-workflow)
-
-```bash
-# Local (faster iteration)
-./marcus start
-
-# Docker (production-like)
-docker compose up -d marcus
-docker compose logs -f marcus
-```
-
-## ✅ Code Quality and Pre-Commit
-
-We use pre-commit hooks to ensure consistent code quality. These run automatically before every commit.
-
-### Pre-Commit Hooks
-
-Our pre-commit configuration includes:
-
-- **MyPy**: Static type checking to catch type errors
-- **Ruff**: Fast Python linter for code quality
-- **Black**: Code formatter for consistent style
-- **isort**: Import statement organizer
-- **detect-secrets**: Prevents committing secrets and API keys
-- **YAML/JSON validation**: Ensures configuration files are valid
-- **Trailing whitespace removal**: Cleans up extra spaces
-- **End-of-file fixer**: Ensures files end with newlines
-
-### Running Quality Checks
-
-```bash
-# Run all pre-commit hooks on all files
-pre-commit run --all-files
-
-# Run pre-commit hooks on staged files only
-pre-commit run
-
-# Run specific checks
-mypy src/
-ruff check src/
-black src/ --check
-pytest tests/
-
-# Fix formatting issues
-black src/
-isort src/
-ruff check --fix src/
-```
-
-### Quality Standards
-
-All code must pass these checks:
-
-1. **Type Safety**: MyPy must pass with no errors
-2. **Code Style**: Black formatting must be applied
-3. **Import Order**: isort must organize imports
-4. **Linting**: Ruff must pass with no violations
-5. **Security**: No secrets or API keys in code
-6. **Tests**: Minimum 80% test coverage for new code
-
-## 📋 Coding Standards
-
-### Python Style Guide
-
-We follow PEP 8 with these additions:
-
-```python
-# Good: Clear, typed, documented with NumPy-style docstrings
-def assign_task(agent_id: str, task_id: str, priority: int = 1) -> TaskAssignment:
-    """
-    Assign a task to an agent with optional priority.
-
-    Parameters
-    ----------
-    agent_id : str
-        Unique identifier of the agent
-    task_id : str
-        Unique identifier of the task
-    priority : int, optional
-        Task priority (1-5), by default 1
-
-    Returns
-    -------
-    TaskAssignment
-        Assignment details including agent, task, and timestamp
-
-    Raises
-    ------
-    AgentNotFoundError
-        If agent doesn't exist
-    TaskNotFoundError
-        If task doesn't exist
-    """
-    # Implementation here
-    pass
-
-# Bad: Unclear, untyped, undocumented
-def assign(a, t, p=1):
-    # assigns task
-    pass
-```
-
-### Best Practices
-
-1. **Type Hints**: Always use type hints for function arguments and returns
-2. **Docstrings**: Every public function/class needs a NumPy-style docstring
-3. **Error Handling**: Use Marcus Error Framework for user-facing errors (see [CLAUDE.md](CLAUDE.md))
-4. **Logging**: Use structured logging, not print statements
-5. **Constants**: Define at module level in UPPER_CASE
-6. **Tests**: Aim for 80% coverage, test edge cases
-
-### Commit Messages
-
-We use [Conventional Commits](https://www.conventionalcommits.org/):
-
-```
-<type>(<scope>): <subject>
-
-<body>
-
-<footer>
-```
-
-**Types**:
-- `feat`: New feature
-- `fix`: Bug fix
-- `docs`: Documentation only
-- `style`: Code style (formatting, semicolons, etc)
-- `refactor`: Code change that neither fixes a bug nor adds a feature
-- `perf`: Performance improvement
-- `test`: Adding or correcting tests
-- `chore`: Maintenance tasks
-
-**Examples**:
-```bash
-# Good examples
-git commit -m "feat(worker): add exponential backoff for retries"
-git commit -m "fix(kanban): handle GitHub API rate limits"
-git commit -m "docs(concepts): add MCP protocol explanation"
-git commit -m "test(core): add tests for task dependency resolution"
-
-# Bad examples
-git commit -m "fixed stuff"
-git commit -m "WIP"
-git commit -m "updates"
-```
-
-## 🧪 Testing
-
-### Test Organization
-
-📖 **See:** [Test Writing Instructions in CLAUDE.md](CLAUDE.md#test-writing-instructions)
-
-```
-tests/
-├── unit/                    # Fast, isolated unit tests
-│   ├── ai/
-│   ├── core/
-│   ├── mcp/
-│   └── visualization/
-├── integration/             # Tests requiring external services
-│   ├── e2e/
-│   ├── api/
-│   ├── external/
-│   └── diagnostics/
-├── future_features/         # TDD tests for unimplemented features
-└── performance/             # Performance tests
-```
-
-### Running Tests
-
-```bash
-# Run all tests
-pytest
-
-# Run with coverage
-pytest --cov=src --cov-report=html
-
-# Run specific test file
-pytest tests/unit/core/test_task_manager.py
-
-# Run specific test
-pytest tests/unit/core/test_task_manager.py::test_assign_task
-
-# Run only unit tests (fast)
-pytest tests/unit/
-
-# Run integration tests
-pytest tests/integration/
-
-# Skip slow tests
-pytest -m "not slow"
-```
-
-### Writing Tests
-
-Follow the Test-Driven Development (TDD) approach:
-
-```python
-# Good test example with NumPy-style docstring
-def test_agent_registration_with_valid_data():
-    """
-    Test that agents can register with valid data.
-
-    This test verifies the happy path for agent registration,
-    ensuring all required fields are properly stored.
-    """
-    # Arrange
-    agent_data = {
-        "agent_id": "test-001",
-        "name": "Test Agent",
-        "skills": ["python", "testing"]
-    }
-
-    # Act
-    result = agent_manager.register_agent(agent_data)
-
-    # Assert
-    assert result.success is True
-    assert result.agent.id == "test-001"
-    assert "python" in result.agent.skills
-
-# Use fixtures for common setup
-@pytest.fixture
-def mock_agent():
-    """Create a mock agent for testing."""
-    return Agent(
-        id="test-001",
-        name="Test Agent",
-        skills=["python", "testing"]
-    )
-```
-
-## 📚 Documentation
-
-### When to Update Docs
-
-Update documentation when you:
-- Add a new feature
-- Change existing behavior
-- Fix a confusing part of the docs
-- Add a new example or tutorial
-
-### Documentation Structure
-
-📖 **See:** [docs/README.md](docs/README.md) for the complete structure
-
-```
-docs/source/
-├── getting-started/     # New user guides and quickstart
-├── guides/              # How-to guides for users
-├── developer/           # Developer and contributor guides
-│   ├── local-development.md
-│   ├── development-workflow.md
-│   └── configuration.md
-├── concepts/            # High-level design and philosophy
-├── systems/             # Technical architecture (53 systems)
-├── api/                 # API reference
-└── roadmap/             # Future plans
-```
-
-### Documentation Placement Rules
-
-📖 **See:** [CLAUDE.md - DOCUMENTATION_PLACEMENT_RULES](CLAUDE.md#documentation-placement-rules)
-
-1. **Determine audience FIRST:**
-   - End users → `/docs/source/guides/`
-   - Developers → `/docs/source/developer/`
-   - Concepts → `/docs/source/concepts/`
-   - Architecture → `/docs/source/systems/`
-
-2. **Use descriptive filenames**: `setup-github-integration.md` not `github.md`
-
-3. **Check if docs already exist**: Update rather than duplicate
-
-### Writing Good Documentation
-
-```markdown
-# Good: Clear, structured, helpful
-## How to Configure GitHub Provider
-
-To use GitHub as your kanban provider, follow these steps:
-
-1. **Get a GitHub Token**
-   - Go to Settings > Developer settings > Personal access tokens
-   - Click "Generate new token"
-   - Select scopes: `repo`, `project`
-
-2. **Set Environment Variables**
-   ```bash
-   export MARCUS_KANBAN_PROVIDER=github
-   export MARCUS_KANBAN_GITHUB_TOKEN=ghp_xxxxxxxxxxxx
-   export MARCUS_KANBAN_GITHUB_OWNER=your_username
-   export MARCUS_KANBAN_GITHUB_REPO=your_repo
-   ```
-
-3. **Verify Connection**
-   ```bash
-   docker compose restart marcus
-   docker compose logs marcus
-   ```
-
-# Bad: Vague, unstructured
-## GitHub Setup
-You need a token and project URL. Set them in the environment.
-```
-
-## 🔍 Code Review Guidelines
-
-Effective code review benefits both the reviewer and the author. Here's how to make the most of it:
-
-### For Reviewers
-
-**Review Priorities (in order):**
-
-1. **Correctness**: Does the code solve the intended problem?
-2. **Tests**: Are edge cases and error conditions covered?
-3. **Clarity**: Is the code understandable to others?
-4. **Performance**: Are there obvious inefficiencies?
-5. **Security**: Any potential vulnerabilities?
-6. **Compatibility**: Does it break existing functionality?
-
-**Giving Constructive Feedback:**
-
-✅ **Do:**
-- Be respectful and constructive
-- Explain the "why" behind suggestions
-- Distinguish between "must fix" and "nice to have"
-- Acknowledge good work and clever solutions
-- Ask questions rather than making demands
-- Provide examples or references when possible
-
-❌ **Don't:**
-- Make personal comments
-- Be dismissive of different approaches
-- Nitpick trivial style issues (we have pre-commit for that)
-- Block PRs without clear rationale
-
-**Example feedback:**
-
-```markdown
-# Good
-"This could be more efficient using a dictionary lookup instead of a
-list search. For large datasets, this would be O(1) vs O(n). See
-example: [link]"
-
-# Not helpful
-"This is slow and wrong."
-```
-
-### For Authors
-
-**Receiving Feedback:**
-
-✅ **Do:**
-- Assume good intentions from reviewers
-- Ask for clarification if feedback is unclear
-- Discuss disagreements professionally with technical reasoning
-- Learn from suggestions and apply patterns to future work
-- Thank reviewers for their time
-- Update the PR promptly to address feedback
-
-❌ **Don't:**
-- Take feedback personally
-- Ignore or dismiss comments without discussion
-- Make changes without understanding why
-- Get defensive about your approach
-
-**Responding to Reviews:**
-
-```markdown
-# Good responses
-"Great point! I've updated to use the dictionary approach. Much cleaner."
-"I kept the list approach here because X, Y, Z. What do you think?"
-"I'm not sure I understand this suggestion. Could you clarify?"
-
-# Not helpful
-"Whatever, I'll change it."
-"This is fine."
-```
-
-### Review Etiquette
-
-- **Response Time**: We aim to review PRs within 3-5 business days
-- **Review Iterations**: Expect 1-3 rounds of feedback for most PRs
-- **Stale PRs**: PRs without activity for 6 weeks may be closed (you can reopen later)
-- **Breaking the Ice**: First-time contributors may need extra guidance - be patient and welcoming!
-
-## 🔄 Pull Request Process
-
-### Before Submitting
-
-- [ ] All pre-commit hooks pass (`pre-commit run --all-files`)
-- [ ] Tests pass locally (`pytest`)
-- [ ] MyPy type checking passes (`mypy src/`)
-- [ ] Code is formatted with Black (`black src/`)
-- [ ] Imports are organized with isort (`isort src/`)
-- [ ] Ruff linting passes (`ruff check src/`)
-- [ ] No secrets detected (`detect-secrets scan`)
-- [ ] Documentation is updated
-- [ ] Commit messages follow convention
-- [ ] PR description explains the change
-
-### PR Template
-
-When you open a PR, you'll see our template. Fill it out completely:
-
-```markdown
-## Description
-Brief description of what this PR does
-
-## Type of Change
-- [ ] Bug fix
-- [ ] New feature
-- [ ] Breaking change
-- [ ] Documentation update
-
-## Branch Information
-- [ ] This PR targets the `develop` branch
-- [ ] My branch is up-to-date with `upstream/develop`
-- [ ] I'm working in my fork's feature branch
-
-## Testing
-- [ ] Unit tests pass
-- [ ] Integration tests pass
-- [ ] Manual testing completed
-- [ ] Test coverage is ≥80%
-
-## Documentation
-- [ ] Updated relevant docs
-- [ ] Added docstrings to new code
-- [ ] Updated CHANGELOG.md (if applicable)
-
-## Checklist
-- [ ] My code follows the style guide
-- [ ] I've added tests for my changes
-- [ ] All quality checks pass
-```
-
-### Review Process
-
-1. **Automated Checks**: CI runs tests, linting, and security checks
-2. **Code Review**: Maintainers review for quality and fit
-3. **Feedback**: Address any requested changes
-4. **Approval**: Once approved, we'll merge your PR!
-
-### After Your PR is Merged
-
-```bash
-# 1. Delete your feature branch locally and remotely
-git branch -d feature/your-feature-name
-git push origin --delete feature/your-feature-name
-
-# 2. Update your fork's develop branch
-git checkout develop
-git pull upstream develop
-git push origin develop
-
-# 3. Celebrate! You've contributed to Marcus! 🎉
-```
-
-## 🔄 Backwards Compatibility and Deprecation
-
-Marcus is committed to maintaining backwards compatibility for our users while continuing to evolve the project.
-
-### Breaking Changes Policy
-
-- **Major versions** (1.0 → 2.0): May include breaking changes
-- **Minor versions** (1.1 → 1.2): No breaking changes to public APIs
-- **Patch versions** (1.1.1 → 1.1.2): Bug fixes only, no breaking changes
-
-### Deprecation Process
-
-When we need to remove or change functionality:
-
-1. **Announce Deprecation** (Release N):
-   - Add deprecation warning to the function/feature
-   - Document in CHANGELOG.md and release notes
-   - Update documentation with migration guide
-
-2. **Maintain Deprecated Code** (Release N+1):
-   - Keep functionality working with warnings
-   - Continue to support users during transition
-
-3. **Remove Deprecated Code** (Release N+2):
-   - After two minor versions, remove deprecated code
-   - Document removal in breaking changes section
-
-**Example:**
-
-```python
-import warnings
-
-def old_function():
-    """
-    Deprecated: Use new_function() instead.
-
-    .. deprecated:: 0.5.0
-        `old_function` will be removed in version 0.7.0.
-        Use `new_function` instead.
-    """
-    warnings.warn(
-        "old_function is deprecated and will be removed in version 0.7.0. "
-        "Use new_function instead.",
-        DeprecationWarning,
-        stacklevel=2
-    )
-    # ... existing implementation
-```
-
-### API Stability
-
-- **Public API**: Methods, classes, and functions in main modules (guaranteed stable)
-- **Internal API**: Anything in `_internal` or prefixed with `_` (may change without notice)
-- **Experimental**: Clearly marked features (may change based on feedback)
-
-## 🎯 Areas Needing Help
-
-Looking for something to work on? These areas need attention:
-
-### High Priority
-- 🧪 **Test Coverage**: Especially integration tests
-- 📚 **Documentation**: Tutorials and examples
-- 🐛 **Bug Fixes**: Check the issue tracker
-- 🔧 **Provider Support**: Add support for Jira, Trello, Linear
-
-### Feature Ideas
-- 📊 Better progress visualization
-- 🔌 More MCP tool implementations
-- 🌐 Internationalization support
-- 📱 Mobile-friendly dashboard
-- 🤖 More AI provider integrations
-
-## 💬 Getting Help
-
-### Where to Ask Questions
-
-- **[GitHub Discussions](https://github.com/lwgray/marcus/discussions)**: For general questions and ideas
-- **Issue Comments**: For specific issues
-- **[Discord](https://discord.gg/marcus)**: Join our community
-
-### Tips for Getting Help
-
-1. **Search First**: Check docs, issues, and discussions
-2. **Be Specific**: Include error messages, code samples, and context
-3. **Show Your Work**: Explain what you've already tried
-4. **Be Patient**: Maintainers are volunteers
-
-## 🏆 Recognition
-
-We value all contributions! Contributors are recognized in:
-
-- `CONTRIBUTORS.md` file (automatic)
-- Release notes (for significant contributions)
-- Project README (for major contributors)
-
-## 📖 Additional Resources
-
-### Learn More About Marcus
-- [Core Concepts](docs/source/getting-started/core-concepts.md)
-- [Agent Workflow Guide](docs/source/guides/agent-workflows/agent-workflow.md)
-- [Philosophy](docs/source/concepts/philosophy.md)
-- [Systems Architecture](docs/source/systems/README.md)
-
-### Developer Resources
-- [Local Development Setup](docs/source/developer/local-development.md)
-- [Development Workflow](docs/source/developer/development-workflow.md)
-- [Configuration Reference](docs/source/developer/configuration.md)
-- [CLAUDE.md](CLAUDE.md) - Project-specific development guidelines
-
-### Improve Your Skills
-- [Python Testing Guide](https://realpython.com/python-testing/)
-- [Conventional Commits](https://www.conventionalcommits.org/)
-- [How to Write Good Documentation](https://www.writethedocs.org/guide/)
-
-### Tools We Use
-- [Black](https://black.readthedocs.io/) - Code formatter
-- [Pytest](https://docs.pytest.org/) - Testing framework
-- [MyPy](https://mypy.readthedocs.io/) - Type checking
-- [Pre-commit](https://pre-commit.com/) - Git hooks
-- [Sphinx](https://www.sphinx-doc.org/) - Documentation
+Thanks for contributing. This guide is short on purpose. The [README](README.md) covers what Marcus is and how to run it — this file covers the rules for changing it.
 
 ---
 
-## Thank You!
+## TL;DR
 
-Every contribution makes Marcus better. Whether it's your first open source contribution or your thousandth, we're grateful you're here.
+1. Fork → branch from `develop` → PR back to `develop` (never `main`).
+2. Conventional commit messages (`feat:`, `fix:`, `docs:`...).
+3. `pre-commit run --all-files` + `pytest tests/unit/` must pass.
+4. New code: NumPy-style docstrings, type hints, ≥80% coverage.
 
-Welcome to the Marcus community! 🚀
+---
+
+## 1. Set up your environment
+
+Follow the [README Quickstart](README.md#get-started) to install Marcus and pick an LLM provider. Then add the dev extras:
+
+```bash
+pip install -r requirements-dev.txt
+pre-commit install
+```
+
+That's it. The SQLite kanban provider is the default — you don't need Docker or Planka unless you want the visual board.
+
+### Free option: Ollama
+
+You can develop without any paid API key. Recommended model:
+
+```bash
+# Install Ollama: https://ollama.ai
+ollama pull qwen3.5:35b-a3b-coding-nvfp4
+```
+
+Point the **planner** at it in `config_marcus.json`:
+
+```json
+"ai": {
+  "provider": "local",
+  "model": "qwen3.5:35b-a3b-coding-nvfp4"
+}
+```
+
+Then launch each **worker** against the same model:
+
+```bash
+ollama launch code --model qwen3.5:35b-a3b-coding-nvfp4
+```
+
+Marcus needs both — the planner decomposes the project, workers write the code. On 16GB RAM expect to cap at 1 planner + 2 workers. Smaller machines (8GB) can substitute `qwen2.5-coder:7b` or `deepseek-coder:6.7b`. All Marcus features work with local or cloud models. Full guide: [Setup Local LLM](docs/source/getting-started/setup-local-llm.md).
+
+---
+
+## 2. Branching
+
+Marcus uses a `develop` branch workflow. `main` is protected for releases.
+
+```bash
+git remote add upstream https://github.com/lwgray/marcus.git
+git checkout develop
+git pull upstream develop
+git checkout -b fix/<issue-number>     # or feat/<short-name>
+```
+
+Open PRs against `develop`. Rebase on `upstream/develop` before pushing if your branch is stale.
+
+---
+
+## 3. Commit messages
+
+[Conventional Commits](https://www.conventionalcommits.org/). Subject ≤ 70 chars. Scope is optional.
+
+```
+feat(worker): add exponential backoff for retries
+fix(kanban): handle GitHub API rate limits
+docs(readme): clarify ollama setup
+test(core): cover task dependency resolution
+```
+
+Types: `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `chore`.
+
+---
+
+## 4. Code quality
+
+Pre-commit hooks run on every commit: Black, isort, Ruff, MyPy, detect-secrets, YAML/JSON validation.
+
+```bash
+pre-commit run --all-files     # everything
+mypy src/                      # types only
+ruff check --fix src/          # autofix lint
+black src/ && isort src/       # format
+```
+
+All checks must pass before review.
+
+---
+
+## 5. Tests
+
+```bash
+pytest -m unit                                          # fast (CI baseline)
+pytest --cov=src --cov-report=html                      # with coverage
+pytest tests/unit/core/test_task_manager.py             # one file
+```
+
+**Placement** — unit tests go in `tests/unit/{ai,core,mcp,visualization}/`. Anything that needs DB, network, or files goes in `tests/integration/`. Unimplemented features go in `tests/future_features/`. Full rules in [CLAUDE.md](CLAUDE.md#test_writing_instructions).
+
+**Required for new code**: NumPy-style docstrings, type hints, ≥80% coverage, Arrange-Act-Assert, one logical assertion per test, mock all external services in unit tests.
+
+---
+
+## 6. Code style
+
+- PEP 8 + Black (88 char lines)
+- Type hints on every public function
+- NumPy-style docstrings on every public class/function (see CLAUDE.md)
+- Marcus Error Framework for user/agent-facing errors — regular Python exceptions only for internal programming bugs ([details](CLAUDE.md#error_handling_framework))
+- Structured logging, no `print()`
+
+---
+
+## 7. Pull requests
+
+Open the PR against `develop`. The template will appear — fill in:
+
+- **What changed and why** (one paragraph is plenty)
+- **Issue link** — `Fixes #123`
+- **Test plan** — checkboxes the reviewer can run
+
+Reviewers look for: correctness, tests, clarity, performance, security, no regressions. Expect 1–3 rounds of feedback. PRs idle 6 weeks may be closed; you can reopen.
+
+---
+
+## 8. Ways to contribute (not just code)
+
+| Type                 | Example                                                  |
+|----------------------|----------------------------------------------------------|
+| **Bugs**             | Reproducible repro + environment in the issue            |
+| **Features**         | Open a GitHub Discussion first to validate the idea      |
+| **Kanban providers** | Jira, Trello, Linear adapters                            |
+| **Runners**          | Codex, Gemini, Kimi, AutoGen — see [PROTOCOL.md](PROTOCOL.md) |
+| **Docs**             | Tutorials, examples, error-message clarifications        |
+
+Newcomers: filter issues by [`good first issue`](https://github.com/lwgray/marcus/labels/good%20first%20issue) or the sprint label.
+
+---
+
+## 9. Help and community
+
+- [Discord](https://discord.com/channels/1409498120739487859/1409498121456848907) — real-time help
+- [GitHub Discussions](https://github.com/lwgray/marcus/discussions) — design questions
+- [GitHub Issues](https://github.com/lwgray/marcus/issues) — bugs, features
+
+---
+
+## Reference
+
+- [README](README.md) — what Marcus is, how to run it
+- [PROTOCOL.md](PROTOCOL.md) — agent protocol spec
+- [ROADMAP.md](ROADMAP.md) — direction
+- [CLAUDE.md](CLAUDE.md) — full coding rules (tests, errors, file management, git)
+- [Local Development Setup](docs/source/developer/local-development.md)
+- [Development Workflow](docs/source/developer/development-workflow.md)
+- [Configuration Reference](docs/source/developer/configuration.md)
+
+Every contribution makes Marcus better. Welcome.

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ src="https://img.shields.io/discord/1409498120739487859?color=7289da&label=Disco
   <img src="https://img.shields.io/badge/python-3.11+-blue?logo=python&logoColor=white" alt="Python 3.11+">
   <a href="https://opensource.org/licenses/MIT"><img src="https://img.shields.io/badge/License-MIT-yellow.svg" alt="License: MIT"></a>
   <a href="https://modelcontextprotocol.io/"><img src="https://img.shields.io/badge/MCP-Compatible-green" alt="MCP Compatible"></a>
+  <a href="docs/source/getting-started/setup-local-llm.md"><img src="https://img.shields.io/badge/Contribute-Free%20with%20Ollama-ff6b35?logo=ollama&logoColor=white" alt="Contribute for free with Ollama"></a>
 </p>
 
   ---

--- a/docs/source/getting-started/setup-local-llm.md
+++ b/docs/source/getting-started/setup-local-llm.md
@@ -1,128 +1,120 @@
-# Setting Up Local LLM with Marcus
+# Setting Up Local LLMs with Marcus
 
-This guide shows you how to run Marcus with a local Large Language Model (LLM) for completely offline operation.
+Run Marcus end-to-end on your own hardware — no API keys, no usage costs. This guide covers picking models, configuring Ollama, and running enough capacity to keep multiple agents busy in parallel.
 
-## Configuration Methods
+## What you need to set up
 
-Marcus supports two ways to configure local models:
+Marcus is multi-agent. Two distinct LLM roles must both work:
 
-1. **config_marcus.json** (Recommended)
-2. **Environment variables** (Override config values)
+| Role | What it does | Hard requirement |
+|------|--------------|------------------|
+| **Planner** | Decomposes a project description into a task graph on the board. Marcus calls it once at `create_project` time. | Strong instruction-following + structured-output reliability |
+| **Workers** | Actual coding agents (Claude Code, Codex, Aider, custom). Each pulls tasks from the board and writes code. | **Must support tool / function calling** — Marcus and MCP both depend on it |
 
-## Recommended Models for Coding & Reasoning
+> ⚠️ **Worker models without tool-calling will silently fail.** They can't invoke `request_next_task`, `report_task_progress`, `log_artifact`, etc. If you pick a worker model, verify it advertises tool-calling support on its model card.
 
-For Marcus's task analysis and code understanding, these models work best:
+## Recommended models
 
-### 🏆 Top Pick for Contributors
+### 🏆 Top pick for Apple Silicon — one model, both roles
 
-1. **Qwen2.5-Coder** ⭐ **(Highly Recommended - Best Free Coding Model)**
-   - **Best for:** Complex software development, Marcus contribution
-   - **Quality:** Rivals GPT-4 on coding benchmarks
-   - **Sizes:** 1.5B, 7B, 14B, 32B
-   - **Best balance:** `qwen2.5-coder:7b` (runs on 8GB RAM)
-   - **Why choose this:** State-of-the-art code understanding, excellent instruction following
-   - **Released:** Late 2024, specifically optimized for software engineering tasks
+**`qwen3.5:35b-a3b-coding-nvfp4`** runs comfortably on a 16GB+ M-series Mac and serves as **both planner and worker**. NVFP4 quantization is tuned for Apple Silicon — strong code generation, reliable structured output, and tool-calling support. If you're on a Mac, start here and skip the rest of the matrix.
 
-### Other Excellent Options
+```bash
+ollama pull qwen3.5:35b-a3b-coding-nvfp4
+```
 
-2. **DeepSeek-Coder** (Also Excellent)
-   - Great for code understanding and generation
-   - Sizes: 1.3B, 6.7B, 33B
-   - Best balance: `deepseek-coder:6.7b`
-   - Slightly older than Qwen2.5 but still very capable
+Capacity on 16GB unified memory: 1 planner + ~2 workers concurrently.
 
-3. **CodeLlama**
-   - Meta's code-specialized model
-   - Sizes: 7B, 13B, 34B
-   - Best for Marcus: `codellama:13b`
-   - Good for smaller tasks, fast responses
+### Planner — verified working
 
-4. **Mixtral** (For advanced reasoning)
-   - Strong general reasoning + code
-   - Size: 8x7B (requires ~48GB RAM)
-   - Use: `mixtral:8x7b`
-   - Best for complex multi-step reasoning
+| Model | Quantization | Notes |
+|-------|--------------|-------|
+| `qwen3.5:35b-a3b-coding-nvfp4` | NVFP4 | **Best on Apple Silicon.** Doubles as worker. |
+| `qwen2.5-coder:7b` | **Q4 or Q5** | **Lowest known-working planner.** Reliable on modest hardware. |
+| `ministral:14b` (Ministral-3-14B) | Q4+ | Larger planner option — better task decomposition on complex projects. |
+| `qwen2.5-coder:14b` | Q4+ | Higher-quality plans when you have RAM to spare. |
 
-5. **Mistral** (Lightweight option)
-   - Good general purpose model
-   - Size: 7B
-   - Use: `mistral:7b`
-   - Best for: Low-end hardware, fast iteration
+Anything below 7B has not produced reliable plans in our testing.
 
-## Quick Start with Ollama
+### Workers — must support tool calling
+
+| Model | Notes |
+|-------|-------|
+| `qwen3.5:35b-a3b-coding-nvfp4` | **Best on Apple Silicon.** Same model can serve the planner. |
+| `qwen2.5-coder:7b` / `:14b` / `:32b` | Tool-calling supported, strong code generation. |
+| `deepseek-coder` (instruct variants) | Tool-calling supported. |
+| Hosted Claude / GPT via the worker agent itself | The easiest path — let Claude Code or Codex use their normal models. |
+
+If you're unsure whether a model supports tool calling, check the Ollama model page for "Tools" in the capabilities list.
+
+### Running multiple workers in parallel
+
+**One Ollama process serves requests serially per model.** If two workers ask the same `ollama` instance for completions at the same time, the second request waits. To get real parallelism:
+
+- **Option A — multiple Ollama instances.** Launch additional `ollama serve` processes on different ports (`OLLAMA_HOST=127.0.0.1:11435 ollama serve`, then point a worker at `:11435`). One instance per concurrent worker.
+- **Option B — `OLLAMA_NUM_PARALLEL`.** Set `export OLLAMA_NUM_PARALLEL=4` before starting Ollama to let a single instance handle multiple requests concurrently. Each parallel slot uses additional VRAM — verify you have headroom.
+- **Option C — fewer workers.** If hardware is tight, run 1 planner + 2 workers. Most coordination value shows up before you saturate the box.
+
+Rule of thumb: 16GB unified memory → 1 planner + 2 workers. 32GB+ → 4+ workers comfortably.
+
+## Quick start
 
 ### 1. Install Ollama
 
 ```bash
-# macOS/Linux
 curl -fsSL https://ollama.com/install.sh | sh
-
-# Or download from: https://ollama.com/download
+# Or download from https://ollama.com/download
 ```
 
-### 2. Pull a Model
+### 2. Pull a model
 
 ```bash
-# Best for Marcus development (recommended)
+# Apple Silicon — best dual-role pick (planner + workers)
+ollama pull qwen3.5:35b-a3b-coding-nvfp4
+
+# Or, the lowest known-working planner for modest hardware
 ollama pull qwen2.5-coder:7b
 
-# Alternative: DeepSeek-Coder (also excellent)
-ollama pull deepseek-coder:6.7b
-
-# Alternative: CodeLlama
-ollama pull codellama:13b
-
-# For lighter systems (8GB RAM minimum)
-ollama pull mistral:7b
+# Or, a larger planner option
+ollama pull ministral:14b
 ```
 
-### 3. Configure Marcus
+### 3. Point Marcus at it
 
-#### Method 1: Using config_marcus.json (Recommended)
-
-Update your `config_marcus.json`:
+Edit `config_marcus.json`:
 
 ```json
 {
   "ai": {
     "provider": "local",
     "enabled": true,
-    "local_model": "qwen2.5-coder:7b",
+    "local_model": "qwen3.5:35b-a3b-coding-nvfp4",
     "local_url": "http://localhost:11434/v1",
     "local_key": "none"
   }
 }
 ```
 
-#### Method 2: Using Environment Variables
-
-Environment variables override config values:
+Or override with environment variables (these win over `config_marcus.json`):
 
 ```bash
-# Override the provider
 export MARCUS_LLM_PROVIDER=local
-
-# Override the model (use the best one)
-export MARCUS_LOCAL_LLM_PATH=qwen2.5-coder:7b
-
-# Override the URL (if not using default Ollama)
+export MARCUS_LOCAL_LLM_PATH=qwen3.5:35b-a3b-coding-nvfp4
 export MARCUS_LOCAL_LLM_URL=http://localhost:11434/v1
-
-# Override the API key (if needed)
-export MARCUS_LOCAL_LLM_KEY=your-key-here
 ```
 
 ### 4. Start Marcus
 
 ```bash
-# Ollama starts automatically when you pull a model
-# Just run Marcus normally
-python -m marcus_mcp
+./marcus start
+./marcus board   # check tasks land on the board
 ```
 
-## Complete Configuration Example
+### 5. Wire your workers
 
-Here's a full `config_marcus.json` configured for local model usage:
+Each worker is a coding agent — most commonly Claude Code, but any MCP-compatible agent works. Point each worker at its own Ollama endpoint (see "Running multiple workers in parallel" above) and confirm the model supports tool calling.
+
+## Complete configuration example
 
 ```json
 {
@@ -139,8 +131,7 @@ Here's a full `config_marcus.json` configured for local model usage:
     "local_url": "http://localhost:11434/v1",
     "local_key": "none",
     "anthropic_api_key": "",
-    "openai_api_key": "",
-    "model": "claude-haiku-4-5-20251001"
+    "openai_api_key": ""
   },
   "features": {
     "events": true,
@@ -151,137 +142,75 @@ Here's a full `config_marcus.json` configured for local model usage:
 }
 ```
 
-## Advanced Configuration
+## Advanced
 
-### Using Different Inference Servers
+### Non-Ollama OpenAI-compatible servers
 
-Marcus supports any OpenAI-compatible API. Configure in `config_marcus.json`:
+Anything that speaks the OpenAI API works (`llama.cpp` server, LocalAI, text-generation-webui, vLLM):
 
 ```json
 {
   "ai": {
     "provider": "local",
-    "local_model": "your-model-name",
+    "local_model": "your-model",
     "local_url": "http://localhost:8080/v1",
-    "local_key": "your-api-key"
+    "local_key": "your-api-key-if-needed"
   }
 }
 ```
 
-Examples for different servers:
-- **llama.cpp server**: `"local_url": "http://localhost:8080/v1"`
-- **text-generation-webui**: `"local_url": "http://localhost:5000/v1"`
-- **LocalAI**: `"local_url": "http://localhost:8080/v1"`
+### Configuration priority
 
-### Configuration Priority
+1. Environment variables (`MARCUS_*`)
+2. `config_marcus.json`
+3. Built-in defaults
 
-Marcus uses this priority order:
-1. Environment variables (highest priority)
-2. config_marcus.json
-3. Default values (lowest priority)
+### Ollama performance knobs
 
-This allows you to:
-- Set defaults in config_marcus.json
-- Override temporarily with environment variables
-- Test different models without changing config
-
-### Performance Tuning
-
-1. **Model Selection by RAM**:
-   - 8GB RAM: Use 7B models (`mistral:7b`)
-   - 16GB RAM: Use 13B models (`codellama:13b`)
-   - 32GB+ RAM: Use 33B+ models (`deepseek-coder:33b`)
-
-2. **Ollama Performance Settings**:
-   ```bash
-   # Increase context window
-   export OLLAMA_NUM_CTX=8192
-
-   # Use GPU acceleration (if available)
-   export OLLAMA_CUDA_VISIBLE_DEVICES=0
-   ```
-
-3. **Timeout Configuration**:
-   Local models can be slower. The LocalLLMProvider sets a 120-second timeout by default.
-
-## Switching Between Local and Cloud Models
-
-You can easily switch between providers:
-
-### Temporary Switch (Environment Variable)
 ```bash
-# Use local model
-export MARCUS_LLM_PROVIDER=local
-
-# Switch back to Anthropic
-export MARCUS_LLM_PROVIDER=anthropic
+export OLLAMA_NUM_CTX=8192        # bigger context window
+export OLLAMA_NUM_PARALLEL=4      # concurrent requests per instance
+export OLLAMA_KEEP_ALIVE=30m      # keep model resident between calls
 ```
 
-### Permanent Switch (config_marcus.json)
-```json
-{
-  "ai": {
-    "provider": "anthropic",  // or "local" or "openai"
-    // ... rest of config
-  }
-}
+Local-provider request timeout is 120s by default.
+
+### Switching back to cloud
+
+```bash
+export MARCUS_LLM_PROVIDER=anthropic   # or openai
 ```
+
+Or set `"ai.provider"` in `config_marcus.json`.
 
 ## Troubleshooting
 
-### "Failed to connect to local LLM server"
-- Check Ollama is running: `ollama list`
-- Verify the model is downloaded: `ollama pull <model>`
-- Check the URL: `curl http://localhost:11434/api/tags`
+**`Failed to connect to local LLM server`**
+- `ollama list` — is Ollama actually running?
+- `curl http://localhost:11434/api/tags` — does it answer?
+- Did you pull the model? `ollama pull <model>`
 
-### "Local LLM API error: 404"
-- Your Ollama might not have OpenAI compatibility
-- The LocalLLMProvider will automatically fallback to Ollama's native API
+**Worker silently does nothing / never calls `request_next_task`**
+- The model likely lacks tool-calling support. Switch to a model whose card lists Tools as a capability.
 
-### Slow Performance
-- Use smaller models for faster response
-- Enable GPU acceleration if available
-- Reduce max tokens in config if needed
+**Plans come back malformed / empty**
+- Your planner model is too small or too quantized. Try `qwen2.5-coder:7b` at Q5 minimum.
 
-## Model Recommendations by Use Case
+**Second worker stalls when first is busy**
+- One Ollama instance, no parallelism. Set `OLLAMA_NUM_PARALLEL` or run a second `ollama serve` on a different port.
 
-| Use Case | Recommended Model | Why |
-|----------|------------------|-----|
-| **Contributing to Marcus** | `qwen2.5-coder:7b` | **Best overall - state-of-the-art coding** |
-| General Marcus usage | `qwen2.5-coder:7b` or `deepseek-coder:6.7b` | Excellent code understanding |
-| Low-end hardware (8GB) | `mistral:7b` | Good balance of size/performance |
-| High-end hardware (16GB+) | `qwen2.5-coder:14b` | Even better quality |
-| Complex reasoning | `mixtral:8x7b` | Advanced reasoning (needs 48GB RAM) |
-| Fast responses | `codellama:7b` | Smaller but still code-focused |
+**Slow responses**
+- Smaller model, GPU acceleration, lower `max_tokens`, or reduce `OLLAMA_NUM_CTX`.
 
-## Example Session
+## Why local
 
-```bash
-# 1. Install and setup
-curl -fsSL https://ollama.com/install.sh | sh
-ollama pull qwen2.5-coder:7b
+- **Privacy** — code never leaves your machine
+- **Cost** — zero per-token charges, run as many experiments as you want
+- **Offline** — works on a plane
+- **Reproducibility** — pin a quantization, get the same outputs
 
-# 2. Configure for local development
-cp .env.dev.example .env
-# Or update config_marcus.json: Set "provider": "local" and "local_model": "qwen2.5-coder:7b"
+## Next
 
-# 3. Use Marcus normally
-python -m marcus_mcp
-
-# Marcus will now use your local model for all AI operations!
-# Zero API costs, excellent code quality ✨
-```
-
-## Benefits of Local Models
-
-- **Privacy**: All data stays on your machine
-- **No API Costs**: Unlimited usage
-- **Offline Operation**: Works without internet
-- **Customization**: Fine-tune models for your needs
-- **Low Latency**: No network round trips
-
-## Next Steps
-
-- Try different models to find what works best for your workflow
-- Consider fine-tuning a model on your codebase
-- Adjust temperature settings for more/less creative responses
+- Browse [`good first issue`](https://github.com/lwgray/marcus/labels/good%20first%20issue) and try a contribution end-to-end on local models.
+- See [Configuration Reference](../developer/configuration.md) for every option.
+- See [PROTOCOL.md](../../../PROTOCOL.md) if you're building a worker runner for a non-Claude agent.

--- a/src/ai/advanced/prd/advanced_parser.py
+++ b/src/ai/advanced/prd/advanced_parser.py
@@ -1154,40 +1154,27 @@ Return ONLY the JSON object. Do not include commentary.
           features
         """
         try:
-            # Use AI to analyze PRD
-            # Create a simple context object that has max_tokens
-            class SimpleContext:
-                def __init__(self, max_tokens: int) -> None:
-                    self.max_tokens = max_tokens
-
-            # Increase max_tokens to handle complex PRDs with many requirements
-            # 2000 tokens is too small - causes JSON truncation for 15+ features
-            # Task Management (18 features) and Restaurant Booking (17 features)
-            # need ~4000 tokens for complete JSON response
-            # Note: Claude Haiku max_tokens limit is 4096
-            context = SimpleContext(max_tokens=4096)
+            # PRD analysis returns a dense JSON schema (functional /
+            # integration / non-functional requirements, personas,
+            # complexity assessment, risk factors).  For a 4-domain
+            # project this routinely exceeds the legacy 4096 cap;
+            # safe_structured_call starts at 16384 and auto-retries
+            # with doubled budget on truncation.
+            from src.utils.structured_llm import safe_structured_call
 
             logger.info("Attempting to use LLM for PRD analysis...")
 
-            # Use the actual LLM to analyze the PRD
-            analysis_result = await self.llm_client.analyze(
-                prompt=analysis_prompt, context=context, operation="decompose_prd"
-            )
-
-            result_len = len(analysis_result) if analysis_result else 0
-            logger.info(f"LLM response received: {result_len} chars")
-
-            # Parse the AI response using our JSON parser utility
-            from src.utils.json_parser import parse_ai_json_response
-
             try:
-                analysis_data = parse_ai_json_response(analysis_result)
+                analysis_data = await safe_structured_call(
+                    llm=self.llm_client,
+                    prompt=analysis_prompt,
+                    operation="decompose_prd",
+                )
                 logger.info("Successfully parsed AI response as JSON")
             except (json.JSONDecodeError, ValueError) as e:
                 from src.core.error_framework import AIProviderError, ErrorContext
 
                 logger.error(f"Failed to parse AI response as JSON: {e}")
-                logger.error(f"Response was: {analysis_result[:200]}...")
 
                 raise AIProviderError(
                     "LLM",
@@ -1197,13 +1184,7 @@ Return ONLY the JSON object. Do not include commentary.
                         integration_name="advanced_prd_parser",
                         custom_context={
                             "prd_length": len(prd_content),
-                            "response_length": (
-                                len(analysis_result) if analysis_result else 0
-                            ),
                             "parsing_error": str(e),
-                            "response_preview": (
-                                analysis_result[:200] if analysis_result else "None"
-                            ),
                             "details": (
                                 "AI returned malformed JSON response. "
                                 "This indicates an issue with the AI "
@@ -1479,23 +1460,18 @@ IMPORTANT:
 Provide ONLY valid JSON, no preamble."""
 
         try:
-            # Create context for AI call
-            class SimpleContext:
-                def __init__(self, max_tokens: int) -> None:
-                    self.max_tokens = max_tokens
+            # Domain discovery output is typically small (a handful of
+            # domains with feature-id arrays). Start at 2048 — the
+            # helper escalates on truncation if a project has many
+            # functional requirements that bloat the response.
+            from src.utils.structured_llm import safe_structured_call
 
-            context = SimpleContext(max_tokens=500)
-
-            # Use LLM to discover domains
-            result = await self.llm_client.analyze(
-                prompt, context, operation="discover_domains"
+            domain_data = await safe_structured_call(
+                llm=self.llm_client,
+                prompt=prompt,
+                operation="discover_domains",
+                initial_max_tokens=2048,
             )
-            response_text = str(result) if result else "{}"
-
-            # Parse JSON response (handle markdown fences, preamble, etc.)
-            from src.utils.json_parser import parse_ai_json_response
-
-            domain_data = parse_ai_json_response(response_text)
             domains_list = domain_data.get("domains", [])
 
             # Convert to simple dict mapping

--- a/src/ai/advanced/prd/outcome_extractor.py
+++ b/src/ai/advanced/prd/outcome_extractor.py
@@ -173,13 +173,6 @@ _EXTRACTION_PROMPT = _EXTRACTION_PROMPT_TEMPLATE.replace(
 )
 
 
-class _MaxTokensContext:
-    """Minimal context wrapper passed to LLM clients that expect one."""
-
-    def __init__(self, max_tokens: int) -> None:
-        self.max_tokens = max_tokens
-
-
 async def extract_user_outcomes(
     spec: str, llm_client: Any, max_tokens: int = 1500
 ) -> List[UserOutcome]:

--- a/src/ai/advanced/prd/outcome_extractor.py
+++ b/src/ai/advanced/prd/outcome_extractor.py
@@ -38,8 +38,6 @@ import logging
 from dataclasses import dataclass
 from typing import Any, List
 
-from src.utils.json_parser import parse_ai_json_response
-
 logger = logging.getLogger(__name__)
 
 _VALID_SCOPES: frozenset[str] = frozenset({"in_scope", "out_of_scope"})
@@ -215,13 +213,15 @@ async def extract_user_outcomes(
         any individual outcome fails :class:`UserOutcome` validation.
     """
     prompt = _EXTRACTION_PROMPT.format(spec=spec)
-    raw = await llm_client.analyze(
-        prompt, _MaxTokensContext(max_tokens), operation="extract_outcomes"
-    )
-    raw_text = str(raw) if raw is not None else ""
+    from src.utils.structured_llm import safe_structured_call
 
     try:
-        payload = parse_ai_json_response(raw_text)
+        payload = await safe_structured_call(
+            llm=llm_client,
+            prompt=prompt,
+            operation="extract_outcomes",
+            initial_max_tokens=max_tokens,
+        )
     except (ValueError, json.JSONDecodeError) as exc:
         raise ValueError(
             f"User-outcome extractor: LLM returned malformed JSON: {exc}"
@@ -382,14 +382,15 @@ async def filter_to_verifiable_capabilities(
         for o in outcomes
     )
     prompt = _FILTER_PROMPT.format(outcomes_block=outcomes_block)
-
-    raw = await llm_client.analyze(
-        prompt, _MaxTokensContext(max_tokens), operation="filter_outcomes"
-    )
-    raw_text = str(raw) if raw is not None else ""
+    from src.utils.structured_llm import safe_structured_call
 
     try:
-        payload = parse_ai_json_response(raw_text)
+        payload = await safe_structured_call(
+            llm=llm_client,
+            prompt=prompt,
+            operation="filter_outcomes",
+            initial_max_tokens=max_tokens,
+        )
     except (ValueError, json.JSONDecodeError) as exc:
         raise ValueError(
             f"User-outcome filter: LLM returned malformed JSON: {exc}"

--- a/src/ai/providers/anthropic_provider.py
+++ b/src/ai/providers/anthropic_provider.py
@@ -73,7 +73,7 @@ class AnthropicProvider(BaseLLMProvider):
         self.model = config.ai.model or "claude-3-haiku-20240307"
         self.max_tokens = config.ai.max_tokens
         self.temperature = config.ai.temperature  # Read temperature from config
-        self.timeout = 30.0
+        self.timeout = 120.0
 
         # HTTP client with proper headers
         # Disable HTTP/2 to avoid connection issues in Docker environments

--- a/src/ai/providers/cloud_provider.py
+++ b/src/ai/providers/cloud_provider.py
@@ -136,6 +136,12 @@ class CloudLLMProvider(LocalLLMProvider):
         """
         if max_tokens is None:
             max_tokens = self.max_tokens
+        else:
+            # Floor caller-supplied budget to config.ai.max_tokens. Reasoning
+            # models (R1, Qwen3p5, etc.) spend tokens on chain-of-thought
+            # before emitting JSON; when truncated, providers like Fireworks
+            # spill the partial CoT into `content` and break JSON parsers.
+            max_tokens = max(max_tokens, self.max_tokens)
         if temperature is None:
             temperature = self.temperature
 
@@ -154,6 +160,10 @@ class CloudLLMProvider(LocalLLMProvider):
             ],
             "max_tokens": max_tokens,
             "temperature": temperature,
+            # Disable reasoning/chain-of-thought on models that support it
+            # (Qwen3, DeepSeek-R1 via Fireworks). Drastically reduces tokens
+            # and keeps JSON in `content` rather than `reasoning_content`.
+            "reasoning_effort": "none",
             "stream": False,
         }
 

--- a/src/integrations/ai_analysis_engine.py
+++ b/src/integrations/ai_analysis_engine.py
@@ -1705,23 +1705,24 @@ IMPORTANT: Respond with valid JSON matching this exact schema:
 Your response must be pure JSON with no markdown formatting, \
 explanations, or additional text."""
 
-            # Use LLM abstraction to call configured provider
-            # (Anthropic, OpenAI, or local)
-            response_text = await llm.analyze(
-                full_prompt,
-                context=type("obj", (object,), {"max_tokens": 4096})(),
-                operation=operation,
+            # Delegate to the shared safe_structured_call helper, which
+            # owns the default budget (16384, up from the Haiku-3-era
+            # 4096) and the auto-retry-on-truncation policy. Single
+            # source of truth across every structured-JSON caller in
+            # Marcus — see src/utils/structured_llm.py.
+            from src.utils.structured_llm import safe_structured_call
+
+            return await safe_structured_call(
+                llm=llm,
+                prompt=full_prompt,
+                operation=operation or "generate_structured_response",
             )
 
-            # Parse JSON response
-            from src.utils.json_parser import parse_ai_json_response
-
-            return parse_ai_json_response(response_text)
-
-        except json.JSONDecodeError as e:
-            raw_text = response_text if "response_text" in locals() else "N/A"
-            print(f"Failed to parse structured response as JSON: {e}", file=sys.stderr)
-            print(f"Raw response: {raw_text}", file=sys.stderr)
+        except (json.JSONDecodeError, ValueError) as e:
+            # The helper already logged a structured_llm.retry event for
+            # any truncation-driven retries that were attempted before
+            # this exception bubbled out — re-raise as RuntimeError so
+            # callers keep their existing failure semantics.
             raise RuntimeError(
                 f"AI returned invalid JSON: {e}. This may indicate the AI "
                 "did not follow the schema correctly."

--- a/src/integrations/nlp_tools.py
+++ b/src/integrations/nlp_tools.py
@@ -1044,8 +1044,7 @@ class NaturalLanguageProjectCreator(NaturalLanguageTaskCreator):
         """
         import uuid as _uuid
 
-        class _Ctx:
-            max_tokens = 1024
+        from src.utils.structured_llm import safe_structured_call
 
         # Appended to every synthesized description so foundation tasks
         # carry the same Marcus workflow reminder as any implementation
@@ -1161,31 +1160,22 @@ class NaturalLanguageProjectCreator(NaturalLanguageTaskCreator):
         )
 
         try:
-            raw = await self.prd_parser.llm_client.analyze(
+            parsed = await safe_structured_call(
+                llm=self.prd_parser.llm_client,
                 prompt=prompt,
-                context=_Ctx(),
                 operation="synthesize_foundation_tasks",
+                # Foundation synthesis output is small (typically 3-6
+                # task stubs). Start tight; helper escalates on
+                # truncation if a project ever needs more.
+                initial_max_tokens=2048,
             )
-        except Exception as exc:
-            logger.warning(
-                f"[pre-fork synthesis] LLM call failed ({exc}); "
-                "no foundation tasks injected"
-            )
-            return []
-
-        try:
-            from src.utils.json_parser import parse_ai_json_response
-
-            # parse_ai_json_response raises ValueError when the LLM
-            # output is not a JSON object — caught by the except below.
-            parsed = parse_ai_json_response(raw)
             raw_tasks = parsed.get("foundation_tasks")
             if not isinstance(raw_tasks, list) or not raw_tasks:
                 return []
         except Exception as exc:
             logger.warning(
-                f"[pre-fork synthesis] JSON parse failed ({exc}); "
-                "no foundation tasks injected"
+                f"[pre-fork synthesis] structured LLM call failed "
+                f"({exc}); no foundation tasks injected"
             )
             return []
 

--- a/src/marcus_mcp/coordinator/outcome_coverage.py
+++ b/src/marcus_mcp/coordinator/outcome_coverage.py
@@ -35,7 +35,6 @@ from src.ai.advanced.prd.outcome_extractor import UserOutcome
 from src.config.outcome_coverage_config import is_outcome_coverage_enabled
 from src.core.models import Priority, Task, TaskStatus
 from src.marcus_mcp.coordinator.graph_augmentation import AugmentationResult
-from src.utils.json_parser import parse_ai_json_response
 
 if TYPE_CHECKING:
     # TYPE_CHECKING-only to avoid the runtime cycle:
@@ -463,13 +462,15 @@ async def compute_coverage_with_llm(
         outcomes_block=outcomes_block, tasks_block=tasks_block
     )
 
-    raw = await llm_client.analyze(
-        prompt, _MaxTokensContext(max_tokens), operation="outcome_coverage_check"
-    )
-    raw_text = str(raw) if raw is not None else ""
+    from src.utils.structured_llm import safe_structured_call
 
     try:
-        payload = parse_ai_json_response(raw_text)
+        payload = await safe_structured_call(
+            llm=llm_client,
+            prompt=prompt,
+            operation="outcome_coverage_check",
+            initial_max_tokens=max_tokens,
+        )
     except (ValueError, json.JSONDecodeError) as exc:
         raise ValueError(f"LLM coverage: malformed JSON: {exc}") from exc
 
@@ -579,13 +580,6 @@ Rules:
   ``null`` when the task is purely a consumer.
 - Return ONLY the JSON object — no preamble, no markdown fences.
 """
-
-
-class _MaxTokensContext:
-    """Minimal context wrapper passed to LLM clients that expect one."""
-
-    def __init__(self, max_tokens: int) -> None:
-        self.max_tokens = max_tokens
 
 
 def _format_existing_tasks_block(existing_tasks: List[Task]) -> str:
@@ -723,13 +717,15 @@ async def fill_gaps(
         + schema_section
     )
 
-    raw = await llm_client.analyze(
-        prompt, _MaxTokensContext(max_tokens), operation="outcome_gap_fill"
-    )
-    raw_text = str(raw) if raw is not None else ""
+    from src.utils.structured_llm import safe_structured_call
 
     try:
-        payload = parse_ai_json_response(raw_text)
+        payload = await safe_structured_call(
+            llm=llm_client,
+            prompt=prompt,
+            operation="outcome_gap_fill",
+            initial_max_tokens=max_tokens,
+        )
     except (ValueError, json.JSONDecodeError) as exc:
         raise ValueError(
             f"Outcome gap-fill: LLM returned malformed JSON: {exc}"

--- a/src/utils/structured_llm.py
+++ b/src/utils/structured_llm.py
@@ -94,6 +94,29 @@ def _looks_truncated(raw: str) -> bool:
     return not tail.endswith(("}", "]"))
 
 
+def _deployment_ceiling() -> int:
+    """Return the maximum ``max_tokens`` value safe for this deployment.
+
+    ``config.ai.max_tokens`` is a per-deployment knob the operator sets
+    to match the configured model's output cap (Claude 3 Haiku caps at
+    4096; Claude Haiku 4.5 supports 64K).  The helper must not escalate
+    beyond it — sending more than the model allows fails with a 400
+    before any retry can help.
+
+    Falls back to :data:`DEFAULT_MAX_TOKENS` if config is unavailable
+    (test harnesses, partial imports).
+    """
+    try:
+        from src.config.marcus_config import get_config
+
+        ceiling = int(get_config().ai.max_tokens)
+        # Clamp to module hard cap so a misconfigured ai.max_tokens
+        # can't blow past the Claude Haiku 4.5 limit.
+        return min(ceiling, MAX_OUTPUT_TOKENS)
+    except Exception:
+        return DEFAULT_MAX_TOKENS
+
+
 async def safe_structured_call(
     *,
     llm: Any,
@@ -119,12 +142,14 @@ async def safe_structured_call(
     initial_max_tokens : int, default :data:`DEFAULT_MAX_TOKENS`
         Starting token budget for the first attempt.  Callers that
         know their output is small (e.g. yes/no classifier, domain
-        discovery) may pass a smaller value; the retry path will
-        still escalate up to :data:`MAX_OUTPUT_TOKENS` on truncation.
-    max_retries : int, default 2
+        discovery) may pass a smaller value.  Whatever the caller
+        passes, the helper clamps it to the per-deployment ceiling
+        (``config.ai.max_tokens``) so older models like Claude 3 Haiku
+        (4096 cap) don't get a request bigger than the API allows.
+    max_retries : int, default 3
         Additional attempts after the first if the response looks
-        truncated. Budget doubles each attempt, capped at
-        :data:`MAX_OUTPUT_TOKENS`.
+        truncated. Budget doubles each attempt, capped at the
+        per-deployment ceiling.
 
     Returns
     -------
@@ -147,7 +172,12 @@ async def safe_structured_call(
             f"input or split the call."
         )
 
-    max_tokens = initial_max_tokens
+    # The configured model's output cap is the real ceiling for
+    # everything the helper does — first attempt and retry escalation.
+    # Sending more than the model supports fails with a 400 before any
+    # retry can help (Codex P1 on PR #542).
+    ceiling = _deployment_ceiling()
+    max_tokens = min(initial_max_tokens, ceiling)
     raw_text = ""
     last_err: Optional[Exception] = None
 
@@ -165,9 +195,10 @@ async def safe_structured_call(
             last_err = exc
             if attempt == max_retries or not _looks_truncated(raw_text):
                 raise
-            next_budget = min(max_tokens * 2, MAX_OUTPUT_TOKENS)
+            next_budget = min(max_tokens * 2, ceiling)
             if next_budget == max_tokens:
-                # Already at ceiling; doubling won't help.
+                # Already at the per-deployment ceiling; doubling won't
+                # help and would just trigger an API rejection.
                 raise
             logger.warning(
                 "structured_llm.retry",

--- a/src/utils/structured_llm.py
+++ b/src/utils/structured_llm.py
@@ -18,7 +18,9 @@ caller gets the same defense:
 * Detect mid-stream truncation via a closing-brace heuristic on the
   raw text.
 * Auto-retry with doubled budget up to ``MAX_OUTPUT_TOKENS`` (64K —
-  Claude Haiku 4.5 ceiling).
+  Claude Haiku 4.5 ceiling).  Three retries by default so a tight
+  initial budget (2048) still escalates all the way to 16384 before
+  giving up.
 * Bail out fast on schema drift / non-truncation parse failures —
   more tokens won't fix those.
 * Emit a structured warning when retry triggers so Cato can graph
@@ -98,7 +100,7 @@ async def safe_structured_call(
     prompt: str,
     operation: str,
     initial_max_tokens: int = DEFAULT_MAX_TOKENS,
-    max_retries: int = 2,
+    max_retries: int = 3,
 ) -> Dict[str, Any]:
     """Run an LLM call expecting structured JSON, with truncation retry.
 

--- a/src/utils/structured_llm.py
+++ b/src/utils/structured_llm.py
@@ -1,0 +1,187 @@
+"""Resilient structured-JSON calls to the planner LLM.
+
+Why
+---
+Marcus's planner LLM (PRD analysis, contract decomposition, outcome
+extraction, domain discovery, foundation synthesis) emits structured
+JSON. The model's ``max_tokens`` cap is hard to size statically: a
+4-domain project needs more tokens than a 2-domain project. When the
+cap is too low, the JSON truncates mid-string and downstream parsing
+fails — the silent fallback to ``feature_based`` decomposition is
+visible only as a log warning, and the planner's intent is lost.
+
+This module centralizes the per-call policy so every structured-JSON
+caller gets the same defense:
+
+* Start at a sensible default (``16384`` — 4x the Haiku-3-era 4096
+  that was scattered through the codebase).
+* Detect mid-stream truncation via a closing-brace heuristic on the
+  raw text.
+* Auto-retry with doubled budget up to ``MAX_OUTPUT_TOKENS`` (64K —
+  Claude Haiku 4.5 ceiling).
+* Bail out fast on schema drift / non-truncation parse failures —
+  more tokens won't fix those.
+* Emit a structured warning when retry triggers so Cato can graph
+  retry frequency per operation.
+* Hard-cap prompt length to bound cost on runaway inputs.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any, Dict, Optional
+
+from src.utils.json_parser import parse_ai_json_response
+
+logger = logging.getLogger(__name__)
+
+# Hard cap on prompt length. ~200K chars ≈ 50K input tokens — generous
+# but bounds runaway cost from someone passing a giant PRD or context.
+MAX_PROMPT_CHARS = 200_000
+
+# Output token ceiling. Claude Haiku 4.5 supports 64K output; this
+# matches. Older Haiku 3 capped at 4096, which is what the legacy
+# scattered defaults were sized for.
+MAX_OUTPUT_TOKENS = 65_536
+
+# Default starting budget. 4x the legacy 4096 covers the realistic
+# upper bound of contract-first decomposition output for 4-domain
+# projects without needing a retry round-trip.
+DEFAULT_MAX_TOKENS = 16_384
+
+
+class _Ctx:
+    """Minimal context passed to LLMAbstraction.analyze with max_tokens."""
+
+    def __init__(self, max_tokens: int) -> None:
+        self.max_tokens = max_tokens
+
+
+def _looks_truncated(raw: str) -> bool:
+    """Return True if ``raw`` looks like the model ran out of tokens mid-emit.
+
+    A complete JSON document — even when the model wrapped it in
+    markdown fences or appended a polite "let me know if you need
+    changes" — strips back to something that ends with ``}`` or
+    ``]``. Anything else suggests the stream cut off mid-string,
+    mid-array, or mid-key, which is the failure mode that more tokens
+    fixes.
+
+    Schema drift (wrong field names, missing required fields) still
+    produces well-formed JSON that ends correctly — retrying won't
+    help those, so this heuristic deliberately lets them fall through
+    to the caller as a hard failure.
+
+    Future work
+    -----------
+    The authoritative truncation signal is the provider's
+    ``stop_reason``/``finish_reason`` field (``max_tokens`` on
+    Anthropic, ``length`` on OpenAI/Fireworks).  Plumbing that
+    through ``LLMAbstraction.analyze`` requires changing the return
+    type from ``str`` to a typed response object across all four
+    provider implementations and their callers.  For now this
+    heuristic is sufficient: Claude truncates mid-string, which is
+    the case the suffix check catches reliably; the change-of-return-
+    type refactor can land separately when its blast radius is worth
+    paying for.
+    """
+    if not raw:
+        return True
+    tail = raw.rstrip().rstrip("`").rstrip()
+    return not tail.endswith(("}", "]"))
+
+
+async def safe_structured_call(
+    *,
+    llm: Any,
+    prompt: str,
+    operation: str,
+    initial_max_tokens: int = DEFAULT_MAX_TOKENS,
+    max_retries: int = 2,
+) -> Dict[str, Any]:
+    """Run an LLM call expecting structured JSON, with truncation retry.
+
+    Parameters
+    ----------
+    llm : Any
+        A client exposing async ``analyze(prompt, context, operation)``.
+        Typically :class:`src.ai.providers.llm_abstraction.LLMAbstraction`.
+    prompt : str
+        The full prompt (system + user + schema instructions). Caller
+        composes this; the helper does not add extra wrapping.
+    operation : str
+        Cost-event operation key (see
+        :mod:`src.cost_tracking.operations`).  Forwarded to the
+        provider and used as the retry-event tag.
+    initial_max_tokens : int, default :data:`DEFAULT_MAX_TOKENS`
+        Starting token budget for the first attempt.  Callers that
+        know their output is small (e.g. yes/no classifier, domain
+        discovery) may pass a smaller value; the retry path will
+        still escalate up to :data:`MAX_OUTPUT_TOKENS` on truncation.
+    max_retries : int, default 2
+        Additional attempts after the first if the response looks
+        truncated. Budget doubles each attempt, capped at
+        :data:`MAX_OUTPUT_TOKENS`.
+
+    Returns
+    -------
+    dict
+        Parsed JSON response.
+
+    Raises
+    ------
+    ValueError
+        Prompt exceeds :data:`MAX_PROMPT_CHARS`, or the LLM returned a
+        non-JSON / schema-drift response that retrying cannot fix.
+    json.JSONDecodeError
+        Final attempt still failed to parse (truncation kept exceeding
+        the doubled budget — should not happen in practice).
+    """
+    if len(prompt) > MAX_PROMPT_CHARS:
+        raise ValueError(
+            f"Prompt is {len(prompt)} chars; safe_structured_call "
+            f"caps at {MAX_PROMPT_CHARS} to bound cost. Trim the "
+            f"input or split the call."
+        )
+
+    max_tokens = initial_max_tokens
+    raw_text = ""
+    last_err: Optional[Exception] = None
+
+    for attempt in range(max_retries + 1):
+        result = await llm.analyze(
+            prompt=prompt,
+            context=_Ctx(max_tokens),
+            operation=operation,
+        )
+        raw_text = str(result) if result is not None else ""
+
+        try:
+            return parse_ai_json_response(raw_text)
+        except (ValueError, json.JSONDecodeError) as exc:
+            last_err = exc
+            if attempt == max_retries or not _looks_truncated(raw_text):
+                raise
+            next_budget = min(max_tokens * 2, MAX_OUTPUT_TOKENS)
+            if next_budget == max_tokens:
+                # Already at ceiling; doubling won't help.
+                raise
+            logger.warning(
+                "structured_llm.retry",
+                extra={
+                    "event": "structured_llm.retry",
+                    "operation": operation,
+                    "attempt": attempt + 1,
+                    "initial_budget": initial_max_tokens,
+                    "attempted_budget": max_tokens,
+                    "retry_budget": next_budget,
+                    "raw_chars": len(raw_text),
+                    "prompt_chars": len(prompt),
+                },
+            )
+            max_tokens = next_budget
+
+    # Defensive — loop only exits via return or raise.
+    assert last_err is not None
+    raise last_err

--- a/src/utils/structured_llm.py
+++ b/src/utils/structured_llm.py
@@ -34,7 +34,12 @@ import json
 import logging
 from typing import Any, Dict, Optional
 
-from src.utils.json_parser import parse_ai_json_response
+# Import the module (not the function) so callers that
+# ``patch("src.utils.json_parser.parse_ai_json_response")`` in tests
+# see the patched name when this helper resolves it at call time.
+# Binding the function at module load (``from json_parser import ...``)
+# would freeze the reference before any patch can take effect.
+from src.utils import json_parser
 
 logger = logging.getLogger(__name__)
 
@@ -190,7 +195,7 @@ async def safe_structured_call(
         raw_text = str(result) if result is not None else ""
 
         try:
-            return parse_ai_json_response(raw_text)
+            return json_parser.parse_ai_json_response(raw_text)
         except (ValueError, json.JSONDecodeError) as exc:
             last_err = exc
             if attempt == max_retries or not _looks_truncated(raw_text):

--- a/tests/unit/ai/test_bundled_domain_designs.py
+++ b/tests/unit/ai/test_bundled_domain_designs.py
@@ -154,7 +154,7 @@ class TestBundledDomainDiscovery:
 
         # Assert - Should suggest 2-3 domains for small projects
         parser.llm_client.analyze.assert_called_once()
-        call_args = parser.llm_client.analyze.call_args[0][0]
+        call_args = parser.llm_client.analyze.call_args.kwargs["prompt"]
         assert "2-3" in call_args  # Target domain count for small projects
 
     @pytest.mark.unit
@@ -194,7 +194,7 @@ class TestBundledDomainDiscovery:
 
         # Assert - Should suggest 4-7 domains for medium projects
         parser.llm_client.analyze.assert_called_once()
-        call_args = parser.llm_client.analyze.call_args[0][0]
+        call_args = parser.llm_client.analyze.call_args.kwargs["prompt"]
         assert "4-7" in call_args  # Target domain count for medium projects
 
     @pytest.mark.unit
@@ -212,7 +212,7 @@ class TestBundledDomainDiscovery:
         await parser._discover_domains(sample_functional_requirements)
 
         # Assert - Verify prompt includes feature details
-        call_args = parser.llm_client.analyze.call_args[0][0]
+        call_args = parser.llm_client.analyze.call_args.kwargs["prompt"]
         assert "User Login" in call_args
         assert "frontend" in call_args
         assert "coordinated" in call_args

--- a/tests/unit/ai/test_contract_first_outcome_integration.py
+++ b/tests/unit/ai/test_contract_first_outcome_integration.py
@@ -256,7 +256,7 @@ class TestContractCoverageHelper:
 
         # The fill_gaps prompt is the second call; assert the contract
         # content appears in it.
-        fill_prompt = parser.llm_client.analyze.await_args_list[1][0][0]
+        fill_prompt = parser.llm_client.analyze.await_args_list[1].kwargs["prompt"]
         assert "RenderingAgent" in fill_prompt
         assert "Render.ts" in fill_prompt
         assert "responsibility" in fill_prompt

--- a/tests/unit/coordinator/test_outcome_coverage.py
+++ b/tests/unit/coordinator/test_outcome_coverage.py
@@ -514,7 +514,8 @@ class TestFillGaps:
             ],
             llm_client=llm,
         )
-        prompt = llm.analyze.call_args[0][0]
+        # safe_structured_call passes the prompt as a keyword argument.
+        prompt = llm.analyze.call_args.kwargs["prompt"]
         assert "t_engine" in prompt
         assert "Game Engine" in prompt
         assert "t_input" in prompt
@@ -550,7 +551,7 @@ class TestFillGaps:
                 }
             },
         )
-        prompt = llm.analyze.call_args[0][0]
+        prompt = llm.analyze.call_args.kwargs["prompt"]
         assert "GameStateUpdate" in prompt
         assert "GameState.ts" in prompt
         # Schema variant with responsibility is selected when contracts present
@@ -569,7 +570,7 @@ class TestFillGaps:
             llm_client=llm,
             contract_artifacts=None,
         )
-        prompt = llm.analyze.call_args[0][0]
+        prompt = llm.analyze.call_args.kwargs["prompt"]
         # No-contract schema explicitly does NOT mention responsibility
         assert "responsibility" not in prompt
         # And the contract-section header does not appear
@@ -939,7 +940,12 @@ class TestApplyOutcomeCoverage:
         """
         outcomes = [_outcome("o1", "user can play", "moves")]
         tasks = [_task("t1", "task one")]
-        llm = self._llm_with_responses("not json")
+        # safe_structured_call retries on apparent truncation. "not json"
+        # doesn't end with a closing brace so each attempt looks
+        # truncated — feed enough responses to exhaust the retry path
+        # (initial + max_retries=3 attempts = 4 total) so the test
+        # reaches the final raise rather than running out of mocks.
+        llm = self._llm_with_responses("not json", "not json", "not json", "not json")
 
         with pytest.raises(ValueError, match="malformed JSON"):
             await apply_outcome_coverage(

--- a/tests/unit/utils/test_structured_llm.py
+++ b/tests/unit/utils/test_structured_llm.py
@@ -1,0 +1,288 @@
+"""Unit tests for :mod:`src.utils.structured_llm`.
+
+Covers:
+
+* The closing-brace truncation heuristic (the only signal the helper
+  uses to distinguish "ran out of tokens" from "schema drift").
+* Retry escalation (budget doubling, ceiling enforcement, attempt count).
+* Bail-out on schema drift so we don't burn tokens chasing a problem
+  more tokens won't fix.
+* Prompt-length sanity check.
+
+The helper itself is small — these tests guard the policy, since the
+helper is the resilience layer that other modules depend on.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, List
+from unittest.mock import AsyncMock
+
+import pytest
+
+from src.utils import structured_llm
+from src.utils.structured_llm import (
+    DEFAULT_MAX_TOKENS,
+    MAX_OUTPUT_TOKENS,
+    MAX_PROMPT_CHARS,
+    _looks_truncated,
+    safe_structured_call,
+)
+
+
+class TestLooksTruncated:
+    """Heuristic used to decide whether a parse failure should retry."""
+
+    def test_empty_response_treated_as_truncated(self) -> None:
+        assert _looks_truncated("") is True
+
+    def test_clean_object_not_truncated(self) -> None:
+        assert _looks_truncated('{"x": 1}') is False
+
+    def test_clean_array_not_truncated(self) -> None:
+        assert _looks_truncated("[1, 2, 3]") is False
+
+    def test_markdown_fenced_object_not_truncated(self) -> None:
+        """Models often wrap JSON in ```json...``` fences; helper strips
+        trailing backticks before checking the closing brace."""
+        assert _looks_truncated('```json\n{"x": 1}\n```') is False
+
+    def test_object_with_trailing_whitespace_not_truncated(self) -> None:
+        assert _looks_truncated('{"x": 1}\n\n  ') is False
+
+    def test_mid_string_cutoff_is_truncated(self) -> None:
+        """The actual failure mode: response ends mid-string value."""
+        assert _looks_truncated('{"x": "hello wor') is True
+
+    def test_mid_array_cutoff_is_truncated(self) -> None:
+        assert _looks_truncated('{"items": [1, 2,') is True
+
+    def test_trailing_prose_after_complete_json_not_truncated(self) -> None:
+        """Some models append a polite closing — parse_ai_json_response
+        already strips trailing prose. The closing-brace heuristic
+        deliberately treats this as truncated (so retry fires when
+        the parser fails), but in practice the parser succeeds first.
+        We assert the heuristic's actual behavior here, not what the
+        end-to-end flow does."""
+        assert _looks_truncated('{"x": 1}\n\nHope this helps!') is True
+
+
+class TestSafeStructuredCall:
+    """End-to-end behavior of the retry-on-truncation policy."""
+
+    @pytest.mark.asyncio
+    async def test_first_attempt_succeeds(self) -> None:
+        llm = AsyncMock()
+        llm.analyze = AsyncMock(return_value='{"ok": true}')
+        result = await safe_structured_call(llm=llm, prompt="p", operation="op")
+        assert result == {"ok": True}
+        assert llm.analyze.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_initial_budget_passed_to_first_call(self) -> None:
+        llm = AsyncMock()
+        llm.analyze = AsyncMock(return_value='{"ok": true}')
+        await safe_structured_call(
+            llm=llm,
+            prompt="p",
+            operation="op",
+            initial_max_tokens=2048,
+        )
+        ctx = llm.analyze.await_args.kwargs["context"]
+        assert ctx.max_tokens == 2048
+
+    @pytest.mark.asyncio
+    async def test_truncated_response_triggers_retry_with_doubled_budget(
+        self,
+    ) -> None:
+        truncated = '{"items": ["a", "b'
+        complete = '{"items": ["a", "b", "c"]}'
+        llm = AsyncMock()
+        llm.analyze = AsyncMock(side_effect=[truncated, complete])
+
+        result = await safe_structured_call(
+            llm=llm,
+            prompt="p",
+            operation="op",
+            initial_max_tokens=2048,
+        )
+        assert result == {"items": ["a", "b", "c"]}
+        assert llm.analyze.await_count == 2
+        # Second call should have run with doubled budget.
+        second_ctx = llm.analyze.await_args_list[1].kwargs["context"]
+        assert second_ctx.max_tokens == 4096
+
+    @pytest.mark.asyncio
+    async def test_retry_emits_structured_warning(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        truncated = '{"x": "hel'
+        complete = '{"x": "hello"}'
+        llm = AsyncMock()
+        llm.analyze = AsyncMock(side_effect=[truncated, complete])
+
+        with caplog.at_level("WARNING", logger="src.utils.structured_llm"):
+            await safe_structured_call(
+                llm=llm,
+                prompt="p",
+                operation="my_op",
+                initial_max_tokens=4096,
+            )
+
+        retry_records = [
+            r for r in caplog.records if r.message == "structured_llm.retry"
+        ]
+        assert len(retry_records) == 1
+        rec = retry_records[0]
+        # Structured fields are mounted via ``extra=`` so Cato can graph
+        # retry frequency per operation.
+        assert getattr(rec, "operation") == "my_op"
+        assert getattr(rec, "attempt") == 1
+        assert getattr(rec, "attempted_budget") == 4096
+        assert getattr(rec, "retry_budget") == 8192
+
+    @pytest.mark.asyncio
+    async def test_schema_drift_bails_immediately_no_retry(self) -> None:
+        """Well-formed JSON that doesn't match expectations should NOT
+        retry — more tokens won't fix a wrong-shape response."""
+        # An array — parse_ai_json_response only accepts objects.
+        bad_shape = "[1, 2, 3]"
+        llm = AsyncMock()
+        llm.analyze = AsyncMock(return_value=bad_shape)
+
+        with pytest.raises(ValueError):
+            await safe_structured_call(llm=llm, prompt="p", operation="op")
+        # Exactly one call — bailout, no retry.
+        assert llm.analyze.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_exhausts_retries_then_raises(self) -> None:
+        """All attempts truncated → raise after final attempt."""
+        truncated = '{"items": ["incomplete'
+        llm = AsyncMock()
+        llm.analyze = AsyncMock(return_value=truncated)
+
+        with pytest.raises((ValueError, json.JSONDecodeError)):
+            await safe_structured_call(
+                llm=llm,
+                prompt="p",
+                operation="op",
+                initial_max_tokens=2048,
+                max_retries=2,
+            )
+        # initial + 2 retries = 3 attempts total.
+        assert llm.analyze.await_count == 3
+
+    @pytest.mark.asyncio
+    async def test_budget_caps_at_max_output_tokens(self) -> None:
+        """Escalation must not request more than the Claude ceiling."""
+        truncated = '{"items": ["incomplete'
+        llm = AsyncMock()
+        llm.analyze = AsyncMock(return_value=truncated)
+
+        with pytest.raises((ValueError, json.JSONDecodeError)):
+            await safe_structured_call(
+                llm=llm,
+                prompt="p",
+                operation="op",
+                # Start near the ceiling so a single double would
+                # exceed MAX_OUTPUT_TOKENS — escalation must clamp.
+                initial_max_tokens=MAX_OUTPUT_TOKENS // 2,
+                max_retries=3,
+            )
+        budgets = [
+            call.kwargs["context"].max_tokens for call in llm.analyze.await_args_list
+        ]
+        # No budget exceeds the ceiling.
+        assert max(budgets) <= MAX_OUTPUT_TOKENS
+
+    @pytest.mark.asyncio
+    async def test_no_retry_when_already_at_ceiling(self) -> None:
+        """Doubling can't go higher than ceiling — give up immediately."""
+        truncated = '{"items": ["incomplete'
+        llm = AsyncMock()
+        llm.analyze = AsyncMock(return_value=truncated)
+
+        with pytest.raises((ValueError, json.JSONDecodeError)):
+            await safe_structured_call(
+                llm=llm,
+                prompt="p",
+                operation="op",
+                initial_max_tokens=MAX_OUTPUT_TOKENS,
+                max_retries=3,
+            )
+        # First attempt is at ceiling; doubling would not help; raise.
+        assert llm.analyze.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_prompt_too_long_rejected_before_llm_call(self) -> None:
+        """Hard-cap prompt size to bound runaway cost."""
+        llm = AsyncMock()
+        llm.analyze = AsyncMock(return_value='{"ok": true}')
+
+        oversized = "x" * (MAX_PROMPT_CHARS + 1)
+        with pytest.raises(ValueError, match="caps at"):
+            await safe_structured_call(llm=llm, prompt=oversized, operation="op")
+        # No LLM call happens — sanity check runs first.
+        assert llm.analyze.await_count == 0
+
+    @pytest.mark.asyncio
+    async def test_default_budget_is_4x_legacy_haiku_3_cap(self) -> None:
+        """Sanity check on the documented constant — Haiku 3 capped at
+        4096; the new default is 4x that to absorb 4-domain projects
+        without a retry round-trip."""
+        assert DEFAULT_MAX_TOKENS == 16_384
+
+
+class TestRetryEndToEndThroughAIAnalysisEngine:
+    """Exercise the retry path through the public entry point that
+    Marcus actually uses for contract decomposition.
+
+    The other tests prove safe_structured_call's policy in isolation.
+    These prove the wiring: when contract decomposition truncates,
+    AIAnalysisEngine.generate_structured_response retries, escalates
+    the budget, and ultimately returns the parsed JSON.  The original
+    bug bypassed all this — the parse failed, control flow fell back
+    to feature_based, and the planner intent was silently lost."""
+
+    @pytest.mark.asyncio
+    async def test_generate_structured_response_retries_on_truncation(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The originally-failing call path — contract decomposition —
+        now recovers from a truncated first response and returns the
+        complete JSON on retry."""
+        from src.integrations.ai_analysis_engine import AIAnalysisEngine
+
+        truncated = '{"tasks": [{"name": "Build snake mov'
+        complete = (
+            '{"tasks": [{"name": "Build snake movement", '
+            '"description": "Owns grid movement contract"}]}'
+        )
+        mock_analyze = AsyncMock(side_effect=[truncated, complete])
+
+        class _MockLLM:
+            analyze = mock_analyze
+
+        # generate_structured_response does ``from src.ai.providers.
+        # llm_abstraction import LLMAbstraction`` lazily inside the
+        # function, so we patch the source module — same import path
+        # the function will resolve.
+        monkeypatch.setattr(
+            "src.ai.providers.llm_abstraction.LLMAbstraction",
+            lambda: _MockLLM(),
+        )
+
+        engine = AIAnalysisEngine()
+        result = await engine.generate_structured_response(
+            prompt="Decompose this PRD into contract-owned tasks.",
+            operation="generate_contracts",
+        )
+
+        assert result["tasks"][0]["name"] == "Build snake movement"
+        assert mock_analyze.await_count == 2
+        # Second call must have escalated the budget.
+        first_budget = mock_analyze.await_args_list[0].kwargs["context"].max_tokens
+        second_budget = mock_analyze.await_args_list[1].kwargs["context"].max_tokens
+        assert second_budget == first_budget * 2

--- a/tests/unit/utils/test_structured_llm.py
+++ b/tests/unit/utils/test_structured_llm.py
@@ -31,6 +31,17 @@ from src.utils.structured_llm import (
 )
 
 
+@pytest.fixture(autouse=True)
+def _decouple_from_config(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Tests assert on the helper's policy, not on whatever
+    ``config.ai.max_tokens`` happens to be in the test environment.
+    Lift the deployment ceiling to the module hard cap so the retry
+    math the tests exercise is reachable."""
+    monkeypatch.setattr(
+        structured_llm, "_deployment_ceiling", lambda: MAX_OUTPUT_TOKENS
+    )
+
+
 class TestLooksTruncated:
     """Heuristic used to decide whether a parse failure should retry."""
 
@@ -226,6 +237,58 @@ class TestSafeStructuredCall:
             await safe_structured_call(llm=llm, prompt=oversized, operation="op")
         # No LLM call happens — sanity check runs first.
         assert llm.analyze.await_count == 0
+
+    @pytest.mark.asyncio
+    async def test_initial_budget_clamped_to_deployment_ceiling(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Codex P1: Marcus's default model (claude-3-haiku-20240307)
+        caps output at 4096; the helper must not send more.  Even when
+        the caller passes a larger ``initial_max_tokens``, the helper
+        clamps to ``config.ai.max_tokens`` before any API call."""
+        # Override the autouse fixture for this test — we want to
+        # exercise the clamp behavior with a Haiku-3-sized ceiling.
+        monkeypatch.setattr(structured_llm, "_deployment_ceiling", lambda: 4096)
+        llm = AsyncMock()
+        llm.analyze = AsyncMock(return_value='{"ok": true}')
+
+        await safe_structured_call(
+            llm=llm,
+            prompt="p",
+            operation="op",
+            initial_max_tokens=16384,
+        )
+
+        first_budget = llm.analyze.await_args.kwargs["context"].max_tokens
+        assert first_budget == 4096, (
+            f"Helper sent max_tokens={first_budget}; deployment ceiling "
+            f"4096 should have clamped it. Older Claude models (3 Haiku) "
+            f"would 400 on anything bigger."
+        )
+
+    @pytest.mark.asyncio
+    async def test_retry_escalation_clamped_to_deployment_ceiling(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Retry doubling must respect the deployment ceiling — same
+        reason as the initial-budget clamp.  When already at ceiling,
+        bail out rather than waste an API rejection."""
+        monkeypatch.setattr(structured_llm, "_deployment_ceiling", lambda: 4096)
+        truncated = '{"items": ["incomplete'
+        llm = AsyncMock()
+        llm.analyze = AsyncMock(return_value=truncated)
+
+        with pytest.raises((ValueError, json.JSONDecodeError)):
+            await safe_structured_call(
+                llm=llm,
+                prompt="p",
+                operation="op",
+                initial_max_tokens=4096,
+                max_retries=3,
+            )
+        # First attempt at 4096 (= ceiling); doubling would exceed —
+        # bail immediately, exactly one call.
+        assert llm.analyze.await_count == 1
 
     @pytest.mark.asyncio
     async def test_default_budget_is_4x_legacy_haiku_3_cap(self) -> None:


### PR DESCRIPTION
## Summary

- **Root cause**: a hardcoded `max_tokens=4096` (set 2025-10-07 for Claude Haiku 3) silently truncated contract-first decomposition mid-string for 4-domain projects. Claude Haiku 4.5 supports 64K output; the legacy cap was untouchable until project complexity grew.
- **Fix**: new `src/utils/structured_llm.py` centralizes the per-call policy — default 16384, auto-retry to 64K on detected truncation, 200K-char prompt cap, structured retry telemetry. Five JSON-parsing call sites migrated.
- **Companion provider fixes**: anthropic timeout 30→120s (Haiku 4.5 needs ~28s for PRD analysis, was tripping the 30s edge); cloud provider sends `reasoning_effort:"none"` for Fireworks Qwen models that burned the entire budget on chain-of-thought before emitting JSON.

## What changed

| File | What |
|---|---|
| `src/utils/structured_llm.py` (new) | `safe_structured_call` helper — defaults, retry, cap, telemetry |
| `src/integrations/ai_analysis_engine.py` | Delegate `generate_structured_response` to helper |
| `src/integrations/nlp_tools.py` | Migrate foundation-synthesis call (1024-token cap → helper) |
| `src/ai/advanced/prd/advanced_parser.py` | Migrate PRD analysis + domain discovery calls |
| `src/ai/advanced/prd/outcome_extractor.py` | Migrate both extractor + filter calls |
| `src/ai/providers/anthropic_provider.py` | Timeout 30→120s |
| `src/ai/providers/cloud_provider.py` | `max_tokens` floor + `reasoning_effort:"none"` |

Also bundled: pre-existing docs polish (CONTRIBUTING trim, setup-local-llm refresh, Ollama badge on README) — separate commit.

## Why centralize

Same stale-cap pattern lived at 4 other JSON-parsing call sites (1024 / 500 / 1500 / 1500). Each was a future bug waiting for a complex-enough project. Helper means: one place owns the policy, every structured-JSON caller gets the same defense, future bumps land in one diff. Per Kaia's review: \"reactive, not principled\" was the problem with the original one-site fix.

## Telemetry

When retry triggers, helper emits:

```python
logger.warning("structured_llm.retry", extra={
    "operation": ..., "attempt": ..., "initial_budget": ...,
    "attempted_budget": ..., "retry_budget": ...,
    "raw_chars": ..., "prompt_chars": ...,
})
```

Cato can graph retry frequency by operation — the signal that tells us when defaults need bumping again.

## Deferred

Plumbing Anthropic's `stop_reason` through `LLMAbstraction.analyze` return type for an authoritative truncation signal touches 4 providers + 30+ callers. The closing-brace heuristic is reliable for Claude's actual truncation pattern (always mid-string). Documented as future work in `_looks_truncated` docstring.

## Test plan

- [x] 84 unit tests passing across `test_outcome_extractor`, `test_ai_analysis_engine`, `test_advanced_parser_nfr`, `test_nlp_tools`
- [x] Smoke tests on `_looks_truncated`: empty / valid / mid-string / fenced / trailing-prose
- [x] End-to-end: the exact `snake-game-fireworks-standard` PRD that fell back to `feature_based` on `develop` now succeeds with `actual_decomposer="contract_first"` on a 4-domain decomposition — no retry needed (16384 default absorbs ~4096 actual output)
- [ ] Run on a deliberately-large PRD (8+ domains) to exercise the retry path

🤖 Generated with [Claude Code](https://claude.com/claude-code)