### PR TITLE
feat(mcp): deliver task context in request_next_task response (#605)

### DIFF
--- a/src/marcus_mcp/tools/context.py
+++ b/src/marcus_mcp/tools/context.py
@@ -619,7 +619,7 @@ async def _collect_task_artifacts(
     return artifacts
 
 
-def _collect_transitive_context(
+async def _collect_transitive_context(
     task_id: str, task: Any, state: Any
 ) -> Dict[str, List[Dict[str, Any]]]:
     """
@@ -708,6 +708,46 @@ def _collect_transitive_context(
             artifact.setdefault("usage_guidance", _COORDINATION_REFERENCE_GUIDANCE)
             artifacts.append(artifact)
 
+        # PR #606 review P2: _collect_task_artifacts pulls Kanban
+        # attachments for direct deps; the transitive walk has to do
+        # the same or architectural docs that were attached (but not
+        # logged via ``log_artifact``) silently disappear past the
+        # first hop.
+        kanban = getattr(state, "kanban_client", None)
+        if kanban is not None and anc_task is not None:
+            try:
+                card_id = getattr(anc_task, "kanban_card_id", None) or anc_id
+                kanban_result = await kanban.get_attachments(card_id=card_id)
+                if kanban_result.get("success", False):
+                    for attachment in kanban_result.get("data", []) or []:
+                        attach_artifact: Dict[str, Any] = {
+                            "filename": attachment.get("name"),
+                            "location": (
+                                f"./attachments/{attachment.get('id')}/"
+                                f"{attachment.get('name')}"
+                            ),
+                            "storage_type": "attachment",
+                            "artifact_type": "reference",
+                            "created_by": attachment.get("userId"),
+                            "created_at": attachment.get("createdAt"),
+                            "dependency_task_id": anc_id,
+                            "dependency_task_name": anc_name,
+                            "description": (
+                                f"Attachment from transitive ancestor: " f"{anc_name}"
+                            ),
+                            "scope_annotation": "reference_only",
+                            "usage_guidance": _COORDINATION_REFERENCE_GUIDANCE,
+                        }
+                        if _is_architectural_artifact(attach_artifact):
+                            artifacts.append(attach_artifact)
+            except Exception as exc:  # noqa: BLE001
+                logger.warning(
+                    "Failed to get Kanban attachments for transitive "
+                    "ancestor %s: %s",
+                    anc_id,
+                    exc,
+                )
+
     decisions: List[Dict[str, Any]] = []
     context = getattr(state, "context", None)
     if context is not None:
@@ -759,11 +799,19 @@ async def assemble_task_context(task_id: str, task: Any, state: Any) -> Dict[str
     project_contract = _collect_foundation_contract(state)
 
     direct_artifacts = await _collect_task_artifacts(task_id, task, state)
+    # PR #606 review P2: _collect_task_artifacts also returns the
+    # requesting task's *own* logged artifacts and Kanban attachments,
+    # which lack ``dependency_task_id``. Filter to dependency-sourced
+    # entries so ``dependency_artifacts`` is what its name claims and
+    # downstream consumers that rely on the scope/coordination shape
+    # never see the task's own artifacts mis-tagged as deps.
     dependency_artifacts = [
-        a for a in direct_artifacts if _is_architectural_artifact(a)
+        a
+        for a in direct_artifacts
+        if a.get("dependency_task_id") and _is_architectural_artifact(a)
     ]
 
-    transitive_context = _collect_transitive_context(task_id, task, state)
+    transitive_context = await _collect_transitive_context(task_id, task, state)
 
     return {
         "project_contract": project_contract,

--- a/src/marcus_mcp/tools/context.py
+++ b/src/marcus_mcp/tools/context.py
@@ -6,7 +6,7 @@ This module contains tools for context management:
 """
 
 import logging
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Set
 
 from src.core.project_history import Decision as HistoryDecision
 from src.core.project_history import (
@@ -253,6 +253,52 @@ async def get_task_context(task_id: str, state: Any) -> Dict[str, Any]:
 
     except Exception as e:
         return {"success": False, "error": str(e)}
+
+
+# Issue #605: context carries architectural artifacts only — never source
+# code. These are the artifact types whose canonical home is under ``docs/``
+# (see ``ARTIFACT_PATHS`` in ``attachment.py``). Any artifact whose
+# ``artifact_type`` is not in this set (e.g. ``temporary`` or a custom type
+# pointing at real code) is excluded from delivered context.
+ARCHITECTURAL_ARTIFACT_TYPES = frozenset(
+    {
+        "specification",
+        "api",
+        "design",
+        "architecture",
+        "documentation",
+        "reference",
+    }
+)
+
+
+def _is_architectural_artifact(artifact: Dict[str, Any]) -> bool:
+    """
+    Return ``True`` when an artifact is architectural (safe to deliver).
+
+    Issue #605: delivered context carries decisions and architectural
+    artifacts only, never source code. An artifact qualifies when its
+    ``artifact_type`` is one of :data:`ARCHITECTURAL_ARTIFACT_TYPES`.
+    Artifacts with no ``artifact_type`` are treated as architectural —
+    Kanban attachments, for example, are stamped ``artifact_type:
+    "reference"`` already, and missing the field should not silently
+    drop a doc.
+
+    Parameters
+    ----------
+    artifact : Dict[str, Any]
+        An artifact dict from ``state.task_artifacts`` or a Kanban
+        attachment record.
+
+    Returns
+    -------
+    bool
+        ``True`` when the artifact may be delivered as context.
+    """
+    artifact_type = artifact.get("artifact_type")
+    if artifact_type is None:
+        return True
+    return artifact_type in ARCHITECTURAL_ARTIFACT_TYPES
 
 
 _COORDINATION_REFERENCE_GUIDANCE = (
@@ -571,6 +617,159 @@ async def _collect_task_artifacts(
         print(f"Warning: Artifact collection encountered an error: {e}")
 
     return artifacts
+
+
+def _collect_transitive_context(
+    task_id: str, task: Any, state: Any
+) -> Dict[str, List[Dict[str, Any]]]:
+    """
+    Collect ambient context from a task's *transitive* ancestors.
+
+    Issue #605 tier 3: beyond the foundation contract (project-global)
+    and direct-dependency artifacts (one hop, ``in_scope``), an agent
+    also benefits from architectural artifacts and decisions produced
+    further upstream. This helper walks the dependency graph past the
+    first hop and gathers that ambient reference material.
+
+    Everything returned is labelled ``scope_annotation: "reference_only"``
+    — it is context to coordinate against, not work the requesting agent
+    owns. Direct (one-hop) dependencies are excluded here; those are
+    handled by :func:`_collect_task_artifacts` with proper ``in_scope`` /
+    ``reference_only`` annotation. Foundation (pre-fork synthesis) tasks
+    are also excluded — their output rides the project-global contract.
+
+    Only architectural artifacts are returned (see
+    :func:`_is_architectural_artifact`); source-code artifacts are never
+    delivered as context.
+
+    Decisions propagate fully: every decision made on any transitive
+    ancestor is returned, because architectural decisions are small and
+    cross-cutting and every descendant should see them.
+
+    Parameters
+    ----------
+    task_id : str
+        The requesting task's ID.
+    task : Any
+        The requesting task. Its ``dependencies`` list seeds the walk.
+    state : Any
+        Marcus server state. ``project_tasks``, ``task_artifacts`` and
+        ``context`` are each consulted defensively.
+
+    Returns
+    -------
+    Dict[str, List[Dict[str, Any]]]
+        ``{"artifacts": [...], "decisions": [...]}`` — transitive
+        ancestor artifacts and decisions, each ``reference_only``. Both
+        lists are empty when there is no transitive ancestry.
+    """
+    project_tasks = getattr(state, "project_tasks", None) or []
+    tasks_by_id = {t.id: t for t in project_tasks}
+    task_artifacts = getattr(state, "task_artifacts", None) or {}
+
+    direct_deps = set(getattr(task, "dependencies", None) or [])
+    foundation_ids = {
+        t.id
+        for t in project_tasks
+        if getattr(t, "source_type", None) == "pre_fork_synthesis"
+    }
+
+    # Breadth-first walk of all ancestors. ``visited`` guards against
+    # cycles in a malformed dependency graph.
+    ancestors: Set[str] = set()
+    visited: Set[str] = {task_id}
+    frontier = list(direct_deps)
+    while frontier:
+        dep_id = frontier.pop()
+        if dep_id in visited:
+            continue
+        visited.add(dep_id)
+        ancestors.add(dep_id)
+        dep_task = tasks_by_id.get(dep_id)
+        if dep_task is not None:
+            for upstream in getattr(dep_task, "dependencies", None) or []:
+                if upstream not in visited:
+                    frontier.append(upstream)
+
+    # Transitive-only = ancestors minus direct deps minus foundation.
+    transitive_ids = ancestors - direct_deps - foundation_ids
+
+    artifacts: List[Dict[str, Any]] = []
+    for anc_id in transitive_ids:
+        anc_task = tasks_by_id.get(anc_id)
+        anc_name = getattr(anc_task, "name", anc_id) if anc_task else anc_id
+        for raw in task_artifacts.get(anc_id, []):
+            if not _is_architectural_artifact(raw):
+                continue
+            artifact = dict(raw)
+            artifact["scope_annotation"] = "reference_only"
+            artifact["dependency_task_id"] = anc_id
+            artifact["dependency_task_name"] = anc_name
+            artifact.setdefault("usage_guidance", _COORDINATION_REFERENCE_GUIDANCE)
+            artifacts.append(artifact)
+
+    decisions: List[Dict[str, Any]] = []
+    context = getattr(state, "context", None)
+    if context is not None:
+        for decision in getattr(context, "decisions", None) or []:
+            if getattr(decision, "task_id", None) in transitive_ids:
+                decision_dict = decision.to_dict()
+                decision_dict["scope_annotation"] = "reference_only"
+                decisions.append(decision_dict)
+
+    return {"artifacts": artifacts, "decisions": decisions}
+
+
+async def assemble_task_context(task_id: str, task: Any, state: Any) -> Dict[str, Any]:
+    """
+    Assemble the full delivered context for a freshly assigned task.
+
+    Issue #605: context must be delivered *with* the task in the
+    ``request_next_task`` response, not left to the optional
+    ``get_task_context`` call. This helper builds the three-tier context
+    bundle so :func:`request_next_task` can attach it directly.
+
+    The three tiers, each scope-labelled:
+
+    1. ``project_contract`` — the project-global foundation contract
+       (:func:`_collect_foundation_contract`). Reaches every task.
+    2. ``dependency_artifacts`` — direct-dependency artifacts, filtered
+       to architectural types, carrying the ``in_scope`` /
+       ``reference_only`` annotation set by :func:`_collect_task_artifacts`.
+    3. ``transitive_context`` — transitive ancestor artifacts and all
+       upstream decisions (:func:`_collect_transitive_context`), every
+       entry ``reference_only``.
+
+    Parameters
+    ----------
+    task_id : str
+        The assigned task's ID.
+    task : Any
+        The assigned task object.
+    state : Any
+        Marcus server state.
+
+    Returns
+    -------
+    Dict[str, Any]
+        ``{"project_contract": {...}, "dependency_artifacts": [...],
+        "transitive_context": {...}}``. Each field degrades to an empty
+        value rather than raising when a subsystem is unavailable.
+    """
+    project_contract = _collect_foundation_contract(state)
+
+    direct_artifacts = await _collect_task_artifacts(task_id, task, state)
+    dependency_artifacts = [
+        a for a in direct_artifacts if _is_architectural_artifact(a)
+    ]
+
+    transitive_context = _collect_transitive_context(task_id, task, state)
+
+    return {
+        "project_contract": project_contract,
+        "dependency_artifacts": dependency_artifacts,
+        "transitive_context": transitive_context,
+    }
 
 
 async def _collect_sibling_subtask_context(

--- a/src/marcus_mcp/tools/task.py
+++ b/src/marcus_mcp/tools/task.py
@@ -1603,21 +1603,11 @@ async def request_next_task(agent_id: str, state: Any) -> Any:
                 context_data = None
                 dependency_awareness = None
 
-                # Skip context building during project creation to avoid blocking
-                # Context can be built asynchronously after task assignment
+                # Issue #605: context is delivered IN this response, so it
+                # must never be skipped. The old ">5 TODO tasks" guard
+                # dropped context exactly when a large backlog made
+                # coordination matter most — it has been removed.
                 build_context = hasattr(state, "context") and state.context
-
-                # Check if we're in project creation mode (many tasks being
-                # created)
-                if build_context and hasattr(state, "project_tasks"):
-                    # If more than 5 tasks in TODO state, likely creating
-                    # a project
-                    todo_count = sum(
-                        1 for t in state.project_tasks if t.status == TaskStatus.TODO
-                    )
-                    if todo_count > 5:
-                        # Skip context during bulk creation
-                        build_context = False
 
                 if build_context:
                     # Add any GitHub implementations to context first
@@ -1917,6 +1907,37 @@ async def request_next_task(agent_id: str, state: Any) -> Any:
                     response["task"]["full_context"] = context_data
                 if predictions:
                     response["task"]["predictions"] = predictions
+
+                # Issue #605: deliver task context IN this response. The
+                # agent pulls a task; the three-tier context bundle —
+                # project_contract (project-global), dependency_artifacts
+                # (direct deps, in_scope), and transitive_context
+                # (ancestor artifacts + all upstream decisions,
+                # reference_only) — comes with it. This is always
+                # attached, never skipped, so an agent that never calls
+                # the optional get_task_context tool still has full
+                # context to build against.
+                try:
+                    from src.marcus_mcp.tools.context import assemble_task_context
+
+                    delivered_context = await assemble_task_context(
+                        optimal_task.id, optimal_task, state
+                    )
+                    response["task"]["project_contract"] = delivered_context[
+                        "project_contract"
+                    ]
+                    response["task"]["dependency_artifacts"] = delivered_context[
+                        "dependency_artifacts"
+                    ]
+                    response["task"]["transitive_context"] = delivered_context[
+                        "transitive_context"
+                    ]
+                except Exception as ctx_err:
+                    # Context delivery must never break task assignment.
+                    logger.warning(
+                        "Failed to assemble delivered context for task "
+                        f"{optimal_task.id}: {ctx_err}"
+                    )
 
                 # Log task assignment to conversation (CRITICAL for debugging)
                 conversation_logger.log_worker_message(

--- a/tests/unit/mcp/test_delivered_task_context.py
+++ b/tests/unit/mcp/test_delivered_task_context.py
@@ -1,0 +1,328 @@
+"""
+Unit tests for guaranteed task-context delivery (issue #605).
+
+Marcus is a multi-agent coordination platform. An agent pulls a task via
+the ``request_next_task`` MCP tool, then builds it. To build something
+that fits the rest of the project the agent needs *context*: the
+project's shared foundation contract and the architectural artifacts and
+decisions of its dependencies.
+
+Before #605 that context only arrived if the agent made a *second*,
+optional ``get_task_context`` call — and a context-build was skipped
+entirely whenever more than five TODO tasks existed. Issue #605 folds
+context into the ``request_next_task`` response itself, in three
+scope-labelled tiers:
+
+1. ``project_contract`` — the project-global foundation contract.
+2. ``dependency_artifacts`` — direct-dependency artifacts (``in_scope``).
+3. ``transitive_context`` — transitive ancestor artifacts + all upstream
+   decisions (``reference_only``).
+
+These tests cover the new assembly helpers
+(:func:`_collect_transitive_context`, :func:`assemble_task_context`) and
+the architectural-artifact filter that keeps source code out of context.
+"""
+
+from datetime import datetime, timezone
+from typing import Any, Dict, List
+
+import pytest
+
+from src.core.models import Priority, Task, TaskStatus
+from src.marcus_mcp.tools.context import (
+    ARCHITECTURAL_ARTIFACT_TYPES,
+    _collect_transitive_context,
+    _is_architectural_artifact,
+    assemble_task_context,
+)
+
+pytestmark = pytest.mark.unit
+
+
+class _MockDecision:
+    """Minimal architectural-decision stand-in."""
+
+    def __init__(self, task_id: str, what: str) -> None:
+        self.task_id = task_id
+        self._what = what
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {"task_id": self.task_id, "what": self._what}
+
+
+class _MockContext:
+    """Mock Context subsystem carrying a flat decision list."""
+
+    def __init__(self) -> None:
+        self.decisions: List[_MockDecision] = []
+
+
+class _MockState:
+    """Mock Marcus server state."""
+
+    def __init__(self) -> None:
+        self.task_artifacts: Dict[str, List[Dict[str, Any]]] = {}
+        self.project_tasks: List[Task] = []
+        self.context = _MockContext()
+        self.kanban_client = None
+        self.events = None
+        self.subtask_manager: Any = None
+
+
+def _task(
+    task_id: str,
+    *,
+    source_type: str = "",
+    dependencies: List[str] | None = None,
+    labels: List[str] | None = None,
+) -> Task:
+    """Build a Task with the fields the context helpers touch."""
+    return Task(
+        id=task_id,
+        name=f"Task {task_id}",
+        description="",
+        status=TaskStatus.TODO,
+        priority=Priority.MEDIUM,
+        assigned_to=None,
+        created_at=datetime.now(timezone.utc),
+        updated_at=datetime.now(timezone.utc),
+        due_date=None,
+        estimated_hours=1.0,
+        dependencies=dependencies or [],
+        labels=labels or [],
+        source_type=source_type,
+    )
+
+
+@pytest.fixture()
+def state() -> _MockState:
+    """Provide a fresh mock state per test."""
+    return _MockState()
+
+
+class TestIsArchitecturalArtifact:
+    """_is_architectural_artifact keeps source code out of context."""
+
+    @pytest.mark.parametrize("artifact_type", sorted(ARCHITECTURAL_ARTIFACT_TYPES))
+    def test_architectural_types_pass(self, artifact_type: str) -> None:
+        """All six doc-backed artifact types are deliverable."""
+        assert _is_architectural_artifact({"artifact_type": artifact_type})
+
+    def test_temporary_type_rejected(self) -> None:
+        """The ``temporary`` type is not delivered as context."""
+        assert not _is_architectural_artifact({"artifact_type": "temporary"})
+
+    def test_custom_type_rejected(self) -> None:
+        """A non-standard type (e.g. real code) is not delivered."""
+        assert not _is_architectural_artifact({"artifact_type": "source_code"})
+
+    def test_missing_type_treated_as_architectural(self) -> None:
+        """An artifact with no artifact_type is treated as deliverable."""
+        assert _is_architectural_artifact({"filename": "notes.md"})
+
+
+class TestCollectTransitiveContext:
+    """_collect_transitive_context gathers ambient ancestor material."""
+
+    def test_collects_artifacts_beyond_first_hop(self, state: _MockState) -> None:
+        """
+        Artifacts two hops upstream are returned as reference_only.
+
+        Graph: leaf -> mid -> root. ``mid`` is a direct dependency of
+        ``leaf`` (handled elsewhere); ``root`` is transitive and should
+        appear here.
+        """
+        leaf = _task("leaf", dependencies=["mid"])
+        mid = _task("mid", dependencies=["root"])
+        root = _task("root")
+        state.project_tasks = [leaf, mid, root]
+        state.task_artifacts["mid"] = [
+            {"filename": "mid.md", "artifact_type": "design"}
+        ]
+        state.task_artifacts["root"] = [
+            {"filename": "root.md", "artifact_type": "architecture"}
+        ]
+
+        result = _collect_transitive_context("leaf", leaf, state)
+
+        # ``mid`` is a direct dep — excluded here. ``root`` is transitive.
+        assert [a["filename"] for a in result["artifacts"]] == ["root.md"]
+        assert result["artifacts"][0]["scope_annotation"] == "reference_only"
+
+    def test_excludes_direct_dependencies(self, state: _MockState) -> None:
+        """Direct (one-hop) dependency artifacts are not transitive."""
+        leaf = _task("leaf", dependencies=["mid"])
+        mid = _task("mid")
+        state.project_tasks = [leaf, mid]
+        state.task_artifacts["mid"] = [
+            {"filename": "mid.md", "artifact_type": "design"}
+        ]
+
+        result = _collect_transitive_context("leaf", leaf, state)
+
+        assert result["artifacts"] == []
+
+    def test_excludes_foundation_tasks(self, state: _MockState) -> None:
+        """Foundation output rides project_contract, not transitive."""
+        leaf = _task("leaf", dependencies=["mid"])
+        mid = _task("mid", dependencies=["f1"])
+        foundation = _task("f1", source_type="pre_fork_synthesis")
+        state.project_tasks = [leaf, mid, foundation]
+        state.task_artifacts["f1"] = [
+            {"filename": "tsconfig.json", "artifact_type": "specification"}
+        ]
+
+        result = _collect_transitive_context("leaf", leaf, state)
+
+        assert result["artifacts"] == []
+
+    def test_excludes_source_code_artifacts(self, state: _MockState) -> None:
+        """Non-architectural artifacts are filtered out transitively."""
+        leaf = _task("leaf", dependencies=["mid"])
+        mid = _task("mid", dependencies=["root"])
+        root = _task("root")
+        state.project_tasks = [leaf, mid, root]
+        state.task_artifacts["root"] = [
+            {"filename": "feature.py", "artifact_type": "temporary"},
+            {"filename": "spec.md", "artifact_type": "specification"},
+        ]
+
+        result = _collect_transitive_context("leaf", leaf, state)
+
+        assert [a["filename"] for a in result["artifacts"]] == ["spec.md"]
+
+    def test_collects_transitive_decisions(self, state: _MockState) -> None:
+        """Decisions on transitive ancestors propagate as reference_only."""
+        leaf = _task("leaf", dependencies=["mid"])
+        mid = _task("mid", dependencies=["root"])
+        root = _task("root")
+        state.project_tasks = [leaf, mid, root]
+        state.context.decisions = [
+            _MockDecision("root", "Use UTC everywhere"),
+            _MockDecision("unrelated", "off-graph decision"),
+        ]
+
+        result = _collect_transitive_context("leaf", leaf, state)
+
+        assert [d["what"] for d in result["decisions"]] == ["Use UTC everywhere"]
+        assert result["decisions"][0]["scope_annotation"] == "reference_only"
+
+    def test_handles_dependency_cycle(self, state: _MockState) -> None:
+        """A cyclic dependency graph does not cause infinite recursion."""
+        leaf = _task("leaf", dependencies=["a"])
+        a = _task("a", dependencies=["b"])
+        b = _task("b", dependencies=["a"])  # cycle a <-> b
+        state.project_tasks = [leaf, a, b]
+        state.task_artifacts["b"] = [{"filename": "b.md", "artifact_type": "design"}]
+
+        result = _collect_transitive_context("leaf", leaf, state)
+
+        assert [a["filename"] for a in result["artifacts"]] == ["b.md"]
+
+    def test_empty_without_transitive_ancestry(self, state: _MockState) -> None:
+        """A task with only direct deps has empty transitive context."""
+        leaf = _task("leaf", dependencies=["mid"])
+        mid = _task("mid")
+        state.project_tasks = [leaf, mid]
+
+        result = _collect_transitive_context("leaf", leaf, state)
+
+        assert result == {"artifacts": [], "decisions": []}
+
+
+class TestAssembleTaskContext:
+    """assemble_task_context builds the full three-tier delivery bundle."""
+
+    @pytest.mark.asyncio
+    async def test_bundle_has_all_three_tiers(self, state: _MockState) -> None:
+        """The assembled bundle exposes the three documented fields."""
+        leaf = _task("leaf")
+        state.project_tasks = [leaf]
+
+        bundle = await assemble_task_context("leaf", leaf, state)
+
+        assert set(bundle) == {
+            "project_contract",
+            "dependency_artifacts",
+            "transitive_context",
+        }
+
+    @pytest.mark.asyncio
+    async def test_includes_foundation_contract(self, state: _MockState) -> None:
+        """Tier 1: the project-global foundation contract is present."""
+        foundation = _task("f1", source_type="pre_fork_synthesis")
+        leaf = _task("leaf")
+        state.project_tasks = [foundation, leaf]
+        state.task_artifacts["f1"] = [
+            {"filename": "package.json", "artifact_type": "specification"}
+        ]
+
+        bundle = await assemble_task_context("leaf", leaf, state)
+
+        contract = bundle["project_contract"]
+        assert [a["filename"] for a in contract["artifacts"]] == ["package.json"]
+
+    @pytest.mark.asyncio
+    async def test_includes_direct_dependency_artifacts(
+        self, state: _MockState
+    ) -> None:
+        """Tier 2: architectural artifacts from direct dependencies."""
+        leaf = _task("leaf", dependencies=["mid"])
+        mid = _task("mid")
+        state.project_tasks = [leaf, mid]
+        state.task_artifacts["mid"] = [
+            {"filename": "mid.md", "artifact_type": "design"}
+        ]
+
+        bundle = await assemble_task_context("leaf", leaf, state)
+
+        assert [a["filename"] for a in bundle["dependency_artifacts"]] == ["mid.md"]
+
+    @pytest.mark.asyncio
+    async def test_filters_source_code_from_direct_dependencies(
+        self, state: _MockState
+    ) -> None:
+        """Source-code artifacts from direct deps are not delivered."""
+        leaf = _task("leaf", dependencies=["mid"])
+        mid = _task("mid")
+        state.project_tasks = [leaf, mid]
+        state.task_artifacts["mid"] = [
+            {"filename": "mid.py", "artifact_type": "temporary"},
+            {"filename": "mid.md", "artifact_type": "design"},
+        ]
+
+        bundle = await assemble_task_context("leaf", leaf, state)
+
+        assert [a["filename"] for a in bundle["dependency_artifacts"]] == ["mid.md"]
+
+    @pytest.mark.asyncio
+    async def test_includes_transitive_context(self, state: _MockState) -> None:
+        """Tier 3: transitive ancestor artifacts ride transitive_context."""
+        leaf = _task("leaf", dependencies=["mid"])
+        mid = _task("mid", dependencies=["root"])
+        root = _task("root")
+        state.project_tasks = [leaf, mid, root]
+        state.task_artifacts["root"] = [
+            {"filename": "root.md", "artifact_type": "architecture"}
+        ]
+
+        bundle = await assemble_task_context("leaf", leaf, state)
+
+        transitive = bundle["transitive_context"]
+        assert [a["filename"] for a in transitive["artifacts"]] == ["root.md"]
+        assert transitive["artifacts"][0]["scope_annotation"] == "reference_only"
+
+    @pytest.mark.asyncio
+    async def test_degrades_to_empty_without_subsystems(
+        self, state: _MockState
+    ) -> None:
+        """Bundle fields degrade to empty values, never raising."""
+        leaf = _task("leaf")
+        state.project_tasks = [leaf]
+        state.context = None  # type: ignore[assignment]
+
+        bundle = await assemble_task_context("leaf", leaf, state)
+
+        assert bundle["project_contract"] == {"artifacts": [], "decisions": []}
+        assert bundle["dependency_artifacts"] == []
+        assert bundle["transitive_context"] == {"artifacts": [], "decisions": []}

--- a/tests/unit/mcp/test_delivered_task_context.py
+++ b/tests/unit/mcp/test_delivered_task_context.py
@@ -69,6 +69,22 @@ class _MockState:
         self.subtask_manager: Any = None
 
 
+class _MockKanbanClient:
+    """Mock Kanban client returning canned attachment data per card_id."""
+
+    def __init__(
+        self,
+        attachments_by_card: Dict[str, List[Dict[str, Any]]] | None = None,
+    ) -> None:
+        self._attachments_by_card = attachments_by_card or {}
+
+    async def get_attachments(self, card_id: str) -> Dict[str, Any]:
+        return {
+            "success": True,
+            "data": self._attachments_by_card.get(card_id, []),
+        }
+
+
 def _task(
     task_id: str,
     *,
@@ -124,7 +140,8 @@ class TestIsArchitecturalArtifact:
 class TestCollectTransitiveContext:
     """_collect_transitive_context gathers ambient ancestor material."""
 
-    def test_collects_artifacts_beyond_first_hop(self, state: _MockState) -> None:
+    @pytest.mark.asyncio
+    async def test_collects_artifacts_beyond_first_hop(self, state: _MockState) -> None:
         """
         Artifacts two hops upstream are returned as reference_only.
 
@@ -143,13 +160,14 @@ class TestCollectTransitiveContext:
             {"filename": "root.md", "artifact_type": "architecture"}
         ]
 
-        result = _collect_transitive_context("leaf", leaf, state)
+        result = await _collect_transitive_context("leaf", leaf, state)
 
         # ``mid`` is a direct dep — excluded here. ``root`` is transitive.
         assert [a["filename"] for a in result["artifacts"]] == ["root.md"]
         assert result["artifacts"][0]["scope_annotation"] == "reference_only"
 
-    def test_excludes_direct_dependencies(self, state: _MockState) -> None:
+    @pytest.mark.asyncio
+    async def test_excludes_direct_dependencies(self, state: _MockState) -> None:
         """Direct (one-hop) dependency artifacts are not transitive."""
         leaf = _task("leaf", dependencies=["mid"])
         mid = _task("mid")
@@ -158,11 +176,12 @@ class TestCollectTransitiveContext:
             {"filename": "mid.md", "artifact_type": "design"}
         ]
 
-        result = _collect_transitive_context("leaf", leaf, state)
+        result = await _collect_transitive_context("leaf", leaf, state)
 
         assert result["artifacts"] == []
 
-    def test_excludes_foundation_tasks(self, state: _MockState) -> None:
+    @pytest.mark.asyncio
+    async def test_excludes_foundation_tasks(self, state: _MockState) -> None:
         """Foundation output rides project_contract, not transitive."""
         leaf = _task("leaf", dependencies=["mid"])
         mid = _task("mid", dependencies=["f1"])
@@ -172,11 +191,12 @@ class TestCollectTransitiveContext:
             {"filename": "tsconfig.json", "artifact_type": "specification"}
         ]
 
-        result = _collect_transitive_context("leaf", leaf, state)
+        result = await _collect_transitive_context("leaf", leaf, state)
 
         assert result["artifacts"] == []
 
-    def test_excludes_source_code_artifacts(self, state: _MockState) -> None:
+    @pytest.mark.asyncio
+    async def test_excludes_source_code_artifacts(self, state: _MockState) -> None:
         """Non-architectural artifacts are filtered out transitively."""
         leaf = _task("leaf", dependencies=["mid"])
         mid = _task("mid", dependencies=["root"])
@@ -187,11 +207,12 @@ class TestCollectTransitiveContext:
             {"filename": "spec.md", "artifact_type": "specification"},
         ]
 
-        result = _collect_transitive_context("leaf", leaf, state)
+        result = await _collect_transitive_context("leaf", leaf, state)
 
         assert [a["filename"] for a in result["artifacts"]] == ["spec.md"]
 
-    def test_collects_transitive_decisions(self, state: _MockState) -> None:
+    @pytest.mark.asyncio
+    async def test_collects_transitive_decisions(self, state: _MockState) -> None:
         """Decisions on transitive ancestors propagate as reference_only."""
         leaf = _task("leaf", dependencies=["mid"])
         mid = _task("mid", dependencies=["root"])
@@ -202,12 +223,13 @@ class TestCollectTransitiveContext:
             _MockDecision("unrelated", "off-graph decision"),
         ]
 
-        result = _collect_transitive_context("leaf", leaf, state)
+        result = await _collect_transitive_context("leaf", leaf, state)
 
         assert [d["what"] for d in result["decisions"]] == ["Use UTC everywhere"]
         assert result["decisions"][0]["scope_annotation"] == "reference_only"
 
-    def test_handles_dependency_cycle(self, state: _MockState) -> None:
+    @pytest.mark.asyncio
+    async def test_handles_dependency_cycle(self, state: _MockState) -> None:
         """A cyclic dependency graph does not cause infinite recursion."""
         leaf = _task("leaf", dependencies=["a"])
         a = _task("a", dependencies=["b"])
@@ -215,19 +237,49 @@ class TestCollectTransitiveContext:
         state.project_tasks = [leaf, a, b]
         state.task_artifacts["b"] = [{"filename": "b.md", "artifact_type": "design"}]
 
-        result = _collect_transitive_context("leaf", leaf, state)
+        result = await _collect_transitive_context("leaf", leaf, state)
 
         assert [a["filename"] for a in result["artifacts"]] == ["b.md"]
 
-    def test_empty_without_transitive_ancestry(self, state: _MockState) -> None:
+    @pytest.mark.asyncio
+    async def test_empty_without_transitive_ancestry(self, state: _MockState) -> None:
         """A task with only direct deps has empty transitive context."""
         leaf = _task("leaf", dependencies=["mid"])
         mid = _task("mid")
         state.project_tasks = [leaf, mid]
 
-        result = _collect_transitive_context("leaf", leaf, state)
+        result = await _collect_transitive_context("leaf", leaf, state)
 
         assert result == {"artifacts": [], "decisions": []}
+
+    @pytest.mark.asyncio
+    async def test_kanban_attachments_from_transitive_ancestors(
+        self, state: _MockState
+    ) -> None:
+        """
+        Regression (PR #606 review P2): the transitive walk also fetches
+        Kanban attachments for ancestors — not just artifacts logged via
+        log_artifact — otherwise architectural docs attached to a multi-
+        hop ancestor silently disappear.
+        """
+        leaf = _task("leaf", dependencies=["mid"])
+        mid = _task("mid", dependencies=["root"])
+        root = _task("root")
+        state.project_tasks = [leaf, mid, root]
+        state.kanban_client = _MockKanbanClient(
+            {
+                "root": [
+                    {"id": "att-1", "name": "design.md", "userId": "u1"},
+                ]
+            }
+        )
+
+        result = await _collect_transitive_context("leaf", leaf, state)
+
+        names = [a["filename"] for a in result["artifacts"]]
+        assert names == ["design.md"]
+        assert result["artifacts"][0]["scope_annotation"] == "reference_only"
+        assert result["artifacts"][0]["dependency_task_id"] == "root"
 
 
 class TestAssembleTaskContext:
@@ -311,6 +363,36 @@ class TestAssembleTaskContext:
         transitive = bundle["transitive_context"]
         assert [a["filename"] for a in transitive["artifacts"]] == ["root.md"]
         assert transitive["artifacts"][0]["scope_annotation"] == "reference_only"
+
+    @pytest.mark.asyncio
+    async def test_dependency_artifacts_excludes_own_artifacts(
+        self, state: _MockState
+    ) -> None:
+        """
+        Regression (PR #606 review P2): dependency_artifacts is filtered
+        to dependency-sourced entries only — the requesting task's *own*
+        logged artifacts must not appear there. _collect_task_artifacts
+        returns both the task's own artifacts and its dependencies', so
+        assemble_task_context filters by dependency_task_id.
+        """
+        leaf = _task("leaf", dependencies=["mid"])
+        mid = _task("mid")
+        state.project_tasks = [leaf, mid]
+        # Own artifact on leaf — no dependency_task_id will be set by
+        # _collect_task_artifacts.
+        state.task_artifacts["leaf"] = [
+            {"filename": "leaf-own.md", "artifact_type": "design"}
+        ]
+        # Dependency artifact on mid — _collect_task_artifacts will
+        # tag it with dependency_task_id=mid.
+        state.task_artifacts["mid"] = [
+            {"filename": "mid.md", "artifact_type": "design"}
+        ]
+
+        bundle = await assemble_task_context("leaf", leaf, state)
+
+        names = [a["filename"] for a in bundle["dependency_artifacts"]]
+        assert names == ["mid.md"]
 
     @pytest.mark.asyncio
     async def test_degrades_to_empty_without_subsystems(


### PR DESCRIPTION
## What this is

Marcus is a multi-agent platform — you describe a project, Marcus decomposes it into a task graph, and AI agents pick up tasks from a shared kanban board. To build something that fits, each agent needs **context**: the project's foundation contract (language, build setup, test harness, the public API surface), its direct dependencies' architectural artifacts, and ambient reference from further upstream.

This PR fixes a real delivery gap from issue #605. Context was being delivered through an *optional* tool call (`get_task_context`) that agents could skip. A probe of run `test54` showed only **4 of 6 agents** received the foundation contract — the other two built their task blind to the project-global contract.

## Why

The defect was narrow but load-bearing: universal information rode the *optional* pull (`get_task_context`) instead of the *mandatory* one (`request_next_task`). You cannot force an autonomous LLM agent to make a tool call — telling agents to call `get_task_context` does not guarantee they will. The fix is to **deliver context with the task** — fold the context bundle into the `request_next_task` response so every agent gets it at assignment.

Marcus stays pull-based by design (Agent Invariant #1): the agent pulls a task via `request_next_task`; the context comes back with it. No push, no separate required call.

## What changed

**`src/marcus_mcp/tools/context.py`** (+201):
- `_collect_transitive_context` — walks the task's transitive dependencies past the direct hop, collects architectural artifacts and decisions from ancestors, every entry carrying `scope_annotation: "reference_only"`. Foundation tasks are excluded (their content rides `project_contract`); source-code artifacts are excluded.
- `assemble_task_context` — composes the three-tier bundle: `project_contract`, `dependency_artifacts`, `transitive_context`.

**`src/marcus_mcp/tools/task.py`** (+49 / −14): `request_next_task` calls `assemble_task_context` after building its response and attaches three new keys to `response["task"]`:

| Key | Tier | Scope | Reaches |
|---|---|---|---|
| `project_contract` | Foundation contract | (global) | Every task |
| `dependency_artifacts` | Direct deps | `in_scope` | One hop |
| `transitive_context` | Transitive ancestors | `reference_only` | Past one hop |

The **`>5-TODO` context skip is removed**; context is never withheld under load. `get_task_context` survives only as an optional mid-task refresh tool.

**`tests/unit/mcp/test_delivered_task_context.py`** (new, 330 lines, `@pytest.mark.unit`): 22 unit tests covering the three tiers, scope annotations, source-code exclusion, and the transitive walk.

## Test plan

- [x] 22 unit tests in `test_delivered_task_context.py` pass under `pytest -m unit`.
- [x] `mypy` clean on both changed source files.
- [x] `flake8` clean on the three changed files.
- [ ] Verify in a real experiment: every agent's `request_next_task` response carries a non-empty `project_contract` + `dependency_artifacts` + `transitive_context`. Confirm an agent that never calls `get_task_context` still has full context.

## What is out of scope

Issue #605 also names a producer/consumer race — foundation tasks should be DONE (artifacts logged) *before* dependents are claimable. That is a separate scheduler-side concern and is **not** in this PR.

## Related

- #604 — what goes *into* the foundation contract (tech-stack pinning). #604 is the contract's *content*; this PR is its *delivery*.
- #595 / #600 — "Fix 2" introduced the project-global foundation contract; this PR makes its delivery actually guaranteed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
