### PR TITLE
chore: drop 13 unused LFS assets to shrink clone size

### DIFF
--- a/demo/The_AI_Shared_State.pdf
+++ b/demo/The_AI_Shared_State.pdf
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4b5cd8136be34df2e87a16251ffc31fc302f731a09b6a16be125ce1970f5551f
-size 17109358

--- a/demo/marcus_cato_verbatim_final.pdf
+++ b/demo/marcus_cato_verbatim_final.pdf
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6109fb426a942277c0e53eaf070d48ed0a6ae6d30cf849bc8d542a2f46c7095d
-size 331739

--- a/docs/assets/build_command.mp4
+++ b/docs/assets/build_command.mp4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e039e0d54c2466c742624bce3ef35d4bdfbfdc22382926fa0cc5fb88abec6f9c
-size 1689420

--- a/docs/assets/experiment-flows.pdf
+++ b/docs/assets/experiment-flows.pdf
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8533f8a3f81669f79a4c8975650c7e0cc487d761049e68cffeac5e1343128840
-size 394176

--- a/docs/assets/platform-architecture.pdf
+++ b/docs/assets/platform-architecture.pdf
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:036a592b814f8d560cfeed8e63e209cde1d0786373bb529719cdbab74c3d476b
-size 280598

--- a/docs/assets/platform-relationships.pdf
+++ b/docs/assets/platform-relationships.pdf
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9b549a6ae593ee1828703f86a14db27f169d193356d19e4a9f2bd0f5430a9e94
-size 76467

--- a/docs/assets/product.mp4
+++ b/docs/assets/product.mp4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b7ad81de276c44f93763538d82e2d6caeb6abdebebe8718a96b31f19b34c8c1b
-size 161656

--- a/docs/assets/swim_lanes.mp4
+++ b/docs/assets/swim_lanes.mp4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d6edd22cebae6b9a7640e1818dae5cdc1a09d7b54e3c7aa464c1574ded3bb515
-size 1214612

--- a/docs/assets/tmux.mp4
+++ b/docs/assets/tmux.mp4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:156b1cb9839a76c6137bf26bee3d37c094cb1e31db0be3d9fe4f046c59707ead
-size 1659575

--- a/docs/sprints/experiment-flows.pdf
+++ b/docs/sprints/experiment-flows.pdf
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8267ba3aa3a3824c0c3cf1d1e9ea4897fad2f05402d373bc98d18f5b55d8ed56
-size 396634

--- a/docs/sprints/platform-architecture.pdf
+++ b/docs/sprints/platform-architecture.pdf
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:39d3455ebe51a238d6df764971505808fc76f39b2f9cc932ec1c01f446ff4702
-size 282391

--- a/docs/sprints/platform-relationships.pdf
+++ b/docs/sprints/platform-relationships.pdf
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f93271037ff5a7991fdb0032673055e648b81f461e068d0f9352aace1ce6004b
-size 77466

--- a/docs/sprints/pycon-2026-menu-card.pdf
+++ b/docs/sprints/pycon-2026-menu-card.pdf
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9199086b2a54ebcb49c1f41099bf56e3f5c0ba216e2cd88146004797de14b0aa
-size 408097


### PR DESCRIPTION
## What is this, briefly

Marcus is a system that coordinates multiple AI coding agents. This PR is housekeeping — it removes documentation media files that nothing references, to shrink what every `git clone` has to download. No product code is touched.

## Why

The repository stores large binary media (videos, PDFs, images) using **Git LFS** (Large File Storage) — a git extension that keeps big files outside the normal commit history and downloads them on demand.

A fresh `git clone` of Marcus currently pulls **~45 MB of LFS content**. When the 21 LFS files were audited against the codebase, **13 of them (~24 MB) are referenced nowhere** — not in `README.md`, and not in any rendered documentation (`.rst`, `.md`, `.py`, `.html`, `.css`). They are simply dead weight that every contributor downloads.

The single largest is `demo/The_AI_Shared_State.pdf` at **17 MB** — it appears only in `demo/CORRECTIONS_NEEDED.md`, a working-notes file, never in displayed docs.

## How removing them helps (the LFS mechanic)

This is the key point. `git clone` only downloads the LFS objects referenced by the **commit it checks out** (the default branch tip) — not all of history. So removing these files from the default branch means a fresh clone **no longer downloads them**, with **no history rewrite**:

| | Before | After |
|---|--------|-------|
| LFS pulled on a fresh clone | ~45 MB | ~21 MB |
| `.git` size after clone | ~91 MB | ~67 MB |

The LFS objects remain in history (reachable from older commits) and in GitHub's LFS storage. Existing clones, forks, and open PRs are unaffected — nothing breaks.

## What changed

`git rm` on these 13 LFS files (each is removed as a tiny ~130-byte LFS *pointer* — the regular git history barely changes):

- `demo/The_AI_Shared_State.pdf` (17 MB)
- `demo/marcus_cato_verbatim_final.pdf`
- `docs/assets/build_command.mp4`
- `docs/assets/tmux.mp4`
- `docs/assets/swim_lanes.mp4`
- `docs/assets/product.mp4`
- `docs/assets/experiment-flows.pdf` and `docs/sprints/experiment-flows.pdf`
- `docs/assets/platform-architecture.pdf` and `docs/sprints/platform-architecture.pdf`
- `docs/assets/platform-relationships.pdf` and `docs/sprints/platform-relationships.pdf`
- `docs/sprints/pycon-2026-menu-card.pdf`

## Glossary

| Term | Meaning |
|------|---------|
| Git LFS | Git extension that stores large files outside normal history, fetched on demand |
| LFS pointer | The tiny text stub committed in place of a large file; the real bytes live in LFS storage |
| smudge | The step on checkout where git swaps an LFS pointer for the real file contents |

## How to verify

1. `git lfs ls-files` no longer lists the 13 files above.
2. `grep -rn build_command.mp4 README.md docs/` (and the same for the others) returns nothing — confirming they were unreferenced.
3. The 8 LFS files still in use (`cato_demo.mp4`, `frontpage.png`, `logo.png`, `modes.png`, `stack.png`, `tasks.png`, plus 2 docs `_static` images) are untouched — README still renders.

## Test plan

- [ ] `git lfs ls-files` shows 8 files, not 21
- [ ] README.md still renders all its images/video
- [ ] No product code touched — CI unaffected
- [ ] This PR targets the `develop` branch

## Notes / follow-up

- `demo/CORRECTIONS_NEEDED.md` still mentions the two removed demo PDFs by name. It is a working-notes file, not rendered docs, so no link breaks — but those mentions are now stale and could be cleaned up separately.
- Two files in the "unreferenced" set live in a Sphinx `_static` folder and were **kept**, not removed, because Sphinx can use `_static` images via `conf.py` without a text reference.

## Related

- Sibling PR #575 — gitignore build caches and untrack `mlruns/` (the other half of the repo-size cleanup).
