### PR TITLE
fix(experiments): unbreak `--init` and sanitize tmux session names

### DIFF
--- a/dev-tools/experiments/runners/run_experiment.py
+++ b/dev-tools/experiments/runners/run_experiment.py
@@ -89,8 +89,10 @@ They will accept and complete tasks regardless of their listed skill preferences
     # causes worktrees to branch from the wrong repo.
     stale_git = experiment_dir / ".git"
     if stale_git.exists() and stale_git.is_dir():
-        import shutil
-
+        # ``shutil`` is already imported at module scope (line 10);
+        # re-importing here would make Python treat the name as local
+        # across the whole function and raise ``UnboundLocalError`` on
+        # the earlier ``shutil.copy`` call.
         shutil.rmtree(stale_git)
         print("✓ Removed stale .git at experiment root")
 

--- a/dev-tools/experiments/runners/spawn_agents.py
+++ b/dev-tools/experiments/runners/spawn_agents.py
@@ -8,6 +8,7 @@ All agents work on the main branch in the experiment's implementation directory.
 
 import json
 import os
+import re
 import subprocess  # nosec B404
 import sys
 import time
@@ -499,9 +500,19 @@ class AgentSpawner:
         # old name.  TODO: remove once nothing reads it externally.
         self.claude_model_flag: str = self.model_flag
         self.processes: List[subprocess.Popen[bytes]] = []
-        self.tmux_session = (
-            f"marcus_{self.config.project_name.lower().replace(' ', '_')}"
-        )
+        # tmux uses ``:`` as the session/window separator and ``.``
+        # as the window/pane separator, so any of those characters in
+        # the session name turn every later ``tmux`` call into a parse
+        # error (``no such window: marcus_foo:_bar``). Strip every
+        # character that is not safe for a tmux target identifier —
+        # keep ASCII letters, digits, underscore, and hyphen — and
+        # collapse runs of unsafe chars into a single underscore.
+        safe_name = re.sub(
+            r"[^A-Za-z0-9_-]+",
+            "_",
+            self.config.project_name.lower(),
+        ).strip("_")
+        self.tmux_session = f"marcus_{safe_name or 'experiment'}"
         self.panes_per_window = 2
         self.current_window = 0
         self.current_pane = 0

--- a/tests/unit/experiments/test_run_experiment.py
+++ b/tests/unit/experiments/test_run_experiment.py
@@ -1,0 +1,94 @@
+"""
+Unit tests for ``dev-tools/experiments/runners/run_experiment.py``.
+
+The runner script is loaded via importlib because ``dev-tools`` uses
+hyphens and is not importable as a normal package — same pattern the
+sibling ``test_spawn_agents.py`` uses.
+"""
+
+import importlib.util
+import subprocess
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+_RUN_EXPERIMENT_PATH = (
+    Path(__file__).parent.parent.parent.parent
+    / "dev-tools"
+    / "experiments"
+    / "runners"
+    / "run_experiment.py"
+)
+_spec = importlib.util.spec_from_file_location("run_experiment", _RUN_EXPERIMENT_PATH)
+assert _spec is not None and _spec.loader is not None
+run_experiment = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(run_experiment)
+
+
+class TestCreateExperimentStructureShutilShadowing:
+    """``create_experiment_structure`` must not shadow module-level shutil.
+
+    Python's scoping rule treats any name assigned in a function
+    (including via ``import``) as local for the entire function. A
+    previous version of the runner had ``import shutil`` inside a
+    conditional block, which made the earlier ``shutil.copy`` call at
+    the top of the same function raise ``UnboundLocalError`` whenever
+    the function executed at all — fully breaking ``--init`` mode.
+
+    Regression: when a stale ``.git`` exists at the experiment root,
+    the function must clean it up using the module-level ``shutil`` and
+    keep going, not crash before getting there.
+    """
+
+    def test_init_succeeds_when_stale_git_present(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """A pre-existing ``.git`` at the experiment root does not crash --init.
+
+        Builds an experiment directory containing a stale ``.git`` so
+        the function's cleanup branch fires, supplies a templates dir
+        with the bundled config, and stubs the ``git`` / ``claude``
+        subprocess calls because they would otherwise reach out to
+        external binaries the CI runner may not have.
+        """
+        # Arrange — stale .git that must be removed by shutil.rmtree.
+        experiment_dir = tmp_path / "experiment"
+        experiment_dir.mkdir()
+        stale_git = experiment_dir / ".git"
+        stale_git.mkdir()
+        (stale_git / "HEAD").write_text("ref: refs/heads/main\n")
+
+        # Templates dir with a minimal config.yaml.template the function
+        # copies in.
+        templates_dir = tmp_path / "templates"
+        templates_dir.mkdir()
+        (templates_dir / "config.yaml.template").write_text(
+            "project_name: 'test'\nagents: []\n"
+        )
+
+        # Stub subprocess.run so ``git init`` / ``claude mcp list`` are
+        # no-ops on hosts that lack those binaries.
+        with patch.object(
+            (
+                run_experiment.subprocess
+                if hasattr(run_experiment, "subprocess")
+                else subprocess
+            ),
+            "run",
+            return_value=type("R", (), {"returncode": 0, "stdout": "marcus"})(),
+        ):
+            # Act — must not raise UnboundLocalError on shutil.
+            run_experiment.create_experiment_structure(experiment_dir, templates_dir)
+
+        # Assert — stale .git was actually removed and the templated
+        # config.yaml landed in place.
+        assert not stale_git.exists(), "Stale .git should have been rmtree'd"
+        assert (
+            experiment_dir / "config.yaml"
+        ).exists(), "config.yaml should have been copied from the template"

--- a/tests/unit/experiments/test_spawn_agents.py
+++ b/tests/unit/experiments/test_spawn_agents.py
@@ -2270,3 +2270,74 @@ class TestHarnessPreflight:
         # parent-PATH-only false-negative is already ruled out.
         assert "parent PATH" in out
         assert "~/.zshrc" in out
+
+
+# ---------------------------------------------------------------------------
+# Tmux session name sanitization
+# ---------------------------------------------------------------------------
+
+
+class TestTmuxSessionNameSanitization:
+    """``AgentSpawner.__init__`` builds ``tmux_session`` from project_name.
+
+    tmux uses ``:`` as the session/window separator and ``.`` as the
+    window/pane separator, so any of those characters in the session
+    name turn every subsequent ``tmux`` call into a parse error
+    (``no such window: marcus_foo:_bar``). The constructor must strip
+    every character that is not safe for a tmux target identifier —
+    ASCII letters, digits, underscore, hyphen — and fall back to a
+    constant when the result is empty.
+
+    Regression for the cold-launch failure where a project_name like
+    ``"Codex Validation: TODO CLI"`` produced
+    ``marcus_codex_validation:_todo_cli`` and the very first
+    ``tmux set-option -t <session>`` call failed.
+    """
+
+    def _spawner_with_project_name(self, project_name: str, tmp_path: Path) -> Any:
+        """Build an AgentSpawner whose only purpose is exposing tmux_session."""
+        config = MagicMock()
+        config.project_name = project_name
+        config.agent_model = None
+        templates = tmp_path / "templates"
+        templates.mkdir()
+        with patch("subprocess.run"):
+            spawner = spawn_agents.AgentSpawner(config, templates)
+        return spawner
+
+    def test_colon_in_project_name_stripped(self, tmp_path: Path) -> None:
+        """A colon in the project name must not survive into tmux_session."""
+        spawner = self._spawner_with_project_name(
+            "Codex Validation: TODO CLI", tmp_path
+        )
+        assert ":" not in spawner.tmux_session
+        assert spawner.tmux_session == "marcus_codex_validation_todo_cli"
+
+    def test_dot_in_project_name_stripped(self, tmp_path: Path) -> None:
+        """A dot in the project name must not survive — tmux pane separator."""
+        spawner = self._spawner_with_project_name("My App v2.0", tmp_path)
+        assert "." not in spawner.tmux_session
+        assert spawner.tmux_session == "marcus_my_app_v2_0"
+
+    def test_slash_quote_and_other_specials_stripped(self, tmp_path: Path) -> None:
+        """Slashes, quotes, and other shell-special chars are scrubbed."""
+        spawner = self._spawner_with_project_name("foo/bar O'Brien (test)", tmp_path)
+        for char in "/'() ":
+            assert (
+                char not in spawner.tmux_session
+            ), f"Unsafe char {char!r} survived in {spawner.tmux_session!r}"
+
+    def test_empty_or_whitespace_project_name_falls_back(self, tmp_path: Path) -> None:
+        """All-whitespace names degrade to ``marcus_experiment``."""
+        spawner = self._spawner_with_project_name("   ", tmp_path)
+        assert spawner.tmux_session == "marcus_experiment"
+
+    def test_safe_project_name_unchanged(self, tmp_path: Path) -> None:
+        """Letters / digits / underscore / hyphen pass through untouched."""
+        spawner = self._spawner_with_project_name("simple-name_42", tmp_path)
+        assert spawner.tmux_session == "marcus_simple-name_42"
+
+    def test_lowercasing_preserved(self, tmp_path: Path) -> None:
+        """Mixed-case input is lowercased the same way as before the fix."""
+        spawner = self._spawner_with_project_name("UpperCaseProject", tmp_path)
+        assert spawner.tmux_session == "marcus_uppercaseproject"


### PR DESCRIPTION
## Why

Two pre-existing bugs in the Marcus experiment runner that block first-time use entirely. Both surfaced while validating PR #554 (the codex CLI harness). Neither is caused by #554 — they are sitting on `develop` today. Lifted to their own PR so they don't get bundled with unrelated codex work.

> **About this project, briefly:** Marcus is a multi-agent system. To launch an experiment, you run `python dev-tools/experiments/runners/run_experiment.py <dir> --init` once to scaffold a working directory, then `python run_experiment.py <dir>` to spawn the agents in tmux panes. Both bugs sit on that hot path.

## Bug 1 — `--init` raises `UnboundLocalError`

`run_experiment.py:create_experiment_structure` imports `shutil` at module scope (line 10) and uses it via `shutil.copy(...)` at line 41 to write the config template. A later conditional block (`if stale_git.exists()`) contained a redundant `import shutil` *inside* the function:

```python
def create_experiment_structure(experiment_dir: Path, ...) -> bool:
    ...
    if not config_file.exists():
        shutil.copy(template_config, config_file)  # ← line 41
    ...
    stale_git = experiment_dir / ".git"
    if stale_git.exists() and stale_git.is_dir():
        import shutil   # ← redundant; makes shutil function-local!

        shutil.rmtree(stale_git)
```

Python's scoping rule: any name assigned anywhere in a function body — including via `import` — is local for the *entire* function. So the earlier `shutil.copy` call (line 41) always raised `UnboundLocalError`, regardless of whether the conditional ever ran:

```
Traceback (most recent call last):
  ...
  File ".../run_experiment.py", line 41, in create_experiment_structure
    shutil.copy(template_config, config_file)
UnboundLocalError: cannot access local variable 'shutil'
where it is not associated with a value
```

`--init` was fully broken — fresh contributors could not scaffold an experiment at all without either pre-creating the directory or hand-running the template copy.

**Fix:** remove the inner `import shutil` (the module-level one suffices), and leave a comment explaining the scoping pitfall so a future change does not reintroduce it.

## Bug 2 — tmux session name parsed as `session:window` target

`AgentSpawner.__init__` (`spawn_agents.py:502`) built the session name with only `lower()` + space-to-underscore:

```python
self.tmux_session = (
    f"marcus_{self.config.project_name.lower().replace(' ', '_')}"
)
```

Any character with syntactic meaning in tmux target identifiers survived. tmux uses `:` for the session/window separator and `.` for the window/pane separator, so a project_name of `"Codex Validation: TODO CLI"` produced session name `marcus_codex_validation:_todo_cli`. The very first `tmux set-option -t <session>` after session creation failed with:

```
no such window: marcus_codex_validation:_todo_cli
subprocess.CalledProcessError: ['tmux', 'set-option', '-t',
  'marcus_codex_validation:_todo_cli', 'pane-border-status', 'top']
returned non-zero exit status 1.
```

Same class of failure would hit any project name containing `.`, `/`, `'`, `(`, `)`, etc.

**Fix:** replace the transform with a regex sanitizer that keeps only ASCII letters, digits, underscore, and hyphen, collapses runs of unsafe characters into a single underscore, and falls back to `marcus_experiment` when the result is empty (e.g. all-whitespace project_name):

```python
safe_name = re.sub(
    r"[^A-Za-z0-9_-]+",
    "_",
    self.config.project_name.lower(),
).strip("_")
self.tmux_session = f"marcus_{safe_name or 'experiment'}"
```

**Behavior table:**

| `project_name` | Old `tmux_session` | New `tmux_session` |
|---|---|---|
| `"simple"` | `marcus_simple` | `marcus_simple` ← unchanged |
| `"Codex Validation: TODO CLI"` | `marcus_codex_validation:_todo_cli` ❌ | `marcus_codex_validation_todo_cli` |
| `"My App v2.0"` | `marcus_my_app_v2.0` ❌ | `marcus_my_app_v2_0` |
| `"foo/bar"` | `marcus_foo/bar` ❌ | `marcus_foo_bar` |
| `"   "` | `marcus_` ❌ | `marcus_experiment` |

## Where to look in the code first

| File | Purpose |
|---|---|
| `dev-tools/experiments/runners/run_experiment.py:91-95` | Bug 1 fix — inner `import shutil` removed |
| `dev-tools/experiments/runners/spawn_agents.py:502-515` | Bug 2 fix — regex sanitizer in `AgentSpawner.__init__` |
| `tests/unit/experiments/test_run_experiment.py` (new) | Regression test for Bug 1: stale `.git` no longer triggers `UnboundLocalError` |
| `tests/unit/experiments/test_spawn_agents.py:TestTmuxSessionNameSanitization` | 6 cases covering Bug 2 (colon / dot / slash + quote + paren + space / empty / safe / case) |

## Glossary

| Term | Meaning |
|---|---|
| `tmux target identifier` | The `session:window.pane` string passed to every `tmux` command. Uses `:` and `.` as structural separators. |
| `UnboundLocalError` | Python error raised when a function references a name that is assigned later in the same function — Python's scoping treats it as local everywhere. |
| `--init` | Subcommand on `run_experiment.py` that scaffolds a new experiment directory (config + spec + git + tmux state). |
| `create_experiment_structure` | The function in `run_experiment.py` that handles `--init`. |

## How to verify it works

1. **Bug 1 — `--init` on a fresh dir:**

   ```bash
   /bin/rm -rf /tmp/_smoke_init
   python dev-tools/experiments/runners/run_experiment.py /tmp/_smoke_init --init
   ls /tmp/_smoke_init
   ```

   Expected: command exits 0, prints `✓ Experiment initialized!`, leaves `config.yaml`, `project_spec.md`, `implementation/`, `prompts/`, `logs/`, `worktrees/` in the directory. Before this PR: `UnboundLocalError`.

2. **Bug 2 — sanitizer:**

   ```bash
   python -c "
   import sys; sys.path.insert(0, 'dev-tools/experiments/runners')
   from unittest.mock import MagicMock, patch
   import importlib.util as u
   spec = u.spec_from_file_location('s', 'dev-tools/experiments/runners/spawn_agents.py')
   m = u.module_from_spec(spec); spec.loader.exec_module(m)
   cfg = MagicMock(); cfg.project_name = 'Codex Validation: TODO CLI'; cfg.agent_model = None
   with patch('subprocess.run'):
       sp = m.AgentSpawner(cfg, '/tmp')
   print(sp.tmux_session)
   "
   ```

   Expected: `marcus_codex_validation_todo_cli`. Before this PR: `marcus_codex_validation:_todo_cli`.

3. **Unit tests:**

   ```bash
   pytest tests/unit/experiments/ -m unit
   ```

   Expected: `108 passed`.

## Test plan

- [ ] `pytest tests/unit/experiments/ -m unit` → 108 passed
- [ ] `python run_experiment.py /tmp/_smoke_init --init` exits 0 from a fresh dir
- [ ] A project_name with `:` no longer crashes the spawner on session creation
- [ ] An all-whitespace project_name falls back to `marcus_experiment` instead of `marcus_`

## Related

- Found while validating PR #554 (codex CLI harness)
- PR #583 — separate pre-existing fix for the same env-debugging arc (mcp 1.10 / anyio 4.5 deps)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
