### PR TITLE
feat(experiments): add monitor stall watchdog

### DIFF
--- a/dev-tools/experiments/runners/spawn_agents.py
+++ b/dev-tools/experiments/runners/spawn_agents.py
@@ -279,6 +279,13 @@ class ExperimentConfig:
         # (where agent count is the independent variable) get the
         # exact count specified.
         self.cpm_override = bool(self.config.get("cpm_override", False))
+        # Stall watchdog: if the monitor sees no change in task counts
+        # (completed/in_progress/blocked) for this many minutes, it kills
+        # the tmux session to stop idle agents from polling and burning
+        # tokens. 0 disables the watchdog. Kept at config top level (not
+        # in project_options) so it is not forwarded to Marcus's
+        # create_project, which would reject the unknown key.
+        self.stall_timeout_minutes = int(self.config.get("stall_timeout_minutes", 20))
 
         # Set up experiment directories
         self.prompts_dir = self.experiment_dir / "prompts"
@@ -759,6 +766,40 @@ START NOW!
             f"      - Exit"
         )
 
+    def _monitor_stall_action(self) -> str:
+        """
+        Return the stall-action instructions for the monitor prompt.
+
+        Triggered when task counts have not changed for
+        ``stall_timeout_minutes``.  The monitor prints a diagnostic and
+        — unless epictetus mode is ON — kills the tmux session to stop
+        idle agents from polling.  It deliberately does NOT call
+        ``end_experiment``: leaving Marcus's ``is_running`` at True is the
+        marker that distinguishes a stalled run from a clean completion.
+
+        Returns
+        -------
+        str
+            One or more instruction lines to embed in the monitor prompt.
+        """
+        if self.epictetus:
+            return (
+                'Print: "Epictetus mode active — session kept alive '
+                'despite stall for agent interrogation"\n'
+                "      - Exit this monitor process. Do NOT kill the "
+                "tmux session. Do NOT call end_experiment."
+            )
+        return (
+            f"Run this bash command to terminate all agent panes:\n"
+            f"          tmux kill-session -t {self.tmux_session}\n"
+            f"        (This kills ONLY the '{self.tmux_session}' session. "
+            f"Other concurrent Marcus sessions are unaffected.)\n"
+            f"      - Do NOT call end_experiment. Leaving Marcus's "
+            f"is_running at True is the deliberate marker that this run "
+            f"stalled rather than completed.\n"
+            f"      - Exit"
+        )
+
     def create_monitor_prompt(self) -> str:
         """
         Create the prompt for the experiment monitor agent.
@@ -768,6 +809,27 @@ START NOW!
         str
             Prompt for monitor agent
         """
+        # Stall watchdog: at a 120s poll interval, this many consecutive
+        # unchanged polls equals stall_timeout_minutes of no progress.
+        stall_minutes = self.config.stall_timeout_minutes
+        stall_polls = max(1, stall_minutes // 2) if stall_minutes > 0 else 0
+
+        if stall_polls > 0:
+            stall_watchdog = (
+                f"      - STALL WATCHDOG: build the tuple "
+                f"(completed_tasks, in_progress_tasks, blocked_tasks).\n"
+                f"        If it is identical to the tuple from the "
+                f"previous poll, increment a stall counter; otherwise "
+                f"reset the stall counter to 0 and store the new tuple.\n"
+                f"        If the stall counter reaches {stall_polls} "
+                f"(={stall_minutes} minutes of no task-count change), "
+                f"the experiment has stalled — go to step (e)."
+            )
+        else:
+            stall_watchdog = (
+                "      - STALL WATCHDOG: disabled " "(stall_timeout_minutes is 0)."
+            )
+
         prompt = f"""You are the Experiment Monitor Agent for a Marcus \
 multi-agent experiment.
 
@@ -813,6 +875,7 @@ status["is_running"] is True:
         "  In Progress: {{status['in_progress_tasks']}}, \
 Blocked: {{status['blocked_tasks']}}"
         "  Registered agents: {{status['registered_agents']}}"
+{stall_watchdog}
       - Sleep 120 seconds, then loop back to (a)
 
    d. If status["experiment_started"] is True and \
@@ -821,6 +884,16 @@ status["is_running"] is False:
       - Print the final values of total_tasks, completed_tasks,
         in_progress_tasks, blocked_tasks, and registered_agents
       - {self._monitor_completion_action()}
+
+   e. STALL DETECTED (reached only from the stall watchdog in (c)):
+      - Print "EXPERIMENT STALLED — no task-count change for \
+{stall_minutes} minutes"
+      - Print a diagnostic: total_tasks, completed_tasks,
+        in_progress_tasks, blocked_tasks, registered_agents, and the
+        last-seen task-count tuple.
+      - List the task IDs/names currently stuck in_progress if the
+        status response exposes them.
+      - {self._monitor_stall_action()}
 
 CRITICAL INSTRUCTIONS:
 - Work in: {self.config.implementation_dir}
@@ -832,6 +905,10 @@ CRITICAL INSTRUCTIONS:
   (completed_tasks + blocked_tasks) == total_tasks. Your job is to
   display progress while the experiment is active and exit when it
   finishes.
+- Stall watchdog: a clean completion exits via (d); a stall exits via
+  (e). The (e) path deliberately never calls end_experiment, so a
+  stalled run is identifiable afterward by Marcus still reporting
+  is_running=True.
 - This is an automated process - no human interaction needed
 """
         return prompt

--- a/skills/marcus/SKILL.md
+++ b/skills/marcus/SKILL.md
@@ -12,7 +12,7 @@ description: >
   The /marcus skill launches experiments that USE the Marcus MCP server — they are
   complementary, not competing. The MCP server must be running before invoking this skill.
 user-invocable: true
-argument-hint: "<project description> [--name \"Project Name\"] [--agents N] [--complexity prototype|standard|enterprise] [--stall-timeout N] [--decomposer contract_first|feature_based] [--epictetus] [--model <model>] [--harness claude|codex]"
+argument-hint: "<project description> [--name \"Project Name\"] [--agents N] [--complexity prototype|standard|enterprise] [--stall-timeout N] [--decomposer contract_first|feature_based] [--epictetus] [--model <model>]"
 ---
 
 # Marcus Multi-Agent Experiment Launcher
@@ -58,8 +58,7 @@ The user's input comes in as `$ARGUMENTS`. Extract:
   - `contract_first` — default. Generates interface contracts before decomposition. Board is fully populated before any agent starts (no Phase A race). Each agent owns one side of a contract. Best for tightly-coupled projects (games, dashboards, state machines).
   - `feature_based` — legacy path, splits tasks by functional requirement. Fine for loosely-coupled projects where features don't share files.
 - **Epictetus mode**: Look for `--epictetus` flag. Default: not set (false). When present, the monitor agent does NOT kill the tmux session after the experiment completes — it stays alive for Epictetus post-experiment interrogation.
-- **Agent model**: Look for `--model <value>`. Default: not set — Marcus reads `ai.model` from `config_marcus.json` and uses that same value for the spawned Agent CLI processes (so by default Planners and Agents share one model). When `--model X` is provided, X overrides for THIS run only and applies to all spawned panes (project creator + workers + monitor). The same string is passed verbatim to whichever harness is active — accepts `claude --model` values (e.g. `sonnet`, `opus`, `haiku`, `claude-haiku-4-5-20251001`) or `codex --model` values (e.g. `gpt-5-codex`, `o3`). No client-side validation against per-harness namespaces — invalid model names surface as CLI errors inside the agent panes. Affects ONLY the spawned Agents — Marcus's Planner model continues to read from `config_marcus.json`.
-- **Agent harness**: Look for `--harness claude|codex`. Default: `claude`. `claude` spawns Anthropic's claude CLI with `--dangerously-skip-permissions`. `codex` spawns OpenAI's codex CLI with `exec --dangerously-bypass-approvals-and-sandbox` (the documented form of "YOLO mode" — sets `approval: never, sandbox: danger-full-access`). All agents in a single experiment use the same harness; mixed-harness teams are out of scope for v1. The runner pre-flights `which <cli>` and fails fast if the binary is missing.
+- **Agent model**: Look for `--model <value>`. Default: not set — Marcus reads `ai.model` from `config_marcus.json` and uses that same value for the spawned `claude` Agent processes (so by default Planners and Agents share one model). When `--model X` is provided, X overrides for THIS run only and applies to all spawned `claude` panes (project creator + workers + monitor). Accepts any value `claude --model` accepts: aliases (`sonnet`, `opus`, `haiku`) or full ids (e.g. `claude-haiku-4-5-20251001`). Affects ONLY the spawned Agents — Marcus's Planner model continues to read from `config_marcus.json`.
 
 Examples:
 - `/marcus Build a snake game with 3 agents` -> description="Build a snake game", name="snake_game", agents=3, complexity="prototype", decomposer="contract_first"
@@ -68,10 +67,8 @@ Examples:
 - `/marcus Use 2 agents to build a pomodoro timer --complexity standard --name "FocusTimer"` -> description="build a pomodoro timer", name="FocusTimer", agents=2, complexity="standard", decomposer="contract_first"
 - `/marcus Build a snake game with 2 agents --decomposer feature_based` -> description="Build a snake game", name="snake_game", agents=2, complexity="prototype", decomposer="feature_based"
 - `/marcus --decomposer feature_based Build a weather dashboard with 3 agents` -> description="Build a weather dashboard", name="weather_dashboard", agents=3, complexity="prototype", decomposer="feature_based"
-- `/marcus Build a snake game --model haiku` -> description="Build a snake game", name="snake_game", agents=2, complexity="prototype", decomposer="contract_first", model="haiku", harness="claude"
-- `/marcus Build a chat app with 3 agents --model claude-haiku-4-5-20251001` -> description="Build a chat app", name="chat_app", agents=3, complexity="prototype", decomposer="contract_first", model="claude-haiku-4-5-20251001", harness="claude"
-- `/marcus Build a TODO CLI with 2 agents --harness codex --model gpt-5-codex` -> description="Build a TODO CLI", name="todo_cli", agents=2, complexity="prototype", decomposer="contract_first", model="gpt-5-codex", harness="codex"
-- `/marcus Build a snake game --harness codex` -> description="Build a snake game", name="snake_game", agents=2, complexity="prototype", decomposer="contract_first", harness="codex" (model left unset; codex uses its global default)
+- `/marcus Build a snake game --model haiku` -> description="Build a snake game", name="snake_game", agents=2, complexity="prototype", decomposer="contract_first", model="haiku"
+- `/marcus Build a chat app with 3 agents --model claude-haiku-4-5-20251001` -> description="Build a chat app", name="chat_app", agents=3, complexity="prototype", decomposer="contract_first", model="claude-haiku-4-5-20251001"
 
 ## Step-by-Step Execution
 
@@ -170,21 +167,17 @@ Bash timeout will kill the process prematurely.
 
 If `--epictetus` was passed by the user, append `--epictetus` to the command.
 If `--model <value>` was passed by the user, append `--model <value>`.
-If `--harness <value>` was passed by the user, append `--harness <value>`.
-All flags can be combined.
+Both flags can be combined.
 
 ```bash
-# Default (session killed after experiment ends, claude harness):
+# Default (session killed after experiment ends):
 cd "${MARCUS_ROOT}/dev-tools/experiments" && python runners/run_experiment.py <cwd>
 
 # With Epictetus mode (session kept alive for interrogation):
 cd "${MARCUS_ROOT}/dev-tools/experiments" && python runners/run_experiment.py <cwd> --epictetus
 
-# With agent model override (spawned panes run on this model):
+# With agent model override (spawned `claude` panes run on this model):
 cd "${MARCUS_ROOT}/dev-tools/experiments" && python runners/run_experiment.py <cwd> --model claude-haiku-4-5-20251001
-
-# With codex harness (agents spawn as `codex exec --yolo`):
-cd "${MARCUS_ROOT}/dev-tools/experiments" && python runners/run_experiment.py <cwd> --harness codex --model gpt-5-codex
 ```
 
 This will:
@@ -208,7 +201,7 @@ After launching, tell the user:
 ## Important Notes
 
 - The Marcus MCP server must be running at `http://localhost:4298/mcp` before launching
-- Each agent is a fully independent harness CLI process: `claude --dangerously-skip-permissions` (default) or `codex exec --dangerously-bypass-approvals-and-sandbox` when `--harness codex`
+- Each agent is a fully independent `claude` CLI process with `--dangerously-skip-permissions`
 - Agents coordinate via MCP tools (register_agent, request_next_task, report_task_progress, etc.)
 - All agents work on the `main` branch in `implementation/`; Marcus prevents task conflicts
 - MLflow tracks experiment metrics in `<experiment_dir>/mlruns/`
@@ -220,17 +213,12 @@ After launching, tell the user:
 ## Pre-flight Checks
 
 Before running, verify:
-1. Marcus MCP is running: check `claude mcp list` for "marcus" showing "Connected" (claude harness) OR `codex mcp list` for "marcus" (codex harness)
+1. Marcus MCP is running: check `claude mcp list` for "marcus" showing "Connected"
 2. tmux is installed: `which tmux`
-3. Harness CLI is available: `which claude` or `which codex` depending on `--harness`
+3. Claude CLI is available: `which claude`
 
 If Marcus MCP is not running, tell the user:
 ```
 Marcus MCP server is not running. Start it first:
   cd <MARCUS_ROOT> && ./marcus start
-```
-
-If `--harness codex` and Marcus MCP is not yet registered with codex, tell the user:
-```
-codex mcp add marcus --url http://localhost:4298/mcp/
 ```

--- a/skills/marcus/SKILL.md
+++ b/skills/marcus/SKILL.md
@@ -12,7 +12,7 @@ description: >
   The /marcus skill launches experiments that USE the Marcus MCP server — they are
   complementary, not competing. The MCP server must be running before invoking this skill.
 user-invocable: true
-argument-hint: "<project description> [--name \"Project Name\"] [--agents N] [--complexity prototype|standard|enterprise] [--decomposer contract_first|feature_based] [--epictetus] [--model <model>]"
+argument-hint: "<project description> [--name \"Project Name\"] [--agents N] [--complexity prototype|standard|enterprise] [--stall-timeout N] [--decomposer contract_first|feature_based] [--epictetus] [--model <model>] [--harness claude|codex]"
 ---
 
 # Marcus Multi-Agent Experiment Launcher
@@ -53,11 +53,13 @@ The user's input comes in as `$ARGUMENTS`. Extract:
 - **Project name**: Look for `--name "Some Name"` or `--name some_name`. If not provided, derive a short name from the description.
 - **Agent count**: Look for patterns like "N agents", "--agents N", "with N workers". Default: 2
 - **Complexity**: Look for "--complexity prototype|standard|enterprise". Default: "prototype"
+- **Stall timeout**: Look for "--stall-timeout N" (minutes). Default: 20. Sets `stall_timeout_minutes` in config.yaml — the monitor kills the tmux session if task counts don't change for that long, so idle agents stop burning tokens. Pass `--stall-timeout 0` to disable the watchdog.
 - **Decomposer**: Look for "--decomposer contract_first|feature_based". Default: "contract_first" (as of v0.3.4). This controls Marcus's task decomposition strategy (GH-320):
   - `contract_first` — default. Generates interface contracts before decomposition. Board is fully populated before any agent starts (no Phase A race). Each agent owns one side of a contract. Best for tightly-coupled projects (games, dashboards, state machines).
   - `feature_based` — legacy path, splits tasks by functional requirement. Fine for loosely-coupled projects where features don't share files.
 - **Epictetus mode**: Look for `--epictetus` flag. Default: not set (false). When present, the monitor agent does NOT kill the tmux session after the experiment completes — it stays alive for Epictetus post-experiment interrogation.
-- **Agent model**: Look for `--model <value>`. Default: not set — Marcus reads `ai.model` from `config_marcus.json` and uses that same value for the spawned `claude` Agent processes (so by default Planners and Agents share one model). When `--model X` is provided, X overrides for THIS run only and applies to all spawned `claude` panes (project creator + workers + monitor). Accepts any value `claude --model` accepts: aliases (`sonnet`, `opus`, `haiku`) or full ids (e.g. `claude-haiku-4-5-20251001`). Affects ONLY the spawned Agents — Marcus's Planner model continues to read from `config_marcus.json`.
+- **Agent model**: Look for `--model <value>`. Default: not set — Marcus reads `ai.model` from `config_marcus.json` and uses that same value for the spawned Agent CLI processes (so by default Planners and Agents share one model). When `--model X` is provided, X overrides for THIS run only and applies to all spawned panes (project creator + workers + monitor). The same string is passed verbatim to whichever harness is active — accepts `claude --model` values (e.g. `sonnet`, `opus`, `haiku`, `claude-haiku-4-5-20251001`) or `codex --model` values (e.g. `gpt-5-codex`, `o3`). No client-side validation against per-harness namespaces — invalid model names surface as CLI errors inside the agent panes. Affects ONLY the spawned Agents — Marcus's Planner model continues to read from `config_marcus.json`.
+- **Agent harness**: Look for `--harness claude|codex`. Default: `claude`. `claude` spawns Anthropic's claude CLI with `--dangerously-skip-permissions`. `codex` spawns OpenAI's codex CLI with `exec --dangerously-bypass-approvals-and-sandbox` (the documented form of "YOLO mode" — sets `approval: never, sandbox: danger-full-access`). All agents in a single experiment use the same harness; mixed-harness teams are out of scope for v1. The runner pre-flights `which <cli>` and fails fast if the binary is missing.
 
 Examples:
 - `/marcus Build a snake game with 3 agents` -> description="Build a snake game", name="snake_game", agents=3, complexity="prototype", decomposer="contract_first"
@@ -66,8 +68,10 @@ Examples:
 - `/marcus Use 2 agents to build a pomodoro timer --complexity standard --name "FocusTimer"` -> description="build a pomodoro timer", name="FocusTimer", agents=2, complexity="standard", decomposer="contract_first"
 - `/marcus Build a snake game with 2 agents --decomposer feature_based` -> description="Build a snake game", name="snake_game", agents=2, complexity="prototype", decomposer="feature_based"
 - `/marcus --decomposer feature_based Build a weather dashboard with 3 agents` -> description="Build a weather dashboard", name="weather_dashboard", agents=3, complexity="prototype", decomposer="feature_based"
-- `/marcus Build a snake game --model haiku` -> description="Build a snake game", name="snake_game", agents=2, complexity="prototype", decomposer="contract_first", model="haiku"
-- `/marcus Build a chat app with 3 agents --model claude-haiku-4-5-20251001` -> description="Build a chat app", name="chat_app", agents=3, complexity="prototype", decomposer="contract_first", model="claude-haiku-4-5-20251001"
+- `/marcus Build a snake game --model haiku` -> description="Build a snake game", name="snake_game", agents=2, complexity="prototype", decomposer="contract_first", model="haiku", harness="claude"
+- `/marcus Build a chat app with 3 agents --model claude-haiku-4-5-20251001` -> description="Build a chat app", name="chat_app", agents=3, complexity="prototype", decomposer="contract_first", model="claude-haiku-4-5-20251001", harness="claude"
+- `/marcus Build a TODO CLI with 2 agents --harness codex --model gpt-5-codex` -> description="Build a TODO CLI", name="todo_cli", agents=2, complexity="prototype", decomposer="contract_first", model="gpt-5-codex", harness="codex"
+- `/marcus Build a snake game --harness codex` -> description="Build a snake game", name="snake_game", agents=2, complexity="prototype", decomposer="contract_first", harness="codex" (model left unset; codex uses its global default)
 
 ## Step-by-Step Execution
 
@@ -101,6 +105,8 @@ Use this exact format — field names are case-sensitive:
 ```yaml
 project_name: "<--name value if provided, otherwise derived from description>"
 project_spec_file: "project_spec.md"
+
+stall_timeout_minutes: 20   # Monitor kills the tmux session if task counts don't change for this many minutes. 0 disables the watchdog.
 
 project_options:
   complexity: "<parsed complexity>"  # "prototype" (default), "standard" for medium, "enterprise" for large
@@ -164,17 +170,21 @@ Bash timeout will kill the process prematurely.
 
 If `--epictetus` was passed by the user, append `--epictetus` to the command.
 If `--model <value>` was passed by the user, append `--model <value>`.
-Both flags can be combined.
+If `--harness <value>` was passed by the user, append `--harness <value>`.
+All flags can be combined.
 
 ```bash
-# Default (session killed after experiment ends):
+# Default (session killed after experiment ends, claude harness):
 cd "${MARCUS_ROOT}/dev-tools/experiments" && python runners/run_experiment.py <cwd>
 
 # With Epictetus mode (session kept alive for interrogation):
 cd "${MARCUS_ROOT}/dev-tools/experiments" && python runners/run_experiment.py <cwd> --epictetus
 
-# With agent model override (spawned `claude` panes run on this model):
+# With agent model override (spawned panes run on this model):
 cd "${MARCUS_ROOT}/dev-tools/experiments" && python runners/run_experiment.py <cwd> --model claude-haiku-4-5-20251001
+
+# With codex harness (agents spawn as `codex exec --yolo`):
+cd "${MARCUS_ROOT}/dev-tools/experiments" && python runners/run_experiment.py <cwd> --harness codex --model gpt-5-codex
 ```
 
 This will:
@@ -198,7 +208,7 @@ After launching, tell the user:
 ## Important Notes
 
 - The Marcus MCP server must be running at `http://localhost:4298/mcp` before launching
-- Each agent is a fully independent `claude` CLI process with `--dangerously-skip-permissions`
+- Each agent is a fully independent harness CLI process: `claude --dangerously-skip-permissions` (default) or `codex exec --dangerously-bypass-approvals-and-sandbox` when `--harness codex`
 - Agents coordinate via MCP tools (register_agent, request_next_task, report_task_progress, etc.)
 - All agents work on the `main` branch in `implementation/`; Marcus prevents task conflicts
 - MLflow tracks experiment metrics in `<experiment_dir>/mlruns/`
@@ -210,12 +220,17 @@ After launching, tell the user:
 ## Pre-flight Checks
 
 Before running, verify:
-1. Marcus MCP is running: check `claude mcp list` for "marcus" showing "Connected"
+1. Marcus MCP is running: check `claude mcp list` for "marcus" showing "Connected" (claude harness) OR `codex mcp list` for "marcus" (codex harness)
 2. tmux is installed: `which tmux`
-3. Claude CLI is available: `which claude`
+3. Harness CLI is available: `which claude` or `which codex` depending on `--harness`
 
 If Marcus MCP is not running, tell the user:
 ```
 Marcus MCP server is not running. Start it first:
   cd <MARCUS_ROOT> && ./marcus start
+```
+
+If `--harness codex` and Marcus MCP is not yet registered with codex, tell the user:
+```
+codex mcp add marcus --url http://localhost:4298/mcp/
 ```

--- a/tests/unit/experiments/test_spawn_agents.py
+++ b/tests/unit/experiments/test_spawn_agents.py
@@ -554,6 +554,7 @@ class TestMonitorPromptKanbanTruth:
         config.project_info_file = tmp_path / "project_info.json"
         config.prompts_dir = tmp_path / "prompts"
         config.prompts_dir.mkdir()
+        config.stall_timeout_minutes = 20
 
         instance = MagicMock(spec=spawn_agents.AgentSpawner)
         instance.config = config


### PR DESCRIPTION
## Problem

The experiment monitor only terminated on Marcus's kanban-completion formula (`in_progress == 0 AND completed + blocked == total`). If a run stalled — agent processes hung, API throttled, or a task that can never complete — that formula never tripped, `is_running` stayed `True` forever, and surviving agents kept polling `request_next_task` indefinitely, burning tokens.

## Change

Stall watchdog in the experiment monitor:

- New top-level config field `stall_timeout_minutes` (default 20, `0` disables), kept out of `project_options` so it is not forwarded to `create_project`.
- Monitor branch (c) tracks the `(completed, in_progress, blocked)` tuple per 120s poll; unchanged for `stall_timeout_minutes` triggers new branch (e).
- Branch (e) prints a stall diagnostic and kills the tmux session, but deliberately does **not** call `end_experiment` — leaving `is_running=True` is the marker that distinguishes a stalled run from a clean completion.
- Epictetus mode keeps the session alive on stall (diagnostic only).
- `/marcus` skill: config template gains `stall_timeout_minutes` and a new `--stall-timeout N` flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)