### PR TITLE
fix(mcp): log_artifact accepts JSON dict/list content (#595)

### DIFF
--- a/src/marcus_mcp/server.py
+++ b/src/marcus_mcp/server.py
@@ -2214,7 +2214,7 @@ class MarcusServer:
             async def log_artifact(
                 task_id: str,
                 filename: str,
-                content: str,
+                content: Union[str, Dict[str, Any], List[Any]],
                 artifact_type: str,
                 project_root: str,
                 description: str = "",
@@ -2245,8 +2245,9 @@ class MarcusServer:
                     The current task ID
                 filename : str
                     Name for the artifact file
-                content : str
-                    The artifact content to store
+                content : str or dict or list
+                    The artifact content to store. A dict or list is
+                    serialized to a JSON string; a str is stored as-is.
                 artifact_type : str
                     Type of artifact (any string accepted - use descriptive names
                     like "podcast-script", "research", "video-storyboard", etc.)

--- a/src/marcus_mcp/tools/attachment.py
+++ b/src/marcus_mcp/tools/attachment.py
@@ -6,11 +6,12 @@ artifacts in organized locations while allowing flexibility when needed.
 """
 
 import hashlib
+import json
 import logging
 import subprocess
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Union
 
 from src.core.project_history import ArtifactMetadata, ProjectHistoryPersistence
 
@@ -31,7 +32,7 @@ ARTIFACT_PATHS = {
 async def log_artifact(
     task_id: str,
     filename: str,
-    content: str,
+    content: Union[str, Dict[str, Any], List[Any]],
     artifact_type: str,
     project_root: Optional[str] = None,
     description: Optional[str] = None,
@@ -66,8 +67,12 @@ async def log_artifact(
         The current task ID
     filename : str
         Name for the artifact file
-    content : str
-        The artifact content to store
+    content : str or dict or list
+        The artifact content to store. A ``dict`` or ``list`` is
+        serialized to a pretty-printed JSON string before being written;
+        a ``str`` is stored verbatim. Accepting structured input lets
+        agents log parsed JSON (e.g. ``tsconfig.json``) directly without
+        pre-stringifying it (issue #595 Fix 1).
     artifact_type : str
         Type of artifact (determines default location)
     project_root : Optional[str], optional
@@ -98,6 +103,13 @@ async def log_artifact(
         Dict with artifact location and storage details
     """
     try:
+        # Issue #595 Fix 1: agents (and the generated MCP schema) may pass
+        # structured JSON — e.g. a parsed tsconfig.json — as ``content``.
+        # Serialize any dict/list to a JSON string up front, before the
+        # size guard and file write, both of which require text.
+        if isinstance(content, (dict, list)):
+            content = json.dumps(content, indent=2)
+
         # Validate project_root is provided
         if not project_root:
             return {

--- a/tests/unit/mcp/test_log_artifact_json_content.py
+++ b/tests/unit/mcp/test_log_artifact_json_content.py
@@ -1,0 +1,156 @@
+"""
+Unit tests for log_artifact accepting structured (JSON) content.
+
+Issue #595 Fix 1: ``log_artifact``'s ``content`` parameter was typed
+``str``. When an agent passed a parsed JSON object (a ``dict``) — for
+example the contents of ``tsconfig.json`` — the call was rejected and the
+artifact was never stored. ``log_artifact`` must accept ``dict`` / ``list``
+content and serialize it to a JSON string before writing, while leaving
+plain ``str`` content unchanged.
+"""
+
+import json
+import sys
+from pathlib import Path
+from typing import Any, Dict, List
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+
+from src.marcus_mcp.tools.attachment import log_artifact
+
+# Pre-stub live_experiment_monitor so the artifact write path has no
+# external dependency (mirrors test_log_artifact_size_guard.py).
+_MONITOR_MODULE_PATH = "src.experiments.live_experiment_monitor"
+if _MONITOR_MODULE_PATH not in sys.modules:
+    _mock_monitor_mod = Mock()
+    _mock_monitor_mod.get_active_monitor = Mock(return_value=None)
+    sys.modules[_MONITOR_MODULE_PATH] = _mock_monitor_mod
+
+pytestmark = pytest.mark.unit
+
+
+class _MockState:
+    """Minimal stand-in for Marcus server state."""
+
+    def __init__(self) -> None:
+        self.task_artifacts: Dict[str, List[Dict[str, Any]]] = {}
+        self.project_tasks: List[Any] = []
+        self.kanban_client: Any = None
+
+
+@pytest.fixture()
+def state() -> _MockState:
+    """Provide a fresh mock state per test."""
+    return _MockState()
+
+
+@pytest.fixture()
+def project_root(tmp_path: Path) -> Path:
+    """Use pytest's tmp_path as an absolute, existing project root."""
+    return tmp_path
+
+
+def _patch_history() -> Any:
+    """Patch out project-history persistence (external write path)."""
+    return patch(
+        "src.marcus_mcp.tools.attachment._persist_artifact_to_history",
+        new_callable=AsyncMock,
+    )
+
+
+class TestLogArtifactJsonContent:
+    """log_artifact accepts dict/list content and stores it as JSON."""
+
+    @pytest.mark.asyncio
+    async def test_dict_content_is_serialized_to_json(
+        self, project_root: Path, state: _MockState
+    ) -> None:
+        """A dict passed as content is written as a pretty-printed JSON string."""
+        tsconfig = {"compilerOptions": {"strict": True, "target": "ES2020"}}
+
+        with _patch_history():
+            result = await log_artifact(
+                task_id="task-json-1",
+                filename="tsconfig.json",
+                content=tsconfig,
+                artifact_type="specification",
+                project_root=str(project_root),
+                state=state,
+            )
+
+        assert result["success"] is True
+        written = (project_root / result["data"]["location"]).read_text()
+        assert written == json.dumps(tsconfig, indent=2)
+        assert json.loads(written) == tsconfig
+
+    @pytest.mark.asyncio
+    async def test_list_content_is_serialized_to_json(
+        self, project_root: Path, state: _MockState
+    ) -> None:
+        """A list passed as content is written as a JSON string."""
+        dependencies = ["react", "typescript", "vite"]
+
+        with _patch_history():
+            result = await log_artifact(
+                task_id="task-json-2",
+                filename="deps.json",
+                content=dependencies,
+                artifact_type="specification",
+                project_root=str(project_root),
+                state=state,
+            )
+
+        assert result["success"] is True
+        written = (project_root / result["data"]["location"]).read_text()
+        assert json.loads(written) == dependencies
+
+    @pytest.mark.asyncio
+    async def test_str_content_is_unchanged(
+        self, project_root: Path, state: _MockState
+    ) -> None:
+        """Plain string content is written verbatim (regression guard)."""
+        text = "# Design notes\n\nPlain markdown, not JSON."
+
+        with _patch_history():
+            result = await log_artifact(
+                task_id="task-json-3",
+                filename="notes.md",
+                content=text,
+                artifact_type="documentation",
+                project_root=str(project_root),
+                state=state,
+            )
+
+        assert result["success"] is True
+        written = (project_root / result["data"]["location"]).read_text()
+        assert written == text
+
+    @pytest.mark.asyncio
+    async def test_dict_content_overwriting_existing_docs_file(
+        self, project_root: Path, state: _MockState
+    ) -> None:
+        """
+        Dict content survives the docs/ size-guard path.
+
+        The size guard calls ``content.encode()``, which only works once
+        the dict has been coerced to a string. Overwriting an existing
+        small docs/ file exercises that code path.
+        """
+        existing = project_root / "docs" / "specifications" / "config.json"
+        existing.parent.mkdir(parents=True, exist_ok=True)
+        existing.write_text('{"old": true}', encoding="utf-8")
+
+        with _patch_history():
+            result = await log_artifact(
+                task_id="task-json-4",
+                filename="config.json",
+                content={"new": True, "nested": {"value": 1}},
+                artifact_type="specification",
+                project_root=str(project_root),
+                state=state,
+            )
+
+        assert result["success"] is True
+        written = (project_root / result["data"]["location"]).read_text()
+        assert json.loads(written) == {"new": True, "nested": {"value": 1}}

--- a/tests/unit/mcp/test_log_artifact_json_content.py
+++ b/tests/unit/mcp/test_log_artifact_json_content.py
@@ -154,3 +154,39 @@ class TestLogArtifactJsonContent:
         assert result["success"] is True
         written = (project_root / result["data"]["location"]).read_text()
         assert json.loads(written) == {"new": True, "nested": {"value": 1}}
+
+
+class TestLogArtifactToolSchema:
+    """The registered MCP tool schema accepts structured content."""
+
+    @pytest.mark.asyncio
+    async def test_tool_schema_content_accepts_object_and_array(self) -> None:
+        """
+        The generated log_artifact MCP schema accepts objects and arrays.
+
+        The original #595 bug lived at the MCP argument-validation layer:
+        a ``content: str`` parameter made FastMCP emit a string-only
+        schema, so a dict was rejected before the implementation ran. The
+        impl-level tests above call the function directly and would stay
+        green even if the server wrapper were narrowed back to ``str`` —
+        this test closes that gap by inspecting the registered schema.
+        """
+        from mcp.server.fastmcp import FastMCP
+
+        from src.marcus_mcp.server import MarcusServer
+
+        app = FastMCP("schema-test")
+        # Registration only introspects function signatures; the tool
+        # closures capture ``self`` but are never invoked here, so a bare
+        # object stands in for a fully constructed server.
+        MarcusServer._register_endpoint_tools(object(), app, "agent")
+
+        tools = await app.list_tools()
+        log_artifact_tool = next(t for t in tools if t.name == "log_artifact")
+        content_schema = log_artifact_tool.inputSchema["properties"]["content"]
+
+        assert (
+            "anyOf" in content_schema
+        ), f"log_artifact `content` must accept multiple types; got {content_schema}"
+        accepted = {variant.get("type") for variant in content_schema["anyOf"]}
+        assert {"string", "object", "array"} <= accepted


### PR DESCRIPTION
## What is this system, briefly

**Marcus** coordinates a team of independent AI coding agents that build software together. Agents publish files and decisions to a shared board so later agents can reuse them. `log_artifact` is the tool an agent calls to publish such a file (an "artifact") to the board.

## Why

When a Marcus agent finishes a piece of work, it is supposed to publish its output via `log_artifact` so downstream agents can find it. The "Tech Foundation Setup" task, for example, publishes the shared project configuration (`tsconfig.json`, `package.json`) this way.

`log_artifact`'s `content` parameter was typed as `str`. The MCP tool layer generates an argument schema from that type, so when an agent passed a **parsed JSON object** (a Python `dict`) — the natural shape of a config file it just built — the call was **rejected before the implementation ever ran**:

```
Error executing tool log_artifact: 1 validation error for log_artifactArguments
content: Input should be a valid string ... input_type=dict
```

The artifact was silently never recorded. In the `test18` Snake-game run this is one reason the shared technical contract never reached downstream agents, who then each guessed the language/test-framework independently and spent significant cost reconciling. This PR is **Fix 1** of issue #595.

## What changed

- **`src/marcus_mcp/server.py`** — the `log_artifact` MCP wrapper's `content` parameter is widened from `str` to `Union[str, Dict[str, Any], List[Any]]`. This is the change that matters at the boundary: FastMCP now generates an `anyOf: [string, object, array]` schema, so a dict/list is accepted at argument validation instead of rejected.
- **`src/marcus_mcp/tools/attachment.py`** — the `log_artifact` implementation accepts the same union and serializes any `dict`/`list` to a pretty-printed JSON string (`json.dumps(content, indent=2)`) before the size guard and file write, both of which require text. Plain `str` content is unchanged.
- **`tests/unit/mcp/test_log_artifact_json_content.py`** — new test file, 5 tests.

Scope note: this PR only makes the contract **recordable**. Making it **reach** downstream agents is Fix 2 of #595 and is intentionally not included here.

## Test plan

- [x] `test_dict_content_is_serialized_to_json` — a dict is written as pretty-printed JSON and round-trips
- [x] `test_list_content_is_serialized_to_json` — a list is written as JSON and round-trips
- [x] `test_str_content_is_unchanged` — plain string content is written verbatim (regression guard)
- [x] `test_dict_content_overwriting_existing_docs_file` — dict content survives the `docs/` size-guard path (which calls `.encode()` and so needs the coercion to have happened)
- [x] `test_tool_schema_content_accepts_object_and_array` — registers the tool and asserts the generated MCP schema's `content` accepts `object`/`array`; guards against the wrapper being narrowed back to `str` (the impl-level tests alone would not catch that)
- [x] `mypy` clean on both changed source files
- [x] Full `tests/unit/mcp` suite passes (192 passed, 0 regressions)

## Related

- Issue #595 — "Cut multi-agent run cost: fix contract sharing and idle-agent polling" (this PR is Fix 1 of 4)
- Simon: decision `6cf598f6`, thoughts `fcf8e8a4` / `6077b7eb` / `d23e05c0`
