### PR TITLE
fix(mcp): expose foundation contract as project-global context (#595)

### DIFF
--- a/src/marcus_mcp/tools/context.py
+++ b/src/marcus_mcp/tools/context.py
@@ -202,6 +202,11 @@ async def get_task_context(task_id: str, state: Any) -> Dict[str, Any]:
                 context_dict["sibling_artifacts"] = sibling_context["artifacts"]
                 context_dict["sibling_decisions"] = sibling_context["decisions"]
 
+                # #595 Fix 2: the foundation contract is project-global —
+                # every task, including subtasks, receives it regardless
+                # of dependency-graph position.
+                context_dict["project_contract"] = _collect_foundation_contract(state)
+
                 # Add parent task's context if Context system is available
                 if hasattr(state, "context") and state.context and parent_task:
                     parent_context = await state.context.get_context(
@@ -234,6 +239,11 @@ async def get_task_context(task_id: str, state: Any) -> Dict[str, Any]:
         # Add artifact information
         artifacts = await _collect_task_artifacts(task_id, task, state)
         context_dict["artifacts"] = artifacts
+
+        # #595 Fix 2: the foundation contract is project-global. Unlike
+        # `artifacts` (scoped to direct dependencies), it is returned to
+        # every task regardless of dependency-graph position.
+        context_dict["project_contract"] = _collect_foundation_contract(state)
 
         # Add recovery information if present
         if task.recovery_info:
@@ -277,10 +287,13 @@ def _inject_usage_guidance(
     Priority (highest to lowest):
 
     1. ``artifact_role`` field — role-aware guidance (Option C).
-    2. ``_is_foundation_dep`` marker — pre-fork synthesis tasks (GH-355).
-       Set by ``_collect_task_artifacts`` when ``source_type == "pre_fork_synthesis"``.
-    3. ``is_design_dep`` label-based fallback for feature_based design
+    2. ``is_design_dep`` label-based fallback for feature_based design
        artifacts that predate the ``artifact_role`` field (Option B).
+
+    Foundation (pre-fork synthesis) artifacts are no longer handled here.
+    They are delivered project-globally via ``project_contract`` and
+    carry ``_FOUNDATION_USAGE_GUIDANCE`` from :func:`_collect_foundation_contract`
+    (issue #595 Fix 2).
 
     Parameters
     ----------
@@ -298,15 +311,68 @@ def _inject_usage_guidance(
         artifact.setdefault("usage_guidance", _COORDINATION_REFERENCE_GUIDANCE)
     elif role == "implementation_spec":
         artifact.setdefault("usage_guidance", _IMPLEMENTATION_GUIDE_GUIDANCE)
-    elif artifact.get("_is_foundation_dep"):
-        # Pre-fork synthesis artifacts (GH-355): shared setup that
-        # completed before domain work began.  Consumption guidance
-        # delivered here, not in the task description, so Marcus
-        # stays on the coordination side of the bright line.
-        artifact.setdefault("usage_guidance", _FOUNDATION_USAGE_GUIDANCE)
     elif is_design_dep and not is_contract_first_ghost:
         # Option B label-based fallback: feature_based design artifacts
         artifact.setdefault("usage_guidance", _COORDINATION_REFERENCE_GUIDANCE)
+
+
+def _collect_foundation_contract(state: Any) -> Dict[str, List[Dict[str, Any]]]:
+    """
+    Collect the project-global foundation contract (issue #595 Fix 2).
+
+    The foundation (pre-fork synthesis) tasks establish the shared
+    technical contract — language, build config, test harness, public
+    API surface — that every task must build against, regardless of its
+    position in the dependency graph. Unlike ordinary task artifacts,
+    which :func:`_collect_task_artifacts` scopes to a task's *direct*
+    dependencies, this contract is project-global and is returned to
+    every task by :func:`get_task_context`.
+
+    Foundation tasks are identified by
+    ``source_type == "pre_fork_synthesis"`` — the exact, Marcus-set
+    marker. This deliberately excludes domain-specific design artifacts,
+    whose 1-hop dependency scoping is correct.
+
+    Parameters
+    ----------
+    state : Any
+        Marcus server state. ``project_tasks``, ``task_artifacts`` and
+        ``context`` are each consulted defensively and treated as
+        optional, so the helper degrades to empty results rather than
+        raising when a subsystem is unavailable.
+
+    Returns
+    -------
+    Dict[str, List[Dict[str, Any]]]
+        ``{"artifacts": [...], "decisions": [...]}`` — the union of
+        artifacts and architectural decisions produced by every
+        foundation task in the project. Both lists are empty when there
+        is no foundation work or the backing state is unavailable.
+    """
+    foundation_task_ids = {
+        t.id
+        for t in (getattr(state, "project_tasks", None) or [])
+        if getattr(t, "source_type", None) == "pre_fork_synthesis"
+    }
+    if not foundation_task_ids:
+        return {"artifacts": [], "decisions": []}
+
+    artifacts: List[Dict[str, Any]] = []
+    task_artifacts = getattr(state, "task_artifacts", None) or {}
+    for fid in foundation_task_ids:
+        for raw in task_artifacts.get(fid, []):
+            artifact = dict(raw)
+            artifact.setdefault("usage_guidance", _FOUNDATION_USAGE_GUIDANCE)
+            artifacts.append(artifact)
+
+    decisions: List[Dict[str, Any]] = []
+    context = getattr(state, "context", None)
+    if context is not None:
+        for decision in getattr(context, "decisions", None) or []:
+            if getattr(decision, "task_id", None) in foundation_task_ids:
+                decisions.append(decision.to_dict())
+
+    return {"artifacts": artifacts, "decisions": decisions}
 
 
 async def _collect_task_artifacts(
@@ -376,9 +442,18 @@ async def _collect_task_artifacts(
                     (t for t in state.project_tasks if t.id == dep_id), None
                 )
                 if dep_task:
+                    # #595 Fix 2: foundation (pre-fork synthesis) output is
+                    # delivered project-globally via `project_contract`.
+                    # Skipping foundation deps here keeps that the single
+                    # channel and avoids double-shipping the contract into
+                    # agent context.
+                    dep_is_foundation = (
+                        getattr(dep_task, "source_type", None) == "pre_fork_synthesis"
+                    )
                     # Logged artifacts from dependency
                     if (
-                        hasattr(state, "task_artifacts")
+                        not dep_is_foundation
+                        and hasattr(state, "task_artifacts")
                         and dep_id in state.task_artifacts
                     ):
                         # P1 fix (GH-356 Codex review): deep-copy each
@@ -395,10 +470,6 @@ async def _collect_task_artifacts(
                         # from the contract_notice layer in
                         # build_tiered_instructions, so we skip guidance here.
                         is_contract_first_ghost = "auto_completed" in dep_labels
-                        is_foundation_dep = (
-                            getattr(dep_task, "source_type", None)
-                            == "pre_fork_synthesis"
-                        )
                         # GH-356: ``domain:`` labels on the dep task for
                         # scope_annotation comparison.
                         dep_domain_labels = {
@@ -411,17 +482,11 @@ async def _collect_task_artifacts(
                                 f"{artifact.get('description', '')} "
                                 f"(from dependency: {dep_task.name})"
                             )
-                            # Mark foundation artifacts so _inject_usage_guidance
-                            # can apply GH-355 consumption guidance without
-                            # widening the function signature.
-                            if is_foundation_dep:
-                                artifact["_is_foundation_dep"] = True
                             # Option C: artifact_role field takes precedence.
                             # Option B: fall back to label-based detection.
                             _inject_usage_guidance(
                                 artifact, is_design_dep, is_contract_first_ghost
                             )
-                            artifact.pop("_is_foundation_dep", None)
                             # GH-356: scope annotation at retrieval time.
                             # The same artifact is in_scope for one agent and
                             # reference_only for another — annotation cannot be

--- a/src/marcus_mcp/tools/context.py
+++ b/src/marcus_mcp/tools/context.py
@@ -444,16 +444,15 @@ async def _collect_task_artifacts(
                 if dep_task:
                     # #595 Fix 2: foundation (pre-fork synthesis) output is
                     # delivered project-globally via `project_contract`.
-                    # Skipping foundation deps here keeps that the single
-                    # channel and avoids double-shipping the contract into
-                    # agent context.
-                    dep_is_foundation = (
-                        getattr(dep_task, "source_type", None) == "pre_fork_synthesis"
-                    )
+                    # Skip foundation deps entirely here — both logged
+                    # artifacts and Kanban attachments — so that channel
+                    # stays the single source and direct dependents are
+                    # not handed foundation data the 1-hop way.
+                    if getattr(dep_task, "source_type", None) == "pre_fork_synthesis":
+                        continue
                     # Logged artifacts from dependency
                     if (
-                        not dep_is_foundation
-                        and hasattr(state, "task_artifacts")
+                        hasattr(state, "task_artifacts")
                         and dep_id in state.task_artifacts
                     ):
                         # P1 fix (GH-356 Codex review): deep-copy each

--- a/tests/unit/mcp/test_get_task_context_project_contract.py
+++ b/tests/unit/mcp/test_get_task_context_project_contract.py
@@ -1,0 +1,238 @@
+"""
+Unit tests for the project-global foundation contract in get_task_context.
+
+Issue #595 Fix 2: ``get_task_context`` only returned artifacts from a
+task's *direct* dependencies, so the shared technical contract produced
+by the foundation (pre-fork synthesis) tasks never reached tasks more
+than one hop away. Fix 2 adds a project-global ``project_contract`` field
+that returns the foundation tasks' artifacts and decisions to *every*
+task, regardless of its position in the dependency graph.
+
+Foundation tasks are identified by ``source_type == "pre_fork_synthesis"``
+— the exact, Marcus-set marker. Ordinary task artifacts keep their
+existing 1-hop dependency scoping.
+"""
+
+from datetime import datetime, timezone
+from typing import Any, Dict, List
+
+import pytest
+
+from src.core.models import Priority, Task, TaskStatus
+from src.marcus_mcp.tools.context import (
+    _collect_foundation_contract,
+    get_task_context,
+)
+
+pytestmark = pytest.mark.unit
+
+
+class _MockDecision:
+    """Minimal architectural-decision stand-in."""
+
+    def __init__(self, task_id: str, what: str) -> None:
+        self.task_id = task_id
+        self._what = what
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {"task_id": self.task_id, "what": self._what}
+
+
+class _MockContextResult:
+    """Result returned by MockContext.get_context."""
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {"previous_implementations": {}, "architectural_decisions": []}
+
+
+class _MockContext:
+    """Mock Context subsystem carrying a flat decision list."""
+
+    def __init__(self) -> None:
+        self.decisions: List[_MockDecision] = []
+
+    async def get_context(
+        self, task_id: str, dependencies: List[str]
+    ) -> _MockContextResult:
+        return _MockContextResult()
+
+
+class _MockSubtaskManager:
+    """Mock SubtaskManager exposing the surface get_task_context touches."""
+
+    def __init__(self, subtask_id: str, parent_task_id: str) -> None:
+        self.subtasks = {subtask_id: object()}
+        self._subtask_id = subtask_id
+        self._parent_task_id = parent_task_id
+
+    def get_subtask_context(self, task_id: str) -> Dict[str, Any]:
+        return {
+            "parent_task_id": self._parent_task_id,
+            "subtask": {"id": task_id, "name": "Sub"},
+            "shared_conventions": {},
+            "dependency_artifacts": [],
+            "sibling_subtasks": [],
+        }
+
+    def get_subtasks(self, parent_task_id: str, project_tasks: List[Task]) -> List[Any]:
+        return []
+
+
+class _MockState:
+    """Mock Marcus server state."""
+
+    def __init__(self) -> None:
+        self.task_artifacts: Dict[str, List[Dict[str, Any]]] = {}
+        self.project_tasks: List[Task] = []
+        self.context = _MockContext()
+        self.kanban_client = None
+        self.events = None
+        self.subtask_manager: Any = None
+
+
+def _task(
+    task_id: str,
+    *,
+    source_type: str = "",
+    dependencies: List[str] | None = None,
+) -> Task:
+    """Build a Task with the fields get_task_context touches."""
+    return Task(
+        id=task_id,
+        name=f"Task {task_id}",
+        description="",
+        status=TaskStatus.TODO,
+        priority=Priority.MEDIUM,
+        assigned_to=None,
+        created_at=datetime.now(timezone.utc),
+        updated_at=datetime.now(timezone.utc),
+        due_date=None,
+        estimated_hours=1.0,
+        dependencies=dependencies or [],
+        source_type=source_type,
+    )
+
+
+@pytest.fixture()
+def state() -> _MockState:
+    """Provide a fresh mock state per test."""
+    return _MockState()
+
+
+class TestCollectFoundationContract:
+    """_collect_foundation_contract gathers only foundation-task output."""
+
+    def test_collects_artifacts_from_foundation_tasks(self, state: _MockState) -> None:
+        """Artifacts from pre_fork_synthesis tasks are returned."""
+        state.project_tasks = [_task("f1", source_type="pre_fork_synthesis")]
+        state.task_artifacts["f1"] = [
+            {"filename": "tsconfig.json", "artifact_type": "specification"}
+        ]
+
+        contract = _collect_foundation_contract(state)
+
+        assert [a["filename"] for a in contract["artifacts"]] == ["tsconfig.json"]
+
+    def test_collects_decisions_from_foundation_tasks(self, state: _MockState) -> None:
+        """Decisions made on a foundation task are returned."""
+        state.project_tasks = [_task("f1", source_type="pre_fork_synthesis")]
+        state.context.decisions = [
+            _MockDecision("f1", "Public API surface"),
+            _MockDecision("other", "unrelated decision"),
+        ]
+
+        contract = _collect_foundation_contract(state)
+
+        assert [d["what"] for d in contract["decisions"]] == ["Public API surface"]
+
+    def test_excludes_non_foundation_task_artifacts(self, state: _MockState) -> None:
+        """Artifacts from ordinary (non-foundation) tasks are not global."""
+        state.project_tasks = [
+            _task("f1", source_type="pre_fork_synthesis"),
+            _task("impl1", source_type="pre_fork_synthesis_NOT"),
+            _task("design1"),  # no source_type
+        ]
+        state.task_artifacts["f1"] = [{"filename": "package.json"}]
+        state.task_artifacts["impl1"] = [{"filename": "feature.ts"}]
+        state.task_artifacts["design1"] = [{"filename": "design.md"}]
+
+        contract = _collect_foundation_contract(state)
+
+        assert [a["filename"] for a in contract["artifacts"]] == ["package.json"]
+
+    def test_empty_when_no_foundation_tasks(self, state: _MockState) -> None:
+        """No foundation tasks yields empty artifact and decision lists."""
+        state.project_tasks = [_task("impl1")]
+        state.task_artifacts["impl1"] = [{"filename": "feature.ts"}]
+
+        contract = _collect_foundation_contract(state)
+
+        assert contract == {"artifacts": [], "decisions": []}
+
+
+class TestGetTaskContextProjectContract:
+    """get_task_context exposes project_contract regardless of DAG position."""
+
+    @pytest.mark.asyncio
+    async def test_task_with_no_foundation_dependency_still_gets_contract(
+        self, state: _MockState
+    ) -> None:
+        """
+        A task that does NOT depend on the foundation task still receives
+        the foundation contract via the global project_contract field.
+
+        This is the core #595 Fix 2 behavior: contract reaches every task,
+        not only the foundation task's direct dependents.
+        """
+        foundation = _task("f1", source_type="pre_fork_synthesis")
+        # leaf task depends on nothing — several hops from foundation
+        leaf = _task("leaf", dependencies=[])
+        state.project_tasks = [foundation, leaf]
+        state.task_artifacts["f1"] = [
+            {"filename": "tsconfig.json", "artifact_type": "specification"}
+        ]
+        state.context.decisions = [_MockDecision("f1", "Public API surface")]
+
+        result = await get_task_context("leaf", state)
+
+        assert result["success"] is True
+        contract = result["context"]["project_contract"]
+        assert [a["filename"] for a in contract["artifacts"]] == ["tsconfig.json"]
+        assert [d["what"] for d in contract["decisions"]] == ["Public API surface"]
+
+    @pytest.mark.asyncio
+    async def test_project_contract_empty_without_foundation(
+        self, state: _MockState
+    ) -> None:
+        """project_contract is present but empty when no foundation exists."""
+        state.project_tasks = [_task("leaf")]
+
+        result = await get_task_context("leaf", state)
+
+        assert result["success"] is True
+        assert result["context"]["project_contract"] == {
+            "artifacts": [],
+            "decisions": [],
+        }
+
+    @pytest.mark.asyncio
+    async def test_subtask_also_receives_project_contract(
+        self, state: _MockState
+    ) -> None:
+        """
+        A subtask receives the foundation contract via project_contract.
+
+        get_task_context has a separate code path for subtasks; Fix 2
+        wires project_contract into that path too, so a subtask is not
+        cut off from the project-global contract.
+        """
+        state.project_tasks = [_task("f1", source_type="pre_fork_synthesis")]
+        state.task_artifacts["f1"] = [{"filename": "tsconfig.json"}]
+        state.subtask_manager = _MockSubtaskManager("sub-1", "parent-1")
+
+        result = await get_task_context("sub-1", state)
+
+        assert result["success"] is True
+        assert result["context"]["is_subtask"] is True
+        contract = result["context"]["project_contract"]
+        assert [a["filename"] for a in contract["artifacts"]] == ["tsconfig.json"]

--- a/tests/unit/mcp/test_scope_annotation.py
+++ b/tests/unit/mcp/test_scope_annotation.py
@@ -337,12 +337,16 @@ class TestFeatureBasedScopeAnnotation:
         assert dep_artifacts[0]["scope_annotation"] == "reference_only"
 
     @pytest.mark.asyncio
-    async def test_foundation_dep_is_reference_only(self) -> None:
+    async def test_foundation_dep_excluded_from_collected_artifacts(self) -> None:
         """
-        Pre-fork synthesis foundation dep (source_type='pre_fork_synthesis') →
-        ``reference_only``.
+        Pre-fork synthesis foundation deps are excluded from
+        ``_collect_task_artifacts``.
 
-        Foundation artifacts are shared setup the agent should USE, not implement.
+        Issue #595 Fix 2: foundation (``source_type='pre_fork_synthesis'``)
+        output is delivered project-globally via the ``project_contract``
+        field, not through the 1-hop dependency artifact path. Skipping it
+        here keeps ``project_contract`` the single channel and avoids
+        double-shipping the contract into agent context.
         """
         # Arrange
         foundation_task = _make_task(
@@ -365,12 +369,12 @@ class TestFeatureBasedScopeAnnotation:
         # Act
         artifacts = await _collect_task_artifacts("feature-3", feature_task, state)
 
-        # Assert
+        # Assert — foundation dep artifacts are NOT in the 1-hop result;
+        # they are delivered via project_contract instead.
         dep_artifacts = [
             a for a in artifacts if a.get("dependency_task_id") == "foundation-1"
         ]
-        assert len(dep_artifacts) == 1
-        assert dep_artifacts[0]["scope_annotation"] == "reference_only"
+        assert dep_artifacts == []
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/mcp/test_scope_annotation.py
+++ b/tests/unit/mcp/test_scope_annotation.py
@@ -627,3 +627,50 @@ class TestKanbanDepAttachmentAnnotation:
         ]
         assert len(dep_artifacts) == 1
         assert dep_artifacts[0]["scope_annotation"] == "reference_only"
+
+    @pytest.mark.asyncio
+    async def test_foundation_dep_kanban_attachment_also_excluded(self) -> None:
+        """
+        Foundation deps are skipped entirely — Kanban attachments included.
+
+        Issue #595 Fix 2: ``project_contract`` is the sole foundation
+        channel. Gating only logged artifacts would still leak a
+        foundation task's Kanban attachments to direct dependents via the
+        1-hop path, reintroducing the split-channel inconsistency the fix
+        removes (Codex P2 on PR #598).
+        """
+        # Arrange
+        foundation_task = _make_task(
+            "foundation-k",
+            "Shared Setup",
+            labels=["design"],
+            source_type="pre_fork_synthesis",
+        )
+        feature_task = _make_task(
+            "feature-k",
+            "Implement widget",
+            labels=[],
+            dependencies=["foundation-k"],
+        )
+
+        state = MockState()
+        state.project_tasks = [feature_task, foundation_task]
+        state.kanban_client = MockKanbanClientWithAttachments(
+            [
+                {
+                    "id": "attach-f",
+                    "name": "setup.ts",
+                    "userId": "marcus",
+                    "createdAt": "2026-05-21T00:00:00Z",
+                }
+            ]
+        )
+
+        # Act
+        artifacts = await _collect_task_artifacts("feature-k", feature_task, state)
+
+        # Assert — nothing from the foundation dep, neither logged nor Kanban
+        dep_artifacts = [
+            a for a in artifacts if a.get("dependency_task_id") == "foundation-k"
+        ]
+        assert dep_artifacts == []


### PR DESCRIPTION
## What is this system, briefly

**Marcus** coordinates a team of independent AI coding agents that build software together. Agents publish files and decisions to a shared board; later agents read them back. `get_task_context` is the tool an agent calls to retrieve the outputs of the tasks its current task depends on.

## Why

Before agents start, Marcus runs **foundation tasks** (internally marked `source_type == "pre_fork_synthesis"`) that establish the shared technical contract — language, build config, test harness, the public API surface every other task must build against.

That contract was not reaching most agents. `get_task_context` only returned artifacts from a task's **direct** dependencies. A task two or more hops from the foundation task (for example a "Compose entry point" task that depends on feature tasks, which in turn depend on the foundation task) never saw the contract. In the `test18` Snake-game run this is one reason agents each guessed the language and test framework independently and then spent significant cost reconciling. This PR is **Fix 2** of issue #595.

## What changed

- **`src/marcus_mcp/tools/context.py`** — new helper `_collect_foundation_contract(state)`. It gathers artifacts and architectural decisions from **every** `source_type == "pre_fork_synthesis"` task in the project and returns them in a new **`project_contract`** field on every `get_task_context` response — both the standard-task path and the subtask path — regardless of where the requesting task sits in the dependency graph.
  - `source_type == "pre_fork_synthesis"` is the exact, Marcus-set marker for foundation tasks. This deliberately excludes domain-specific design artifacts, whose 1-hop dependency scoping is correct.
- **Deduplication.** `project_contract` is made the **sole** delivery channel for foundation output. The dependency loop in `_collect_task_artifacts` now skips foundation dependencies, and the now-vestigial `_is_foundation_dep` handling (plus its branch in `_inject_usage_guidance`) is removed. Without this, the majority of tasks — which *do* depend directly on the foundation task — would receive the contract twice in one response (once in `artifacts`, once in `project_contract`), inflating agent context.
- Ordinary (non-foundation) artifacts keep their existing 1-hop dependency scoping — unchanged.

Scope note: this PR makes the contract **reachable** by every task. Pointing agents at the new `project_contract` field (task-instruction wording) is a separate follow-up.

## Test plan

- [x] `test_collects_artifacts_from_foundation_tasks` — foundation-task artifacts are gathered
- [x] `test_collects_decisions_from_foundation_tasks` — foundation-task decisions are gathered
- [x] `test_excludes_non_foundation_task_artifacts` — only `pre_fork_synthesis` tasks are global
- [x] `test_empty_when_no_foundation_tasks` — empty `artifacts`/`decisions` when no foundation work
- [x] `test_task_with_no_foundation_dependency_still_gets_contract` — a task that does NOT depend on the foundation task still receives the contract (core Fix 2 behavior)
- [x] `test_project_contract_empty_without_foundation` — field is always present
- [x] `test_subtask_also_receives_project_contract` — the subtask code path is wired too
- [x] `test_scope_annotation.py` updated — foundation deps are now *excluded* from the 1-hop artifact path (the deduplication contract)
- [x] `mypy` clean on `context.py`
- [x] `tests/unit/mcp` (195 passed) and foundation-synthesis suites (50 passed) — 0 regressions

## Related

- Issue #595 — "Cut multi-agent run cost: fix contract sharing and idle-agent polling" (this PR is Fix 2 of 4)
- PR #597 — Fix 1 (`log_artifact` accepts JSON). Fix 1 makes the contract *recordable*; this PR makes it *reachable*. The two are independent files and can merge in either order.
- Simon: decision `39ded5ab`; review thought `05186455`
