### PR TITLE
fix(nlp_tools): default project_root so design auto-completion always runs (#588)

### DIFF
--- a/src/integrations/nlp_tools.py
+++ b/src/integrations/nlp_tools.py
@@ -13,6 +13,7 @@ import logging
 import os
 import sys
 from datetime import datetime, timezone
+from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 # Add src to path
@@ -42,6 +43,68 @@ from src.marcus_mcp.coordinator.scheduler import (  # noqa: E402
 from src.modes.adaptive.basic_adaptive import BasicAdaptiveMode  # noqa: E402
 
 logger = logging.getLogger(__name__)
+
+
+def _resolve_project_root(
+    options: Optional[Dict[str, Any]],
+    project_id: Optional[str],
+) -> Optional[str]:
+    """
+    Resolve the on-disk project root for design artifact generation.
+
+    Returns the caller-supplied ``options["project_root"]`` when set.
+    When the caller did not supply one and a stable ``project_id`` is
+    available, defaults to ``~/.marcus/projects/<project_id>`` and
+    ensures the directory exists on disk so downstream artifact
+    writers don't hit ``FileNotFoundError``.
+
+    Parameters
+    ----------
+    options : Optional[Dict[str, Any]]
+        Options dict passed to ``create_project``. May be ``None`` or
+        omit the ``project_root`` key.
+    project_id : Optional[str]
+        Stable project identifier (set by the kanban provider before
+        this is called).
+
+    Returns
+    -------
+    Optional[str]
+        Absolute path to the project root, or ``None`` when no default
+        can be derived (no ``project_id``) or the default cannot be
+        created on disk (read-only home, restricted container). When
+        ``None`` is returned for a fixable reason, a warning is logged
+        so the deadlock root cause is visible.
+
+    Notes
+    -----
+    GH-588: the design auto-completion phase (``_run_design_phase``)
+    is gated on this being truthy. Before #588, callers that omitted
+    ``project_root`` got ``None`` here, which silently skipped design
+    auto-completion and deadlocked any project whose feature tasks
+    depended on design tasks.
+    """
+    explicit = options.get("project_root") if options else None
+    if explicit:
+        return str(explicit)
+    if not project_id:
+        return None
+    default_root = Path.home() / ".marcus" / "projects" / project_id
+    try:
+        default_root.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:
+        # Read-only home, NFS quota, restricted container — degrade
+        # gracefully rather than killing create_project. Returning
+        # None preserves the pre-#588 behavior (design auto-completion
+        # skipped) but surfaces the cause in the log so the caller can
+        # see why hello-world-style projects deadlock on this host.
+        logger.warning(
+            f"[create_project] failed to create default project root "
+            f"{default_root}: {exc}; design auto-completion will be "
+            f"skipped for project_id={project_id}"
+        )
+        return None
+    return str(default_root)
 
 
 def _task_type_breakdown(
@@ -1626,7 +1689,19 @@ class NaturalLanguageProjectCreator(NaturalLanguageTaskCreator):
             # design (hard) dependencies are DONE. Once the background
             # task completes, it marks design tasks DONE on the board
             # and workers' next request_next_task call will succeed.
-            project_root = options.get("project_root") if options else None
+            # GH-588: default to ``~/.marcus/projects/<project_id>`` when
+            # the caller omits ``project_root`` so the design
+            # auto-completion phase always runs. Skipping it leaves
+            # design tasks in TODO and deadlocks every dependent
+            # feature task.
+            #
+            # TODO(GH-589): decouple board-state design completion from
+            # on-disk scaffold generation. ``_run_design_phase`` is
+            # currently gated as a single unit on ``project_root``, but
+            # marking design tasks DONE is pure board-state mutation and
+            # does not need a filesystem root. Splitting these would
+            # eliminate the need to default ``project_root`` here at all.
+            project_root = _resolve_project_root(options, self.active_project_id)
             for task in safe_tasks:
                 if _is_design_task(task):
                     task.assigned_to = "Marcus"

--- a/src/integrations/nlp_tools.py
+++ b/src/integrations/nlp_tools.py
@@ -83,24 +83,41 @@ def _resolve_project_root(
     ``project_root`` got ``None`` here, which silently skipped design
     auto-completion and deadlocked any project whose feature tasks
     depended on design tasks.
+
+    Scope: this helper is intentionally wired into the design-phase
+    gate only. Two other call sites read ``options["project_root"]``
+    directly and must remain caller-explicit: (1) the contract-first
+    decomposer, which warns loudly when the caller omits a root
+    (see ``_build_decomposer_warning``); and (2) the SQLite kanban
+    ``auto_setup_project`` call. GH-589 tracks the deeper refactor
+    that would eliminate the need to default ``project_root`` here
+    at all by splitting board-state design completion from on-disk
+    scaffold generation.
     """
     explicit = options.get("project_root") if options else None
     if explicit:
         return str(explicit)
     if not project_id:
         return None
-    default_root = Path.home() / ".marcus" / "projects" / project_id
     try:
+        default_root = Path.home() / ".marcus" / "projects" / project_id
         default_root.mkdir(parents=True, exist_ok=True)
-    except OSError as exc:
-        # Read-only home, NFS quota, restricted container — degrade
-        # gracefully rather than killing create_project. Returning
-        # None preserves the pre-#588 behavior (design auto-completion
-        # skipped) but surfaces the cause in the log so the caller can
-        # see why hello-world-style projects deadlock on this host.
+    except (OSError, RuntimeError) as exc:
+        # Degrade gracefully rather than killing ``create_project``.
+        # ``OSError`` covers read-only home, NFS quota, restricted
+        # container; ``RuntimeError`` covers ``Path.home()`` raising
+        # when ``$HOME`` (or the platform equivalent) is unset in
+        # containerized/service environments. Returning ``None``
+        # preserves the pre-#588 behavior (design auto-completion
+        # skipped) but surfaces the cause in the log so the caller
+        # can see why hello-world-style projects deadlock on this
+        # host. ``default_root`` is referenced only when bound; if
+        # ``Path.home()`` itself raised, the log falls back to a
+        # path-less message.
+        location = locals().get("default_root", "<unresolved home>")
         logger.warning(
             f"[create_project] failed to create default project root "
-            f"{default_root}: {exc}; design auto-completion will be "
+            f"{location}: {exc}; design auto-completion will be "
             f"skipped for project_id={project_id}"
         )
         return None

--- a/tests/unit/integrations/test_nlp_tools.py
+++ b/tests/unit/integrations/test_nlp_tools.py
@@ -260,3 +260,62 @@ class TestResolveProjectRoot:
             and "abc123" in rec.message
             for rec in caplog.records
         ), [rec.message for rec in caplog.records]
+
+    def test_default_root_is_truthy_so_design_phase_gate_runs(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """
+        Regression guard for the user-visible #588 claim.
+
+        ``_run_design_phase`` is gated on ``if project_root and
+        has_design_tasks`` (``src/integrations/nlp_tools.py`` ~L2057).
+        The whole point of this helper is that callers omitting
+        ``options["project_root"]`` must still get a truthy value
+        here so the gate passes and design tasks transition TODO →
+        DONE on the board. Without this, agents calling
+        ``request_next_task`` get nothing (the original deadlock).
+
+        Pinning the truthy contract directly catches the regression
+        without needing to mock ``create_project_from_description``'s
+        full setup chain. The end-to-end integration is exercised by
+        the manual smoke test described in PR #590's "How to verify"
+        section.
+        """
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        result = _resolve_project_root(None, project_id="abc123")
+        assert result, (
+            "helper returned a falsy value — design-phase gate would "
+            "be skipped and create_project would deadlock for callers "
+            "that omit options['project_root']"
+        )
+
+    def test_home_unresolved_degrades_gracefully(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """
+        ``Path.home()`` raises ``RuntimeError`` when ``$HOME`` (or the
+        platform equivalent) is unset — common in container/service
+        environments. The helper must catch that alongside ``OSError``,
+        return ``None``, and log a warning. Without this guard,
+        ``create_project`` hard-fails before design-phase scheduling
+        for callers that omit ``options["project_root"]`` (Codex P1
+        on PR #590).
+        """
+        import logging
+
+        def _no_home() -> Path:
+            raise RuntimeError("Could not determine home directory")
+
+        monkeypatch.setattr(Path, "home", _no_home)
+
+        with caplog.at_level(logging.WARNING, logger="src.integrations.nlp_tools"):
+            result = _resolve_project_root(None, project_id="abc123")
+
+        assert result is None
+        assert any(
+            "failed to create default project root" in rec.message
+            and "abc123" in rec.message
+            for rec in caplog.records
+        ), [rec.message for rec in caplog.records]

--- a/tests/unit/integrations/test_nlp_tools.py
+++ b/tests/unit/integrations/test_nlp_tools.py
@@ -8,12 +8,15 @@ suite.
 """
 
 from datetime import datetime
+from pathlib import Path
 
 import pytest
 
 from src.core.models import Priority, Task, TaskStatus
 from src.integrations.enhanced_task_classifier import EnhancedTaskClassifier
-from src.integrations.nlp_tools import _task_type_breakdown
+from src.integrations.nlp_tools import _resolve_project_root, _task_type_breakdown
+
+pytestmark = pytest.mark.unit
 
 
 def _make_task(
@@ -161,3 +164,99 @@ class TestTaskTypeBreakdown:
     ) -> None:
         """No tasks → empty histogram, not an error."""
         assert _task_type_breakdown([], classifier) == {}
+
+
+class TestResolveProjectRoot:
+    """
+    Test suite for ``_resolve_project_root`` (GH-588).
+
+    The design auto-completion phase that marks design tasks DONE on
+    the board is gated on ``project_root`` being truthy. Before #588,
+    callers that omitted ``project_root`` got ``None``, which silently
+    skipped design auto-completion and deadlocked any project whose
+    feature tasks depended on design tasks.
+    """
+
+    def test_explicit_project_root_is_returned_unchanged(self, tmp_path: Path) -> None:
+        """
+        Caller-supplied ``project_root`` wins — the helper does not
+        override it even when ``project_id`` is also available.
+        """
+        explicit = str(tmp_path / "caller_supplied")
+        result = _resolve_project_root({"project_root": explicit}, project_id="abc123")
+        assert result == explicit
+
+    def test_missing_options_falls_back_to_marcus_projects_dir(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """
+        ``options=None`` and a known ``project_id`` produce a default
+        rooted at ``<home>/.marcus/projects/<project_id>`` (GH-588).
+        """
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        result = _resolve_project_root(None, project_id="abc123")
+        assert result == str(tmp_path / ".marcus" / "projects" / "abc123")
+
+    def test_options_without_project_root_key_falls_back(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Empty options dict triggers the same fallback as ``None``."""
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        result = _resolve_project_root({}, project_id="xyz789")
+        assert result == str(tmp_path / ".marcus" / "projects" / "xyz789")
+
+    def test_default_directory_is_created_on_disk(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """
+        The defaulted directory must exist after the call so
+        ``_run_design_phase`` can write artifacts into it without a
+        ``FileNotFoundError``.
+        """
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        _resolve_project_root(None, project_id="abc123")
+        expected = tmp_path / ".marcus" / "projects" / "abc123"
+        assert expected.is_dir()
+
+    def test_no_project_id_returns_none(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """
+        Without a stable ``project_id`` we cannot derive a default
+        path — return ``None`` rather than guess. The caller (currently
+        ``create_project_from_description``) ensures ``active_project_id``
+        is set well before this is invoked, so this branch is defensive.
+        """
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        assert _resolve_project_root(None, project_id=None) is None
+        assert _resolve_project_root({}, project_id="") is None
+
+    def test_mkdir_failure_degrades_gracefully(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """
+        ``OSError`` from ``mkdir`` (read-only home, NFS quota, restricted
+        container) must NOT propagate out of ``create_project``. The
+        helper returns ``None`` and logs a warning so the operator can
+        see why design auto-completion was skipped.
+        """
+        import logging
+
+        def _explode(*args: object, **kwargs: object) -> None:
+            raise PermissionError("read-only filesystem")
+
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setattr(Path, "mkdir", _explode)
+
+        with caplog.at_level(logging.WARNING, logger="src.integrations.nlp_tools"):
+            result = _resolve_project_root(None, project_id="abc123")
+
+        assert result is None
+        assert any(
+            "failed to create default project root" in rec.message
+            and "abc123" in rec.message
+            for rec in caplog.records
+        ), [rec.message for rec in caplog.records]


### PR DESCRIPTION
## What is Marcus, briefly

Marcus is a multi-agent coordination system. It turns a natural-language project description into a kanban-style task graph, then lets independent agents pull tasks whose dependencies are complete. Some tasks — called **design tasks** — are coordination-only: Marcus auto-completes them in the background so the feature tasks that depend on them become assignable.

## Why

A project created through `create_project` **without** an `options.project_root` value would deadlock: every agent calling `request_next_task` got "no tasks available" forever, even though the board showed real work in Backlog.

Root cause (issue #588): the background **design auto-completion** phase — the code that flips design tasks to `DONE` so dependent work unblocks — was gated behind `if project_root and has_design_tasks:` at `src/integrations/nlp_tools.py:1981`. When the caller omitted `project_root`, the value was `None`, the whole phase was skipped, design tasks stayed in `TODO`, and every feature task depending on them was permanently unassignable.

This was discovered while testing two projects in one session:
- `snake-game` — appeared to work, because Marcus synthesized a **pre-fork foundation task** (a shared-setup task with no design dependency) that agents could grab immediately.
- `hello-world-sandbox` — a trivial CLI project. No foundation task was synthesized (correctly — it's trivial), so *every* task depended on design tasks that never completed. Total deadlock.

Worked example from the Marcus log for `hello-world-sandbox`: all 7 backlog tasks were blocked, each waiting on `Design Script Development & Execution` and/or `Design Project Documentation` — both stuck in `TODO` because the design phase never ran. 0 of 7 assignable.

## What changed

- New helper `_resolve_project_root(options, project_id)` in `src/integrations/nlp_tools.py`:
  - Returns the caller-supplied `options["project_root"]` when set (caller always wins).
  - Otherwise defaults to `~/.marcus/projects/<project_id>` and creates that directory.
  - On `OSError` (read-only home, NFS quota, restricted container) or `RuntimeError` (`Path.home()` raising when `$HOME` is unset) it logs a warning and returns `None` — degrading to the pre-#588 behavior instead of crashing `create_project`, with the cause visible in the log.
- Wired this helper into the design-phase gate at `nlp_tools.py:1629` (replacing the raw `options.get("project_root")` read).
- Left two other `project_root` call sites caller-explicit on purpose, documented in the helper docstring: the contract-first decomposer (which already warns loudly when a root is missing) and the SQLite kanban `auto_setup_project` call.
- Added a `TODO(GH-589)` marker for the architectural follow-up (see below).

## Scope note / follow-up

This is the surface fix. The deeper issue — `_run_design_phase` bundles **board-state mutation** (marking design tasks `DONE`, needs no filesystem) with **on-disk scaffold generation** (legitimately needs `project_root`) under one gate — is tracked separately in **#589**. That refactor would remove the need to default `project_root` here at all.

## Where to look in the code first

| File | Purpose |
|------|---------|
| `src/integrations/nlp_tools.py` (`_resolve_project_root`) | New helper: resolve or default the project root |
| `src/integrations/nlp_tools.py:1629` | Wire-in site for the design-phase gate + `TODO(GH-589)` marker |
| `src/integrations/nlp_tools.py:1981` | The `if project_root and has_design_tasks:` gate this fix feeds |
| `tests/unit/integrations/test_nlp_tools.py` (`TestResolveProjectRoot`) | Unit tests for the new helper |

## Glossary

| Term | Meaning |
|------|---------|
| `create_project` | MCP tool that turns a description into a kanban task graph. |
| `project_root` | Filesystem path where Marcus writes design artifacts and scaffold code. |
| Design task | A coordination-only task auto-completed by Marcus, not done by agents. |
| Design auto-completion | The background phase that flips design tasks to `DONE` so dependents unblock. |
| `request_next_task` | MCP tool agents call to pull work; returns nothing if no task has all dependencies complete. |

## Test plan

- [x] `pytest tests/unit/integrations/test_nlp_tools.py` — 11 passed (helper: explicit-wins, fallback default, dir creation, no-`project_id`, `OSError`/`RuntimeError` graceful degradation)
- [x] `pytest -m unit` — 1911 passed, 1 skipped
- [x] `mypy src/integrations/nlp_tools.py` — clean
- [ ] End-to-end: restart MCP server with this branch, call `create_project` for a CLI-style description with no `options`, wait ~5s, confirm `[design_autocomplete] Phase A: ... status=DONE` appears in `logs/marcus_*.log`, then register an agent and confirm `request_next_task` returns an implementation task instead of "no tasks available"

## Related

- Fixes #588
- Follow-up refactor: #589
- Simon: decision `1d91917b`, thoughts `53698539` / `75597f39`

🤖 Generated with [Claude Code](https://claude.com/claude-code)