### PR TITLE
Bug: Audit log missing duration_ms for request_next_task — no perform…

### DIFF
--- a/src/marcus_mcp/audit.py
+++ b/src/marcus_mcp/audit.py
@@ -118,18 +118,22 @@ class AuditLogger:
         duration_ms: float,
         success: bool = True,
         error: Optional[str] = None,
+        task_count: Optional[int] = None,
     ) -> None:
         """Log a tool call event."""
+        details: Dict[str, Any] = {
+            "arguments": arguments,
+            "result": result if success else None,
+            "duration_ms": duration_ms,
+        }
+        if task_count is not None:
+            details["task_count"] = task_count
         await self.log_event(
             event_type="tool_call",
             client_id=client_id,
             client_type=client_type,
             tool_name=tool_name,
-            details={
-                "arguments": arguments,
-                "result": result if success else None,
-                "duration_ms": duration_ms,
-            },
+            details=details,
             success=success,
             error=error,
         )
@@ -140,12 +144,13 @@ class AuditLogger:
         client_type: Optional[str],
         tool_name: str,
         reason: str,
-        duration_ms: Optional[float] = None,
+        duration_ms: float,
+        task_count: Optional[int] = None,
     ) -> None:
         """Log an access denied event."""
-        details: Dict[str, Any] = {"reason": reason}
-        if duration_ms is not None:
-            details["duration_ms"] = duration_ms
+        details: Dict[str, Any] = {"reason": reason, "duration_ms": duration_ms}
+        if task_count is not None:
+            details["task_count"] = task_count
         await self.log_event(
             event_type="access_denied",
             client_id=client_id,

--- a/src/marcus_mcp/handlers.py
+++ b/src/marcus_mcp/handlers.py
@@ -97,6 +97,18 @@ from .tools.scheduling import (  # Scheduling tools
 logger = logging.getLogger(__name__)
 
 
+def _audit_task_count(tool_name: str, state: Any) -> Optional[int]:
+    """Return request_next_task board size for audit logging."""
+    if tool_name != "request_next_task" or not hasattr(state, "project_tasks"):
+        return None
+
+    project_tasks = state.project_tasks
+    if project_tasks is None:
+        return None
+
+    return len(project_tasks)
+
+
 def get_all_tool_definitions() -> Dict[str, types.Tool]:
     """
     Get all tool definitions as a mapping.
@@ -1124,6 +1136,7 @@ async def handle_tool_call(
     if name not in allowed_tools and "*" not in allowed_tools:
         # Audit access denied
         duration_ms = (time.time() - start_time) * 1000
+        _task_count = _audit_task_count(name, state)
         await audit_logger.log_access_denied(
             client_id=client_id,
             client_type=client_type,
@@ -1133,6 +1146,7 @@ async def handle_tool_call(
                 f"'{client_type or 'unregistered'}'"
             ),
             duration_ms=duration_ms,
+            task_count=_task_count,
         )
 
         return [
@@ -1644,6 +1658,7 @@ async def handle_tool_call(
 
         # Audit successful tool call
         duration_ms = (time.time() - start_time) * 1000
+        _task_count = _audit_task_count(name, state)
         await audit_logger.log_tool_call(
             client_id=client_id,
             client_type=client_type,
@@ -1652,6 +1667,7 @@ async def handle_tool_call(
             result=result,
             duration_ms=duration_ms,
             success=True,
+            task_count=_task_count,
         )
 
         return response
@@ -1659,6 +1675,7 @@ async def handle_tool_call(
     except Exception as e:
         # Audit failed tool call
         duration_ms = (time.time() - start_time) * 1000
+        _task_count = _audit_task_count(name, state)
         await audit_logger.log_tool_call(
             client_id=client_id,
             client_type=client_type,
@@ -1668,6 +1685,7 @@ async def handle_tool_call(
             duration_ms=duration_ms,
             success=False,
             error=str(e),
+            task_count=_task_count,
         )
 
         error_response: List[

--- a/src/marcus_mcp/server.py
+++ b/src/marcus_mcp/server.py
@@ -391,6 +391,25 @@ class MarcusServer:
         signal.signal(signal.SIGINT, signal_handler)
         signal.signal(signal.SIGTERM, signal_handler)
 
+    async def _call_tool_via_handler_as_dict(
+        self, name: str, arguments: Dict[str, Any]
+    ) -> Dict[str, Any]:
+        """Route a tool through the audited handler and decode the JSON result."""
+        response = await handle_tool_call(name, arguments, self)
+        if not response:
+            return {"error": "Empty response from tool handler"}
+
+        first_item = response[0]
+        if not isinstance(first_item, types.TextContent):
+            return {"error": f"Unsupported response type: {type(first_item).__name__}"}
+
+        try:
+            parsed = json.loads(first_item.text)
+        except json.JSONDecodeError:
+            return {"error": "Invalid JSON response format"}
+
+        return parsed if isinstance(parsed, dict) else {"result": parsed}
+
     def _sync_cleanup(self) -> None:
         """Clean up resources synchronously when event loop is not available."""
         if self._cleanup_done:
@@ -1272,10 +1291,9 @@ class MarcusServer:
         @self._fastmcp.tool()  # type: ignore[misc]
         async def request_next_task(agent_id: str) -> Dict[str, Any]:
             """Request the next optimal task assignment for an agent."""
-            from .tools.task import request_next_task as impl
-
-            result = await impl(agent_id=agent_id, state=server)
-            return result  # type: ignore[no-any-return]
+            return await server._call_tool_via_handler_as_dict(
+                "request_next_task", {"agent_id": agent_id}
+            )
 
         @self._fastmcp.tool()  # type: ignore[misc]
         async def report_task_progress(
@@ -1464,13 +1482,8 @@ class MarcusServer:
                 """Request the next optimal task assignment for an agent."""
                 from src.logging.mcp_tool_logger import log_mcp_tool_response
 
-                from .tools.task import request_next_task as impl
-
-                result = await impl(agent_id=agent_id, state=server)
-                final_result = (
-                    dict(result)
-                    if isinstance(result, dict)
-                    else {"error": "Invalid response format"}
+                final_result = await server._call_tool_via_handler_as_dict(
+                    "request_next_task", {"agent_id": agent_id}
                 )
 
                 # Log MCP tool response

--- a/tests/unit/marcus_mcp/test_audit.py
+++ b/tests/unit/marcus_mcp/test_audit.py
@@ -1,0 +1,174 @@
+"""
+Unit tests for src/marcus_mcp/audit.py
+"""
+
+import json
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, mock_open, patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent.parent))
+
+from src.marcus_mcp.audit import AuditLogger
+
+
+@pytest.fixture
+def logger(tmp_path: Path) -> AuditLogger:
+    """Create an AuditLogger writing to a temp directory."""
+    return AuditLogger(log_dir=tmp_path)
+
+
+class TestLogAccessDenied:
+    """Test suite for AuditLogger.log_access_denied"""
+
+    @pytest.fixture
+    def logger(self, tmp_path: Path) -> AuditLogger:
+        """Create an AuditLogger writing to a temp directory."""
+        return AuditLogger(log_dir=tmp_path)
+
+    @pytest.mark.asyncio
+    async def test_access_denied_entry_contains_numeric_duration_ms(
+        self, logger: AuditLogger
+    ) -> None:
+        """Audit entry written by log_access_denied must include a numeric duration_ms field."""
+        # Arrange
+        captured: list[str] = []
+
+        original_log_event = logger.log_event
+
+        async def capturing_log_event(**kwargs):  # type: ignore[override]
+            captured.append(json.dumps(kwargs.get("details", {})))
+            await original_log_event(**kwargs)
+
+        logger.log_event = capturing_log_event  # type: ignore[method-assign]
+
+        # Act
+        await logger.log_access_denied(
+            client_id="agent-1",
+            client_type="agent",
+            tool_name="get_next_task",
+            reason="insufficient permissions",
+            duration_ms=42.5,
+        )
+
+        # Assert
+        assert len(captured) == 1
+        details = json.loads(captured[0])
+        assert "duration_ms" in details, "duration_ms missing from audit details"
+        assert isinstance(
+            details["duration_ms"], (int, float)
+        ), f"duration_ms must be numeric, got {type(details['duration_ms'])}"
+        assert details["duration_ms"] == 42.5
+
+    @pytest.mark.asyncio
+    async def test_access_denied_writes_duration_ms_to_log_file(
+        self, logger: AuditLogger
+    ) -> None:
+        """duration_ms appears in the JSONL file written to disk."""
+        # Act
+        await logger.log_access_denied(
+            client_id="agent-2",
+            client_type="agent",
+            tool_name="assign_next_task",
+            reason="role not allowed",
+            duration_ms=7.0,
+        )
+
+        # Assert
+        log_files = list(logger.log_dir.glob("audit_*.jsonl"))
+        assert log_files, "No audit log file was created"
+
+        line = log_files[0].read_text().strip()
+        event = json.loads(line)
+        assert event["details"]["duration_ms"] == 7.0
+        assert isinstance(event["details"]["duration_ms"], (int, float))
+
+    @pytest.mark.asyncio
+    async def test_access_denied_includes_task_count_when_provided(
+        self, logger: AuditLogger
+    ) -> None:
+        """task_count appears in the audit entry when passed to log_access_denied."""
+        # Act
+        await logger.log_access_denied(
+            client_id="agent-3",
+            client_type="agent",
+            tool_name="request_next_task",
+            reason="role not allowed",
+            duration_ms=5.0,
+            task_count=17,
+        )
+
+        # Assert
+        log_files = list(logger.log_dir.glob("audit_*.jsonl"))
+        event = json.loads(log_files[0].read_text().strip())
+        assert event["details"]["task_count"] == 17
+        assert isinstance(event["details"]["task_count"], int)
+
+    @pytest.mark.asyncio
+    async def test_access_denied_omits_task_count_when_not_provided(
+        self, logger: AuditLogger
+    ) -> None:
+        """task_count is absent from the audit entry when not passed."""
+        # Act
+        await logger.log_access_denied(
+            client_id="agent-4",
+            client_type="agent",
+            tool_name="get_project_status",
+            reason="role not allowed",
+            duration_ms=3.0,
+        )
+
+        # Assert
+        log_files = list(logger.log_dir.glob("audit_*.jsonl"))
+        event = json.loads(log_files[0].read_text().strip())
+        assert "task_count" not in event["details"]
+
+
+class TestLogToolCall:
+    """Test suite for AuditLogger.log_tool_call"""
+
+    @pytest.mark.asyncio
+    async def test_tool_call_includes_task_count_when_provided(
+        self, logger: AuditLogger
+    ) -> None:
+        """task_count appears in the audit entry when passed to log_tool_call."""
+        # Act
+        await logger.log_tool_call(
+            client_id="agent-1",
+            client_type="agent",
+            tool_name="request_next_task",
+            arguments={"agent_id": "agent-1"},
+            result={"success": True},
+            duration_ms=120.0,
+            success=True,
+            task_count=42,
+        )
+
+        # Assert
+        log_files = list(logger.log_dir.glob("audit_*.jsonl"))
+        event = json.loads(log_files[0].read_text().strip())
+        assert event["details"]["task_count"] == 42
+        assert isinstance(event["details"]["task_count"], int)
+
+    @pytest.mark.asyncio
+    async def test_tool_call_omits_task_count_when_not_provided(
+        self, logger: AuditLogger
+    ) -> None:
+        """task_count is absent from non-request_next_task audit entries."""
+        # Act
+        await logger.log_tool_call(
+            client_id="agent-1",
+            client_type="agent",
+            tool_name="get_project_status",
+            arguments={},
+            result={"status": "ok"},
+            duration_ms=10.0,
+            success=True,
+        )
+
+        # Assert
+        log_files = list(logger.log_dir.glob("audit_*.jsonl"))
+        event = json.loads(log_files[0].read_text().strip())
+        assert "task_count" not in event["details"]

--- a/tests/unit/mcp/test_marcus_server_complete.py
+++ b/tests/unit/mcp/test_marcus_server_complete.py
@@ -45,8 +45,12 @@ async def create_test_server() -> MarcusServer:
     os.environ["GITHUB_OWNER"] = "test-owner"
     os.environ["GITHUB_REPO"] = "test-repo"
     os.environ["MARCUS_TEST_MODE"] = "true"
+    os.environ["CLAUDE_API_KEY"] = "test-key"
 
-    with patch("src.core.context.Context._load_persisted_data"):
+    with (
+        patch("src.core.context.Context._load_persisted_data"),
+        patch("src.cost_tracking.cost_store.CostStore.load_seed_prices"),
+    ):
         server = MarcusServer()
 
     # Mock the kanban client
@@ -72,8 +76,12 @@ async def test_server_initialization():
     """Test server initializes correctly"""
     os.environ["KANBAN_PROVIDER"] = "planka"
     os.environ["MARCUS_TEST_MODE"] = "true"
+    os.environ["CLAUDE_API_KEY"] = "test-key"
 
-    with patch("src.core.context.Context._load_persisted_data"):
+    with (
+        patch("src.core.context.Context._load_persisted_data"),
+        patch("src.cost_tracking.cost_store.CostStore.load_seed_prices"),
+    ):
         server = MarcusServer()
 
     # Provider comes from config_marcus.json — assert it matches config
@@ -287,6 +295,86 @@ async def test_request_next_task_no_tasks():
     else:
         assert "message" in data
         assert "no suitable tasks" in data["message"].lower()
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("anyio_backend", ["asyncio"])
+async def test_request_next_task_audit_logs_zero_task_count_on_success():
+    """request_next_task audits task_count=0 when the board is empty."""
+    server = await create_test_server()
+    server.project_tasks = []
+    server._current_client_id = "test-client-006"
+    server._registered_clients = {
+        "test-client-006": {"client_type": "agent", "role": "developer"}
+    }
+
+    audit_logger = AsyncMock()
+
+    with (
+        patch("src.marcus_mcp.handlers.get_audit_logger", return_value=audit_logger),
+        patch(
+            "src.marcus_mcp.handlers.request_next_task",
+            AsyncMock(return_value={"success": True, "task": None}),
+        ),
+    ):
+        result = await handle_tool_call(
+            "request_next_task", {"agent_id": "test-001"}, server
+        )
+
+    data = json.loads(get_text_content(result[0]))
+    assert data == {"success": True, "task": None}
+    audit_logger.log_tool_call.assert_awaited_once()
+    assert audit_logger.log_tool_call.await_args.kwargs["task_count"] == 0
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("anyio_backend", ["asyncio"])
+async def test_request_next_task_access_denied_audit_logs_zero_task_count():
+    """Denied request_next_task audits task_count=0 when the board is empty."""
+    server = await create_test_server()
+    server.project_tasks = []
+
+    audit_logger = AsyncMock()
+
+    with patch("src.marcus_mcp.handlers.get_audit_logger", return_value=audit_logger):
+        result = await handle_tool_call(
+            "request_next_task", {"agent_id": "test-001"}, server
+        )
+
+    data = json.loads(get_text_content(result[0]))
+    assert "Access denied" in data["error"]
+    audit_logger.log_access_denied.assert_awaited_once()
+    assert audit_logger.log_access_denied.await_args.kwargs["task_count"] == 0
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("anyio_backend", ["asyncio"])
+async def test_fastmcp_request_next_task_delegates_through_handle_tool_call():
+    """FastMCP request_next_task should use the audited handler path."""
+    server = await create_test_server()
+    fastmcp = server._create_fastmcp()
+    tool_manager = fastmcp._tool_manager
+
+    expected = {"success": True, "task": None}
+    tool_response = [
+        types.TextContent(type="text", text=json.dumps(expected, indent=2))
+    ]
+
+    with (
+        patch(
+            "src.marcus_mcp.server.handle_tool_call",
+            AsyncMock(return_value=tool_response),
+        ) as mock_handle_tool_call,
+        patch("src.logging.mcp_tool_logger.log_mcp_tool_response"),
+    ):
+        result = await tool_manager.call_tool(
+            "request_next_task", {"agent_id": "test-001"}
+        )
+
+    assert result == expected
+    mock_handle_tool_call.assert_awaited_once_with(
+        "request_next_task", {"agent_id": "test-001"}, server
+    )
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
# Pull Request

> **PyCon 2026 Sprint contributor?** Welcome! Fill this out and a maintainer will review within the sprint day.

## Description

This PR closes the remaining gaps in the request_next_task audit logging work for issue #228. It adds regression tests first, then fixes the two missing behaviors: audit entries now record task_count=0 when the board is empty instead of omitting the field, and the FastMCP/HTTP request_next_task path now routes through the same audited handler used by the stdio server so duration_ms and task_count are captured consistently across transports.

**What does this PR do?**

It adds regression coverage for request_next_task audit behavior, fixes audit task counting so empty boards log task_count=0, and routes FastMCP request_next_task calls through handle_tool_call so HTTP/FastMCP requests use the same audit wrapper as stdio.

**Why is this change needed?**

Before this change, the acceptance criteria for #228 were only partially met: task_count was dropped when the board was empty, and the FastMCP/HTTP request_next_task path bypassed the audit wrapper entirely. That meant duration_ms and task-count telemetry were not reliably recorded on all supported request paths.

**Related Issue(s):**

Fixes #(issue number)

- Added regression tests covering request_next_task audit logging for task_count=0 on both success and access-denied paths.
- Added a regression test proving FastMCP request_next_task delegates through handle_tool_call instead of calling the tool implementation directly.
- Updated audit task-count handling to preserve 0 for empty boards and routed FastMCP/HTTP request_next_task through the audited handler path.

---

## 📸 Proof: Marcus ran on my machine

<!--
REQUIRED for code PRs. Exempt for docs-only changes (typos, rewording, .rst edits).

Run `./marcus start` then `./marcus status` in your terminal.
Paste a screenshot of the output here.

PRs without this section filled in will not be reviewed.
-->

_Replace this line with your screenshot or terminal output._

---

## Type of Change

<!-- Check all that apply -->

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ ] ♻️ Code refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test updates or additions
- [ ] 🔧 Configuration/build changes

## Branch Information

<!-- Verify your branch setup -->

- [x] This PR targets the `develop` branch (not `main`)
- [x] My branch is up-to-date with `upstream/develop`
- [ ] I'm working in my fork's feature branch
- [x] I've synced with upstream to avoid conflicts

## Changes Made

<!-- Provide a bullet-point list of key changes -->

-
-
-

## Testing

<!-- Describe how you tested your changes -->

**Unit Tests:**

- [ ] All existing tests pass (`pytest`)
- [ ] I have added tests for my changes
- [ ] Test coverage is ≥80% for new code

**Integration Tests:**

- [ ] Integration tests pass (if applicable)
- [ ] I have tested with external services (Planka/GitHub/etc.) if applicable

**Manual Testing:**

Describe what manual testing you performed:

-
-

**Test Environment:**

- OS: [e.g., macOS 13, Ubuntu 22.04]
- Python Version: [e.g., 3.11.5]
- Running via: [Docker / Local Python]

## Code Quality

<!-- Verify all quality checks pass -->

- [x] All pre-commit hooks pass (`pre-commit run --all-files`)
- [ ] MyPy type checking passes (`mypy src/`)
- [ ] Code is formatted with Black (`black src/`)
- [ ] Imports are organized with isort (`isort src/`)
- [ ] Ruff linting passes (`ruff check src/`)
- [ ] No secrets detected (`detect-secrets scan`)
- [ ] My code follows the project's style guidelines

## Documentation

<!-- Verify documentation is updated -->

- [ ] I have updated relevant documentation in `docs/`
- [ ] I have added NumPy-style docstrings to new functions/classes
- [ ] I have updated CHANGELOG.md (if user-facing change)
- [ ] Code comments explain complex logic or decisions
- [ ] README.md updated (if needed)

## Privacy / Telemetry

<!--
Only relevant if the PR touches:
  - `docs/telemetry.md`
  - Anything under `src/telemetry/`
  - Any code that adds, removes, or changes a field that the
    disclosure document promises to (or not to) collect.

Skip this section entirely for PRs that do not touch any of the
above.
-->

- [ ] Every field listed in `docs/telemetry.md` § *What we collect*
      has a writer in the codebase that actually populates it by
      the time this PR merges (no "we collect this" promises
      without code that ships the data).
- [ ] Every field NOT in `docs/telemetry.md` § *What we collect*
      is verifiably not shipped (no code paths add it to a
      telemetry event).
- [ ] Any `print` / `sys.stdout.write` added to a telemetry code
      path is justified — Marcus's MCP stdio mode reserves stdout
      for JSON-RPC, and any non-protocol bytes corrupt the channel.
      Default: write to stderr or a log file.
- [ ] If a new event type, new field, or new dimension is added,
      `docs/telemetry.md` is updated in the same PR.

**Documentation Changes:**

<!-- List what documentation was updated -->

-
-

## Backwards Compatibility

<!-- For breaking changes or deprecations -->

- [ ] This change maintains backwards compatibility
- [ ] This change includes breaking changes (described below)
- [ ] This change follows the deprecation process (if applicable)

**Breaking Changes** (if any):


**Migration Guide** (if needed):


## Screenshots / Demos

<!-- For UI changes or new features, include screenshots or GIFs -->

**Before:**


**After:**


## Performance Impact

<!-- Describe any performance implications -->

- [ ] No performance impact
- [ ] Performance improved
- [ ] Potential performance impact (described below)

**Performance Notes:**


## Dependencies

<!-- List any new dependencies or version changes -->

- [x] No new dependencies added
- [ ] New dependencies added (listed below)

**New Dependencies:**


## Checklist

<!-- Final verification before submitting -->

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) guide
- [ ] My code follows the project's code style
- [ ] I have performed a self-review of my code
- [ ] I have commented complex code, particularly hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Additional Notes

<!-- Any additional information for reviewers -->

**Reviewer Focus Areas:**

<!-- What should reviewers pay special attention to? -->

-
-

**Open Questions:**

<!-- Any uncertainties or decisions you'd like input on? -->

-
-

## Post-Merge Actions

<!-- What needs to happen after this is merged? -->

- [ ] Update deployment documentation
- [ ] Notify users of breaking changes
- [ ] Update related issues
- [ ] Other: ___________

---

## For Maintainers

<!-- Maintainers: Check these before merging -->

- [ ] Code review completed
- [ ] All CI checks pass
- [ ] Documentation is adequate
- [ ] Breaking changes properly communicated
- [ ] Ready to merge to `develop`
