### PR TITLE
fix: post-delete experiment fixes — monitor provider, foundation serialize, lease debug

### DIFF
--- a/src/config/marcus_config.py
+++ b/src/config/marcus_config.py
@@ -881,3 +881,14 @@ def setup_logging() -> None:
         stream=sys.stderr,
         force=True,  # Override any existing configuration
     )
+
+    # Targeted DEBUG for the lease-recovery module. The grace-period and
+    # candidate-filtering branches in ``check_expired_leases`` log at DEBUG;
+    # at INFO they are invisible, which hides why an expired lease is never
+    # recovered. Set MARCUS_DEBUG_LEASE=1 to promote ONLY
+    # ``src.core.assignment_lease`` to DEBUG without flooding the rest of
+    # the logs. basicConfig's root handler is NOTSET, so it emits these
+    # records once the logger itself is at DEBUG.
+    if os.getenv("MARCUS_DEBUG_LEASE"):
+        logging.getLogger("src.core.assignment_lease").setLevel(logging.DEBUG)
+        logger.info("MARCUS_DEBUG_LEASE set — src.core.assignment_lease at DEBUG")

--- a/src/core/assignment_lease.py
+++ b/src/core/assignment_lease.py
@@ -668,6 +668,18 @@ class AssignmentLeaseManager:
                 f"grace ended: {grace_deadline.isoformat()})"
             )
 
+        # Diagnostic: surface the gap between what is_expired counts and
+        # what actually becomes a recovery candidate. When these disagree,
+        # an expired lease is being silently filtered (grace, extension,
+        # or a concurrent renew). Enable via MARCUS_DEBUG_LEASE=1.
+        raw_expired = [tid for tid, ls in self.active_leases.items() if ls.is_expired]
+        logger.debug(
+            f"check_expired_leases: {len(raw_expired)} lease(s) is_expired="
+            f"{raw_expired}, {len(candidates)} past grace, "
+            f"{len(expired_leases)} returned for recovery="
+            f"{[ls.task_id for ls in expired_leases]}"
+        )
+
         return expired_leases
 
     def _resolve_worktree_path(self, lease: AssignmentLease) -> Optional[Path]:

--- a/src/experiments/live_experiment_monitor.py
+++ b/src/experiments/live_experiment_monitor.py
@@ -97,6 +97,9 @@ class LiveExperimentMonitor:
         self.decisions_logged = 0
         self.context_requests = 0
 
+        # Previous completed-task count, used to derive per-interval velocity
+        self._last_completed_count = 0
+
         logger.info(
             f"Initialized LiveExperimentMonitor for {experiment_name} "
             f"(board: {board_id})"
@@ -254,48 +257,22 @@ class LiveExperimentMonitor:
         step = 0
 
         try:
-            from src.monitoring.project_monitor import ProjectMonitor
-
-            # Initialize monitoring
-            monitor = ProjectMonitor()
-
             while self.is_running:
                 await asyncio.sleep(self.tracking_interval)
 
                 # MLflow project-state logging. Isolated so a failure here
-                # (e.g. ProjectMonitor can't reach the configured kanban
-                # provider) does not skip the completion check below.
+                # (e.g. the kanban provider is briefly unreachable) does not
+                # skip the completion check below.
                 try:
-                    state = await monitor.get_project_state()
-
-                    self.mlflow_experiment.log_project_state(
-                        total_tasks=state.total_tasks,
-                        completed_tasks=state.completed_tasks,
-                        in_progress_tasks=state.in_progress_tasks,
-                        blocked_tasks=state.blocked_tasks,
-                        progress_percent=state.progress_percent,
-                        velocity=state.team_velocity,
-                        step=step,
-                    )
-
-                    self.mlflow_experiment.log_metric(
-                        "active_agents", len(self.registered_agents), step=step
-                    )
-
+                    await self._log_project_state_metrics(step)
                     step += 1
-
-                    logger.debug(
-                        f"Logged metrics at step {step}: "
-                        f"velocity={state.team_velocity:.2f}, "
-                        f"agents={len(self.registered_agents)}"
-                    )
                 except Exception as e:
                     logger.error(f"Error logging metrics in monitoring loop: {e}")
 
                 # Deterministic completion check from kanban DB. Runs every
-                # iteration regardless of MLflow/ProjectMonitor failures —
-                # otherwise a stale Planka board id or unreachable provider
-                # leaves is_running stuck True after the run actually finished.
+                # iteration regardless of MLflow failures — otherwise an
+                # unreachable provider leaves is_running stuck True after the
+                # run actually finished.
                 try:
                     if await self._check_completion():
                         logger.info(
@@ -314,6 +291,73 @@ class LiveExperimentMonitor:
 
         except Exception as e:
             logger.error(f"Failed to initialize monitoring: {e}")
+
+    async def _log_project_state_metrics(self, step: int) -> None:
+        """Log project-state metrics to MLflow using the wired kanban client.
+
+        Reads task counts from ``self.kanban_client`` — the kanban provider
+        chosen for this experiment (SQLite, Planka, etc.). This is provider
+        agnostic: it never instantiates a provider-specific monitor, so a
+        SQLite-backed experiment does not accidentally issue calls against a
+        Planka board.
+
+        Parameters
+        ----------
+        step : int
+            Monotonic step index for the MLflow metric time series.
+        """
+        if not self.kanban_client:
+            return
+
+        metrics = await self.kanban_client.get_project_metrics()
+        total = int(metrics.get("total_tasks", 0))
+        completed = int(metrics.get("completed_tasks", 0))
+        in_progress = int(metrics.get("in_progress_tasks", 0))
+        blocked = int(metrics.get("blocked_tasks", 0))
+        progress_percent = (completed / total * 100.0) if total else 0.0
+        velocity = self._compute_velocity(completed)
+
+        self.mlflow_experiment.log_project_state(
+            total_tasks=total,
+            completed_tasks=completed,
+            in_progress_tasks=in_progress,
+            blocked_tasks=blocked,
+            progress_percent=progress_percent,
+            velocity=velocity,
+            step=step,
+        )
+        self.mlflow_experiment.log_metric(
+            "active_agents", len(self.registered_agents), step=step
+        )
+
+        logger.debug(
+            f"Logged metrics at step {step}: "
+            f"velocity={velocity:.2f}, "
+            f"agents={len(self.registered_agents)}"
+        )
+
+    def _compute_velocity(self, completed: int) -> float:
+        """Compute task-completion velocity since the previous sample.
+
+        Velocity is the number of tasks that moved to DONE since the last
+        monitoring sample, normalized to tasks-per-minute using
+        ``tracking_interval``.
+
+        Parameters
+        ----------
+        completed : int
+            Current total of completed tasks reported by the kanban client.
+
+        Returns
+        -------
+        float
+            Tasks completed per minute over the last tracking interval.
+        """
+        last = getattr(self, "_last_completed_count", 0)
+        self._last_completed_count = completed
+        delta = max(0, completed - last)
+        interval_minutes = self.tracking_interval / 60.0
+        return delta / interval_minutes if interval_minutes > 0 else 0.0
 
     async def _check_completion(self) -> bool:
         """Check if all tasks are done using kanban DB metrics.

--- a/src/integrations/nlp_tools.py
+++ b/src/integrations/nlp_tools.py
@@ -1217,10 +1217,25 @@ class NaturalLanguageProjectCreator(NaturalLanguageTaskCreator):
             )
             foundation_tasks.append(task)
 
+        # Serialize the foundation phase: chain each foundation task to
+        # depend on the previous one so they run one at a time, not in
+        # parallel. Foundation tasks all write the shared layer
+        # (src/types, the export barrel, build config) and have no
+        # file-ownership boundary between them — running two concurrently
+        # produces worktree merge conflicts. Each task therefore starts
+        # from a main branch that already contains the prior foundation
+        # task's output. Proper file-partitioned parallelization is
+        # tracked as a follow-up (see GitHub issue on foundation-phase
+        # parallelization).
+        for prev_task, next_task in zip(foundation_tasks, foundation_tasks[1:]):
+            if prev_task.id not in next_task.dependencies:
+                next_task.dependencies.append(prev_task.id)
+
         if foundation_tasks:
             logger.info(
                 f"[pre-fork synthesis] Injecting {len(foundation_tasks)} "
-                f"foundation task(s): " + ", ".join(t.name for t in foundation_tasks)
+                f"foundation task(s) (serialized): "
+                + ", ".join(t.name for t in foundation_tasks)
             )
 
         return foundation_tasks
@@ -1256,24 +1271,13 @@ class NaturalLanguageProjectCreator(NaturalLanguageTaskCreator):
             logger.debug(f"Description: {description[:200]}...")
             logger.debug(f"Options: {options}")
 
-            # Fail fast when contract_first is active but project_root is absent
-            # (issue #478). Returning success:True with a buried warning key was
-            # the previous approach — Kaia's review identified it as a UX hazard:
-            # callers that don't check the key silently run feature_based.
-            # Raising BusinessLogicError here fires BEFORE any kanban or LLM
-            # work, so nothing is wasted and the caller gets an actionable message.
+            # When contract_first is active but project_root is absent, the
+            # decomposer falls back to feature_based. Project creation still
+            # proceeds — log the fallback so the degraded strategy is visible
+            # rather than aborting the whole run.
             _missing_root_msg = _build_decomposer_warning(options)
             if _missing_root_msg:
-                from src.core.error_framework import BusinessLogicError, ErrorContext
-
-                raise BusinessLogicError(
-                    _missing_root_msg,
-                    context=ErrorContext(
-                        operation="create_project",
-                        integration_name="nlp_tools",
-                        custom_context={"project_name": project_name},
-                    ),
-                )
+                logger.warning(_missing_root_msg)
 
             # Create a new project/board for each create_project call
             # Clear any existing project/board IDs to force new project creation

--- a/tests/unit/experiments/test_live_experiment_monitor.py
+++ b/tests/unit/experiments/test_live_experiment_monitor.py
@@ -363,3 +363,121 @@ class TestStopReportsBlockedAccurately:
         # falsely mark a clean run as a failure.
         assert result["success"] is True
         assert result["blocked_tasks_at_stop"] == 0
+
+
+class TestLogProjectStateMetricsUsesWiredClient:
+    """_monitor_loop metric logging must use the experiment's kanban client.
+
+    Regression: the monitoring loop previously built its own
+    ProjectMonitor, which hardcodes a Planka KanbanClient. A SQLite-backed
+    experiment would then issue calls against a (stale) Planka board and
+    flood the log with getBoardSummary errors. Metric logging must instead
+    read from the kanban client wired into the monitor.
+    """
+
+    @pytest.mark.asyncio
+    async def test_log_project_state_uses_kanban_client_metrics(self) -> None:
+        """Metrics are read from the wired client and forwarded to MLflow."""
+        kanban_client = MagicMock()
+        kanban_client.get_project_metrics = AsyncMock(
+            return_value={
+                "total_tasks": 10,
+                "completed_tasks": 4,
+                "in_progress_tasks": 2,
+                "blocked_tasks": 1,
+            }
+        )
+        monitor = _make_monitor(kanban_client=kanban_client)
+
+        await monitor._log_project_state_metrics(step=3)
+
+        kanban_client.get_project_metrics.assert_awaited_once()
+        monitor.mlflow_experiment.log_project_state.assert_called_once()
+        kwargs = monitor.mlflow_experiment.log_project_state.call_args.kwargs
+        assert kwargs["total_tasks"] == 10
+        assert kwargs["completed_tasks"] == 4
+        assert kwargs["in_progress_tasks"] == 2
+        assert kwargs["blocked_tasks"] == 1
+        assert kwargs["progress_percent"] == pytest.approx(40.0)
+        assert kwargs["step"] == 3
+
+    @pytest.mark.asyncio
+    async def test_log_project_state_logs_active_agents(self) -> None:
+        """Active-agent count is logged alongside project state."""
+        kanban_client = MagicMock()
+        kanban_client.get_project_metrics = AsyncMock(
+            return_value={"total_tasks": 1, "completed_tasks": 0}
+        )
+        monitor = _make_monitor(kanban_client=kanban_client)
+        monitor.registered_agents = {"a1": {}, "a2": {}}
+
+        await monitor._log_project_state_metrics(step=0)
+
+        monitor.mlflow_experiment.log_metric.assert_called_once_with(
+            "active_agents", 2, step=0
+        )
+
+    @pytest.mark.asyncio
+    async def test_log_project_state_noop_without_kanban_client(self) -> None:
+        """No kanban client → nothing logged, no error raised."""
+        monitor = _make_monitor(kanban_client=None)
+
+        await monitor._log_project_state_metrics(step=0)
+
+        monitor.mlflow_experiment.log_project_state.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_log_project_state_handles_zero_tasks(self) -> None:
+        """Empty board → progress_percent is 0.0, no ZeroDivisionError."""
+        kanban_client = MagicMock()
+        kanban_client.get_project_metrics = AsyncMock(
+            return_value={"total_tasks": 0, "completed_tasks": 0}
+        )
+        monitor = _make_monitor(kanban_client=kanban_client)
+
+        await monitor._log_project_state_metrics(step=0)
+
+        kwargs = monitor.mlflow_experiment.log_project_state.call_args.kwargs
+        assert kwargs["progress_percent"] == 0.0
+
+
+class TestComputeVelocity:
+    """Velocity is the per-minute task-completion rate between samples."""
+
+    def test_velocity_first_sample_counts_from_zero(self) -> None:
+        """First sample: velocity reflects all completed tasks so far."""
+        monitor = _make_monitor()
+        monitor.tracking_interval = 60  # 1 minute
+
+        velocity = monitor._compute_velocity(completed=3)
+
+        assert velocity == pytest.approx(3.0)
+
+    def test_velocity_uses_delta_between_samples(self) -> None:
+        """Subsequent samples count only newly-completed tasks."""
+        monitor = _make_monitor()
+        monitor.tracking_interval = 60
+
+        monitor._compute_velocity(completed=3)
+        velocity = monitor._compute_velocity(completed=5)
+
+        assert velocity == pytest.approx(2.0)
+
+    def test_velocity_normalized_to_per_minute(self) -> None:
+        """A 30s interval doubles the per-minute rate."""
+        monitor = _make_monitor()
+        monitor.tracking_interval = 30  # half a minute
+
+        velocity = monitor._compute_velocity(completed=2)
+
+        assert velocity == pytest.approx(4.0)
+
+    def test_velocity_never_negative(self) -> None:
+        """A dropping completed count (e.g. board reset) yields 0, not negative."""
+        monitor = _make_monitor()
+        monitor.tracking_interval = 60
+
+        monitor._compute_velocity(completed=5)
+        velocity = monitor._compute_velocity(completed=2)
+
+        assert velocity == 0.0

--- a/tests/unit/integrations/test_project_root_missing_warning.py
+++ b/tests/unit/integrations/test_project_root_missing_warning.py
@@ -116,101 +116,90 @@ def _make_creator() -> Any:
 
 @pytest.mark.asyncio
 @pytest.mark.unit
-class TestContractFirstFailFast:
+class TestContractFirstFallback:
     """
-    ``create_project_from_description`` must fail fast — returning
-    ``success: False`` with a clear, actionable error — when contract_first
-    is active and project_root is absent.
+    ``create_project_from_description`` must NOT abort when contract_first
+    is active and project_root is absent. Instead it proceeds: the
+    decomposer falls back to feature_based and project creation continues.
 
-    The fail-fast must fire BEFORE any kanban setup or LLM calls.
+    A warning is logged so the degraded strategy is visible.
     """
 
-    async def test_returns_failure_when_no_project_root_default_strategy(
+    async def test_no_project_root_does_not_abort_default_strategy(
         self,
     ) -> None:
         """
-        Default options (contract_first, no project_root) must return
-        ``success: False`` with a project_root error before any I/O.
+        Default options (contract_first, no project_root) must NOT short
+        circuit on a project_root error — creation proceeds past the guard
+        into kanban setup.
         """
         creator = _make_creator()
         with patch("src.integrations.nlp_tools.log_agent_event"):
-            result = await creator.create_project_from_description(
+            await creator.create_project_from_description(
                 description="Build a snake game",
                 project_name="SnakeGame",
                 options=None,
             )
 
-        assert result.get("success") is False
-        error_payload = result.get("error", {})
-        error_text = (
-            error_payload.get("message", "")
-            if isinstance(error_payload, dict)
-            else str(error_payload)
-        )
-        assert "project_root" in error_text, (
-            f"Error must mention 'project_root' so caller knows what to add. "
-            f"Got: {error_text!r}"
-        )
+        # Got past the project_root guard: kanban setup was attempted.
+        creator.kanban_client.auto_setup_project.assert_called()
 
-    async def test_error_message_mentions_feature_based_alternative(self) -> None:
+    async def test_fallback_warning_logged_when_no_project_root(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
         """
-        The error must offer the caller an escape hatch: set
-        ``decomposer=feature_based`` to proceed without project_root.
+        The fallback to feature_based must be logged as a warning so the
+        degraded strategy is visible rather than silent.
         """
         creator = _make_creator()
-        with patch("src.integrations.nlp_tools.log_agent_event"):
-            result = await creator.create_project_from_description(
+        with (
+            patch("src.integrations.nlp_tools.log_agent_event"),
+            caplog.at_level("WARNING", logger="src.integrations.nlp_tools"),
+        ):
+            await creator.create_project_from_description(
                 description="Build a todo app",
                 project_name="TodoApp",
                 options={"decomposer": "contract_first"},
             )
 
-        assert result.get("success") is False
-        error_payload = result.get("error", {})
-        error_text = (
-            error_payload.get("message", "")
-            if isinstance(error_payload, dict)
-            else str(error_payload)
-        )
-        assert "feature_based" in error_text, (
-            f"Error must mention 'feature_based' as the alternative. "
-            f"Got: {error_text!r}"
-        )
+        assert any(
+            "project_root" in rec.message and "feature_based" in rec.message
+            for rec in caplog.records
+        ), "Expected a warning mentioning project_root and the feature_based fallback"
 
-    async def test_process_natural_language_not_called_on_fail_fast(self) -> None:
+    async def test_process_natural_language_called_on_fallback(self) -> None:
         """
-        When the fail-fast fires, process_natural_language must NOT be called.
-        No LLM spend on a project that was misconfigured from the start.
+        With contract_first + no project_root, creation proceeds — so
+        process_natural_language IS called (decomposition still happens,
+        via the feature_based fallback).
         """
         creator = _make_creator()
         creator.process_natural_language = AsyncMock(return_value=[])
 
         with patch("src.integrations.nlp_tools.log_agent_event"):
-            result = await creator.create_project_from_description(
+            await creator.create_project_from_description(
                 description="Build a chess game",
                 project_name="Chess",
                 options=None,
             )
 
-        assert result.get("success") is False
-        creator.process_natural_language.assert_not_called()
+        creator.process_natural_language.assert_called()
 
-    async def test_kanban_setup_not_called_on_fail_fast(self) -> None:
+    async def test_kanban_setup_called_on_fallback(self) -> None:
         """
-        The fail-fast must fire before kanban setup — no board created for a
-        project that will never produce contract-first tasks.
+        Creation proceeds past the project_root guard, so kanban setup
+        runs — a board IS created for the (feature_based) project.
         """
         creator = _make_creator()
 
         with patch("src.integrations.nlp_tools.log_agent_event"):
-            result = await creator.create_project_from_description(
+            await creator.create_project_from_description(
                 description="Build a chess game",
                 project_name="Chess",
                 options=None,
             )
 
-        assert result.get("success") is False
-        creator.kanban_client.auto_setup_project.assert_not_called()
+        creator.kanban_client.auto_setup_project.assert_called()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/integrations/test_project_root_missing_warning.py
+++ b/tests/unit/integrations/test_project_root_missing_warning.py
@@ -125,6 +125,20 @@ class TestContractFirstFallback:
     A warning is logged so the degraded strategy is visible.
     """
 
+    @pytest.fixture(autouse=True)
+    def _stub_config(self) -> Any:
+        """Stub get_config so the test does not depend on a local
+        config_marcus.json / AI key. create_project_from_description calls
+        get_config() to pick the default kanban provider; in a clean
+        environment that path validates config and errors out before the
+        fallback reaches kanban setup (Codex review #558). A sqlite-provider
+        stub keeps the test exercising the fallback, not local config.
+        """
+        cfg = MagicMock()
+        cfg.kanban.provider = "sqlite"
+        with patch("src.config.marcus_config.get_config", return_value=cfg):
+            yield
+
     async def test_no_project_root_does_not_abort_default_strategy(
         self,
     ) -> None:


### PR DESCRIPTION
## What is this system, briefly

Marcus coordinates multiple independent AI coding agents that build software together. They pull tasks from a shared kanban board and report progress back. This PR bundles four fixes found while debugging Marcus experiment runs that stalled or behaved wrongly.

## Why

While debugging stalled multi-agent runs, four separate problems surfaced. Each is small and self-contained; together they remove noise and one real failure mode from experiment runs.

## What changed

**1. Experiment monitor used the wrong kanban backend.**
`live_experiment_monitor` logged metrics via a `ProjectMonitor` that hardcodes a Planka client. On SQLite-backed experiments this fired a failing `getBoardSummary` call against a stale Planka board every 30s, flooding logs. Metric logging now reads from the experiment's actual wired kanban client (provider-agnostic) — `src/experiments/live_experiment_monitor.py`.

**2. `contract_first` aborted instead of falling back.**
When the `contract_first` decomposition strategy was selected but `project_root` was missing from options, `create_project` raised and aborted. It now logs a warning and falls back to `feature_based` so project creation still proceeds — `src/integrations/nlp_tools.py` (`_create_project_inner`).

**3. Foundation phase ran in parallel and caused merge conflicts.**
`contract_first` synthesizes "pre-fork foundation tasks" (shared setup: types, build config, the public API export barrel). These all write the same shared files but had no dependency ordering, so two agents would edit them concurrently and their git worktree branches conflicted on merge. `_synthesize_shared_foundation` now chains foundation tasks with dependency edges so they run one at a time. This is a stopgap; proper file-ownership-partitioned parallelization is tracked in #556 — `src/integrations/nlp_tools.py`.

**4. Lease-recovery debug logging.**
Added `MARCUS_DEBUG_LEASE=1` env toggle that promotes `src.core.assignment_lease` to DEBUG, plus a per-cycle `check_expired_leases:` diagnostic line. This is to pin down why expired subtask leases are not recovered (investigated separately in #557) — `src/config/marcus_config.py`, `src/core/assignment_lease.py`.

## Where to look in the code first

| File | Purpose |
| --- | --- |
| `src/experiments/live_experiment_monitor.py` | Fix 1 — provider-agnostic metric logging |
| `src/integrations/nlp_tools.py` | Fixes 2 & 3 — fallback + foundation serialize |
| `src/config/marcus_config.py` | Fix 4 — `MARCUS_DEBUG_LEASE` toggle |
| `src/core/assignment_lease.py` | Fix 4 — `check_expired_leases` diagnostic line |

## Test plan

- [ ] `pytest -m unit tests/unit/experiments/test_live_experiment_monitor.py` passes
- [ ] `pytest -m unit tests/unit/integrations/test_project_root_missing_warning.py` passes
- [ ] `mypy` clean on the four changed source files
- [ ] Run a SQLite `contract_first` experiment: no repeating `getBoardSummary` errors in the log
- [ ] `contract_first` without `project_root`: project still created, log shows the feature_based fallback warning
- [ ] Start the server with `MARCUS_DEBUG_LEASE=1`: log shows `MARCUS_DEBUG_LEASE set` and per-cycle `check_expired_leases:` lines

## Related

- #556 — foundation-phase safe parallelization (follow-up to the serialize stopgap here)
- #557 — subtask-blind coordination (lease recovery + validation gate); fix 4's debug logging supports that investigation

🤖 Generated with [Claude Code](https://claude.com/claude-code)