### PR TITLE
fix(nlp_tools): default project_root to ~/.marcus/projects/<id> (#588)

### DIFF
--- a/src/integrations/nlp_tools.py
+++ b/src/integrations/nlp_tools.py
@@ -13,6 +13,7 @@ import logging
 import os
 import sys
 from datetime import datetime, timezone
+from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 # Add src to path
@@ -42,6 +43,68 @@ from src.marcus_mcp.coordinator.scheduler import (  # noqa: E402
 from src.modes.adaptive.basic_adaptive import BasicAdaptiveMode  # noqa: E402
 
 logger = logging.getLogger(__name__)
+
+
+def _resolve_project_root(
+    options: Optional[Dict[str, Any]],
+    project_id: Optional[str],
+) -> Optional[str]:
+    """
+    Resolve the on-disk project root for design artifact generation.
+
+    Returns the caller-supplied ``options["project_root"]`` when set.
+    When the caller did not supply one and a stable ``project_id`` is
+    available, defaults to ``~/.marcus/projects/<project_id>`` and
+    ensures the directory exists on disk so downstream artifact
+    writers don't hit ``FileNotFoundError``.
+
+    Parameters
+    ----------
+    options : Optional[Dict[str, Any]]
+        Options dict passed to ``create_project``. May be ``None`` or
+        omit the ``project_root`` key.
+    project_id : Optional[str]
+        Stable project identifier (set by the kanban provider before
+        this is called).
+
+    Returns
+    -------
+    Optional[str]
+        Absolute path to the project root, or ``None`` when no default
+        can be derived (no ``project_id``) or the default cannot be
+        created on disk (read-only home, restricted container). When
+        ``None`` is returned for a fixable reason, a warning is logged
+        so the deadlock root cause is visible.
+
+    Notes
+    -----
+    GH-588: the design auto-completion phase (``_run_design_phase``)
+    is gated on this being truthy. Before #588, callers that omitted
+    ``project_root`` got ``None`` here, which silently skipped design
+    auto-completion and deadlocked any project whose feature tasks
+    depended on design tasks.
+    """
+    explicit = options.get("project_root") if options else None
+    if explicit:
+        return str(explicit)
+    if not project_id:
+        return None
+    default_root = Path.home() / ".marcus" / "projects" / project_id
+    try:
+        default_root.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:
+        # Read-only home, NFS quota, restricted container — degrade
+        # gracefully rather than killing create_project. Returning
+        # None preserves the pre-#588 behavior (design auto-completion
+        # skipped) but surfaces the cause in the log so the caller can
+        # see why hello-world-style projects deadlock on this host.
+        logger.warning(
+            f"[create_project] failed to create default project root "
+            f"{default_root}: {exc}; design auto-completion will be "
+            f"skipped for project_id={project_id}"
+        )
+        return None
+    return str(default_root)
 
 
 def _task_type_breakdown(
@@ -1626,7 +1689,19 @@ class NaturalLanguageProjectCreator(NaturalLanguageTaskCreator):
             # design (hard) dependencies are DONE. Once the background
             # task completes, it marks design tasks DONE on the board
             # and workers' next request_next_task call will succeed.
-            project_root = options.get("project_root") if options else None
+            # GH-588: default to ``~/.marcus/projects/<project_id>`` when
+            # the caller omits ``project_root`` so the design
+            # auto-completion phase always runs. Skipping it leaves
+            # design tasks in TODO and deadlocks every dependent
+            # feature task.
+            #
+            # TODO(GH-589): decouple board-state design completion from
+            # on-disk scaffold generation. ``_run_design_phase`` is
+            # currently gated as a single unit on ``project_root``, but
+            # marking design tasks DONE is pure board-state mutation and
+            # does not need a filesystem root. Splitting these would
+            # eliminate the need to default ``project_root`` here at all.
+            project_root = _resolve_project_root(options, self.active_project_id)
             for task in safe_tasks:
                 if _is_design_task(task):
                     task.assigned_to = "Marcus"

--- a/src/integrations/nlp_tools.py
+++ b/src/integrations/nlp_tools.py
@@ -83,24 +83,41 @@ def _resolve_project_root(
     ``project_root`` got ``None`` here, which silently skipped design
     auto-completion and deadlocked any project whose feature tasks
     depended on design tasks.
+
+    Scope: this helper is intentionally wired into the design-phase
+    gate only. Two other call sites read ``options["project_root"]``
+    directly and must remain caller-explicit: (1) the contract-first
+    decomposer, which warns loudly when the caller omits a root
+    (see ``_build_decomposer_warning``); and (2) the SQLite kanban
+    ``auto_setup_project`` call. GH-589 tracks the deeper refactor
+    that would eliminate the need to default ``project_root`` here
+    at all by splitting board-state design completion from on-disk
+    scaffold generation.
     """
     explicit = options.get("project_root") if options else None
     if explicit:
         return str(explicit)
     if not project_id:
         return None
-    default_root = Path.home() / ".marcus" / "projects" / project_id
     try:
+        default_root = Path.home() / ".marcus" / "projects" / project_id
         default_root.mkdir(parents=True, exist_ok=True)
-    except OSError as exc:
-        # Read-only home, NFS quota, restricted container — degrade
-        # gracefully rather than killing create_project. Returning
-        # None preserves the pre-#588 behavior (design auto-completion
-        # skipped) but surfaces the cause in the log so the caller can
-        # see why hello-world-style projects deadlock on this host.
+    except (OSError, RuntimeError) as exc:
+        # Degrade gracefully rather than killing ``create_project``.
+        # ``OSError`` covers read-only home, NFS quota, restricted
+        # container; ``RuntimeError`` covers ``Path.home()`` raising
+        # when ``$HOME`` (or the platform equivalent) is unset in
+        # containerized/service environments. Returning ``None``
+        # preserves the pre-#588 behavior (design auto-completion
+        # skipped) but surfaces the cause in the log so the caller
+        # can see why hello-world-style projects deadlock on this
+        # host. ``default_root`` is referenced only when bound; if
+        # ``Path.home()`` itself raised, the log falls back to a
+        # path-less message.
+        location = locals().get("default_root", "<unresolved home>")
         logger.warning(
             f"[create_project] failed to create default project root "
-            f"{default_root}: {exc}; design auto-completion will be "
+            f"{location}: {exc}; design auto-completion will be "
             f"skipped for project_id={project_id}"
         )
         return None

--- a/tests/unit/integrations/test_nlp_tools.py
+++ b/tests/unit/integrations/test_nlp_tools.py
@@ -260,3 +260,62 @@ class TestResolveProjectRoot:
             and "abc123" in rec.message
             for rec in caplog.records
         ), [rec.message for rec in caplog.records]
+
+    def test_default_root_is_truthy_so_design_phase_gate_runs(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """
+        Regression guard for the user-visible #588 claim.
+
+        ``_run_design_phase`` is gated on ``if project_root and
+        has_design_tasks`` (``src/integrations/nlp_tools.py`` ~L2057).
+        The whole point of this helper is that callers omitting
+        ``options["project_root"]`` must still get a truthy value
+        here so the gate passes and design tasks transition TODO →
+        DONE on the board. Without this, agents calling
+        ``request_next_task`` get nothing (the original deadlock).
+
+        Pinning the truthy contract directly catches the regression
+        without needing to mock ``create_project_from_description``'s
+        full setup chain. The end-to-end integration is exercised by
+        the manual smoke test described in PR #590's "How to verify"
+        section.
+        """
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        result = _resolve_project_root(None, project_id="abc123")
+        assert result, (
+            "helper returned a falsy value — design-phase gate would "
+            "be skipped and create_project would deadlock for callers "
+            "that omit options['project_root']"
+        )
+
+    def test_home_unresolved_degrades_gracefully(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """
+        ``Path.home()`` raises ``RuntimeError`` when ``$HOME`` (or the
+        platform equivalent) is unset — common in container/service
+        environments. The helper must catch that alongside ``OSError``,
+        return ``None``, and log a warning. Without this guard,
+        ``create_project`` hard-fails before design-phase scheduling
+        for callers that omit ``options["project_root"]`` (Codex P1
+        on PR #590).
+        """
+        import logging
+
+        def _no_home() -> Path:
+            raise RuntimeError("Could not determine home directory")
+
+        monkeypatch.setattr(Path, "home", _no_home)
+
+        with caplog.at_level(logging.WARNING, logger="src.integrations.nlp_tools"):
+            result = _resolve_project_root(None, project_id="abc123")
+
+        assert result is None
+        assert any(
+            "failed to create default project root" in rec.message
+            and "abc123" in rec.message
+            for rec in caplog.records
+        ), [rec.message for rec in caplog.records]

--- a/tests/unit/integrations/test_nlp_tools.py
+++ b/tests/unit/integrations/test_nlp_tools.py
@@ -8,12 +8,15 @@ suite.
 """
 
 from datetime import datetime
+from pathlib import Path
 
 import pytest
 
 from src.core.models import Priority, Task, TaskStatus
 from src.integrations.enhanced_task_classifier import EnhancedTaskClassifier
-from src.integrations.nlp_tools import _task_type_breakdown
+from src.integrations.nlp_tools import _resolve_project_root, _task_type_breakdown
+
+pytestmark = pytest.mark.unit
 
 
 def _make_task(
@@ -161,3 +164,99 @@ class TestTaskTypeBreakdown:
     ) -> None:
         """No tasks → empty histogram, not an error."""
         assert _task_type_breakdown([], classifier) == {}
+
+
+class TestResolveProjectRoot:
+    """
+    Test suite for ``_resolve_project_root`` (GH-588).
+
+    The design auto-completion phase that marks design tasks DONE on
+    the board is gated on ``project_root`` being truthy. Before #588,
+    callers that omitted ``project_root`` got ``None``, which silently
+    skipped design auto-completion and deadlocked any project whose
+    feature tasks depended on design tasks.
+    """
+
+    def test_explicit_project_root_is_returned_unchanged(self, tmp_path: Path) -> None:
+        """
+        Caller-supplied ``project_root`` wins — the helper does not
+        override it even when ``project_id`` is also available.
+        """
+        explicit = str(tmp_path / "caller_supplied")
+        result = _resolve_project_root({"project_root": explicit}, project_id="abc123")
+        assert result == explicit
+
+    def test_missing_options_falls_back_to_marcus_projects_dir(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """
+        ``options=None`` and a known ``project_id`` produce a default
+        rooted at ``<home>/.marcus/projects/<project_id>`` (GH-588).
+        """
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        result = _resolve_project_root(None, project_id="abc123")
+        assert result == str(tmp_path / ".marcus" / "projects" / "abc123")
+
+    def test_options_without_project_root_key_falls_back(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Empty options dict triggers the same fallback as ``None``."""
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        result = _resolve_project_root({}, project_id="xyz789")
+        assert result == str(tmp_path / ".marcus" / "projects" / "xyz789")
+
+    def test_default_directory_is_created_on_disk(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """
+        The defaulted directory must exist after the call so
+        ``_run_design_phase`` can write artifacts into it without a
+        ``FileNotFoundError``.
+        """
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        _resolve_project_root(None, project_id="abc123")
+        expected = tmp_path / ".marcus" / "projects" / "abc123"
+        assert expected.is_dir()
+
+    def test_no_project_id_returns_none(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """
+        Without a stable ``project_id`` we cannot derive a default
+        path — return ``None`` rather than guess. The caller (currently
+        ``create_project_from_description``) ensures ``active_project_id``
+        is set well before this is invoked, so this branch is defensive.
+        """
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        assert _resolve_project_root(None, project_id=None) is None
+        assert _resolve_project_root({}, project_id="") is None
+
+    def test_mkdir_failure_degrades_gracefully(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """
+        ``OSError`` from ``mkdir`` (read-only home, NFS quota, restricted
+        container) must NOT propagate out of ``create_project``. The
+        helper returns ``None`` and logs a warning so the operator can
+        see why design auto-completion was skipped.
+        """
+        import logging
+
+        def _explode(*args: object, **kwargs: object) -> None:
+            raise PermissionError("read-only filesystem")
+
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setattr(Path, "mkdir", _explode)
+
+        with caplog.at_level(logging.WARNING, logger="src.integrations.nlp_tools"):
+            result = _resolve_project_root(None, project_id="abc123")
+
+        assert result is None
+        assert any(
+            "failed to create default project root" in rec.message
+            and "abc123" in rec.message
+            for rec in caplog.records
+        ), [rec.message for rec in caplog.records]


### PR DESCRIPTION
## What is this system, briefly

Marcus is a multi-agent coordination service. When a user calls
`create_project`, Marcus breaks a natural-language description into
a graph of tasks and writes them to a kanban board. Agents (workers)
then independently pull tasks via `request_next_task`.

A subset of those tasks are **design tasks** (interface contracts,
data models, architecture sketches). Marcus completes design tasks
itself in a background "design auto-completion" phase so that
downstream implementation tasks unblock immediately and an agent
never has to wait for design work that humans intended Marcus to do.

## Why

Issue #588: calling `create_project` without an `options.project_root`
silently skipped the design auto-completion phase, which left design
tasks in `TODO` forever and **deadlocked** every dependent feature
task. Hello-world-style projects (no caller-supplied filesystem
root) were the obvious failure mode — workers registered, asked
for a task, and got nothing because the only available tasks were
design tasks gated on Marcus.

The root cause is in `src/integrations/nlp_tools.py:_run_design_phase`:

```python
project_root = options.get("project_root") if options else None
# later:
if project_root:        # ← falsy when caller didn't supply one
    _do_design_auto_completion()
```

When `project_root` is falsy, the whole design phase is skipped.

## What changed

| File | Purpose |
| --- | --- |
| `src/integrations/nlp_tools.py` | New `_resolve_project_root` helper; `_run_design_phase` now calls it |
| `tests/unit/integrations/test_nlp_tools.py` | 6 new unit tests covering the helper; adds `pytestmark = pytest.mark.unit` |

### `_resolve_project_root(options, project_id)`

- If the caller supplied `options["project_root"]`, return it unchanged.
- Otherwise, default to `~/.marcus/projects/<project_id>` and ensure
  the directory exists.
- If `mkdir` fails (read-only home, restricted container, NFS quota),
  log a warning and return `None` — preserves the pre-#588 behavior
  but makes the failure visible in logs instead of silent.
- If no `project_id` is available, return `None`. Defensive: the
  caller currently sets `active_project_id` well before this is hit.

### Inline `TODO(GH-589)`

The deeper fix is to split board-state mutation (marking design tasks
DONE) from on-disk scaffold generation. Marking design tasks DONE is
pure board-state and shouldn't need a filesystem root at all. That's
tracked separately so this PR stays focused on the deadlock.

## Glossary

| Term | Meaning |
| --- | --- |
| `create_project` | MCP tool that turns a natural-language description into a task graph on the kanban board |
| design task | A task Marcus completes itself (interface contracts, data models, architecture) before workers pull anything |
| design auto-completion | The phase inside `_run_design_phase` that marks design tasks DONE on the board so feature tasks unblock |
| `project_root` | On-disk directory where Marcus writes design artifacts (architecture docs, data models, etc.) |
| `active_project_id` | Stable project identifier set by the kanban provider on `create_project` |

## Where to look in the code first

| File | Purpose |
| --- | --- |
| `src/integrations/nlp_tools.py` (top) | New `_resolve_project_root` helper |
| `src/integrations/nlp_tools.py` (`_run_design_phase`) | The deadlock site; now calls the helper |
| `tests/unit/integrations/test_nlp_tools.py::TestResolveProjectRoot` | All 6 new tests |

## Worked example

Before this PR, on a fresh machine:

```python
await create_project(
    project_name="_Sandbox",
    description="...",
    options={"mode": "new_project"},  # no project_root
)
# → tasks created, design tasks stuck in TODO
# → agent calls request_next_task → no task available → idle forever
```

After this PR:

```python
# same call
# → _resolve_project_root returns "/Users/<you>/.marcus/projects/<id>"
# → design auto-completion runs
# → design tasks transition TODO → DONE on the board
# → feature tasks unblock; first agent gets one
```

## How to verify it works

1. Check out this branch.
2. Run unit tests: `pytest tests/unit/integrations/test_nlp_tools.py -m unit -v` — expect **9 passed**.
3. With a running Marcus MCP server, call `create_project` with no
   `project_root` in `options`. Confirm `~/.marcus/projects/<id>/`
   is created on disk.
4. Register an agent and call `request_next_task`. Confirm a feature
   task is returned (not a stalled design task).

## Test plan

- [x] New `_resolve_project_root` helper covered by 6 unit tests
- [x] Explicit `options["project_root"]` still wins (regression guard)
- [x] `options=None` and `options={}` both fall back correctly
- [x] Default directory is created on disk
- [x] `OSError` from `mkdir` returns `None` and logs a warning
- [x] Module-level `pytestmark = pytest.mark.unit` so CI picks the tests up
- [x] All pre-commit hooks pass (mypy, black, flake8, bandit, etc.)
- [ ] Reviewer manually runs a `create_project` smoke test against a live MCP server

## Related

- Issue: #588 (this PR)
- Follow-up: #589 (split board-state design completion from on-disk scaffold generation) — referenced as inline `TODO(GH-589)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)