### PR TITLE
Fix: runtime verification crashes when the Marcus server's stdin is closed

### DIFF
--- a/src/ai/validation/work_analyzer.py
+++ b/src/ai/validation/work_analyzer.py
@@ -633,11 +633,24 @@ class WorkAnalyzer:
 
         # Run tests with timeout
         try:
+            # Runtime verification runs inside the long-lived Marcus
+            # server process, whose stdin (fd 0) may be closed or
+            # invalid — e.g. when the server is started backgrounded.
+            # Without an explicit stdin the test subprocess inherits
+            # that bad fd 0, and Python aborts at interpreter startup
+            # with "init_sys_streams: can't initialize sys standard
+            # streams" (OSError: [Errno 9] Bad file descriptor) — every
+            # test run then fails for a reason that has nothing to do
+            # with the deliverable. DEVNULL gives the child a valid
+            # fd 0; start_new_session detaches it from any dead
+            # controlling terminal.
             proc = await asyncio.create_subprocess_shell(
                 test_command,
+                stdin=subprocess.DEVNULL,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
                 cwd=str(project_root),
+                start_new_session=True,
             )
             stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=30)
 

--- a/tests/unit/ai/validation/test_runtime_validation.py
+++ b/tests/unit/ai/validation/test_runtime_validation.py
@@ -6,6 +6,7 @@ configuration issues like missing dependencies.
 """
 
 import asyncio
+import subprocess
 from datetime import datetime
 from pathlib import Path
 from unittest.mock import AsyncMock, Mock, patch
@@ -316,6 +317,33 @@ class TestRuntimeValidation:
             assert result.passed is True
             assert len(result.issues) == 0
 
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_validate_runtime_spawns_with_safe_stdin(
+        self, analyzer: WorkAnalyzer, mock_task: Mock, nodejs_evidence: WorkEvidence
+    ) -> None:
+        """Runtime tests spawn with stdin=DEVNULL and a new session.
+
+        Regression guard: runtime verification runs inside the Marcus
+        server process, whose stdin (fd 0) may be closed or invalid.
+        Without an explicit stdin the test subprocess inherits that bad
+        fd and Python aborts at startup with "init_sys_streams: can't
+        initialize sys standard streams" — failing every run for a
+        reason unrelated to the deliverable.
+        """
+        mock_proc = AsyncMock()
+        mock_proc.returncode = 0
+        mock_proc.communicate = AsyncMock(return_value=(b"PASS", b""))
+
+        with patch(
+            "asyncio.create_subprocess_shell", return_value=mock_proc
+        ) as mock_subprocess:
+            await analyzer._validate_runtime(mock_task, nodejs_evidence)
+
+        kwargs = mock_subprocess.call_args.kwargs
+        assert kwargs["stdin"] == subprocess.DEVNULL
+        assert kwargs["start_new_session"] is True
+
     @pytest.mark.asyncio
     async def test_validate_runtime_tests_fail_missing_dependency(
         self, analyzer: WorkAnalyzer, mock_task: Mock, nodejs_evidence: WorkEvidence
@@ -327,7 +355,8 @@ class TestRuntimeValidation:
         mock_proc.communicate = AsyncMock(
             return_value=(
                 b"",
-                b"Error: Cannot find module 'identity-obj-proxy'\nRequire stack:\n- jest.config.js",
+                b"Error: Cannot find module 'identity-obj-proxy'\n"
+                b"Require stack:\n- jest.config.js",
             )
         )
 


### PR DESCRIPTION
## What this is

Marcus builds software with AI agents. When an agent reports a task done, the Marcus server **verifies** the work by running the task's tests — `WorkAnalyzer._validate_runtime` in `src/ai/validation/work_analyzer.py`. This PR fixes a bug where that verification can fail for a reason that has nothing to do with the agent's code.

## Why

`_validate_runtime` spawns a shell subprocess to run pytest. It set `stdout` / `stderr` but left **`stdin` unset** — so the child inherits the Marcus server process's `stdin` (file descriptor 0).

`_validate_runtime` runs *inside the long-lived Marcus MCP server*. A server started in the background commonly has a **closed or invalid stdin**. The test subprocess inherits that bad fd 0, and Python aborts at interpreter startup:

```
Fatal Python error: init_sys_streams: can't initialize sys standard streams
OSError: [Errno 9] Bad file descriptor
```

So **every** verification run fails — and because a crashed interpreter exits non-zero, `_validate_runtime` reads it as a **test failure**. The agent's correct, passing code is reported as failing validation.

This was found when an agent (experiment run `test53`) reported a blocker with exactly this error *while its own 112 tests passed*. Reading the blockers of every past experiment run then showed **all six were Marcus infrastructure failures, not agent failures** — verification is the most fragile layer (tracked in #601).

## What changed

`src/ai/validation/work_analyzer.py` — the `create_subprocess_shell` call now passes:
- `stdin=subprocess.DEVNULL` — a valid fd 0, which is exactly what `init_sys_streams` needs.
- `start_new_session=True` — detaches the child from any dead controlling terminal.

Verification is now robust regardless of how the Marcus server process was started.

## Test plan

- [x] New regression test `test_validate_runtime_spawns_with_safe_stdin` — asserts the subprocess is spawned with `stdin=DEVNULL` and `start_new_session=True` (`tests/unit/ai/validation/test_runtime_validation.py`).
- [x] All 19 tests in `test_runtime_validation.py` pass; `mypy` and `flake8` clean on both changed files.
- [ ] **Definitive validation:** a clean experiment run where verification actually executes — confirm `runner.log` shows no `init_sys_streams` / `Bad file descriptor` blockers.

## Related

- **Not** a regression from #595 / #600 — `work_analyzer.py` is unchanged by the layered-spawning branch, and the Marcus server is not spawned by the experiment runner. This is a pre-existing latent bug, exposed by how the server is launched.
- #601 — "the verification layer is systematically unreliable"; this is one of four distinct verification failures found across past experiment runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
