### PR TITLE
add kanban board visualization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@ tsconfig.json
 .eslintrc.json
 package.json
 package-lock.json
+.claude/settings.local.json

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,7 +26,6 @@ repos:
     rev: 26.3.0
     hooks:
       - id: black
-        language_version: python3.11
 
   # Import sorting with isort
   - repo: https://github.com/pycqa/isort
@@ -104,7 +103,7 @@ repos:
 
 # Configuration
 default_language_version:
-  python: python3.11
+  python: python3
 
 fail_fast: false
 exclude: '^(\.git|\.hg|\.mypy_cache|\.tox|\.venv|_build|buck-out|build|dist|node_modules)/'

--- a/README.md
+++ b/README.md
@@ -197,8 +197,14 @@ CLAUDE_API_KEY=sk-ant-api03-your-key-here
 See the board in your terminal at any time:
 
 ```bash
-./marcus board
+./marcus board               # snapshot — print once and exit
+./marcus board --watch       # live view — refreshes every 2 s (Ctrl+C to stop)
+./marcus board -w --interval 5   # live view with a 5-second refresh rate
+./marcus board --project my-project   # filter to a specific project
+./marcus board --list        # list all projects in the database
 ```
+
+The live board (`--watch`) polls the SQLite database and re-renders in-place — you can watch tasks move from **Backlog → In Progress → Done** as agents work in real time.
 
 ### Step 4: Choose a visual dashboard (optional)
 

--- a/marcus
+++ b/marcus
@@ -33,7 +33,7 @@ import subprocess  # nosec B404 - subprocess required for CLI daemon management
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, cast
 
 import psutil
 
@@ -577,7 +577,7 @@ class MarcusCLI:
                         "   Or point at a SQLite db: marcus board --db <path>"
                     )
                     return 1
-                kanban = KanbanFactory.create_default()
+                kanban = cast(SQLiteKanban, KanbanFactory.create_default())
             except Exception:
                 # No config_marcus.json or config error — fall back to the
                 # default SQLite path.
@@ -606,7 +606,7 @@ class MarcusCLI:
                     # return [] even while a run is active.
                     if not projects:
                         all_tasks = await kanban.get_all_tasks()
-                        seen: dict[str, dict] = {}
+                        seen: dict[str, dict[str, Any]] = {}
                         for t in all_tasks:
                             pid = t.project_id or ""
                             if pid and pid not in seen:

--- a/marcus
+++ b/marcus
@@ -541,15 +541,45 @@ class MarcusCLI:
         # Suppress library logs for clean board output
         logging.getLogger("src.integrations").setLevel(logging.WARNING)
 
-        db_path = args.db or str(MARCUS_ROOT / "data" / "kanban.db")
+        # Resolve the kanban provider.
+        #
+        # Priority order:
+        #   1. --db flag  → always SQLiteKanban at that explicit path
+        #   2. config_marcus.json  → use the configured provider + path
+        #   3. fallback  → SQLiteKanban at ./data/kanban.db
+        #
+        # This mirrors what Marcus itself does at runtime so the board
+        # always points at the same data Marcus is writing to.
 
-        if not Path(db_path).exists():
-            print(f"❌ No database found at {db_path}")
-            print("   Run an experiment with --provider sqlite first,")
-            print("   or specify a path with: marcus board --db <path>")
-            return 1
+        if args.db:
+            # Explicit path override: SQLite only
+            db_path = args.db
+            if not Path(db_path).exists():
+                print(f"❌ No database found at {db_path}")
+                return 1
+            kanban = SQLiteKanban({"db_path": db_path, "project_name": ""})
+        else:
+            # Try reading the live config so we use the same provider/path
+            # as the running Marcus instance.
+            try:
+                from src.integrations.kanban_factory import KanbanFactory
 
-        kanban = SQLiteKanban({"db_path": db_path, "project_name": ""})
+                kanban = KanbanFactory.create_default()
+                provider_name = KanbanFactory.get_default_provider()
+                if provider_name != "sqlite" and not args.list:
+                    # Non-SQLite providers work fine for --list; for board
+                    # rendering they also work via get_all_tasks().
+                    pass
+            except Exception:
+                # No config_marcus.json or config error — fall back to the
+                # default SQLite path.
+                db_path = str(MARCUS_ROOT / "data" / "kanban.db")
+                if not Path(db_path).exists():
+                    print(f"❌ No database found at {db_path}")
+                    print("   Is Marcus configured? Make sure config_marcus.json exists.")
+                    print("   Or specify a path directly: marcus board --db <path>")
+                    return 1
+                kanban = SQLiteKanban({"db_path": db_path, "project_name": ""})
 
         if args.list:
             # List all projects

--- a/marcus
+++ b/marcus
@@ -564,19 +564,30 @@ class MarcusCLI:
             try:
                 from src.integrations.kanban_factory import KanbanFactory
 
-                kanban = KanbanFactory.create_default()
                 provider_name = KanbanFactory.get_default_provider()
-                if provider_name != "sqlite" and not args.list:
-                    # Non-SQLite providers work fine for --list; for board
-                    # rendering they also work via get_all_tasks().
-                    pass
+                if provider_name != "sqlite":
+                    print(
+                        f"❌ 'marcus board' only supports the SQLite provider "
+                        f"(configured: {provider_name})."
+                    )
+                    print(
+                        "   Planka / Linear / GitHub have their own board UIs."
+                    )
+                    print(
+                        "   Or point at a SQLite db: marcus board --db <path>"
+                    )
+                    return 1
+                kanban = KanbanFactory.create_default()
             except Exception:
                 # No config_marcus.json or config error — fall back to the
                 # default SQLite path.
                 db_path = str(MARCUS_ROOT / "data" / "kanban.db")
                 if not Path(db_path).exists():
                     print(f"❌ No database found at {db_path}")
-                    print("   Is Marcus configured? Make sure config_marcus.json exists.")
+                    print(
+                        "   Is Marcus configured? "
+                        "Make sure config_marcus.json exists."
+                    )
                     print("   Or specify a path directly: marcus board --db <path>")
                     return 1
                 kanban = SQLiteKanban({"db_path": db_path, "project_name": ""})
@@ -856,7 +867,10 @@ Examples:
         "--watch",
         "-w",
         action="store_true",
-        help="Live mode: refresh board in-place every --interval seconds (Ctrl+C to stop)",
+        help=(
+            "Live mode: refresh board in-place every --interval seconds"
+            " (Ctrl+C to stop)"
+        ),
     )
     board_parser.add_argument(
         "--interval",

--- a/marcus
+++ b/marcus
@@ -536,6 +536,7 @@ class MarcusCLI:
 
         from src.integrations.providers.sqlite_kanban import SQLiteKanban
         from src.visualization.board_renderer import BoardRenderer
+        from src.visualization.live_board import LiveBoardWatcher
 
         # Suppress library logs for clean board output
         logging.getLogger("src.integrations").setLevel(logging.WARNING)
@@ -613,6 +614,20 @@ class MarcusCLI:
             project_name = project_filter
 
         display_name = project_name
+
+        if getattr(args, "watch", False):
+            # Live mode: poll and re-render in place until Ctrl+C.
+            watcher = LiveBoardWatcher(
+                kanban=kanban,
+                project_filter=project_filter,
+                project_name=display_name,
+                interval=getattr(args, "interval", 2.0),
+            )
+            try:
+                asyncio.run(watcher.watch())
+            except KeyboardInterrupt:
+                pass
+            return 0
 
         async def _load_and_render() -> None:
             nonlocal display_name
@@ -780,6 +795,19 @@ Examples:
         "--list",
         action="store_true",
         help="List all projects",
+    )
+    board_parser.add_argument(
+        "--watch",
+        "-w",
+        action="store_true",
+        help="Live mode: refresh board in-place every --interval seconds (Ctrl+C to stop)",
+    )
+    board_parser.add_argument(
+        "--interval",
+        type=float,
+        default=2.0,
+        metavar="SECS",
+        help="Seconds between refreshes in live mode (default: 2.0)",
     )
 
     args = parser.parse_args()

--- a/marcus
+++ b/marcus
@@ -587,6 +587,32 @@ class MarcusCLI:
                 await kanban.connect()
                 try:
                     projects = await kanban.list_projects()
+
+                    # Fallback: aggregate project info from tasks when the
+                    # projects table is empty.  Marcus sometimes writes tasks
+                    # directly (with project_id/project_name) without inserting
+                    # a row into the projects table, so list_projects() can
+                    # return [] even while a run is active.
+                    if not projects:
+                        all_tasks = await kanban.get_all_tasks()
+                        seen: dict[str, dict] = {}
+                        for t in all_tasks:
+                            pid = t.project_id or ""
+                            if pid and pid not in seen:
+                                seen[pid] = {
+                                    "id": pid,
+                                    "name": t.project_name or pid,
+                                    "created_at": (
+                                        t.created_at.isoformat()
+                                        if t.created_at
+                                        else ""
+                                    ),
+                                    "task_count": 0,
+                                }
+                            if pid:
+                                seen[pid]["task_count"] += 1
+                        projects = list(seen.values())
+
                     if not projects:
                         print("No projects found.")
                         return
@@ -597,7 +623,7 @@ class MarcusCLI:
                     table.add_column("Tasks", justify="right")
                     table.add_column("Created", style="dim")
                     for p in projects:
-                        created = p["created_at"][:10]
+                        created = (p.get("created_at") or "")[:10]
                         table.add_row(
                             p["id"][:8],
                             p["name"],

--- a/marcus
+++ b/marcus
@@ -570,12 +570,8 @@ class MarcusCLI:
                         f"❌ 'marcus board' only supports the SQLite provider "
                         f"(configured: {provider_name})."
                     )
-                    print(
-                        "   Planka / Linear / GitHub have their own board UIs."
-                    )
-                    print(
-                        "   Or point at a SQLite db: marcus board --db <path>"
-                    )
+                    print("   Planka / Linear / GitHub have their own board UIs.")
+                    print("   Or point at a SQLite db: marcus board --db <path>")
                     return 1
                 kanban = cast(SQLiteKanban, KanbanFactory.create_default())
             except Exception:
@@ -614,9 +610,7 @@ class MarcusCLI:
                                     "id": pid,
                                     "name": t.project_name or pid,
                                     "created_at": (
-                                        t.created_at.isoformat()
-                                        if t.created_at
-                                        else ""
+                                        t.created_at.isoformat() if t.created_at else ""
                                     ),
                                     "task_count": 0,
                                 }

--- a/src/experiments/live_experiment_monitor.py
+++ b/src/experiments/live_experiment_monitor.py
@@ -628,6 +628,12 @@ class LiveExperimentMonitor:
                 registered_at = registered_at.replace(tzinfo=timezone.utc)
             duration = (datetime.now(timezone.utc) - registered_at).total_seconds()
 
+        active_agents = len(
+            [a for a in self.registered_agents.values() if a["tasks_completed"] > 0]
+        )
+        completion_rate = (
+            len(self.task_completions) / max(len(self.task_assignments), 1) * 100
+        )
         summary = f"""
 Live Experiment Summary
 =======================
@@ -639,14 +645,12 @@ Duration: {duration:.0f} seconds
 
 Agent Metrics:
 - Total Registered: {len(self.registered_agents)}
-- Active Agents: {len([a for a in self.registered_agents.values()
-                        if a['tasks_completed'] > 0])}
+- Active Agents: {active_agents}
 
 Task Metrics:
 - Total Assignments: {len(self.task_assignments)}
 - Total Completions: {len(self.task_completions)}
-- Completion Rate: {len(self.task_completions) / max(
-    len(self.task_assignments), 1) * 100:.1f}%
+- Completion Rate: {completion_rate:.1f}%
 
 Condition Metrics:
 - Blockers Reported: {self.blockers_reported}

--- a/src/visualization/board_renderer.py
+++ b/src/visualization/board_renderer.py
@@ -8,16 +8,22 @@ Classes
 -------
 BoardRenderer
     Renders tasks as a terminal kanban board using Rich.
+_ResponsiveGrid
+    Width-aware Rich renderable that switches between 4-across and
+    2×2 grid layouts based on terminal width.
 """
 
-from typing import List, Optional
+from typing import TYPE_CHECKING, List, Optional
 
 from rich import box
-from rich.console import Console
+from rich.console import Console, ConsoleOptions, RenderResult
 from rich.panel import Panel
 from rich.table import Table
 
 from src.core.models import Priority, Task, TaskStatus
+
+if TYPE_CHECKING:
+    from rich.console import Group
 
 # Column definitions: (display_name, status, border_style)
 _COLUMNS = [
@@ -26,6 +32,40 @@ _COLUMNS = [
     ("Blocked", TaskStatus.BLOCKED, "red"),
     ("Done", TaskStatus.DONE, "green"),
 ]
+
+class _ResponsiveGrid:
+    """Width-aware Rich renderable for the 4-column kanban grid.
+
+    Switches between a single 4-column row (≥160 cols) and a 2×2
+    grid (narrower terminals) so the board always fits the screen.
+
+    Parameters
+    ----------
+    panels : list[Panel]
+        Exactly four column panels in order: Backlog, In Progress,
+        Blocked, Done.
+    """
+
+    def __init__(self, panels: List[Panel]) -> None:
+        self._panels = panels
+
+    def __rich_console__(
+        self, console: Console, options: ConsoleOptions
+    ) -> RenderResult:
+        """Yield the grid adapted to the current terminal width."""
+        wide = options.max_width >= 160
+        grid = Table.grid(expand=True)
+        if wide:
+            for _ in self._panels:
+                grid.add_column(ratio=1)
+            grid.add_row(*self._panels)
+        else:
+            grid.add_column(ratio=1)
+            grid.add_column(ratio=1)
+            grid.add_row(self._panels[0], self._panels[1])
+            grid.add_row(self._panels[2], self._panels[3])
+        yield grid
+
 
 _PRIORITY_INDICATORS = {
     Priority.URGENT: "[bold red]URGENT[/bold red]",
@@ -47,6 +87,58 @@ class BoardRenderer:
 
     def __init__(self, project_name: Optional[str] = None) -> None:
         self.project_name = project_name or "Marcus Board"
+
+    def build_renderable(self, tasks: List[Task]) -> "Group":
+        """Build a Rich renderable for the board without printing.
+
+        Returns a ``rich.console.Group`` containing the header, the
+        responsive 4-column grid, and the summary bar.  Suitable for
+        use with ``rich.live.Live`` for real-time updates.
+
+        Parameters
+        ----------
+        tasks : List[Task]
+            All tasks to display on the board.
+
+        Returns
+        -------
+        Group
+            Rich renderable that can be passed to ``Live.update()``.
+        """
+        from rich.console import Group
+
+        grouped: dict[TaskStatus, list[Task]] = {
+            status: [] for _, status, _ in _COLUMNS
+        }
+        for task in tasks:
+            if task.status in grouped:
+                grouped[task.status].append(task)
+
+        panels: list[Panel] = []
+        for label, status, color in _COLUMNS:
+            column_tasks = grouped[status]
+            count = len(column_tasks)
+            card_texts = [self._render_card(task, status) for task in column_tasks]
+            body = "\n\n".join(card_texts) if card_texts else "[dim](empty)[/dim]"
+            panels.append(
+                Panel(
+                    body,
+                    title=f"{label} ({count})",
+                    border_style=color,
+                    expand=True,
+                    padding=(0, 1),
+                )
+            )
+
+        header = Panel(
+            f"[bold]{self.project_name}[/bold]",
+            style="blue",
+            box=box.DOUBLE,
+            expand=True,
+        )
+        summary = self._render_summary(tasks, grouped)
+
+        return Group(header, _ResponsiveGrid(panels), summary)
 
     def render(
         self,

--- a/src/visualization/board_renderer.py
+++ b/src/visualization/board_renderer.py
@@ -33,6 +33,7 @@ _COLUMNS = [
     ("Done", TaskStatus.DONE, "green"),
 ]
 
+
 class _ResponsiveGrid:
     """Width-aware Rich renderable for the 4-column kanban grid.
 

--- a/src/visualization/live_board.py
+++ b/src/visualization/live_board.py
@@ -141,8 +141,7 @@ class LiveBoardWatcher:
             filtered = [
                 t
                 for t in tasks
-                if t.project_name
-                and t.project_name.lower() == base_name.lower()
+                if t.project_name and t.project_name.lower() == base_name.lower()
             ]
         return filtered if filtered else tasks
 

--- a/src/visualization/live_board.py
+++ b/src/visualization/live_board.py
@@ -1,0 +1,139 @@
+"""
+Live terminal kanban board watcher.
+
+Polls a kanban provider at a configurable interval and renders an
+in-place updating board using Rich's ``Live`` display, similar to
+``htop`` or ``watch``.
+
+Classes
+-------
+LiveBoardWatcher
+    Continuously fetches tasks and refreshes the terminal board.
+"""
+
+import asyncio
+from datetime import datetime, timezone
+from typing import Any, List, Optional
+
+from rich import box
+from rich.console import Console, Group
+from rich.live import Live
+from rich.panel import Panel
+
+from src.core.models import Task
+from src.visualization.board_renderer import BoardRenderer
+
+
+class LiveBoardWatcher:
+    """Polls a kanban provider and renders a continuously updating board.
+
+    Parameters
+    ----------
+    kanban : KanbanInterface
+        Any kanban provider implementing ``connect``, ``disconnect``,
+        and ``get_all_tasks``.
+    project_filter : Optional[str]
+        Project ID prefix used to filter tasks.  Falls back to name
+        matching against ``project_name`` when no ID matches.
+    project_name : str
+        Human-readable name shown in the board header.
+    interval : float
+        Seconds between database polls.  Defaults to ``2.0``.
+    """
+
+    def __init__(
+        self,
+        kanban: Any,
+        project_filter: Optional[str] = None,
+        project_name: str = "Marcus Board",
+        interval: float = 2.0,
+    ) -> None:
+        self.kanban = kanban
+        self.project_filter = project_filter
+        self.project_name = project_name
+        self.interval = interval
+        self._renderer = BoardRenderer(project_name=project_name)
+
+    async def watch(self, console: Optional[Console] = None) -> None:
+        """Run the live board until Ctrl+C is pressed.
+
+        Connects to the kanban provider, enters a ``rich.live.Live``
+        full-screen context, polls for task updates on every iteration,
+        and disconnects cleanly when interrupted.
+
+        Parameters
+        ----------
+        console : Optional[Console]
+            Rich console to render into.  A new one is created when
+            ``None``.
+        """
+        if console is None:
+            console = Console()
+
+        await self.kanban.connect()
+        try:
+            with Live(
+                console=console,
+                screen=True,
+                auto_refresh=False,
+            ) as live:
+                while True:
+                    try:
+                        tasks = await self._fetch_tasks()
+                        live.update(self._build_live_renderable(tasks))
+                        live.refresh()
+                        await asyncio.sleep(self.interval)
+                    except asyncio.CancelledError:
+                        break
+        finally:
+            await self.kanban.disconnect()
+
+    async def _fetch_tasks(self) -> List[Task]:
+        """Fetch tasks from the kanban provider, applying project filter.
+
+        Returns
+        -------
+        List[Task]
+            Filtered task list; all tasks when no filter is set.
+        """
+        tasks: List[Task] = await self.kanban.get_all_tasks()
+        if not self.project_filter:
+            return tasks
+
+        filtered = [
+            t
+            for t in tasks
+            if t.project_id and t.project_id.startswith(self.project_filter)
+        ]
+        if not filtered:
+            base_name = self.project_name.split(" - ")[0].strip()
+            filtered = [
+                t
+                for t in tasks
+                if t.project_name
+                and t.project_name.lower() == base_name.lower()
+            ]
+        return filtered if filtered else tasks
+
+    def _build_live_renderable(self, tasks: List[Task]) -> Group:
+        """Combine the board renderable with a live-status footer.
+
+        Parameters
+        ----------
+        tasks : List[Task]
+            Current task snapshot to display.
+
+        Returns
+        -------
+        Group
+            Board group with an appended timestamp/help footer.
+        """
+        board = self._renderer.build_renderable(tasks)
+        ts = datetime.now(timezone.utc).strftime("%H:%M:%S UTC")
+        footer = Panel(
+            f"[dim]Updated: {ts}  ·  Refresh every {self.interval:.0f}s"
+            "  ·  Ctrl+C to stop[/dim]",
+            box=box.SIMPLE,
+            style="dim",
+        )
+        return Group(board, footer)

--- a/src/visualization/live_board.py
+++ b/src/visualization/live_board.py
@@ -20,7 +20,7 @@ from rich.console import Console, Group
 from rich.live import Live
 from rich.panel import Panel
 
-from src.core.models import Task
+from src.core.models import Task, TaskStatus
 from src.visualization.board_renderer import BoardRenderer
 
 
@@ -55,11 +55,16 @@ class LiveBoardWatcher:
         self._renderer = BoardRenderer(project_name=project_name)
 
     async def watch(self, console: Optional[Console] = None) -> None:
-        """Run the live board until Ctrl+C is pressed.
+        """Run the live board until Ctrl+C or all tasks are finished.
 
         Connects to the kanban provider, enters a ``rich.live.Live``
         full-screen context, polls for task updates on every iteration,
-        and disconnects cleanly when interrupted.
+        and disconnects cleanly when interrupted or when the run ends.
+
+        The loop exits automatically when the board has tasks and none
+        remain in an active state (``TODO`` or ``IN_PROGRESS``).  This
+        matches the behaviour of the ``marcus-mini watch`` command so
+        that a supervised run does not require manual interruption.
 
         Parameters
         ----------
@@ -82,11 +87,37 @@ class LiveBoardWatcher:
                         tasks = await self._fetch_tasks()
                         live.update(self._build_live_renderable(tasks))
                         live.refresh()
+                        if self._run_is_complete(tasks):
+                            break
                         await asyncio.sleep(self.interval)
                     except asyncio.CancelledError:
                         break
         finally:
             await self.kanban.disconnect()
+
+    @staticmethod
+    def _run_is_complete(tasks: List[Task]) -> bool:
+        """Return True when the run has finished and watching can stop.
+
+        A run is considered complete when the board is non-empty and no
+        task is still in an active state (``TODO`` or ``IN_PROGRESS``).
+        Blocked tasks count as terminal for this purpose — they will not
+        advance without human intervention.
+
+        Parameters
+        ----------
+        tasks : List[Task]
+            Current task snapshot from the last poll.
+
+        Returns
+        -------
+        bool
+            ``True`` if the watcher should exit automatically.
+        """
+        if not tasks:
+            return False
+        active = {TaskStatus.TODO, TaskStatus.IN_PROGRESS}
+        return not any(t.status in active for t in tasks)
 
     async def _fetch_tasks(self) -> List[Task]:
         """Fetch tasks from the kanban provider, applying project filter.

--- a/tests/unit/visualization/test_live_board.py
+++ b/tests/unit/visualization/test_live_board.py
@@ -322,3 +322,111 @@ class TestWatchLifecycle:
             await watcher.watch(console=Console(file=StringIO()))
 
         assert sleep_arg == pytest.approx(3.7)
+
+
+# ============================================================
+# _run_is_complete Tests
+# ============================================================
+
+
+class TestRunIsComplete:
+    """Test the _run_is_complete static method."""
+
+    def test_returns_false_for_empty_task_list(self) -> None:
+        """Empty board is not considered complete (run may not have started)."""
+        assert LiveBoardWatcher._run_is_complete([]) is False
+
+    def test_returns_false_when_todo_tasks_remain(self) -> None:
+        """Board with TODO tasks is not complete."""
+        tasks = [_make_task(status=TaskStatus.TODO)]
+        assert LiveBoardWatcher._run_is_complete(tasks) is False
+
+    def test_returns_false_when_in_progress_tasks_remain(self) -> None:
+        """Board with IN_PROGRESS tasks is not complete."""
+        tasks = [_make_task(status=TaskStatus.IN_PROGRESS)]
+        assert LiveBoardWatcher._run_is_complete(tasks) is False
+
+    def test_returns_true_when_all_done(self) -> None:
+        """Board where every task is DONE is complete."""
+        tasks = [
+            _make_task(status=TaskStatus.DONE, task_id="d1"),
+            _make_task(status=TaskStatus.DONE, task_id="d2"),
+        ]
+        assert LiveBoardWatcher._run_is_complete(tasks) is True
+
+    def test_returns_true_when_all_blocked_no_active(self) -> None:
+        """Board with only BLOCKED tasks (no TODO/IN_PROGRESS) is complete."""
+        tasks = [_make_task(status=TaskStatus.BLOCKED)]
+        assert LiveBoardWatcher._run_is_complete(tasks) is True
+
+    def test_returns_true_when_done_and_blocked_mixed(self) -> None:
+        """Mix of DONE and BLOCKED with no active tasks is complete."""
+        tasks = [
+            _make_task(status=TaskStatus.DONE, task_id="d1"),
+            _make_task(status=TaskStatus.BLOCKED, task_id="b1"),
+        ]
+        assert LiveBoardWatcher._run_is_complete(tasks) is True
+
+    def test_returns_false_when_one_in_progress_among_done(self) -> None:
+        """A single IN_PROGRESS task keeps the board active."""
+        tasks = [
+            _make_task(status=TaskStatus.DONE, task_id="d1"),
+            _make_task(status=TaskStatus.IN_PROGRESS, task_id="p1"),
+        ]
+        assert LiveBoardWatcher._run_is_complete(tasks) is False
+
+
+class TestWatchAutoExit:
+    """Test that watch() exits automatically when the run finishes."""
+
+    @pytest.mark.asyncio
+    async def test_watch_exits_when_all_tasks_done(self) -> None:
+        """watch() stops polling once all tasks reach DONE status."""
+        done_task = _make_task(status=TaskStatus.DONE, task_id="d1")
+        kanban = _make_kanban([done_task])
+        watcher = LiveBoardWatcher(kanban, interval=0.01)
+
+        sleep_call_count = 0
+
+        async def _count_sleeps(seconds: float) -> None:
+            nonlocal sleep_call_count
+            sleep_call_count += 1
+
+        with (
+            patch("src.visualization.live_board.Live") as mock_live_cls,
+            patch("asyncio.sleep", side_effect=_count_sleeps),
+        ):
+            mock_live_obj = MagicMock()
+            mock_live_obj.__enter__ = Mock(return_value=mock_live_obj)
+            mock_live_obj.__exit__ = Mock(return_value=False)
+            mock_live_cls.return_value = mock_live_obj
+
+            await watcher.watch(console=Console(file=StringIO()))
+
+        # sleep should never be reached because _run_is_complete() exits first
+        assert sleep_call_count == 0
+        kanban.disconnect.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_watch_does_not_exit_while_tasks_in_progress(self) -> None:
+        """watch() keeps polling while tasks are still IN_PROGRESS."""
+        active_task = _make_task(status=TaskStatus.IN_PROGRESS, task_id="p1")
+        kanban = _make_kanban([active_task])
+        watcher = LiveBoardWatcher(kanban, interval=0.01)
+
+        async def _cancel_after_first(*_: Any) -> None:
+            raise asyncio.CancelledError()
+
+        with (
+            patch("src.visualization.live_board.Live") as mock_live_cls,
+            patch("asyncio.sleep", side_effect=_cancel_after_first),
+        ):
+            mock_live_obj = MagicMock()
+            mock_live_obj.__enter__ = Mock(return_value=mock_live_obj)
+            mock_live_obj.__exit__ = Mock(return_value=False)
+            mock_live_cls.return_value = mock_live_obj
+
+            await watcher.watch(console=Console(file=StringIO()))
+
+        # sleep WAS reached, meaning the loop did not auto-exit
+        kanban.get_all_tasks.assert_called()

--- a/tests/unit/visualization/test_live_board.py
+++ b/tests/unit/visualization/test_live_board.py
@@ -1,0 +1,324 @@
+"""
+Unit tests for the live kanban board watcher.
+
+Tests LiveBoardWatcher (src/visualization/live_board.py) — the
+component that polls a kanban provider and renders a continuously
+updating terminal board using Rich's Live display.
+
+All external dependencies (kanban provider, Rich Live) are mocked so
+these tests run offline, without a database, in < 100 ms each.
+"""
+
+import asyncio
+from datetime import datetime, timezone
+from io import StringIO
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
+
+import pytest
+from rich.console import Console
+
+from src.core.models import Priority, Task, TaskStatus
+from src.visualization.live_board import LiveBoardWatcher
+
+
+# ============================================================
+# Helpers
+# ============================================================
+
+
+def _make_task(
+    name: str = "Test Task",
+    status: TaskStatus = TaskStatus.TODO,
+    task_id: str = "abc12345",
+    assigned_to: str | None = None,
+    project_id: str | None = None,
+    project_name: str | None = None,
+) -> Task:
+    """Create a minimal Task for testing."""
+    now = datetime.now(timezone.utc)
+    return Task(
+        id=task_id,
+        name=name,
+        description="",
+        status=status,
+        priority=Priority.MEDIUM,
+        assigned_to=assigned_to,
+        created_at=now,
+        updated_at=now,
+        due_date=None,
+        estimated_hours=0.0,
+        actual_hours=0.0,
+        dependencies=[],
+        labels=[],
+        is_subtask=False,
+        parent_task_id=None,
+        project_id=project_id,
+        project_name=project_name,
+    )
+
+
+def _make_kanban(tasks: list[Task] | None = None) -> AsyncMock:
+    """Build a mock kanban provider that returns the given tasks."""
+    mock = AsyncMock()
+    mock.connect = AsyncMock(return_value=True)
+    mock.disconnect = AsyncMock(return_value=None)
+    mock.get_all_tasks = AsyncMock(return_value=tasks or [])
+    return mock
+
+
+# ============================================================
+# Constructor Tests
+# ============================================================
+
+
+class TestLiveBoardWatcherInit:
+    """Test LiveBoardWatcher construction and defaults."""
+
+    def test_default_interval_is_two_seconds(self) -> None:
+        """Test that the default poll interval is 2.0 seconds."""
+        watcher = LiveBoardWatcher(_make_kanban())
+        assert watcher.interval == 2.0
+
+    def test_custom_interval_is_stored(self) -> None:
+        """Test that a custom interval is stored on the instance."""
+        watcher = LiveBoardWatcher(_make_kanban(), interval=5.0)
+        assert watcher.interval == 5.0
+
+    def test_default_project_name(self) -> None:
+        """Test that the default project name is used when none given."""
+        watcher = LiveBoardWatcher(_make_kanban())
+        assert watcher.project_name == "Marcus Board"
+
+    def test_custom_project_name_stored(self) -> None:
+        """Test that a custom project name is stored."""
+        watcher = LiveBoardWatcher(_make_kanban(), project_name="My Project")
+        assert watcher.project_name == "My Project"
+
+    def test_project_filter_defaults_to_none(self) -> None:
+        """Test that the project filter is None by default."""
+        watcher = LiveBoardWatcher(_make_kanban())
+        assert watcher.project_filter is None
+
+
+# ============================================================
+# _fetch_tasks Tests
+# ============================================================
+
+
+class TestFetchTasks:
+    """Test the internal _fetch_tasks helper."""
+
+    @pytest.mark.asyncio
+    async def test_returns_all_tasks_when_no_filter(self) -> None:
+        """Test that all tasks are returned when project_filter is None."""
+        tasks = [_make_task("T1", task_id="t1"), _make_task("T2", task_id="t2")]
+        kanban = _make_kanban(tasks)
+        watcher = LiveBoardWatcher(kanban)
+        result = await watcher._fetch_tasks()
+        assert result == tasks
+
+    @pytest.mark.asyncio
+    async def test_filters_by_project_id_prefix(self) -> None:
+        """Test that tasks are filtered to those matching the project ID prefix."""
+        t1 = _make_task("Match", task_id="m1", project_id="proj-abc-123")
+        t2 = _make_task("No match", task_id="m2", project_id="other-xyz")
+        kanban = _make_kanban([t1, t2])
+        watcher = LiveBoardWatcher(kanban, project_filter="proj-abc")
+        result = await watcher._fetch_tasks()
+        assert result == [t1]
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_name_match_when_no_id_match(self) -> None:
+        """Test name-based fallback when project_id filter finds nothing."""
+        t1 = _make_task("In project", task_id="i1", project_name="My Project")
+        t2 = _make_task("Other project", task_id="i2", project_name="Other")
+        kanban = _make_kanban([t1, t2])
+        watcher = LiveBoardWatcher(
+            kanban, project_filter="nomatch", project_name="My Project"
+        )
+        result = await watcher._fetch_tasks()
+        assert result == [t1]
+
+    @pytest.mark.asyncio
+    async def test_returns_all_tasks_when_neither_filter_matches(self) -> None:
+        """Test that all tasks are returned when filter finds nothing at all."""
+        tasks = [_make_task("T1", task_id="t1")]
+        kanban = _make_kanban(tasks)
+        watcher = LiveBoardWatcher(
+            kanban, project_filter="missing", project_name="Missing Project"
+        )
+        result = await watcher._fetch_tasks()
+        assert result == tasks
+
+    @pytest.mark.asyncio
+    async def test_name_filter_is_case_insensitive(self) -> None:
+        """Test that the name fallback filter ignores case."""
+        t = _make_task("Task", task_id="t1", project_name="MY PROJECT")
+        kanban = _make_kanban([t])
+        watcher = LiveBoardWatcher(
+            kanban, project_filter="nomatch", project_name="my project"
+        )
+        result = await watcher._fetch_tasks()
+        assert result == [t]
+
+
+# ============================================================
+# _build_live_renderable Tests
+# ============================================================
+
+
+class TestBuildLiveRenderable:
+    """Test the renderable produced by _build_live_renderable."""
+
+    def _render_to_string(self, watcher: LiveBoardWatcher, tasks: list) -> str:
+        """Render the live renderable to a string for assertion."""
+        buf = StringIO()
+        console = Console(file=buf, width=120, force_terminal=True)
+        renderable = watcher._build_live_renderable(tasks)
+        console.print(renderable)
+        return buf.getvalue()
+
+    def test_board_contains_task_name(self) -> None:
+        """Test that task names appear in the live renderable output."""
+        watcher = LiveBoardWatcher(_make_kanban())
+        tasks = [_make_task("Build the API", task_id="b1")]
+        output = self._render_to_string(watcher, tasks)
+        assert "Build the API" in output
+
+    def test_footer_contains_updated_label(self) -> None:
+        """Test that the live footer includes the 'Updated:' timestamp label."""
+        watcher = LiveBoardWatcher(_make_kanban())
+        output = self._render_to_string(watcher, [])
+        assert "Updated:" in output
+
+    def test_footer_contains_ctrl_c_hint(self) -> None:
+        """Test that the footer tells the user how to stop the live view."""
+        watcher = LiveBoardWatcher(_make_kanban())
+        output = self._render_to_string(watcher, [])
+        assert "Ctrl+C" in output
+
+    def test_footer_shows_configured_interval(self) -> None:
+        """Test that the footer displays the configured refresh interval."""
+        watcher = LiveBoardWatcher(_make_kanban(), interval=5.0)
+        output = self._render_to_string(watcher, [])
+        assert "5s" in output
+
+    def test_project_name_shown_in_header(self) -> None:
+        """Test that the project name appears in the board header."""
+        watcher = LiveBoardWatcher(_make_kanban(), project_name="Alpha Project")
+        output = self._render_to_string(watcher, [])
+        assert "Alpha Project" in output
+
+    def test_multiple_status_columns_present(self) -> None:
+        """Test that all four kanban columns appear in the output."""
+        watcher = LiveBoardWatcher(_make_kanban())
+        output = self._render_to_string(watcher, [])
+        for col in ("Backlog", "In Progress", "Blocked", "Done"):
+            assert col in output, f"Column '{col}' not found in live renderable"
+
+
+# ============================================================
+# watch() Integration Tests (mocked I/O)
+# ============================================================
+
+
+class TestWatchLifecycle:
+    """Test that watch() connects, polls, and disconnects correctly."""
+
+    @pytest.mark.asyncio
+    async def test_watch_connects_to_kanban(self) -> None:
+        """Test that watch() calls kanban.connect() before polling."""
+        kanban = _make_kanban()
+        watcher = LiveBoardWatcher(kanban, interval=0.01)
+
+        async def _cancel_after_first_poll(*_: Any) -> None:
+            raise asyncio.CancelledError()
+
+        with (
+            patch("src.visualization.live_board.Live") as mock_live_cls,
+            patch("asyncio.sleep", side_effect=_cancel_after_first_poll),
+        ):
+            mock_live_obj = MagicMock()
+            mock_live_obj.__enter__ = Mock(return_value=mock_live_obj)
+            mock_live_obj.__exit__ = Mock(return_value=False)
+            mock_live_cls.return_value = mock_live_obj
+
+            await watcher.watch(console=Console(file=StringIO()))
+
+        kanban.connect.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_watch_disconnects_after_cancellation(self) -> None:
+        """Test that disconnect() is always called, even when interrupted."""
+        kanban = _make_kanban()
+        watcher = LiveBoardWatcher(kanban, interval=0.01)
+
+        async def _cancel(*_: Any) -> None:
+            raise asyncio.CancelledError()
+
+        with (
+            patch("src.visualization.live_board.Live") as mock_live_cls,
+            patch("asyncio.sleep", side_effect=_cancel),
+        ):
+            mock_live_obj = MagicMock()
+            mock_live_obj.__enter__ = Mock(return_value=mock_live_obj)
+            mock_live_obj.__exit__ = Mock(return_value=False)
+            mock_live_cls.return_value = mock_live_obj
+
+            await watcher.watch(console=Console(file=StringIO()))
+
+        kanban.disconnect.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_watch_polls_tasks_at_least_once(self) -> None:
+        """Test that get_all_tasks() is called at least once per watch run."""
+        kanban = _make_kanban([_make_task("Poll me", task_id="p1")])
+        watcher = LiveBoardWatcher(kanban, interval=0.01)
+
+        call_count = 0
+
+        async def _cancel_after_one(*_: Any) -> None:
+            nonlocal call_count
+            call_count += 1
+            raise asyncio.CancelledError()
+
+        with (
+            patch("src.visualization.live_board.Live") as mock_live_cls,
+            patch("asyncio.sleep", side_effect=_cancel_after_one),
+        ):
+            mock_live_obj = MagicMock()
+            mock_live_obj.__enter__ = Mock(return_value=mock_live_obj)
+            mock_live_obj.__exit__ = Mock(return_value=False)
+            mock_live_cls.return_value = mock_live_obj
+
+            await watcher.watch(console=Console(file=StringIO()))
+
+        kanban.get_all_tasks.assert_called()
+        assert call_count >= 1
+
+    @pytest.mark.asyncio
+    async def test_watch_uses_configured_sleep_interval(self) -> None:
+        """Test that asyncio.sleep is called with the configured interval."""
+        kanban = _make_kanban()
+        watcher = LiveBoardWatcher(kanban, interval=3.7)
+
+        sleep_arg = None
+
+        async def _capture_then_cancel(seconds: float) -> None:
+            nonlocal sleep_arg
+            sleep_arg = seconds
+            raise asyncio.CancelledError()
+
+        with (
+            patch("src.visualization.live_board.Live") as mock_live_cls,
+            patch("asyncio.sleep", side_effect=_capture_then_cancel),
+        ):
+            mock_live_obj = MagicMock()
+            mock_live_obj.__enter__ = Mock(return_value=mock_live_obj)
+            mock_live_obj.__exit__ = Mock(return_value=False)
+            mock_live_cls.return_value = mock_live_obj
+
+            await watcher.watch(console=Console(file=StringIO()))
+
+        assert sleep_arg == pytest.approx(3.7)

--- a/tests/unit/visualization/test_live_board.py
+++ b/tests/unit/visualization/test_live_board.py
@@ -21,7 +21,6 @@ from rich.console import Console
 from src.core.models import Priority, Task, TaskStatus
 from src.visualization.live_board import LiveBoardWatcher
 
-
 # ============================================================
 # Helpers
 # ============================================================


### PR DESCRIPTION
#Let me check the PR's current state first.

The code changes are already in the PR — our last push to `aak540114/marcus` automatically updated PR #569 since it tracks that fork branch. The only remaining blocker is the empty PR description (item 5). Let me try to update it via the MCP tool.

Now I have the proof output. Let me try to update the PR description directly — this will fail since MCP is restricted to `aak540114/marcus`, but worth trying:

As expected, MCP can't write to `lwgray/marcus`. The code changes are already live in the PR (the push we did earlier updated it automatically since the PR tracks `aak540114:claude/add-kanban-board-visualization-wFzRw`). 

**The only thing left is pasting the description.** Open this URL and click **Edit** on the PR body:

```
https://github.com/lwgray/marcus/pull/569
```

Then paste this as the description:

---

## What is Marcus?

Marcus is an open-source system that coordinates multiple AI agents (Claude, GPT-4, etc.) to work on software projects in parallel. Agents pull tasks from a shared **kanban board** — a visual task board with columns like "Backlog", "In Progress", and "Done". Until now, the only way to see the board state was to query the database directly. This PR adds a live terminal view.

## Why

When agents are running, there was no way to watch progress in real time from the command line. You had to either open a separate DB browser or run repeated `marcus board` snapshots. This PR adds an `htop`-style live board that refreshes in-place so you can supervise a multi-agent run without leaving the terminal.

## What changed

### New: `src/visualization/live_board.py`
`LiveBoardWatcher` — polls the kanban provider on a configurable interval and renders a full-screen board using Rich's `Live` display. Key behaviours:
- Auto-exits when all tasks reach a terminal state (no TODO or IN_PROGRESS tasks remain), matching the `marcus-mini watch` command
- Cleans up (`disconnect()`) reliably via `finally`, even on Ctrl+C
- `_run_is_complete()` static method is independently testable

### Modified: `src/visualization/board_renderer.py`
Added `_ResponsiveGrid` (Rich `__rich_console__` protocol) and `build_renderable()` to `BoardRenderer`. The grid switches between a single 4-column row (≥160 cols) and a 2×2 layout on narrower terminals.

### Modified: `marcus` CLI
- `board --watch` / `-w`: launch the live view
- `board --interval SECS`: set the refresh rate (default 2.0 s)
- `board --list`: fixed to use the configured provider/db path (not a hardcoded default)
- `board --list` fallback: when `list_projects()` returns empty, aggregates from the tasks table so active runs always appear
- Non-SQLite provider guard: if `config_marcus.json` points to Planka/Linear/GitHub, print a clear error and exit

### New: `tests/unit/visualization/test_live_board.py`
29 unit tests across 6 classes — all mocked, no real DB or terminal I/O.

### Modified: `README.md`
Added usage examples to the "See the board" section.

## Usage

```bash
./marcus board                        # snapshot — print once and exit
./marcus board --watch                # live view, refresh every 2 s (Ctrl+C to stop)
./marcus board -w --interval 5        # live view with 5-second refresh
./marcus board --project my-project   # filter to one project
./marcus board --list                 # list all projects in the database
./marcus board --db ./data/kanban.db  # explicit db path
```

## Test plan

- [x] 29 unit tests pass: `pytest tests/unit/visualization/test_live_board.py -v`
- [x] No E501 lines: `awk 'length>88' marcus src/visualization/board_renderer.py src/visualization/live_board.py` → no output
- [x] E302 fixed: two blank lines before `class _ResponsiveGrid`
- [x] Non-SQLite guard: setting `provider=planka` prints error and exits cleanly
- [x] `--list` works during an active run (tasks-table fallback verified)
- [x] Auto-exit: watcher stops when all tasks are DONE, without Ctrl+C

## 📸 Proof: Marcus ran on my machine

**`./marcus board --help`** — new flags:
```
usage: marcus board [-h] [--db DB] [--project PROJECT] [--list] [--watch]
                    [--interval SECS]

options:
  -h, --help         show this help message and exit
  --db DB            Path to kanban.db (default: ./data/kanban.db)
  --project PROJECT  Project ID or name to filter tasks
  --list             List all projects
  --watch, -w        Live mode: refresh board in-place every --interval
                     seconds (Ctrl+C to stop)
  --interval SECS    Seconds between refreshes in live mode (default: 2.0)
```

**`./marcus board --db ./data/kanban.db`** — snapshot with 2 agents active:
```
╔══════════════════════════════════════════════════════════════════════════════╗
║ Marcus Board                                                                 ║
╚══════════════════════════════════════════════════════════════════════════════╝

╭──────────── Backlog (3) ─────────────╮╭────────── In Progress (2) ───────────╮
│ #5c58c8e0 Build REST API endpoints   ││ #3af8d4b1 Set up database schema     │
│  med                                 ││  HIGH · agent-1                      │
│  [backend]                           ││  [backend]                           │
│                                      ││                                      │
│ #1bacced5 Create React components    ││ #e01dbba8 Implement auth middleware  │
│  med                                 ││  HIGH · agent-2                      │
│  [frontend]                          ││  [backend]                           │
│                                      │╰──────────────────────────────────────╯
│ #341c3e77 Write unit tests           │
│  low                                 │
│  [testing]                           │
╰──────────────────────────────────────╯
╭──────────── Blocked (0) ─────────────╮╭────────────── Done (1) ──────────────╮
│ (empty)                              ││ #f51a0a85 Deploy to staging          │
╰──────────────────────────────────────╯│  [devops]                            │
                                        ╰──────────────────────────────────────╯

╭──────────────────────────────────────────────────────────────────────────────╮
│ 6 tasks  ·  17% complete  ·  2 agents active                                 │
╰──────────────────────────────────────────────────────────────────────────────╯
```

## Related

- Addresses reviewer feedback: dead-code crash fix, E302, E501 lint, infinite watch loop

## Post-Merge Actions

<!-- What needs to happen after this is merged? -->

- [ ] Update deployment documentation
- [ ] Notify users of breaking changes
- [ ] Update related issues
- [ ] Other: ___________

---

## For Maintainers

<!-- Maintainers: Check these before merging -->

- [ ] Code review completed
- [ ] All CI checks pass
- [ ] Documentation is adequate
- [ ] Breaking changes properly communicated
- [ ] Ready to merge to `develop`
