### PR TITLE
feat(experiments): codex CLI harness for /marcus experiments (WIP)

### DIFF
--- a/.codex/skills/marcus/SKILL.md
+++ b/.codex/skills/marcus/SKILL.md
@@ -1,0 +1,237 @@
+---
+name: marcus
+description: >
+  Launch Marcus multi-agent experiments with independent CLI agents in tmux panes.
+  Use when the user says "build X with Marcus", "run a Marcus experiment",
+  "spawn N agents with Marcus", "/marcus", or references the Marcus multi-agent
+  framework. This skill handles experiment setup, config generation, and spawning
+  independent agent CLI processes that coordinate via the Marcus MCP server. Each
+  agent runs in its own tmux pane with full autonomy. NOT for ClawTeam — this is
+  specifically for the Marcus MCP-based multi-agent system.
+  NOTE: "Marcus" is also the name of the MCP server that agents use for coordination.
+  The /marcus skill launches experiments that USE the Marcus MCP server — they are
+  complementary, not competing. The MCP server must be running before invoking this skill.
+  The Marcus MCP server is agent-agnostic; this skill supports both Anthropic's
+  claude CLI and OpenAI's codex CLI as agent harnesses (selected via --harness).
+user-invocable: true
+argument-hint: "<project description> [--name \"Project Name\"] [--agents N] [--complexity prototype|standard|enterprise] [--decomposer contract_first|feature_based] [--epictetus] [--model <model>] [--harness claude|codex]"
+---
+
+# Marcus Multi-Agent Experiment Launcher (Codex)
+
+You are helping the user launch a Marcus multi-agent experiment. Marcus uses an MCP
+server to coordinate independent agent CLI processes, each running in its own tmux pane.
+
+This skill is invoked from within the Codex CLI. When the user runs `/marcus` from
+inside Codex, the typical (but not required) intent is to spawn **codex** agents —
+pass `--harness codex` to make that explicit. The skill also accepts `--harness
+claude` to spawn Anthropic CLI agents from a Codex driver session if that's what
+the user wants.
+
+## What You Do
+
+1. Parse the user's request to extract: project description, agent count, harness, model
+2. Create an experiment directory with config.yaml and project_spec.md
+3. Run `run_experiment.py` which spawns agents in tmux panes
+4. Report the tmux session name so the user can attach
+
+## Discovering Paths
+
+Find the Marcus repo root via the installed package:
+
+```bash
+MARCUS_ROOT=$(python3 -c "from pathlib import Path; import marcus_mcp; print(Path(marcus_mcp.__file__).parent.parent.parent)")
+```
+
+From there:
+- **Run script**: `${MARCUS_ROOT}/dev-tools/experiments/runners/run_experiment.py`
+- **Templates**: `${MARCUS_ROOT}/dev-tools/experiments/templates/`
+
+If the import fails, Marcus isn't installed. Tell the user:
+```
+Marcus is not installed. Follow the setup instructions:
+  git clone https://github.com/lwgray/marcus.git
+  cd marcus && pip install -e .
+```
+
+## How to Parse Arguments
+
+The user's input comes in as `$ARGUMENTS`. Extract:
+- **Project description**: Everything that describes what to build
+- **Project name**: Look for `--name "Some Name"` or `--name some_name`. If not provided, derive a short name from the description.
+- **Agent count**: Look for patterns like "N agents", "--agents N", "with N workers". Default: 2
+- **Complexity**: Look for "--complexity prototype|standard|enterprise". Default: "prototype"
+- **Decomposer**: Look for "--decomposer contract_first|feature_based". Default: "contract_first" (as of v0.3.4). This controls Marcus's task decomposition strategy (GH-320):
+  - `contract_first` — default. Generates interface contracts before decomposition. Board is fully populated before any agent starts (no Phase A race). Each agent owns one side of a contract. Best for tightly-coupled projects (games, dashboards, state machines).
+  - `feature_based` — legacy path, splits tasks by functional requirement. Fine for loosely-coupled projects where features don't share files.
+- **Epictetus mode**: Look for `--epictetus` flag. Default: not set (false). When present, the monitor agent does NOT kill the tmux session after the experiment completes — it stays alive for Epictetus post-experiment interrogation.
+- **Agent model**: Look for `--model <value>`. Default: not set — Marcus reads `ai.model` from `config_marcus.json` and uses that same value for the spawned Agent CLI processes (so by default Planners and Agents share one model). When `--model X` is provided, X overrides for THIS run only and applies to all spawned panes (project creator + workers + monitor). The same string is passed verbatim to whichever harness is active — accepts `claude --model` values (e.g. `sonnet`, `opus`, `haiku`, `claude-haiku-4-5-20251001`) or `codex --model` values (e.g. `gpt-5-codex`, `o3`). No client-side validation against per-harness namespaces — invalid model names surface as CLI errors inside the agent panes. Affects ONLY the spawned Agents — Marcus's Planner model continues to read from `config_marcus.json`.
+- **Agent harness**: Look for `--harness claude|codex`. Default: `claude` (matches `run_experiment.py` default). When invoked from inside Codex CLI, you typically want `--harness codex` — but the runner does not auto-detect the caller. `codex` spawns `codex exec --dangerously-bypass-approvals-and-sandbox` (the documented form of "YOLO mode" — sets `approval: never, sandbox: danger-full-access`). All agents in a single experiment use the same harness; mixed-harness teams are out of scope for v1. The runner pre-flights `which <cli>` and fails fast if the binary is missing.
+
+Examples:
+- `/marcus Build a snake game with 3 agents` -> description="Build a snake game", name="snake_game", agents=3, complexity="prototype", decomposer="contract_first", harness="claude"
+- `/marcus Build a TODO CLI with 2 agents --harness codex` -> description="Build a TODO CLI", name="todo_cli", agents=2, complexity="prototype", decomposer="contract_first", harness="codex"
+- `/marcus Build a TODO CLI --harness codex --model gpt-5-codex` -> description="Build a TODO CLI", name="todo_cli", agents=2, complexity="prototype", decomposer="contract_first", model="gpt-5-codex", harness="codex"
+- `/marcus Build a snake game with 4 agents --harness codex --model o3` -> description="Build a snake game", name="snake_game", agents=4, complexity="prototype", decomposer="contract_first", model="o3", harness="codex"
+
+## Step-by-Step Execution
+
+### Step 1: Use the Current Working Directory
+
+Write all files into the current working directory. Do NOT create or mkdir a new directory.
+`run_experiment.py` will create the subdirectories it needs (`prompts/`, `logs/`, `implementation/`).
+
+```
+<cwd>/
+├── config.yaml       (you create this)
+├── project_spec.md   (you create this)
+├── prompts/          (created by run_experiment.py)
+├── logs/             (created by run_experiment.py)
+└── implementation/   (created by run_experiment.py, git repo where agents write code)
+```
+
+### Step 2: Generate project_spec.md
+
+Write the user's project description **as-is** to `project_spec.md`. Do NOT rewrite,
+expand, restructure, or add sections to it. Marcus handles task decomposition — the
+spec is just the raw input from the user.
+
+### Step 3: Generate config.yaml
+
+**CRITICAL: Always write a fresh config.yaml from the template below. Do NOT read or
+preserve values from any existing config.yaml in the directory. Overwrite it completely.**
+
+Use this exact format — field names are case-sensitive:
+
+```yaml
+project_name: "<--name value if provided, otherwise derived from description>"
+project_spec_file: "project_spec.md"
+
+# Harness selection: omit the field (defaults to 'claude') or set explicitly.
+# CLI flag --harness on run_experiment.py overrides this value.
+harness: "<parsed harness>"  # "claude" (default) or "codex"
+
+project_options:
+  complexity: "<parsed complexity>"
+  provider: "sqlite"
+  mode: "new_project"
+  decomposer: "<parsed decomposer>"
+
+agents:
+  - id: "agent_unicorn_1"
+    name: "Unicorn Developer 1"
+    role: "full-stack"
+    skills:
+      - "python"
+      - "javascript"
+      - "typescript"
+      - "react"
+      - "fastapi"
+      - "sqlalchemy"
+      - "postgresql"
+      - "database-design"
+      - "rest-api"
+      - "jwt"
+      - "security"
+      - "pytest"
+      - "integration-testing"
+    subagents: 0
+  # Repeat for each agent...
+
+timeouts:
+  project_creation: 600
+  agent_startup: 60
+```
+
+**Complexity heuristic:**
+- "prototype" — Simple single-page apps, scripts, small tools
+- "standard" — Most projects (APIs, full-stack apps, moderate features)
+- "enterprise" — Large systems with many components, microservices, complex auth
+
+**Decomposer rule:** Default is `contract_first` as of v0.3.4. Only override to
+`feature_based` when the user passes `--decomposer feature_based` explicitly.
+
+**Agent count:** Generate one agent block per requested agent. Use incrementing IDs:
+`agent_unicorn_1`, `agent_unicorn_2`, etc.
+
+### Step 4: Initialize and Run the Experiment
+
+First, discover the Marcus repo root:
+```bash
+MARCUS_ROOT=$(python3 -c "from pathlib import Path; import marcus_mcp; print(Path(marcus_mcp.__file__).parent.parent.parent)")
+```
+
+Then run it directly (using the current working directory as the experiment directory).
+**IMPORTANT:** Use a 600000ms (10 minute) timeout on the Bash command. Project creation
+includes AI design task generation which takes 4-6 minutes. The default 2-minute
+Bash timeout will kill the process prematurely.
+
+Append `--epictetus`, `--model <value>`, and/or `--harness <value>` to the command
+based on what the user passed. All flags combine.
+
+```bash
+# Codex harness, codex's default model:
+cd "${MARCUS_ROOT}/dev-tools/experiments" && python runners/run_experiment.py <cwd> --harness codex
+
+# Codex harness with explicit model:
+cd "${MARCUS_ROOT}/dev-tools/experiments" && python runners/run_experiment.py <cwd> --harness codex --model gpt-5-codex
+
+# Claude harness from inside Codex (rare but supported):
+cd "${MARCUS_ROOT}/dev-tools/experiments" && python runners/run_experiment.py <cwd> --harness claude
+```
+
+This will:
+- Create `prompts/`, `logs/`, `implementation/` directories
+- Initialize a git repo in `implementation/`
+- Copy CLAUDE.md to `implementation/`
+- Pre-flight `which claude` or `which codex` depending on `--harness`
+- Create a tmux session: `marcus_<project_name_lowercase>`
+- Spawn: 1 project creator + N workers + 1 monitor in tmux panes
+- For codex harness, each pane runs `codex exec --dangerously-bypass-approvals-and-sandbox` with the Marcus MCP server registered via `codex mcp add marcus --url http://localhost:4298/mcp/`
+
+### Step 5: Report to User
+
+After launching, tell the user:
+- The tmux session name: `marcus_<project_name_lowercase_underscored>`
+- The harness being used (claude or codex)
+- How to attach: `tmux attach -t <session_name>`
+- How to navigate: Click panes (mouse enabled), Ctrl+b arrow keys, Ctrl+b n/p for windows
+- How to kill: `tmux kill-session -t <session_name>`
+- The experiment directory location
+- Agent count: 1 creator + N workers + 1 monitor = N+2 total panes
+
+## Important Notes
+
+- The Marcus MCP server must be running at `http://localhost:4298/mcp` before launching
+- Each agent is a fully independent harness CLI process. For codex: `codex exec --dangerously-bypass-approvals-and-sandbox` (approval=never, sandbox=danger-full-access). For claude: `claude --dangerously-skip-permissions`.
+- Agents coordinate via MCP tools (register_agent, request_next_task, report_task_progress, etc.)
+- All agents work on isolated git worktrees in `implementation/`; Marcus prevents task conflicts
+- MLflow tracks experiment metrics in `<experiment_dir>/mlruns/`
+- The project creator agent calls `mcp__marcus__create_project` which uses AI to decompose the spec into tasks — this takes 30-60 seconds
+- Workers wait for `project_info.json` before starting (written by project creator)
+- The monitor polls every 2 minutes and calls `end_experiment` when all tasks complete
+
+## Pre-flight Checks
+
+Before running, verify:
+1. Marcus MCP is registered for the active harness:
+   - claude: `claude mcp list` shows "marcus"
+   - codex: `codex mcp list` shows "marcus"
+2. tmux is installed: `which tmux`
+3. Harness CLI is on PATH: `which claude` or `which codex`
+
+If Marcus MCP is not running, tell the user:
+```
+Marcus MCP server is not running. Start it first:
+  cd <MARCUS_ROOT> && ./marcus start
+```
+
+If `--harness codex` and Marcus MCP is not yet registered with codex, tell the user:
+```
+codex mcp add marcus --url http://localhost:4298/mcp/
+```
+
+If `--harness claude` and Marcus MCP is not yet registered with claude, tell the user:
+```
+claude mcp add marcus -t http http://localhost:4298/mcp
+```

--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,12 @@ package.json
 package-lock.json
 .claude/settings.local.json
 .misc/
+
+# codex CLI local state — but keep repo-tracked skills
+.codex/
+!.codex/skills/
+!.codex/skills/**
+
+# AGENTS.md is auto-rendered by codex into per-experiment workdirs and
+# can leak into the repo root; ignore at root to prevent accidental commits.
+AGENTS.md

--- a/dev-tools/experiments/runners/run_experiment.py
+++ b/dev-tools/experiments/runners/run_experiment.py
@@ -254,17 +254,44 @@ Examples:
         type=str,
         default=None,
         help=(
-            "Override the model used for spawned ``claude`` agent "
-            "processes (project creator, workers, monitor).  Accepts "
-            "any value the ``claude --model`` CLI accepts: aliases "
-            "(``sonnet``, ``opus``, ``haiku``) or full ids "
-            "(e.g. ``claude-haiku-4-5-20251001``).  Resolution order: "
-            "this flag overrides ``agent_model`` in ``config.yaml``, "
-            "which overrides ``ai.model`` in ``config_marcus.json``.  "
-            "When unset, falls back to whatever ``claude`` is globally "
-            "configured for.  Affects ONLY the spawned Agent "
-            "processes; Marcus's Planner model continues to read from "
-            "``config_marcus.json`` unchanged."
+            "Override the model used for spawned agent CLI processes "
+            "(project creator, workers, monitor).  The same model "
+            "string is applied to every agent and is passed through "
+            "verbatim to whichever harness is active "
+            "(``claude --model`` or ``codex --model``).  No "
+            "per-harness validation — invalid model names surface as "
+            "CLI errors in the agent panes.  Resolution order: this "
+            "flag overrides ``agent_model`` in ``config.yaml``, which "
+            "overrides ``ai.model`` in ``config_marcus.json``.  When "
+            "unset, falls back to whatever the harness CLI is "
+            "globally configured for.  Affects ONLY the spawned "
+            "Agent processes; Marcus's Planner model continues to "
+            "read from ``config_marcus.json`` unchanged."
+        ),
+    )
+
+    parser.add_argument(
+        "--harness",
+        type=str,
+        default=None,
+        choices=["claude", "codex"],
+        help=(
+            "Agent harness used to spawn each pane.  ``claude`` "
+            "(default) spawns Anthropic's claude CLI with "
+            "``--dangerously-skip-permissions``; ``codex`` spawns "
+            "OpenAI's codex CLI with ``exec "
+            "--dangerously-bypass-approvals-and-sandbox`` (the "
+            "documented flag for approval=never, "
+            "sandbox=danger-full-access; equivalent to the "
+            "colloquial ``--yolo`` mode).  "
+            "When unset, falls back to ``harness`` in "
+            "``config.yaml`` which itself defaults to ``claude``.  "
+            "All agents in a single experiment use the same harness; "
+            "mixed-harness teams are intentionally out of scope for "
+            "v1.  Pre-flight verifies the harness CLI is on PATH and "
+            "that the Marcus MCP server is registered in the "
+            "harness's config (``~/.claude.json`` vs "
+            "``~/.codex/config.toml``)."
         ),
     )
 
@@ -322,6 +349,7 @@ Examples:
         templates_dir,
         epictetus=args.epictetus,
         agent_model=args.model,
+        harness=args.harness,
     )
 
     success = spawner.run()

--- a/dev-tools/experiments/runners/spawn_agents.py
+++ b/dev-tools/experiments/runners/spawn_agents.py
@@ -287,6 +287,22 @@ class ExperimentConfig:
         # create_project, which would reject the unknown key.
         self.stall_timeout_minutes = int(self.config.get("stall_timeout_minutes", 20))
 
+        # Agent harness selection (GH issue: codex harness support).
+        # ``claude`` (default) spawns Anthropic's claude CLI in each pane;
+        # ``codex`` spawns OpenAI's codex CLI. The Marcus MCP server is
+        # agent-agnostic — the harness choice only affects which CLI
+        # process is launched and which MCP registry it reads from
+        # (``~/.claude.json`` vs ``~/.codex/config.toml``). Same model
+        # is applied to all agents; mixed-harness teams are intentionally
+        # out of scope for v1.
+        raw_harness = str(self.config.get("harness", "claude")).strip().lower()
+        if raw_harness not in {"claude", "codex"}:
+            raise ValueError(
+                f"Unsupported harness {raw_harness!r} in config.yaml; "
+                "expected 'claude' or 'codex'."
+            )
+        self.harness: str = raw_harness
+
         # Set up experiment directories
         self.prompts_dir = self.experiment_dir / "prompts"
         self.logs_dir = self.experiment_dir / "logs"
@@ -410,6 +426,7 @@ class AgentSpawner:
         templates_dir: Path,
         epictetus: bool = False,
         agent_model: Optional[str] = None,
+        harness: Optional[str] = None,
     ):
         """
         Initialize the agent spawner.
@@ -425,15 +442,25 @@ class AgentSpawner:
             so that the Epictetus post-experiment interrogation tool can
             query agents after the project is done.  Default: False (kill).
         agent_model : Optional[str], optional
-            Override the model used for spawned ``claude`` processes
+            Override the model used for spawned agent CLI processes
             (project creator, workers, monitor).  Highest priority in
             the resolution chain — overrides ``config.agent_model``
             (which itself reads ``config.yaml`` and
             ``config_marcus.json`` in turn).  When ``None``, falls back
             to whatever ``config.agent_model`` resolved to.  Affects
-            ONLY the spawned Agent ``claude`` processes; the Marcus
-            MCP server's Planner LLM continues to read its model from
-            ``config_marcus.json`` unchanged.
+            ONLY the spawned Agent processes; the Marcus MCP server's
+            Planner LLM continues to read its model from
+            ``config_marcus.json`` unchanged.  Single ``--model``
+            string is passed through to whichever harness is active;
+            no validation against per-harness model namespaces is
+            performed here — invalid model names surface as CLI
+            errors in the agent panes.
+        harness : Optional[str], optional
+            Agent harness to spawn: ``'claude'`` or ``'codex'``.  When
+            ``None``, falls back to ``config.harness`` (which itself
+            defaults to ``'claude'``).  All spawned agents in a single
+            experiment use the same harness; mixed-harness teams are
+            intentionally out of scope for v1.
         """
         self.config = config
         self.templates_dir = templates_dir
@@ -446,14 +473,31 @@ class AgentSpawner:
             agent_model if agent_model else config.agent_model
         )
         self.agent_prompt_template = templates_dir / "agent_prompt.md"
-        # Pre-render the ``--model X`` flag fragment once.  Spliced into
-        # every ``claude`` invocation below so all spawned panes
-        # (project creator, workers, monitor) run on the same model.
-        # Empty string when no model is resolved → no ``--model`` flag
-        # → ``claude`` CLI uses its global default.
-        self.claude_model_flag: str = (
+        # CLI override wins over yaml resolution for harness too.
+        # ``None`` here means "use whatever ExperimentConfig parsed
+        # from yaml" — which itself defaults to ``'claude'``.
+        if harness is not None:
+            normalized = harness.strip().lower()
+            if normalized not in {"claude", "codex"}:
+                raise ValueError(
+                    f"Unsupported harness {harness!r}; " "expected 'claude' or 'codex'."
+                )
+            self.harness: str = normalized
+        else:
+            self.harness = config.harness
+        # Pre-render the model flag fragment once.  Spliced into every
+        # agent invocation below so all spawned panes (project creator,
+        # workers, monitor) run on the same model.  Empty string when
+        # no model is resolved → no ``--model`` flag → harness CLI uses
+        # its global default.  Both ``claude`` and ``codex`` accept the
+        # long-form ``--model X`` spelling, so a single rendered
+        # fragment works for either harness.
+        self.model_flag: str = (
             f"--model {self.agent_model} " if self.agent_model else ""
         )
+        # Back-compat alias for any code path still referencing the
+        # old name.  TODO: remove once nothing reads it externally.
+        self.claude_model_flag: str = self.model_flag
         self.processes: List[subprocess.Popen[bytes]] = []
         self.tmux_session = (
             f"marcus_{self.config.project_name.lower().replace(' ', '_')}"
@@ -478,6 +522,204 @@ class AgentSpawner:
         # default port 4298 even when MARCUS_URL is set in the caller's env.
         self.marcus_mcp_url: str = os.environ.get(
             "MARCUS_URL", "http://localhost:4298/mcp"
+        )
+
+    def _build_mcp_register_snippet(self) -> str:
+        """Return the shell snippet that registers Marcus MCP for this harness.
+
+        Each agent pane re-runs this on startup so that fresh shells
+        (and freshly-provisioned dev machines) pick up the Marcus MCP
+        endpoint without manual setup.  The registration is idempotent
+        for both harnesses and any non-zero exit is swallowed so a
+        pre-existing registration does not abort the pane.
+
+        Returns
+        -------
+        str
+            A one-line shell command (no trailing newline).  The caller
+            interpolates this into the per-pane bash script alongside
+            the ``MARCUS_MCP_URL`` env var.
+        """
+        if self.harness == "codex":
+            # ``codex mcp add`` writes to ~/.codex/config.toml.  The
+            # subcommand errors if the server name already exists; we
+            # silence that with ``|| true`` so re-runs are idempotent.
+            return 'codex mcp add marcus --url "$MARCUS_MCP_URL" ' "2>/dev/null || true"
+        return 'claude mcp add marcus -t http "$MARCUS_MCP_URL" ' "2>/dev/null || true"
+
+    def _build_worker_invocation_block(self, workdir: Path, prompt_file: Path) -> str:
+        """Return the shell block that runs a worker agent in its pane.
+
+        Workers must keep polling Marcus for new tasks until the
+        monitor ends the experiment.  The two harnesses achieve this
+        differently:
+
+        - **claude**: launches once and stays alive in TUI mode
+          across many model turns; the polling loop happens inside
+          one long-lived session.  Single command is enough.
+        - **codex**: even with ``--enable goals`` (which extends the
+          model's "stay engaged" patience dramatically — empirically
+          held a never-ending polling goal for 4+ minutes without
+          wrapping up in a sentinel-file test on v0.130.0), the exec
+          invocation can still exit if the token budget is reached
+          or the model judges the goal complete.  We wrap it in a
+          bash relaunch loop as a safety net so workers stay alive
+          across exits, bounded by ``MAX_RELAUNCHES`` to guard
+          against runaway token spend when something is genuinely
+          wedged.  The monitor pane kills the tmux session at
+          experiment end regardless of where this loop is.
+
+        Parameters
+        ----------
+        workdir : Path
+            Agent's worktree directory.
+        prompt_file : Path
+            Path to the agent prompt fed on stdin to each codex exec
+            invocation.
+
+        Returns
+        -------
+        str
+            Shell block (possibly multi-line) interpolated into the
+            generated worker script.
+        """
+        single_cmd = self._build_agent_command(workdir, prompt_file)
+        if self.harness != "codex":
+            # Claude TUI stays alive across turns — no wrapper needed.
+            return single_cmd
+
+        # Codex wrapper loop. 50 iterations × per-cycle token cost is
+        # the budget guard; in practice the monitor kills the session
+        # well before this fires when --enable goals is doing its job.
+        # Each iteration is its own ``codex exec`` invocation feeding
+        # the same prompt; the agent re-registers (idempotent on
+        # Marcus's side) and resumes polling.
+        # On rc=0 the worker exited cleanly (e.g. agent observed all
+        # tasks done and called update_goal(complete), or the goal
+        # ended on the model's own terms). Relaunching would burn
+        # tokens — and with --epictetus, where the monitor leaves the
+        # tmux session up for post-run interrogation, it would also
+        # keep workers churning instead of staying quiescent. Break
+        # on rc=0 and only relaunch on non-zero exits (crashes, token
+        # budget hits, signal kills).
+        return (
+            "MAX_RELAUNCHES=50\n"
+            "for relaunch in $(seq 1 $MAX_RELAUNCHES); do\n"
+            f'  echo "[worker] codex launch $relaunch/$MAX_RELAUNCHES"\n'
+            f"  {single_cmd}\n"
+            "  rc=$?\n"
+            "  if [ $rc -eq 0 ]; then\n"
+            '    echo "[worker] codex exec finished cleanly (rc=0);'
+            ' not relaunching"\n'
+            "    break\n"
+            "  fi\n"
+            '  echo "[worker] codex exec exited rc=$rc;'
+            ' relaunching in 3s..."\n'
+            "  sleep 3\n"
+            "done\n"
+            'echo "[worker] hit MAX_RELAUNCHES=$MAX_RELAUNCHES — giving up"'
+        )
+
+    def _build_agent_command(
+        self,
+        workdir: Path,
+        prompt_file: Path,
+        *,
+        print_mode: bool = False,
+    ) -> str:
+        """Return the shell command that launches the agent CLI.
+
+        Both harnesses are invoked with a piped prompt
+        (``< prompt_file``) and run unattended:
+
+        - ``claude`` uses ``--dangerously-skip-permissions`` and
+          (optionally) ``--print`` for non-interactive output.
+        - ``codex`` uses ``exec --dangerously-bypass-approvals-and-sandbox``.
+          That is the documented flag (visible in ``codex exec --help``)
+          for "skip all confirmation prompts and execute commands
+          without sandboxing".  There is also a hidden ``--yolo``
+          alias that behaves identically on ``codex-cli`` ≥0.130.0,
+          but hidden aliases are not part of any stability contract
+          and have a history of being renamed/removed without notice.
+          The documented flag has a much longer half-life.
+          ``codex exec`` is inherently non-interactive — the
+          ``print_mode`` argument is therefore ignored for codex.
+
+        Parameters
+        ----------
+        workdir : Path
+            Directory the agent should treat as its writable workspace.
+            Translated to ``claude --add-dir`` or ``codex -C ... --add-dir``.
+        prompt_file : Path
+            File whose contents become the agent's initial prompt
+            (piped on stdin).
+        print_mode : bool, optional
+            For ``claude``: append ``--print`` so the agent runs
+            non-interactively and exits with stdout flushed.  Used by
+            the project creator pane.  Ignored for ``codex`` (which is
+            always non-interactive).
+
+        Returns
+        -------
+        str
+            A single shell command line (line continuations preserved
+            with trailing backslash + newline).
+        """
+        if self.harness == "codex":
+            # ``-C`` sets codex's working root; ``--add-dir`` is a no-op
+            # alongside ``-C`` for the same path, but we pass it anyway
+            # for parity with the claude branch (and in case codex
+            # later distinguishes the two).  ``--skip-git-repo-check``
+            # protects against panes whose cwd is not yet a git repo
+            # at codex startup (e.g. monitor pane reads
+            # implementation_dir before workers have populated it).
+            # Flags explained:
+            #
+            # ``--dangerously-bypass-approvals-and-sandbox``:
+            #   documented form of "YOLO mode" — approval=never,
+            #   sandbox=danger-full-access.  Required for
+            #   unattended tmux panes (no human to confirm
+            #   approvals).
+            #
+            # ``--skip-git-repo-check``: monitor pane and similar
+            #   start before any commits exist; this stops codex
+            #   from refusing to launch on an "empty" repo.
+            #
+            # ``--disable guardian_approval``: turns off codex's
+            #   internal "files changed under me without my doing
+            #   it" safety check.  Separate from sandbox/approvals
+            #   and fires even under the bypass flag.  Marcus
+            #   workers run ``git merge main --no-edit`` before
+            #   each task to pick up other agents' completed work
+            #   (see agent_prompt.md), which brings in files this
+            #   agent did not edit; guardian sees them as anomalous
+            #   and halts the agent to ask the user — but no user
+            #   is attached, so the agent stalls forever.
+            #
+            # ``--enable goals``: turns on codex's autonomous
+            #   agentic loop (experimental but stable in v0.130.0).
+            #   The agent treats the prompt as a goal and keeps
+            #   running tool-call cycles until the goal evaluates
+            #   complete or the codex token budget is exhausted.
+            #   Marcus's agent prompt phrases the polling
+            #   instruction as a never-ending goal so codex stays
+            #   engaged across empty ``request_next_task`` polls
+            #   instead of wrapping up after two empty cycles
+            #   (observed without goals enabled).  Affects only the
+            #   spawned agents; the user's interactive codex
+            #   sessions are untouched.
+            return (
+                f"codex exec --dangerously-bypass-approvals-and-sandbox "
+                f"--skip-git-repo-check --disable guardian_approval "
+                f"--enable goals "
+                f"-C {workdir} --add-dir {workdir} \\\n"
+                f"  {self.model_flag}< {prompt_file}"
+            )
+        print_flag = "--print " if print_mode else ""
+        return (
+            f"claude --add-dir {workdir} \\\n"
+            f"  {self.model_flag}--dangerously-skip-permissions "
+            f"{print_flag}< {prompt_file}"
         )
 
     @staticmethod
@@ -1139,28 +1381,40 @@ CRITICAL INSTRUCTIONS:
             check=True,
         )
 
-        # Auto-confirm any trust or permission prompts from Claude
-        time.sleep(1)  # Let Claude start up before polling
-        confirm_trust_if_prompted(target)
+        # Auto-confirm trust/permission prompts from Claude.  Codex
+        # under ``--yolo`` does not raise an interactive trust dialog,
+        # so polling for it just wastes ~5s of startup.  Gate the call
+        # on harness.
+        if self.harness == "claude":
+            time.sleep(1)  # Let Claude start up before polling
+            confirm_trust_if_prompted(target)
 
     def copy_agent_workflow_to_implementation(self) -> None:
         """
-        Copy agent workflow instructions to CLAUDE.md in implementation directory.
+        Copy agent workflow instructions into the implementation directory.
 
-        This ensures agents can reference the workflow throughout their session
-        even after the initial prompt is forgotten.
+        Writes the workflow to *both* ``CLAUDE.md`` (read by Claude
+        Code) and ``AGENTS.md`` (read by Codex CLI and other
+        AGENTS.md-aware tools — see
+        https://developers.openai.com/codex/guides/agents-md).  Writing
+        both is harmless for the claude harness and load-bearing for
+        the codex harness: codex agents that find no ``AGENTS.md``
+        start with zero Marcus workflow guidance and silently fail to
+        call ``register_agent`` / ``request_next_task``.
+
+        Always writing both files keeps the spawn code harness-agnostic
+        and means a future "swap harness mid-experiment" path stays
+        viable.
         """
-        claude_md_path = self.config.implementation_dir / "CLAUDE.md"
-
-        # Read the agent prompt template
+        # Read the agent prompt template once.
         with open(self.agent_prompt_template, "r") as f:
             workflow_content = f.read()
 
-        # Write to CLAUDE.md in implementation directory
-        with open(claude_md_path, "w") as f:
-            f.write(workflow_content)
-
-        print(f"✓ Agent workflow copied to {claude_md_path}")
+        for filename in ("CLAUDE.md", "AGENTS.md"):
+            target = self.config.implementation_dir / filename
+            with open(target, "w") as f:
+                f.write(workflow_content)
+            print(f"✓ Agent workflow copied to {target}")
 
     def spawn_project_creator(self) -> None:
         """Spawn the project creator agent in a tmux pane."""
@@ -1199,13 +1453,12 @@ echo "=========================================="
 echo ""
 echo "Configuring Marcus MCP..."
 MARCUS_MCP_URL="{self.marcus_mcp_url}"
-claude mcp add marcus -t http "$MARCUS_MCP_URL" 2>/dev/null || true
+{self._build_mcp_register_snippet()}
 echo ""
 echo "Creating Marcus project: {self.config.project_name}"
 echo ""
-# Launch Claude from the implementation directory (cwd matters!)
-claude --add-dir {self.config.implementation_dir} \
-  {self.claude_model_flag}--dangerously-skip-permissions --print < {prompt_file}
+# Launch agent from the implementation directory (cwd matters!)
+{self._build_agent_command(self.config.implementation_dir, prompt_file, print_mode=True)}  # noqa: E501
 echo ""
 echo "=========================================="
 echo "Project Creator Complete"
@@ -1367,7 +1620,7 @@ echo "✓ Project found, starting agent..."
 echo ""
 echo "Configuring Marcus MCP..."
 MARCUS_MCP_URL="{self.marcus_mcp_url}"
-claude mcp add marcus -t http "$MARCUS_MCP_URL" 2>/dev/null || true
+{self._build_mcp_register_snippet()}
 echo ""
 # Sync worktree with main to get design artifacts and any
 # previously merged code (GH-302: per-task visibility)
@@ -1375,9 +1628,11 @@ echo "Syncing worktree with main..."
 git merge main --no-edit 2>/dev/null || true
 echo "✓ Worktree synced"
 echo ""
-# Launch Claude from the agent's isolated worktree (cwd matters!)
-claude --add-dir {agent_workspace} \
-  {self.claude_model_flag}--dangerously-skip-permissions < {prompt_file}
+# Launch agent from the agent's isolated worktree (cwd matters!)
+# Workers use the relaunch-aware helper because codex exec exits
+# when the model judges its goal complete; claude branch returns
+# the single command unwrapped (TUI stays alive on its own).
+{self._build_worker_invocation_block(agent_workspace, prompt_file)}
 echo ""
 echo "=========================================="
 echo "{agent_name} - Work Complete"
@@ -1435,11 +1690,10 @@ echo "✓ Project found, starting monitor..."
 echo ""
 echo "Configuring Marcus MCP..."
 MARCUS_MCP_URL="{self.marcus_mcp_url}"
-claude mcp add marcus -t http "$MARCUS_MCP_URL" 2>/dev/null || true
+{self._build_mcp_register_snippet()}
 echo ""
-# Launch Claude from the implementation directory (cwd matters!)
-claude --add-dir {self.config.implementation_dir} \
-  {self.claude_model_flag}--dangerously-skip-permissions < {prompt_file}
+# Launch agent from the implementation directory (cwd matters!)
+{self._build_agent_command(self.config.implementation_dir, prompt_file)}
 echo ""
 echo "=========================================="
 echo "Experiment Monitor - Complete"
@@ -1582,15 +1836,73 @@ echo "=========================================="
         print(f"Agents: {len(self.config.agents)}")
         total_subagents = sum(a.get("subagents", 0) for a in self.config.agents)
         print(f"Subagents: {total_subagents}")
+        print(f"Harness: {self.harness}")
         print(
             "Agent model: "
             + (
                 self.agent_model
-                or "(claude CLI default — no model set in "
+                or f"({self.harness} CLI default — no model set in "
                 "config.yaml.agent_model, config_marcus.json.ai.model, or "
                 "--model)"
             )
         )
+
+        # Harness pre-flight: fail fast if the chosen CLI is not on
+        # PATH. Without this the per-pane bash script silently fails
+        # inside tmux ("command not found") and the user has to attach
+        # to a pane to discover why nothing ran.
+        #
+        # Two-stage lookup: ``shutil.which`` covers the common case
+        # (binary on the parent process's PATH). When that misses, fall
+        # back to a bash subprocess that sources ``~/.zshrc`` and
+        # ``~/.bashrc`` — exactly what the per-pane scripts do — and
+        # tries ``command -v``. This catches the common nvm / npm / asdf
+        # case where ``claude`` or ``codex`` is added to PATH only by
+        # shell init files and the parent Python's PATH does not see it.
+        import shutil as _shutil
+
+        cli_name = "codex" if self.harness == "codex" else "claude"
+
+        def _harness_binary_available(name: str) -> bool:
+            if _shutil.which(name) is not None:
+                return True
+            try:
+                result = subprocess.run(
+                    [
+                        "bash",
+                        "-c",
+                        (
+                            "[ -f ~/.zshrc ] && source ~/.zshrc "
+                            "2>/dev/null; "
+                            "[ -f ~/.bashrc ] && source ~/.bashrc "
+                            "2>/dev/null; "
+                            f"command -v {name}"
+                        ),
+                    ],
+                    capture_output=True,
+                    text=True,
+                    timeout=10,
+                    check=False,
+                )
+                return result.returncode == 0
+            except (OSError, subprocess.TimeoutExpired):
+                return False
+
+        if not _harness_binary_available(cli_name):
+            print(
+                f"\n❌ Harness CLI '{cli_name}' not found — checked "
+                "parent PATH and an interactive shell that sources "
+                "~/.zshrc / ~/.bashrc."
+            )
+            if self.harness == "codex":
+                print("  Install via: npm install -g @openai/codex")
+                print(
+                    "  Then register Marcus MCP: codex mcp add marcus "
+                    f'--url "{self.marcus_mcp_url}"'
+                )
+            else:
+                print("  Install Claude Code CLI then retry.")
+            return False
 
         # Calculate tmux layout
         total_agents = 1 + len(self.config.agents) + 1  # creator + workers + monitor
@@ -1658,8 +1970,12 @@ echo "=========================================="
             print("\n[Setup] Git repository already initialized")
 
         # Pre-trust the implementation directory so Claude doesn't
-        # show the "Do you trust this folder?" prompt.
-        self._pretrust_directory(self.config.implementation_dir)
+        # show the "Do you trust this folder?" prompt.  Codex under
+        # ``--yolo`` bypasses its own trust/sandbox dialogs entirely,
+        # so the pretrust step (which touches ``~/.claude.json``)
+        # would be a wasted side effect on codex-only runs.
+        if self.harness == "claude":
+            self._pretrust_directory(self.config.implementation_dir)
 
         # Create tmux session
         print("\n[Setup] Creating tmux session")

--- a/dev-tools/experiments/templates/agent_prompt.md
+++ b/dev-tools/experiments/templates/agent_prompt.md
@@ -1,6 +1,40 @@
 WORKER_SYSTEM_PROMPT: |
   You are an autonomous agent working through Marcus's MCP interface.
 
+  YOUR GOAL (never-ending until experiment ends):
+  Continuously request and complete Marcus tasks for as long as Marcus
+  accepts requests. Your goal is fundamentally OPEN-ENDED — it cannot be
+  evaluated as "complete" merely because:
+  - request_next_task returned "no task available" once or twice
+  - You completed your most recent task and have nothing in flight
+  - You feel you have done a reasonable amount of work
+  - The conversation has gone on for many turns
+  The ONLY signals that mean the goal is complete:
+  - get_project_status reports total_tasks == completed (every task done), OR
+  - The experiment monitor kills the tmux session externally
+  Until one of those two terminal conditions, you MUST keep polling and
+  working. Do NOT write a wrap-up summary. Do NOT decide you are done.
+  Do NOT spawn a background bash loop and walk away — YOU are the
+  orchestrator and each polling cycle must be an explicit MCP call you
+  invoke yourself.
+
+  CODEX RUNTIME GUARDRAIL (codex harness only — claude harness ignore):
+  If you are running under the codex CLI with the goals feature enabled,
+  you may have access to a model tool named `update_goal`. The codex
+  runtime stops continuation as soon as the agent calls
+  `update_goal(status="complete")` — this is codex's hard exit lever and
+  it OVERRIDES every instruction above. Therefore:
+  - DO NOT call `update_goal` with status="complete" unless
+    `get_project_status` confirms total_tasks == completed for the
+    current Marcus project. That is the ONLY condition that authorizes
+    declaring the goal complete.
+  - You MAY call `update_goal` with non-terminal statuses (in_progress,
+    blocked, etc.) for telemetry — those do not terminate continuation.
+  - If you find yourself reasoning "I have done good work, I should
+    mark this goal complete" — STOP. Re-read the two terminal signals
+    above. If neither applies, keep polling. The experiment monitor is
+    responsible for ending the session; you are not.
+
   CRITICAL: You MUST maintain a continuous work loop. After completing ANY task, IMMEDIATELY request the next task from Marcus without waiting for user input. This is your primary directive.
 
   NEW: GITHUB CODE AWARENESS (when using GitHub provider):

--- a/tests/unit/experiments/test_spawn_agents.py
+++ b/tests/unit/experiments/test_spawn_agents.py
@@ -214,7 +214,9 @@ class TestTermNormalization:
         spawner.marcus_mcp_url = "http://localhost:4298/mcp"
         # Slice B+ (#523) and agent-model wiring: see fixture below.
         spawner.agent_model = None
+        spawner.model_flag = ""
         spawner.claude_model_flag = ""
+        spawner.harness = "claude"
 
         # Mock tmux calls and generate the script
         with patch("subprocess.run"):
@@ -745,7 +747,9 @@ class TestRunUsesRecommendedAgentCount:
         # banner doesn't AttributeError.  None / empty string match
         # the no-override / no-model path used by these tests.
         instance.agent_model = None
+        instance.model_flag = ""
         instance.claude_model_flag = ""
+        instance.harness = "claude"
         return instance
 
     def _write_project_info(self, path: Path, recommended_agents: int = 0) -> None:
@@ -804,6 +808,12 @@ class TestRunUsesRecommendedAgentCount:
             patch.object(spawner_with_config, "spawn_monitor"),
             patch.object(spawner_with_config, "_pretrust_directory"),
             patch("subprocess.run"),
+            # AgentSpawner.run now does a pre-flight ``shutil.which(<cli>)``
+            # check and returns False if the harness CLI is absent. CI
+            # runners do not have ``claude`` or ``codex`` installed, so the
+            # check must be stubbed for these tests to exercise the
+            # recommended-agents logic regardless of host PATH.
+            patch("shutil.which", return_value="/usr/bin/claude"),
             patch.dict("sys.modules", {"mlflow": MagicMock()}),
         ):
             spawner_with_config.run()
@@ -1391,7 +1401,9 @@ class TestClaudeModelFlagLandsInGeneratedScripts:
         spawner.panes_per_window = 4
         spawner.marcus_mcp_url = "http://localhost:4298/mcp"
         spawner.agent_model = agent_model
-        spawner.claude_model_flag = f"--model {agent_model} " if agent_model else ""
+        spawner.model_flag = f"--model {agent_model} " if agent_model else ""
+        spawner.claude_model_flag = spawner.model_flag
+        spawner.harness = "claude"
         return spawner
 
     def test_project_creator_script_contains_model_flag(self, tmp_path: Path) -> None:
@@ -1546,7 +1558,12 @@ class TestTmuxBaseIndexDetection:
     # ------------------------------------------------------------------
 
     def _bypass_init_spawner(self, base: int, pane_base: int) -> Any:
-        """Build an AgentSpawner without running __init__, with tmux indices set."""
+        """Build an AgentSpawner without running __init__, with tmux indices set.
+
+        ``run_in_tmux_pane`` branches on ``self.harness`` to gate the
+        Claude-only trust-dialog poller, so the attribute must be set
+        even though these tests target the tmux base-index logic.
+        """
         instance = spawn_agents.AgentSpawner.__new__(spawn_agents.AgentSpawner)
         instance.tmux_session = "marcus_test"
         instance.panes_per_window = 2
@@ -1554,6 +1571,7 @@ class TestTmuxBaseIndexDetection:
         instance.current_pane = 0
         instance._tmux_base_index = base
         instance._tmux_pane_base_index = pane_base
+        instance.harness = "claude"
         return instance
 
     def test_new_window_target_includes_base_index_offset(self) -> None:
@@ -1604,3 +1622,651 @@ class TestTmuxBaseIndexDetection:
 
         first_cmd = mock_run.call_args_list[0][0][0]
         assert "marcus_test:0.0" in first_cmd
+
+
+# ---------------------------------------------------------------------------
+# Harness routing (claude vs codex)
+# ---------------------------------------------------------------------------
+
+
+class TestHarnessConfigResolution:
+    """``ExperimentConfig.harness`` reads the yaml field with safe defaults.
+
+    The harness field selects which agent CLI (``claude`` or ``codex``)
+    the runner spawns inside each tmux pane.  Defaulting to ``'claude'``
+    preserves backward compatibility for every config.yaml written
+    before harness support landed.
+    """
+
+    def test_harness_defaults_to_claude_when_absent(self, tmp_path: Path) -> None:
+        """No ``harness:`` key in yaml → config.harness == 'claude'."""
+        config_path = _make_config_yaml(tmp_path)
+        config = spawn_agents.ExperimentConfig(config_path)
+        assert config.harness == "claude"
+
+    def test_harness_codex_from_yaml(self, tmp_path: Path) -> None:
+        """``harness: codex`` in yaml → config.harness == 'codex'."""
+        config_path = _make_config_yaml(tmp_path, harness="codex")
+        config = spawn_agents.ExperimentConfig(config_path)
+        assert config.harness == "codex"
+
+    def test_harness_normalized_to_lowercase(self, tmp_path: Path) -> None:
+        """Yaml ``harness: Codex`` (case quirk) is normalized."""
+        config_path = _make_config_yaml(tmp_path, harness="Codex")
+        config = spawn_agents.ExperimentConfig(config_path)
+        assert config.harness == "codex"
+
+    def test_invalid_harness_raises_value_error(self, tmp_path: Path) -> None:
+        """Unknown harness names error at config load, not at spawn time.
+
+        Failing fast at load time means the bad value surfaces before
+        we touch tmux, git, or MLflow — preserving the user's terminal
+        state and giving a clean message.
+        """
+        config_path = _make_config_yaml(tmp_path, harness="bedrock")
+        with pytest.raises(ValueError, match="bedrock"):
+            spawn_agents.ExperimentConfig(config_path)
+
+
+class TestAgentSpawnerHarnessRouting:
+    """``AgentSpawner`` dispatches MCP register and agent command by harness.
+
+    The helpers :meth:`_build_mcp_register_snippet` and
+    :meth:`_build_agent_command` are the only places where harness
+    semantics diverge.  These tests verify each branch produces the
+    correct CLI surface area: ``claude`` for the claude harness;
+    ``codex exec --yolo`` for the codex harness.
+    """
+
+    def _make_bypass_spawner(self, tmp_path: Path, harness: str) -> Any:
+        """Build a __new__-style spawner with the minimum attrs the helpers
+        read.  Mirrors the bypass pattern used elsewhere in this module."""
+        spawner = spawn_agents.AgentSpawner.__new__(spawn_agents.AgentSpawner)
+        spawner.harness = harness
+        spawner.model_flag = ""
+        spawner.claude_model_flag = ""
+        return spawner
+
+    def test_mcp_register_claude(self, tmp_path: Path) -> None:
+        """Claude harness uses ``claude mcp add ... -t http``."""
+        spawner = self._make_bypass_spawner(tmp_path, "claude")
+        snippet = spawner._build_mcp_register_snippet()
+        assert "claude mcp add marcus -t http" in snippet
+        assert "codex" not in snippet
+        # Idempotent re-runs: errors are swallowed so re-spawning doesn't
+        # abort the pane.
+        assert "|| true" in snippet
+
+    def test_mcp_register_codex(self, tmp_path: Path) -> None:
+        """Codex harness uses ``codex mcp add ... --url``."""
+        spawner = self._make_bypass_spawner(tmp_path, "codex")
+        snippet = spawner._build_mcp_register_snippet()
+        assert "codex mcp add marcus --url" in snippet
+        # No claude-side syntax leaking into the codex branch.
+        assert "claude mcp" not in snippet
+        assert "|| true" in snippet
+
+    def test_agent_command_claude_no_model(self, tmp_path: Path) -> None:
+        """Claude command shape: ``claude --add-dir ... --dangerously-skip-permissions``."""
+        spawner = self._make_bypass_spawner(tmp_path, "claude")
+        cmd = spawner._build_agent_command(tmp_path / "work", tmp_path / "prompt.txt")
+        assert "claude --add-dir" in cmd
+        assert "--dangerously-skip-permissions" in cmd
+        assert "--print" not in cmd  # default print_mode=False
+        assert "codex" not in cmd
+        assert "--yolo" not in cmd
+
+    def test_agent_command_claude_print_mode(self, tmp_path: Path) -> None:
+        """``print_mode=True`` adds ``--print`` (used by project creator)."""
+        spawner = self._make_bypass_spawner(tmp_path, "claude")
+        cmd = spawner._build_agent_command(
+            tmp_path / "work", tmp_path / "prompt.txt", print_mode=True
+        )
+        assert "--print " in cmd
+
+    def test_agent_command_codex_no_model(self, tmp_path: Path) -> None:
+        """Codex command shape: ``codex exec --dangerously-bypass-approvals-and-sandbox``.
+
+        We deliberately use the documented long-form flag rather than
+        the hidden ``--yolo`` alias.  Hidden aliases have no stability
+        contract and can be renamed without notice; the documented
+        flag has a much longer half-life and the behaviour is
+        identical (approval=never, sandbox=danger-full-access).
+        """
+        spawner = self._make_bypass_spawner(tmp_path, "codex")
+        cmd = spawner._build_agent_command(tmp_path / "work", tmp_path / "prompt.txt")
+        assert "codex exec --dangerously-bypass-approvals-and-sandbox" in cmd
+        assert "--skip-git-repo-check" in cmd
+        # Guardian must be disabled — its "unexpected workspace
+        # change" prompt fires on `git merge main` artifacts and
+        # would halt the agent waiting for a user response that
+        # never comes (no human attached to a tmux pane).
+        assert "--disable guardian_approval" in cmd
+        # Goals must be enabled — codex's autonomous loop is what
+        # keeps the model engaged through empty request_next_task
+        # polls.  Without it, the model wraps up after 2-3 empty
+        # cycles and the agent silently exits.
+        assert "--enable goals" in cmd
+        # Hidden alias must not leak in — keeps our dependency on
+        # documented flags only.
+        assert "--yolo" not in cmd
+        # Claude-side flags must NOT leak into the codex branch.
+        assert "claude" not in cmd
+        assert "--dangerously-skip-permissions" not in cmd
+
+    def test_agent_command_codex_ignores_print_mode(self, tmp_path: Path) -> None:
+        """``codex exec`` is inherently non-interactive — print_mode is a no-op.
+
+        We document this in the helper docstring; the test enforces
+        the contract so a well-meaning refactor cannot accidentally
+        start passing ``--print`` (which codex does not accept).
+        """
+        spawner = self._make_bypass_spawner(tmp_path, "codex")
+        cmd = spawner._build_agent_command(
+            tmp_path / "work", tmp_path / "prompt.txt", print_mode=True
+        )
+        assert "--print" not in cmd
+
+    def test_worker_invocation_block_claude_no_wrapper(self, tmp_path: Path) -> None:
+        """Claude TUI stays alive across turns — no relaunch loop needed.
+
+        The worker helper must return the raw single command for the
+        claude harness so the pane runs interactive claude exactly
+        the way pre-codex Marcus has always done.
+        """
+        spawner = self._make_bypass_spawner(tmp_path, "claude")
+        block = spawner._build_worker_invocation_block(
+            tmp_path / "work", tmp_path / "prompt.txt"
+        )
+        # No loop scaffolding leaks into the claude path.
+        assert "MAX_RELAUNCHES" not in block
+        assert "for relaunch" not in block
+        # Single claude invocation is still there.
+        assert "claude --add-dir" in block
+
+    def test_worker_invocation_block_codex_wraps_in_loop(self, tmp_path: Path) -> None:
+        """Codex workers wrap ``codex exec`` in a bounded bash relaunch loop.
+
+        Belt-and-suspenders: ``--enable goals`` keeps the model
+        engaged across empty polls in the common case; the wrapper
+        catches the edge cases where codex exec exits anyway (token
+        budget exhausted, model judges goal complete on a fluke,
+        unrecoverable error).  The loop is bounded so a genuinely
+        wedged worker cannot burn unbounded tokens — the monitor
+        pane kills the session at experiment end on the happy path.
+        """
+        spawner = self._make_bypass_spawner(tmp_path, "codex")
+        block = spawner._build_worker_invocation_block(
+            tmp_path / "work", tmp_path / "prompt.txt"
+        )
+        # Loop scaffolding present.
+        assert "MAX_RELAUNCHES=50" in block
+        assert "for relaunch in $(seq 1 $MAX_RELAUNCHES)" in block
+        assert "sleep 3" in block
+        assert "codex exec --dangerously-bypass-approvals-and-sandbox" in block
+        # Final-give-up echo so a wedged worker is visible in pane history.
+        assert "hit MAX_RELAUNCHES" in block
+
+    def test_worker_invocation_block_codex_breaks_on_clean_exit(
+        self, tmp_path: Path
+    ) -> None:
+        """Codex wrapper breaks the relaunch loop when ``codex exec`` exits
+        cleanly.
+
+        Without this guard the loop would re-launch after every
+        successful completion (rc=0) — burning tokens, and with
+        ``--epictetus`` keeping workers churning instead of staying
+        quiescent for post-run inspection. The shell block must
+        capture the exit code and break when it's 0; non-zero exits
+        (crashes, token budget hits) still trigger a relaunch.
+        Codex review P1 on PR #554.
+        """
+        spawner = self._make_bypass_spawner(tmp_path, "codex")
+        block = spawner._build_worker_invocation_block(
+            tmp_path / "work", tmp_path / "prompt.txt"
+        )
+        # Exit status captured.
+        assert "rc=$?" in block
+        # Branches on rc=0 and breaks out.
+        assert "[ $rc -eq 0 ]" in block
+        assert "break" in block
+        # Non-zero path still relaunches (preserves the sleep + loop).
+        assert "rc=$rc" in block
+
+    def test_agent_command_model_flag_threaded_through_both_harnesses(
+        self, tmp_path: Path
+    ) -> None:
+        """``--model X`` is spliced into both branches verbatim.
+
+        Both harnesses accept the long-form ``--model`` spelling so a
+        single rendered fragment works for either.
+        """
+        for harness in ("claude", "codex"):
+            spawner = self._make_bypass_spawner(tmp_path, harness)
+            spawner.model_flag = "--model my-model "
+            cmd = spawner._build_agent_command(
+                tmp_path / "work", tmp_path / "prompt.txt"
+            )
+            assert (
+                "--model my-model" in cmd
+            ), f"model flag missing in {harness} branch: {cmd}"
+
+
+class TestSpawnerHarnessFromConfig:
+    """Spawner harness defaults flow correctly from config → __init__."""
+
+    def _build_spawner(
+        self,
+        tmp_path: Path,
+        monkeypatch: Any,
+        yaml_harness: str | None = None,
+        cli_harness: str | None = None,
+    ) -> Any:
+        """Build a real-init AgentSpawner with the given harness wiring."""
+        fake_root = tmp_path / "marcus_root"
+        fake_root.mkdir()
+        fake_module_path = (
+            fake_root / "dev-tools" / "experiments" / "runners" / "spawn_agents.py"
+        )
+        fake_module_path.parent.mkdir(parents=True)
+        fake_module_path.write_text("")
+        monkeypatch.setattr(spawn_agents, "__file__", str(fake_module_path))
+
+        extra: Dict[str, Any] = {}
+        if yaml_harness is not None:
+            extra["harness"] = yaml_harness
+        config_path = _make_config_yaml(tmp_path, **extra)
+        config = spawn_agents.ExperimentConfig(config_path)
+
+        templates_dir = tmp_path / "templates"
+        templates_dir.mkdir()
+        (templates_dir / "agent_prompt.md").write_text("stub")
+
+        return spawn_agents.AgentSpawner(
+            config=config,
+            templates_dir=templates_dir,
+            harness=cli_harness,
+        )
+
+    def test_spawner_defaults_to_claude(self, tmp_path: Path, monkeypatch: Any) -> None:
+        spawner = self._build_spawner(tmp_path, monkeypatch)
+        assert spawner.harness == "claude"
+
+    def test_yaml_harness_flows_to_spawner(
+        self, tmp_path: Path, monkeypatch: Any
+    ) -> None:
+        spawner = self._build_spawner(tmp_path, monkeypatch, yaml_harness="codex")
+        assert spawner.harness == "codex"
+
+    def test_cli_harness_overrides_yaml(self, tmp_path: Path, monkeypatch: Any) -> None:
+        """CLI ``--harness`` beats yaml ``harness:`` field.
+
+        Precedence: CLI > yaml > default ('claude').  Same pattern as
+        ``--model``/``agent_model`` — last writer wins, with CLI as
+        the explicit user override.
+        """
+        spawner = self._build_spawner(
+            tmp_path,
+            monkeypatch,
+            yaml_harness="claude",
+            cli_harness="codex",
+        )
+        assert spawner.harness == "codex"
+
+    def test_invalid_cli_harness_raises(self, tmp_path: Path, monkeypatch: Any) -> None:
+        with pytest.raises(ValueError, match="bedrock"):
+            self._build_spawner(tmp_path, monkeypatch, cli_harness="bedrock")
+
+
+# ---------------------------------------------------------------------------
+# Workflow file materialization (CLAUDE.md + AGENTS.md)
+# ---------------------------------------------------------------------------
+
+
+class TestAgentWorkflowFilesMaterialized:
+    """``copy_agent_workflow_to_implementation`` writes BOTH CLAUDE.md and AGENTS.md.
+
+    Claude Code reads ``CLAUDE.md``.  Codex CLI reads ``AGENTS.md``
+    (https://developers.openai.com/codex/guides/agents-md).  Without
+    AGENTS.md, codex agents start with zero Marcus workflow guidance
+    and silently fail to call ``register_agent`` /
+    ``request_next_task``.  Writing both files keeps the spawn code
+    harness-agnostic and is harmless when the claude harness is
+    active.
+    """
+
+    def _make_spawner(self, tmp_path: Path, harness: str = "claude") -> Any:
+        config = MagicMock()
+        config.implementation_dir = tmp_path / "implementation"
+        config.implementation_dir.mkdir()
+
+        spawner = spawn_agents.AgentSpawner.__new__(spawn_agents.AgentSpawner)
+        spawner.config = config
+        spawner.harness = harness
+
+        # Real workflow template content — tests should fail loudly
+        # if either file goes empty.
+        template = tmp_path / "agent_prompt.md"
+        template.write_text(
+            "# Marcus Agent Workflow\n\n"
+            "Call register_agent() then loop on request_next_task().\n"
+        )
+        spawner.agent_prompt_template = template
+        return spawner
+
+    def test_writes_both_files_for_claude_harness(self, tmp_path: Path) -> None:
+        spawner = self._make_spawner(tmp_path, harness="claude")
+        spawner.copy_agent_workflow_to_implementation()
+
+        claude_md = spawner.config.implementation_dir / "CLAUDE.md"
+        agents_md = spawner.config.implementation_dir / "AGENTS.md"
+        assert claude_md.exists()
+        assert agents_md.exists()
+        # Same content — same template feeds both.
+        assert claude_md.read_text() == agents_md.read_text()
+        assert "register_agent" in agents_md.read_text()
+
+    def test_writes_both_files_for_codex_harness(self, tmp_path: Path) -> None:
+        """The load-bearing case: AGENTS.md is what codex actually reads."""
+        spawner = self._make_spawner(tmp_path, harness="codex")
+        spawner.copy_agent_workflow_to_implementation()
+
+        agents_md = spawner.config.implementation_dir / "AGENTS.md"
+        assert agents_md.exists()
+        assert "register_agent" in agents_md.read_text()
+
+
+# ---------------------------------------------------------------------------
+# End-to-end codex script rendering
+# ---------------------------------------------------------------------------
+
+
+class TestCodexScriptsRender:
+    """Rendered bash scripts contain codex CLI invocations, not claude.
+
+    The helper-level tests in :class:`TestAgentSpawnerHarnessRouting`
+    verify the command-builder methods.  These tests verify that those
+    methods actually get spliced into the rendered ``.sh`` files for
+    all three pane types — project creator, worker, monitor.  A
+    regression where someone hard-codes ``claude`` back into an
+    f-string is caught here, not in production.
+    """
+
+    def _make_spawner(self, tmp_path: Path, model: str | None = None) -> Any:
+        """Build a bypass-init spawner wired for the codex harness."""
+        config = MagicMock()
+        config.experiment_dir = tmp_path
+        config.implementation_dir = tmp_path / "implementation"
+        config.implementation_dir.mkdir()
+        config.prompts_dir = tmp_path / "prompts"
+        config.prompts_dir.mkdir()
+        config.project_info_file = tmp_path / "project_info.json"
+        config.project_name = "test"
+        config.project_options = {
+            "complexity": "standard",
+            "provider": "sqlite",
+            "mode": "new_project",
+        }
+        config.agents = []
+        config.get_timeout.return_value = 300
+
+        # Worktrees dir for spawn_worker test.
+        worktrees = tmp_path / "worktrees"
+        worktrees.mkdir(exist_ok=True)
+
+        spawner = spawn_agents.AgentSpawner.__new__(spawn_agents.AgentSpawner)
+        spawner.config = config
+        spawner.tmux_session = "test_session"
+        spawner.current_pane = 0
+        spawner.current_window = 0
+        spawner.panes_per_window = 4
+        spawner.marcus_mcp_url = "http://localhost:4298/mcp"
+        spawner.agent_model = model
+        spawner.model_flag = f"--model {model} " if model else ""
+        spawner.claude_model_flag = spawner.model_flag
+        spawner.harness = "codex"
+
+        # agent_prompt_template — needed by worker prompt creation.
+        template = tmp_path / "agent_prompt.md"
+        template.write_text("# stub workflow\n")
+        spawner.agent_prompt_template = template
+        return spawner
+
+    def test_project_creator_script_renders_codex(self, tmp_path: Path) -> None:
+        """Project creator pane runs ``codex exec`` under codex harness."""
+        spawner = self._make_spawner(tmp_path, model="gpt-5-codex")
+
+        with (
+            patch("subprocess.run"),
+            patch.object(spawner, "copy_agent_workflow_to_implementation"),
+            patch.object(spawner, "run_in_tmux_pane"),
+        ):
+            spawner.spawn_project_creator()
+
+        script = (spawner.config.prompts_dir / "project_creator.sh").read_text()
+        assert "codex exec --dangerously-bypass-approvals-and-sandbox" in script
+        assert "--disable guardian_approval" in script
+        assert "--enable goals" in script
+        assert "codex mcp add marcus --url" in script
+        assert "--model gpt-5-codex" in script
+        # Claude branch must not leak in.
+        assert "claude --add-dir" not in script
+        assert "claude mcp add" not in script
+        assert "--yolo" not in script
+
+    def test_monitor_script_renders_codex(self, tmp_path: Path) -> None:
+        """Monitor pane also runs ``codex exec`` under codex harness."""
+        spawner = self._make_spawner(tmp_path)
+
+        # spawn_monitor calls create_monitor_prompt which reads several
+        # config attrs; stub it to a no-op string to keep this test
+        # focused on the rendered shell invocation.
+        with (
+            patch("subprocess.run"),
+            patch.object(spawner, "run_in_tmux_pane"),
+            patch.object(spawner, "create_monitor_prompt", return_value="stub prompt"),
+        ):
+            spawner.spawn_monitor()
+
+        script = (spawner.config.prompts_dir / "monitor.sh").read_text()
+        assert "codex exec --dangerously-bypass-approvals-and-sandbox" in script
+        assert "--disable guardian_approval" in script
+        assert "--enable goals" in script
+        assert "codex mcp add marcus --url" in script
+        assert "claude --add-dir" not in script
+        assert "claude mcp add" not in script
+        # Monitor must NOT be wrapped in the relaunch loop — it is
+        # intentionally one-shot (exits cleanly when experiment ends).
+        assert "MAX_RELAUNCHES" not in script
+
+    def test_worker_script_renders_codex_with_wrapper(self, tmp_path: Path) -> None:
+        """Worker pane wraps ``codex exec`` in the relaunch loop.
+
+        End-to-end: verify the wrapper actually lands in the
+        rendered worker script.  Helper-level coverage lives in
+        :class:`TestAgentSpawnerHarnessRouting`; this catches the
+        ``spawn_worker`` f-string regression where someone could
+        revert to the unwrapped helper.
+        """
+        spawner = self._make_spawner(tmp_path)
+
+        agent = {
+            "id": "agent_unicorn_1",
+            "name": "Unicorn Developer 1",
+            "role": "full-stack",
+            "skills": ["python"],
+            "subagents": 0,
+        }
+
+        # spawn_worker creates a git worktree before launching codex;
+        # stub the worktree-creation helper and tmux glue so the test
+        # is focused on the script body.
+        with (
+            patch("subprocess.run"),
+            patch.object(spawner, "run_in_tmux_pane"),
+            patch.object(spawner, "_create_agent_worktree"),
+            patch.object(spawner, "create_worker_prompt", return_value="stub prompt"),
+        ):
+            spawner.spawn_worker(agent)
+
+        script = (spawner.config.prompts_dir / "agent_unicorn_1.sh").read_text()
+        # Codex invocation present.
+        assert "codex exec --dangerously-bypass-approvals-and-sandbox" in script
+        assert "--enable goals" in script
+        assert "--disable guardian_approval" in script
+        # Wrapper loop scaffolding lands in the rendered script.
+        assert "MAX_RELAUNCHES=50" in script
+        assert "for relaunch in $(seq 1 $MAX_RELAUNCHES)" in script
+        # Claude path must not leak.
+        assert "claude --add-dir" not in script
+
+
+# ---------------------------------------------------------------------------
+# Harness binary pre-flight
+# ---------------------------------------------------------------------------
+
+
+class TestHarnessPreflight:
+    """``AgentSpawner.run`` pre-flights the harness binary before spawning.
+
+    Two-stage lookup: ``shutil.which`` first (fast, no subprocess) and
+    fall back to a ``bash -c`` invocation that sources ``~/.zshrc`` and
+    ``~/.bashrc`` — the same init the per-pane scripts do. This avoids
+    the false-negative case where ``claude`` or ``codex`` is added to
+    PATH only by shell init files (nvm / npm / asdf), so the parent
+    Python sees no binary but the spawned pane would. Codex review P2
+    on PR #554.
+    """
+
+    def _minimal_spawner(self, tmp_path: Path, harness: str) -> Any:
+        """Build a spawner with just enough state to reach the pre-flight.
+
+        Bypasses ``__init__`` and stubs the bits ``run`` touches before
+        the pre-flight check (banner print, MLflow probe attribute,
+        agent list).
+        """
+        config = MagicMock()
+        config.experiment_dir = tmp_path
+        config.implementation_dir = tmp_path / "implementation"
+        config.implementation_dir.mkdir()
+        config.prompts_dir = tmp_path / "prompts"
+        config.prompts_dir.mkdir()
+        config.project_name = "preflight_test"
+        config.project_options = {"complexity": "prototype", "provider": "sqlite"}
+        config.agents = []
+        config.get_timeout.return_value = 300
+
+        spawner = spawn_agents.AgentSpawner.__new__(spawn_agents.AgentSpawner)
+        spawner.config = config
+        spawner.harness = harness
+        spawner.agent_model = None
+        spawner.marcus_mcp_url = "http://localhost:4298/mcp"
+        # Attributes ``run`` references between the pre-flight check
+        # and ``create_tmux_session`` — set so the patched STOP can
+        # actually fire instead of hitting an AttributeError.
+        spawner.panes_per_window = 2
+        spawner.current_window = 0
+        spawner.current_pane = 0
+        spawner._tmux_base_index = 0
+        spawner._tmux_pane_base_index = 0
+        spawner.tmux_session = "marcus_preflight_test"
+        return spawner
+
+    def test_passes_when_shutil_which_finds_binary(self, tmp_path: Path) -> None:
+        """Fast path: parent PATH has the CLI → no bash subprocess fired."""
+        spawner = self._minimal_spawner(tmp_path, "codex")
+
+        bash_lookup_calls: list[Any] = []
+
+        def _fake_run(cmd: Any, *args: Any, **kwargs: Any) -> Any:
+            if isinstance(cmd, list) and len(cmd) >= 3 and "command -v" in str(cmd[-1]):
+                bash_lookup_calls.append(cmd)
+            return MagicMock(returncode=0, stdout="", stderr="")
+
+        with (
+            patch("shutil.which", return_value="/usr/local/bin/codex"),
+            patch("subprocess.run", side_effect=_fake_run),
+            # Halt run() right after pre-flight so we don't have to
+            # mock the entire spawn pipeline.
+            patch.object(
+                spawner, "create_tmux_session", side_effect=RuntimeError("STOP")
+            ),
+        ):
+            with pytest.raises(RuntimeError, match="STOP"):
+                spawner.run()
+
+        assert bash_lookup_calls == [], (
+            "shutil.which succeeded; bash fallback must not have been called: "
+            f"{bash_lookup_calls}"
+        )
+
+    def test_falls_back_to_interactive_shell_when_parent_path_misses(
+        self, tmp_path: Path
+    ) -> None:
+        """When ``shutil.which`` returns None, retry via ``bash -c`` that
+        sources ~/.zshrc and ~/.bashrc — same as the pane scripts."""
+        spawner = self._minimal_spawner(tmp_path, "codex")
+
+        bash_lookup_calls: list[Any] = []
+
+        def _fake_run(cmd: Any, *args: Any, **kwargs: Any) -> Any:
+            if isinstance(cmd, list) and len(cmd) >= 3 and "command -v" in str(cmd[-1]):
+                bash_lookup_calls.append(cmd)
+                # Simulate the interactive shell finding the binary
+                # only after sourcing rc files.
+                return MagicMock(
+                    returncode=0, stdout="/Users/u/.nvm/.../codex\n", stderr=""
+                )
+            return MagicMock(returncode=0, stdout="", stderr="")
+
+        with (
+            patch("shutil.which", return_value=None),
+            patch("subprocess.run", side_effect=_fake_run),
+            patch.object(
+                spawner, "create_tmux_session", side_effect=RuntimeError("STOP")
+            ),
+        ):
+            with pytest.raises(RuntimeError, match="STOP"):
+                spawner.run()
+
+        assert len(bash_lookup_calls) == 1, (
+            "Expected exactly one bash fallback lookup, got "
+            f"{len(bash_lookup_calls)}: {bash_lookup_calls}"
+        )
+        invocation = bash_lookup_calls[0]
+        assert invocation[0] == "bash"
+        assert invocation[1] == "-c"
+        # The fallback shell must source both rc files (matches the
+        # pane scripts at spawn_agents.py:1422-1423 / :1575-1576 /
+        # :1655-1656) so the lookup sees the same PATH the pane will.
+        assert "~/.zshrc" in invocation[2]
+        assert "~/.bashrc" in invocation[2]
+        assert "command -v codex" in invocation[2]
+
+    def test_aborts_with_clear_message_when_neither_check_finds_binary(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """Both lookups miss → ``run`` returns False with an error mentioning
+        both check paths so the user knows it's not just a PATH problem."""
+        spawner = self._minimal_spawner(tmp_path, "claude")
+
+        def _fake_run(cmd: Any, *args: Any, **kwargs: Any) -> Any:
+            # Interactive shell also doesn't find it.
+            return MagicMock(returncode=1, stdout="", stderr="")
+
+        with (
+            patch("shutil.which", return_value=None),
+            patch("subprocess.run", side_effect=_fake_run),
+        ):
+            result = spawner.run()
+
+        assert result is False, (
+            "run() should return False when pre-flight fails so the runner "
+            "aborts cleanly"
+        )
+        out = capsys.readouterr().out
+        assert "Harness CLI 'claude' not found" in out
+        # Error must reference both lookup paths so the user knows the
+        # parent-PATH-only false-negative is already ruled out.
+        assert "parent PATH" in out
+        assert "~/.zshrc" in out


### PR DESCRIPTION
## ⚠️ WIP / Draft

**Status:** unit tests are green and rendered shell scripts look correct, but live end-to-end runs are still hitting issues. Workers spawn, register with Marcus, and complete tasks — but exit early under conditions we are still characterizing. Opening as a draft for visibility and iteration; do not merge yet.

## What is this?

Marcus is a coordination platform for multi-agent software experiments. It spins up N independent "agent" CLI processes (each in its own tmux pane) and lets them coordinate via a shared MCP server (Marcus itself). To date the spawned agent has always been Anthropic's `claude` CLI. This PR adds opt-in support for OpenAI's `codex` CLI as an alternative agent harness, selectable per experiment.

The Marcus MCP server is **agent-agnostic** — it's already a plain HTTP MCP endpoint. The harness choice only affects which CLI binary is launched in each pane and which per-CLI MCP registry the agent reads from (`~/.claude.json` vs `~/.codex/config.toml`).

## Why

Two motivations:
1. **Cross-harness comparison.** Same Marcus project, same MCP server, different agent CLI → clean A/B data on agent-harness behavior. Useful for the research story and for users who pay OpenAI but not Anthropic (or vice versa).
2. **Reduce vendor lock-in.** Marcus is already MCP-mediated; restricting spawned agents to one vendor was an artificial limitation in the runner, not the architecture.

## How to use

```bash
# Claude harness (existing behavior, unchanged):
python dev-tools/experiments/runners/run_experiment.py <dir> [--model X]

# Codex harness (new):
python dev-tools/experiments/runners/run_experiment.py <dir> \
  --harness codex --model gpt-5.3-codex
```

> **Note on `--model` for codex:** the model string is passed through verbatim to `codex --model` with no per-account validation. Which model identifiers are actually available depends on your codex auth mode:
> - **ChatGPT-plan auth** (`~/.codex/auth.json` `auth_mode: chatgpt`) — supports the base models your ChatGPT subscription tier exposes (e.g. `gpt-5.3-codex`). Variants like `gpt-5.3-codex-spark` return `invalid_request_error: model not supported`.
> - **API-key auth** (`OPENAI_API_KEY` set, no ChatGPT account) — supports the full codex model lineup.
>
> If the live experiment fails with `model not supported`, switch the `--model` value or change auth modes.

The `/marcus` slash command (Claude) gains `--harness codex|claude`, and a mirrored `/marcus` skill is published for Codex CLI invocation at `.codex/skills/marcus/SKILL.md` (and `~/.codex/skills/marcus/SKILL.md` for local install).

## What changed

- **`dev-tools/experiments/runners/run_experiment.py`** — adds `--harness {claude,codex}` CLI flag.
- **`dev-tools/experiments/runners/spawn_agents.py`**:
  - `ExperimentConfig.harness` parses a new `harness:` yaml field (defaults to `claude`).
  - `_build_agent_command(workdir, prompt_file)` dispatches per harness. Codex command surface:
    ```
    codex exec --dangerously-bypass-approvals-and-sandbox \\
      --skip-git-repo-check --disable guardian_approval --enable goals \\
      -C <dir> --add-dir <dir> --model <X> < prompt.txt
    ```
  - `_build_worker_invocation_block` wraps codex worker invocations in a bounded bash `for` loop (`MAX_RELAUNCHES=50`) as a safety net for when codex's `--enable goals` exits earlier than expected. Claude returns the single command unwrapped (claude TUI stays alive on its own).
  - Trust-dialog poller and `~/.claude.json` pretrust gated on `harness == claude`.
  - `copy_agent_workflow_to_implementation` writes BOTH `CLAUDE.md` and `AGENTS.md` so codex agents (which read `AGENTS.md` per OpenAI's docs at https://developers.openai.com/codex/guides/agents-md) get workflow guidance.
  - Pre-flight `which <cli>` for the chosen harness — fails fast if the binary is missing.
- **`dev-tools/experiments/templates/agent_prompt.md`** — adds a never-ending YOUR GOAL block plus an explicit `update_goal` model-tool guardrail (codex's exit lever per OpenAI's documented `/goal` system).
- **`.codex/skills/marcus/SKILL.md`** (new) — repo-tracked codex skill mirror.
- **`.gitignore`** — `.codex/` ignored except `.codex/skills/**` (so user-local codex state doesn't leak into commits but the repo skills do).
- **`tests/unit/experiments/test_spawn_agents.py`** — 27 new unit tests covering harness routing, command rendering for both harnesses, AGENTS.md materialization, and worker wrapper-loop placement. Existing bypass-init fixtures updated for the new `harness` / `model_flag` attrs.

## Glossary

| Term | Meaning |
|---|---|
| **Marcus MCP server** | The HTTP MCP endpoint at `http://localhost:4298/mcp` that all spawned agents register against and pull tasks from. Agent-agnostic. |
| **harness** | The CLI process spawned in each tmux pane. `claude` (Anthropic) or `codex` (OpenAI). Both call the same Marcus MCP server. |
| **`--enable goals`** | Codex CLI experimental flag (stable in v0.130.0) that enables codex's autonomous agentic loop. The agent treats the prompt as a goal and keeps running tool-call cycles until the goal evaluates complete or the codex token budget is exhausted. |
| **`update_goal` model tool** | Codex's exit lever within the goals system. When the agent calls `update_goal(status="complete")`, codex's runtime stops continuation. Our prompt explicitly tells the agent NOT to call it complete unless `get_project_status` confirms all tasks done. |
| **`--disable guardian_approval`** | Turns off codex's "files changed under me without my doing it" safety check. Required because Marcus workers run `git merge main` between tasks (to pick up other agents' completed work) and guardian otherwise halts asking the user to confirm. |
| **Wrapper relaunch loop** | A bash `for i in $(seq 1 50)` loop around `codex exec`. Belt-and-suspenders for the unlikely case that the model still emits `update_goal(complete)` or codex hits a token budget cap mid-experiment. |

## Where to look in the code first

| File | Purpose |
|---|---|
| `dev-tools/experiments/runners/spawn_agents.py` (`_build_agent_command`, `_build_worker_invocation_block`, `_build_mcp_register_snippet`) | All harness-specific shell rendering lives in three helpers |
| `dev-tools/experiments/runners/run_experiment.py` | `--harness` argparse plumbing |
| `dev-tools/experiments/templates/agent_prompt.md` | Top "YOUR GOAL" block + codex runtime guardrail |
| `tests/unit/experiments/test_spawn_agents.py` (`TestHarnessConfigResolution`, `TestAgentSpawnerHarnessRouting`, `TestSpawnerHarnessFromConfig`, `TestCodexScriptsRender`, `TestAgentWorkflowFilesMaterialized`) | New harness test classes |
| `.codex/skills/marcus/SKILL.md` | Codex CLI skill |

## Known WIP issues

These are why this is a draft, not ready to merge:

- **Worker exits early after one task cycle in some live runs.** Pre-fix observation: workers wrap up after 2 empty `request_next_task` polls. Believed addressed by `--enable goals` + the never-ending YOUR GOAL prompt + the `update_goal` guardrail + the bash relaunch loop, but not yet validated on a clean live run.
- **Token cost of relaunches not measured.** Each codex relaunch re-renders the agent prompt (~800–1500 tokens). At MAX_RELAUNCHES=50 worst-case ≈75k tokens per worker. Real but bounded; should be measured and compared against claude cost-per-project before drawing conclusions.
- **`--enable goals` is still flagged experimental on codex CLI.** Today stable on v0.130.0; could change semantics in a future release. Test suite asserts the flag is in the rendered script — if codex deprecates it, our spawn fails loudly rather than silently misbehaving.
- **No codex cost-tracking parity yet.** `src/cost_tracking/worker_ingester.py` parses Claude Code's JSONL session logs only. Codex writes its own session logs in a different schema; the cost-store pricing seed only knows `anthropic` provider rows. Logged as Simon thought; out of scope for this PR.

## Test plan

- [x] Unit tests pass: `pytest tests/unit/experiments/ -q` → 106 passing
- [x] Rendered codex worker script contains `--enable goals` + `--disable guardian_approval` + `MAX_RELAUNCHES=50` wrapper
- [x] Rendered codex creator/monitor scripts do NOT contain the wrapper (intentionally one-shot)
- [x] Both `CLAUDE.md` and `AGENTS.md` written into the implementation directory
- [x] Claude harness path unchanged (`--harness claude` regression: same shell command shape as pre-PR)
- [ ] Live experiment under `--harness codex` completes a small project (e.g. `Build hello world --agents 2 --harness codex --model gpt-5.3-codex`) end-to-end with all tasks marked done
- [ ] Live experiment under `--harness claude` (regression) still completes
- [ ] Workers stay alive across at least 5 consecutive empty `request_next_task` polls without exit
- [ ] Wrapper relaunch fires (visible "[worker] codex launch N/50" in pane history) only when codex exits unexpectedly, not on every cycle
- [ ] Cost-per-project measured for one codex run + one claude run on the same spec for follow-up parity work

## Related

- Codex docs on `/goal`: https://developers.openai.com/codex/guides/agents-md and OpenAI's "Unrolling the Codex agent loop" blog
- Codex `AGENTS.md` convention: https://developers.openai.com/codex/guides/agents-md
- Codex CLI #14233 (MCP stack accumulation in long-lived processes — does NOT hit per-relaunch model used here): https://github.com/openai/codex/issues/14233
- Simon thoughts: `d8042293` (codex mcp-server future direction), `d155f219` (Codex #14233 watch), prior cost-tracking parity entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)
