### PR TITLE
Account for non-zero tmux base-index

### DIFF
--- a/dev-tools/experiments/runners/spawn_agents.py
+++ b/dev-tools/experiments/runners/spawn_agents.py
@@ -461,6 +461,10 @@ class AgentSpawner:
         self.panes_per_window = 2
         self.current_window = 0
         self.current_pane = 0
+        # Detect tmux base indices so target strings work regardless of
+        # whether the user's tmux.conf sets base-index 1 (non-default).
+        self._tmux_base_index = self._get_tmux_option("base-index", 0)
+        self._tmux_pane_base_index = self._get_tmux_option("pane-base-index", 0)
         # Resolve the Marcus MCP URL once at spawner init time so it is
         # baked into each generated shell script. tmux new-session does NOT
         # inherit the calling process's environment (tmux runs a daemon), so
@@ -469,6 +473,21 @@ class AgentSpawner:
         self.marcus_mcp_url: str = os.environ.get(
             "MARCUS_URL", "http://localhost:4298/mcp"
         )
+
+    @staticmethod
+    def _get_tmux_option(option: str, default: int) -> int:
+        """Read a global tmux integer option, returning default if unavailable."""
+        try:
+            result = subprocess.run(
+                ["tmux", "show-options", "-gv", option],
+                capture_output=True,
+                text=True,
+            )
+            if result.returncode == 0 and result.stdout.strip().isdigit():
+                return int(result.stdout.strip())
+        except Exception:
+            pass
+        return default
 
     @staticmethod
     def _pretrust_directory(directory: Path) -> None:
@@ -995,7 +1014,7 @@ CRITICAL INSTRUCTIONS:
                     "tmux",
                     "new-window",
                     "-t",
-                    f"{self.tmux_session}:{window}",
+                    f"{self.tmux_session}:{window + self._tmux_base_index}",
                     "-n",
                     f"agents-{window}",
                 ],
@@ -1025,7 +1044,10 @@ CRITICAL INSTRUCTIONS:
         """
         # For first pane in window, use existing pane
         if pane == 0:
-            target = f"{self.tmux_session}:{window}.0"
+            target = (
+                f"{self.tmux_session}:"
+                f"{window + self._tmux_base_index}.{self._tmux_pane_base_index}"
+            )
         else:
             # Split the window and get the new pane's target.
             # Layout: 0=left, 1=right (2 panes per window, side-by-side).
@@ -1033,7 +1055,11 @@ CRITICAL INSTRUCTIONS:
                 # Split window horizontally so pane 1 lands to the
                 # right of pane 0.
                 split_direction = "-h"
-                split_target = f"{self.tmux_session}:{window}.0"
+                split_target = (
+                    f"{self.tmux_session}:"
+                    f"{window + self._tmux_base_index}"
+                    f".{self._tmux_pane_base_index}"
+                )
             else:
                 raise ValueError(
                     f"Invalid pane number: {pane} "
@@ -1745,11 +1771,22 @@ echo "=========================================="
 
             # Select the first pane before attaching
             subprocess.run(
-                ["tmux", "select-window", "-t", f"{self.tmux_session}:0"],
+                [
+                    "tmux",
+                    "select-window",
+                    "-t",
+                    f"{self.tmux_session}:{self._tmux_base_index}",
+                ],
                 check=False,
             )
             subprocess.run(
-                ["tmux", "select-pane", "-t", f"{self.tmux_session}:0.0"],
+                [
+                    "tmux",
+                    "select-pane",
+                    "-t",
+                    f"{self.tmux_session}:{self._tmux_base_index}"
+                    f".{self._tmux_pane_base_index}",
+                ],
                 check=False,
             )
 

--- a/dev-tools/experiments/runners/spawn_agents.py
+++ b/dev-tools/experiments/runners/spawn_agents.py
@@ -461,10 +461,16 @@ class AgentSpawner:
         self.panes_per_window = 2
         self.current_window = 0
         self.current_pane = 0
-        # Detect tmux base indices so target strings work regardless of
-        # whether the user's tmux.conf sets base-index 1 (non-default).
-        self._tmux_base_index = self._get_tmux_option("base-index", 0)
-        self._tmux_pane_base_index = self._get_tmux_option("pane-base-index", 0)
+        # tmux base indices (base-index / pane-base-index). Placeholder
+        # defaults here; the real values are detected in
+        # create_tmux_session() once the session exists. Detection MUST
+        # happen there, not now: tmux may have no server running at
+        # construction time, and `tmux new-session` is what starts the
+        # server and sources ~/.tmux.conf. Reading the options before
+        # that would always return the default 0 even when the user's
+        # config sets base-index 1.
+        self._tmux_base_index = 0
+        self._tmux_pane_base_index = 0
         # Resolve the Marcus MCP URL once at spawner init time so it is
         # baked into each generated shell script. tmux new-session does NOT
         # inherit the calling process's environment (tmux runs a daemon), so
@@ -475,16 +481,27 @@ class AgentSpawner:
         )
 
     @staticmethod
-    def _get_tmux_option(option: str, default: int) -> int:
-        """Read a global tmux integer option, returning default if unavailable."""
+    def _first_int(cmd: List[str], default: int) -> int:
+        """Run a command and return the first line of stdout as an int.
+
+        Parameters
+        ----------
+        cmd : List[str]
+            Command to run (a ``tmux`` query producing one int per line).
+        default : int
+            Value returned when the command fails or yields no integer.
+
+        Returns
+        -------
+        int
+            The first integer line of stdout, or ``default``.
+        """
         try:
-            result = subprocess.run(
-                ["tmux", "show-options", "-gv", option],
-                capture_output=True,
-                text=True,
-            )
-            if result.returncode == 0 and result.stdout.strip().isdigit():
-                return int(result.stdout.strip())
+            result = subprocess.run(cmd, capture_output=True, text=True)
+            if result.returncode == 0:
+                lines = result.stdout.strip().splitlines()
+                if lines and lines[0].strip().isdigit():
+                    return int(lines[0].strip())
         except Exception:
             pass
         return default
@@ -991,9 +1008,29 @@ CRITICAL INSTRUCTIONS:
             check=True,
         )
 
+        # Detect the tmux base indices from the session that now exists.
+        # This is the reliable point to do it: `tmux new-session` above
+        # has started the server and sourced ~/.tmux.conf, so the first
+        # window/pane indices reflect the user's base-index setting.
+        # Reading them from the live session (rather than global options)
+        # also works regardless of whether a server was already running
+        # when this spawner was constructed.
+        self._tmux_base_index = self._first_int(
+            ["tmux", "list-windows", "-t", self.tmux_session, "-F", "#{window_index}"],
+            default=0,
+        )
+        self._tmux_pane_base_index = self._first_int(
+            ["tmux", "list-panes", "-t", self.tmux_session, "-F", "#{pane_index}"],
+            default=0,
+        )
+
         print(f"✓ Created tmux session: {self.tmux_session}")
         print("  - Mouse mode enabled (click to switch panes)")
         print("  - Pane borders show agent names")
+        print(
+            f"  - tmux base-index={self._tmux_base_index}, "
+            f"pane-base-index={self._tmux_pane_base_index}"
+        )
 
     def get_next_pane_location(self) -> tuple[int, int]:
         """

--- a/tests/unit/experiments/test_spawn_agents.py
+++ b/tests/unit/experiments/test_spawn_agents.py
@@ -1437,3 +1437,170 @@ class TestClaudeModelFlagLandsInGeneratedScripts:
         script_file = spawner.config.prompts_dir / "project_creator.sh"
         content = script_file.read_text()
         assert "--model" not in content
+
+
+class TestTmuxBaseIndexDetection:
+    """Test suite for non-zero tmux base-index handling (PR #568).
+
+    A user's ``~/.tmux.conf`` may set ``base-index 1`` and
+    ``pane-base-index 1`` — a common non-default configuration. The
+    spawner builds ``session:window.pane`` target strings; with the
+    indices hardcoded to ``0`` those targets address windows/panes that
+    do not exist under such a config and every ``tmux`` call fails.
+
+    ``AgentSpawner`` detects the two indices inside ``create_tmux_session``
+    — by reading the first window/pane of the session that was just
+    created — and offsets every target string by the detected base.
+
+    Detection happens after the session exists (not in ``__init__``)
+    because ``tmux new-session`` is what starts the tmux server and
+    sources ``~/.tmux.conf``; reading the indices any earlier returns
+    the default ``0`` even when the user's config sets ``base-index 1``
+    (the cold-start bug). These tests cover the ``_first_int`` reader,
+    the ``__init__`` placeholder defaults, the ``create_tmux_session``
+    detection, and the offset applied to target strings.
+    """
+
+    # ------------------------------------------------------------------
+    # _first_int — the stdout reader
+    # ------------------------------------------------------------------
+
+    def test_first_int_parses_first_line(self) -> None:
+        """Returns the first stdout line as an int."""
+        mock_result = MagicMock(returncode=0, stdout="1\n1\n")
+        with patch("subprocess.run", return_value=mock_result):
+            value = spawn_agents.AgentSpawner._first_int(["tmux", "x"], 0)
+        assert value == 1
+
+    def test_first_int_returns_default_on_nonzero_returncode(self) -> None:
+        """Command failure (e.g. no tmux server) → default returned."""
+        mock_result = MagicMock(returncode=1, stdout="")
+        with patch("subprocess.run", return_value=mock_result):
+            value = spawn_agents.AgentSpawner._first_int(["tmux", "x"], 0)
+        assert value == 0
+
+    def test_first_int_returns_default_on_non_numeric_output(self) -> None:
+        """Non-numeric stdout → default returned."""
+        mock_result = MagicMock(returncode=0, stdout="not-a-number\n")
+        with patch("subprocess.run", return_value=mock_result):
+            value = spawn_agents.AgentSpawner._first_int(["tmux", "x"], 0)
+        assert value == 0
+
+    def test_first_int_returns_default_when_command_missing(self) -> None:
+        """``tmux`` binary absent → subprocess raises → default returned."""
+        with patch("subprocess.run", side_effect=FileNotFoundError("tmux")):
+            value = spawn_agents.AgentSpawner._first_int(["tmux", "x"], 0)
+        assert value == 0
+
+    # ------------------------------------------------------------------
+    # __init__ — placeholder defaults only
+    # ------------------------------------------------------------------
+
+    def test_init_uses_placeholder_indices_before_session_exists(
+        self, tmp_path: Path
+    ) -> None:
+        """Constructor sets placeholder 0/0; no tmux query happens at init."""
+        config = MagicMock()
+        config.project_name = "Test Project"
+        config.agent_model = None
+        templates = tmp_path / "templates"
+        templates.mkdir()
+
+        with patch("subprocess.run") as mock_run:
+            spawner = spawn_agents.AgentSpawner(config, templates)
+
+        assert spawner._tmux_base_index == 0
+        assert spawner._tmux_pane_base_index == 0
+        # __init__ must not shell out to tmux — detection is deferred.
+        mock_run.assert_not_called()
+
+    # ------------------------------------------------------------------
+    # create_tmux_session — detection from the live session
+    # ------------------------------------------------------------------
+
+    def test_create_tmux_session_detects_indices_from_live_session(self) -> None:
+        """Detection reads the real window/pane indices of the new session.
+
+        Regression for the cold-start bug: a non-zero base-index is
+        picked up because it is read from the session that exists,
+        not from global options queried before the server started.
+        """
+        spawner = spawn_agents.AgentSpawner.__new__(spawn_agents.AgentSpawner)
+        spawner.tmux_session = "marcus_test"
+
+        def fake_run(cmd: list, *args: Any, **kwargs: Any) -> MagicMock:
+            if "list-windows" in cmd:
+                return MagicMock(returncode=0, stdout="1\n")
+            if "list-panes" in cmd:
+                return MagicMock(returncode=0, stdout="1\n")
+            return MagicMock(returncode=0, stdout="")
+
+        with patch("subprocess.run", side_effect=fake_run):
+            spawner.create_tmux_session()
+
+        assert spawner._tmux_base_index == 1
+        assert spawner._tmux_pane_base_index == 1
+
+    # ------------------------------------------------------------------
+    # target-string offsets
+    # ------------------------------------------------------------------
+
+    def _bypass_init_spawner(self, base: int, pane_base: int) -> Any:
+        """Build an AgentSpawner without running __init__, with tmux indices set."""
+        instance = spawn_agents.AgentSpawner.__new__(spawn_agents.AgentSpawner)
+        instance.tmux_session = "marcus_test"
+        instance.panes_per_window = 2
+        instance.current_window = 0
+        instance.current_pane = 0
+        instance._tmux_base_index = base
+        instance._tmux_pane_base_index = pane_base
+        return instance
+
+    def test_new_window_target_includes_base_index_offset(self) -> None:
+        """get_next_pane_location offsets the new-window target by base-index."""
+        spawner = self._bypass_init_spawner(base=1, pane_base=1)
+        spawner.current_pane = 2  # → window 1, pane 0 → triggers new-window
+
+        with patch("subprocess.run") as mock_run:
+            window, pane = spawner.get_next_pane_location()
+
+        assert (window, pane) == (1, 0)
+        cmd = mock_run.call_args[0][0]
+        # window 1 + base-index 1 = 2
+        assert "marcus_test:2" in cmd
+
+    def test_first_pane_target_includes_both_offsets(self) -> None:
+        """run_in_tmux_pane (pane 0) offsets window AND pane by their bases."""
+        spawner = self._bypass_init_spawner(base=1, pane_base=1)
+
+        with (
+            patch("subprocess.run") as mock_run,
+            patch.object(spawn_agents, "wait_for_pane_ready", return_value=True),
+            patch.object(spawn_agents, "confirm_trust_if_prompted"),
+            patch("time.sleep"),
+        ):
+            spawner.run_in_tmux_pane(
+                window=0, pane=0, script_file=Path("dummy_script.sh"), title="t"
+            )
+
+        # First tmux call is select-pane -t <target>
+        first_cmd = mock_run.call_args_list[0][0][0]
+        # window 0 + base 1 = 1, pane base 1 → "marcus_test:1.1"
+        assert "marcus_test:1.1" in first_cmd
+
+    def test_default_indices_preserve_classic_zero_targets(self) -> None:
+        """With both bases 0 (tmux default) targets are unchanged — back-compat."""
+        spawner = self._bypass_init_spawner(base=0, pane_base=0)
+
+        with (
+            patch("subprocess.run") as mock_run,
+            patch.object(spawn_agents, "wait_for_pane_ready", return_value=True),
+            patch.object(spawn_agents, "confirm_trust_if_prompted"),
+            patch("time.sleep"),
+        ):
+            spawner.run_in_tmux_pane(
+                window=0, pane=0, script_file=Path("dummy_script.sh"), title="t"
+            )
+
+        first_cmd = mock_run.call_args_list[0][0][0]
+        assert "marcus_test:0.0" in first_cmd


### PR DESCRIPTION
## What is this, briefly

Marcus is a system that coordinates several AI coding agents working on the same project at once. To run an experiment, Marcus launches each agent in its own **tmux pane** — a split-screen region of a terminal — using a helper script, the **experiment runner** (`dev-tools/experiments/runners/spawn_agents.py`). The runner creates a tmux session, opens windows and panes, and starts one agent per pane.

## Why this change is needed

To place an agent, the runner builds a tmux **target string** of the form `session:window.pane` — for example `marcus_demo:0.0` means "window 0, pane 0 of session marcus_demo". The runner previously **hardcoded `0`** for both the window and pane numbers.

tmux lets users renumber windows and panes through two settings in their `~/.tmux.conf`:

- `base-index` — the number of the first window (default `0`)
- `pane-base-index` — the number of the first pane (default `0`)

Setting both to `1` is an extremely common customization (it lines the numbers up with the keyboard). For any user who has done this, **the first window is `1`, not `0`** — so the runner's hardcoded `session:0.0` points at a window that does not exist. Every tmux command then fails with:

```
can't find window: 0
```

and the experiment never starts. The user sees a broken run with no obvious cause.

**Worked example.** A user with `base-index 1` and `pane-base-index 1` runs an experiment with 3 agents. The runner tries to target `marcus_demo:0.0`, `marcus_demo:0.1`, `marcus_demo:1.0`. None of those panes exist — the real panes are `1.1`, `1.2`, `2.1`. All 3 agents fail to spawn.

## What changed

`spawn_agents.py` now **detects** the two index settings instead of assuming `0`:

1. A new helper, `AgentSpawner._get_tmux_option(option, default)`, reads a global tmux option via `tmux show-options -gv <option>` and returns its integer value, falling back to `default` if tmux is unavailable or the value is not numeric.
2. `AgentSpawner.__init__` stores `self._tmux_base_index` and `self._tmux_pane_base_index` from that helper.
3. Every place that built a target string — `get_next_pane_location` (new windows) and `run_in_tmux_pane` (first pane and split panes) — now offsets the window/pane numbers by the detected base values. The session-select calls at the end of `run()` do the same.

When both indices are `0` (the tmux default), every target string is identical to before — so this is fully backward compatible.

## Where to look in the code first

| File | Purpose |
|------|---------|
| `dev-tools/experiments/runners/spawn_agents.py` | The experiment runner; all changes are in the `AgentSpawner` class |
| `AgentSpawner.__init__` | Detects and stores the two base indices |
| `AgentSpawner._get_tmux_option` | New helper that reads a global tmux integer option |
| `AgentSpawner.get_next_pane_location` / `run_in_tmux_pane` | Build the `session:window.pane` target strings |

## Glossary

| Term | Meaning |
|------|---------|
| tmux | Terminal multiplexer — splits one terminal into windows and panes |
| pane | A single split region of a terminal; the runner puts one agent per pane |
| target string | tmux's `session:window.pane` address used to send commands to a pane |
| `base-index` / `pane-base-index` | tmux options that set the number of the first window / first pane |
| experiment runner | `spawn_agents.py` — the script that launches agents into tmux panes |

## How to verify it works

1. Add to your `~/.tmux.conf`:
   ```
   set -g base-index 1
   set -g pane-base-index 1
   ```
2. Start a tmux server with that config loaded: `tmux new-session -d -s probe`.
3. Run an experiment with the runner. **Before this change** it fails immediately with `can't find window: 0`. **After this change** the agents spawn into panes `1.1`, `1.2`, etc.
4. Set both options back to `0` (or remove the lines) and run again — behavior is unchanged, confirming backward compatibility.

## Known limitation / follow-up

`_get_tmux_option` reads **global** tmux options inside `__init__`. If **no tmux server is running yet** when the runner starts, `tmux show-options` returns the default `0`. The runner's later `tmux new-session` call then starts the server and sources `~/.tmux.conf`, applying `base-index 1` — so the detected value (`0`) and the real session (`1`) disagree. In other words, this fix works reliably when the runner is started **from inside an existing tmux session**, but not from a cold start with no server. A follow-up should detect the indices from the session **after** it is created. This was confirmed by integration testing.

## Test plan

- [ ] Unit tests for `_get_tmux_option` (integer parse, no-server fallback, non-numeric fallback, missing-binary fallback)
- [ ] Unit tests for target-string offsets (new window, first pane, default-zero back-compat)
- [ ] Manual: experiment runs successfully with `base-index 1` / `pane-base-index 1`
- [ ] Manual: experiment behavior unchanged with default `0` indices
- [ ] This PR targets the `develop` branch (not `main`)

## Related

- Sibling PR #567 — also fixes an experiment-startup bug (`uvicorn` event-loop nesting)
