### PR TITLE
feat(decomposer): roll test-pair into completion_criteria + TDD as standard (#607 step 3)

### DIFF
--- a/dev-tools/experiments/templates/agent_prompt.md
+++ b/dev-tools/experiments/templates/agent_prompt.md
@@ -69,6 +69,43 @@ WORKER_SYSTEM_PROMPT: |
   a lease is recovered), the runner spawns a fresh agent for it. An idle
   agent that waits only burns tokens.
 
+  PROJECT STANDARD — TDD FOR IMPLEMENTATION TASKS:
+  Test-Driven Development is a project-wide standard on every
+  implementation task, in the same way "all PRs require review" is a
+  standard. It is NOT a prescription of HOW (you pick the framework,
+  structure the tests, write the assertions). It IS a discipline that
+  governs the order of work.
+
+  For any implementation task — i.e. a task whose name starts with
+  "Implement" — you MUST:
+  1. Read the task's `completion_criteria`. They name the behaviors
+     that must be tested (happy path, invalid input, edge cases, and
+     any feature-specific criteria Marcus has rolled up onto the
+     task).
+  2. Write the tests FIRST, against those criteria. Pick the testing
+     framework that fits the project (pytest / unittest / jest /
+     whatever). Place the tests wherever the project's structure
+     calls for.
+  3. Run the tests and WATCH THEM FAIL. A test suite that passes
+     before any implementation has been written is a broken test
+     suite.
+  4. Write the implementation to make the failing tests pass.
+  5. Do NOT modify the tests to fit the implementation. If a test
+     and the implementation disagree, fix the implementation. The
+     tests are the contract.
+
+  Why this is non-negotiable: an LLM agent cannot retrofit a passing
+  test for code that does not yet exist. Tests written first, watched
+  to fail, then made to pass, are the only structural guarantee that
+  your implementation actually satisfies the behaviors Marcus
+  required. The runtime validator runs your tests as part of task
+  validation — tests that don't exist, or trivial tests that just
+  call the function and assert it returned something, will fail
+  validation.
+
+  This applies to implementation tasks across all complexity modes
+  (prototype, standard, enterprise). Issue #607.
+
   CONTEXT AND DECISION TOOLS:
 
   Using get_task_context:

--- a/src/ai/advanced/prd/advanced_parser.py
+++ b/src/ai/advanced/prd/advanced_parser.py
@@ -2438,8 +2438,26 @@ Create design artifacts such as:
         # behavior strings and the extractor preserves them as-is. The
         # type-hint mismatch is flagged as a follow-up rather than fixed
         # in this PR to keep the diff focused.
+        # Codex P1 (PR #608 review): _extract_task_type defaults unknown
+        # task IDs to "implement" (with a logged warning) — so non-feature
+        # tasks like ``infra_setup`` / ``infra_ci_cd`` / NFR requirement
+        # tasks would otherwise inherit test-coverage criteria they have
+        # no business carrying (an infra-setup task should not be asked
+        # to provide happy-path / invalid-input behavior tests). Gate on
+        # the *canonical* type recorded in ``_task_metadata`` instead,
+        # which is populated for every task_id at decomposition time
+        # (bundled designs at line ~1981, feature work via
+        # ``_break_down_epic`` at ~2071, NFRs at ~2096, infrastructure
+        # at ~2118). ``self.TASK_TYPE_IMPLEMENTATION`` is the canonical
+        # marker for true feature implementation tasks emitted by
+        # ``_select_task_pattern``.
+        task_meta_type = (
+            self._task_metadata.get(task_id, {}).get("type")
+            if hasattr(self, "_task_metadata")
+            else None
+        )
         completion_criteria: Optional[List[str]] = None
-        if task_type == "implement":
+        if task_type == "implement" and task_meta_type == self.TASK_TYPE_IMPLEMENTATION:
             completion_criteria = self._generate_test_coverage_criteria(
                 feature_name=feature_name,
                 base_description=(

--- a/src/ai/advanced/prd/advanced_parser.py
+++ b/src/ai/advanced/prd/advanced_parser.py
@@ -2423,6 +2423,30 @@ Create design artifacts such as:
             criteria_type, {}, task_name
         )
 
+        # Issue #607 step 3 — test-pair rollup. The implement task carries
+        # the test-coverage criteria that previously lived on a separate
+        # ``Test {feature}`` task. Surfaced to the agent via
+        # ``request_next_task`` (see ``src/marcus_mcp/tools/task.py`` and
+        # consumed by ``WorkAnalyzer._extract_criteria``, which already
+        # supports list-of-strings shape — see
+        # ``tests/unit/ai/test_criteria_extraction.py``).
+        #
+        # Shape note: the dataclass declares
+        # ``completion_criteria: Optional[Dict[str, Any]]`` but live usage
+        # (extractor + persistence + tests) accepts a ``List[str]``. We
+        # populate the list form here because the criteria are flat
+        # behavior strings and the extractor preserves them as-is. The
+        # type-hint mismatch is flagged as a follow-up rather than fixed
+        # in this PR to keep the diff focused.
+        completion_criteria: Optional[List[str]] = None
+        if task_type == "implement":
+            completion_criteria = self._generate_test_coverage_criteria(
+                feature_name=feature_name,
+                base_description=(
+                    relevant_req.get("description", "") if relevant_req else ""
+                ),
+            )
+
         # Create task with clean AI description
         task = Task(
             id=task_id,
@@ -2438,6 +2462,7 @@ Create design artifacts such as:
             dependencies=[],  # Will be filled by dependency inference
             labels=labels,
             acceptance_criteria=acceptance_criteria,
+            completion_criteria=completion_criteria,  # type: ignore[arg-type]
             # Store context for reference
             source_type="nlp_project",
             source_context={
@@ -3244,11 +3269,22 @@ explanation."""
             hasattr(self, "_bundled_designs") and self._bundled_designs
         )
 
-        # Determine task pattern based on complexity and mode
+        # Determine task pattern based on complexity and mode.
+        #
+        # Issue #607 step 3 (test-pair rollup): the paired ``Test {feature}``
+        # task that previously accompanied every ``Implement {feature}`` task
+        # at standard/enterprise complexity has been REMOVED. The behaviors
+        # that must be tested are instead populated as ``completion_criteria``
+        # on the implement task itself, and the worker prompt makes TDD a
+        # project-wide standard ("write tests first against the criteria,
+        # watch them fail, then make them pass"). The runtime validator
+        # (``_validate_runtime``) remains the enforcement gate that tests
+        # exist and pass. Net effect: one less task per feature per implement,
+        # without losing the testing contract.
         if complexity_mode == "prototype":
-            # Prototype: Speed over structure - skip design tasks
-            # Atomic/simple: just implement
-            # Coordinated/distributed: implement + test
+            # Prototype: Speed over structure - skip design tasks.
+            # Every complexity gets exactly one implement task; the test
+            # behaviors are rolled up onto its completion_criteria.
             tasks.append(
                 {
                     "id": f"task_{req_id}_implement",
@@ -3256,20 +3292,12 @@ explanation."""
                     "type": self.TASK_TYPE_IMPLEMENTATION,
                 }
             )
-            # Add testing for coordinated/distributed features
-            if complexity in ["coordinated", "distributed"]:
-                tasks.append(
-                    {
-                        "id": f"task_{req_id}_test",
-                        "name": f"Test {feature_name}",
-                        "type": self.TASK_TYPE_TESTING,
-                    }
-                )
 
         elif complexity_mode == "enterprise":
-            # Enterprise: Full traceability with design tasks for simple+ features
-            # Atomic features skip design (too simple to need coordination artifacts)
-            # SKIP per-feature designs if bundled domain designs exist (GH-108)
+            # Enterprise: Full traceability with design tasks for simple+
+            # features. Atomic features skip design (too simple to need
+            # coordination artifacts). SKIP per-feature designs if bundled
+            # domain designs exist (GH-108).
             if complexity != "atomic" and not has_bundled_designs:
                 tasks.append(
                     {
@@ -3285,18 +3313,11 @@ explanation."""
                     "type": self.TASK_TYPE_IMPLEMENTATION,
                 }
             )
-            tasks.append(
-                {
-                    "id": f"task_{req_id}_test",
-                    "name": f"Test {feature_name}",
-                    "type": self.TASK_TYPE_TESTING,
-                }
-            )
 
         else:  # standard mode (default)
-            # Design ONLY for coordinated/distributed (produces coordination artifacts)
-            # Atomic/simple: just implement (nothing to coordinate)
-            # SKIP per-feature designs if bundled domain designs exist (GH-108)
+            # Design ONLY for coordinated/distributed (produces coordination
+            # artifacts). Atomic/simple: just implement.  SKIP per-feature
+            # designs if bundled domain designs exist (GH-108).
             if complexity in ["coordinated", "distributed"] and not has_bundled_designs:
                 tasks.append(
                     {
@@ -3312,15 +3333,6 @@ explanation."""
                     "type": self.TASK_TYPE_IMPLEMENTATION,
                 }
             )
-            # Add testing for simple/coordinated/distributed (not atomic)
-            if complexity != "atomic":
-                tasks.append(
-                    {
-                        "id": f"task_{req_id}_test",
-                        "name": f"Test {feature_name}",
-                        "type": self.TASK_TYPE_TESTING,
-                    }
-                )
 
         return tasks
 
@@ -4549,6 +4561,79 @@ explanation."""
             criteria.append("Order workflow is thoroughly tested")
 
         return criteria[:5]  # Return top 5 most relevant criteria
+
+    def _generate_test_coverage_criteria(
+        self,
+        feature_name: str,
+        base_description: str = "",
+    ) -> List[str]:
+        """Generate test-coverage criteria strings for a feature.
+
+        Issue #607 step 3 — these strings replace the per-feature ``Test
+        {feature}`` board task. They are attached to the paired ``Implement
+        {feature}`` task as ``completion_criteria`` and surfaced to the
+        agent via ``request_next_task``. Combined with the worker prompt's
+        TDD-as-standard directive (write tests first, watch fail, then
+        make pass), this preserves the testing contract without the
+        per-feature task explosion documented in #607.
+
+        The criteria name *behaviors that must be tested*, not test
+        framework or structure: the agent picks pytest / unittest / jest
+        / whatever, decides assertion style, and writes the actual tests.
+        The runtime validator (``_validate_runtime``) is the enforcement
+        gate that tests exist and pass.
+
+        Parameters
+        ----------
+        feature_name : str
+            Feature being implemented (e.g., ``"User Login"``,
+            ``"Mark Complete"``). Used to anchor criteria to the feature.
+        base_description : str, optional
+            Feature requirement description. Reserved for future use by
+            heuristics that infer feature-specific edge cases; ignored
+            today so the helper is fully deterministic.
+
+        Returns
+        -------
+        List[str]
+            Non-empty list of test-behavior criterion strings. Each string
+            names a behavior to cover; no string names a framework, test
+            file, assertion library, or other implementation HOW.
+        """
+        # ``base_description`` is intentionally accepted but not used
+        # in this first cut — keeping the signature future-proof for
+        # heuristics that would mine the description for domain-specific
+        # cases (e.g., monetary rounding, timezone handling) without
+        # changing every call site. Reference it to make the intent
+        # clear to readers and silence ``unused argument`` linters.
+        _ = base_description
+
+        # Defaults cover the four behavior categories that an LLM agent
+        # cannot fake under TDD without writing real tests first:
+        # happy path, invalid input, error/edge cases, and a contract
+        # statement tying tests to the feature. Phrasing is deliberately
+        # generic enough to apply to any feature while still being
+        # specific to ``feature_name``.
+        criteria: List[str] = [
+            (
+                f"Tests cover the happy path for {feature_name} with valid "
+                f"input and expected behavior."
+            ),
+            (
+                f"Tests cover invalid input handling for {feature_name} "
+                f"(missing fields, malformed values, type mismatches)."
+            ),
+            (
+                f"Tests cover error and edge cases for {feature_name} "
+                f"(boundaries, empty/large inputs, repeated calls)."
+            ),
+            (
+                "Tests were written before the implementation, watched "
+                "fail, then made to pass — and were not modified to fit "
+                "the implementation."
+            ),
+        ]
+        return criteria
 
     def _generate_subtasks(
         self, task_type: str, context: Dict[str, Any], task_name: str

--- a/tests/unit/ai/test_advanced_prd_parser.py
+++ b/tests/unit/ai/test_advanced_prd_parser.py
@@ -467,14 +467,20 @@ class TestAdvancedPRDParserTaskGeneration:
         tasks1 = await parser._break_down_epic(req1, analysis, mock_constraints)
         tasks2 = await parser._break_down_epic(req2, analysis, mock_constraints)
 
+        # Issue #607 step 3: design + implement only (Test task rolled up
+        # into completion_criteria on the implement task).
+        assert len(tasks1) == 2
+        assert len(tasks2) == 2
+
         # Check task IDs are unique and based on feature
         assert tasks1[0]["id"] == "task_crud_operations_design"
         assert tasks1[1]["id"] == "task_crud_operations_implement"
-        assert tasks1[2]["id"] == "task_crud_operations_test"
 
         assert tasks2[0]["id"] == "task_user_auth_design"
         assert tasks2[1]["id"] == "task_user_auth_implement"
-        assert tasks2[2]["id"] == "task_user_auth_test"
+
+        # No separate testing tasks anywhere.
+        assert all(t["type"] != "testing" for t in tasks1 + tasks2)
 
         # Check task names include feature name
         assert tasks1[0]["name"] == "Design CRUD Operations"
@@ -547,10 +553,10 @@ class TestAdvancedPRDParserTaskGeneration:
         assert "epic_todo_properties" in hierarchy
         assert "epic_user_auth" in hierarchy
 
-        # Each functional epic should have 3 tasks
-        assert len(hierarchy["epic_crud_operations"]) == 3
-        assert len(hierarchy["epic_todo_properties"]) == 3
-        assert len(hierarchy["epic_user_auth"]) == 3
+        # Issue #607 step 3: design + implement only (no Test task) -> 2 tasks each.
+        assert len(hierarchy["epic_crud_operations"]) == 2
+        assert len(hierarchy["epic_todo_properties"]) == 2
+        assert len(hierarchy["epic_user_auth"]) == 2
 
         # NFR epic should have tasks for each NFR
         assert len(hierarchy["epic_non_functional"]) == 2  # Performance + Security

--- a/tests/unit/ai/test_intelligent_task_patterns.py
+++ b/tests/unit/ai/test_intelligent_task_patterns.py
@@ -773,3 +773,136 @@ class TestImplementTaskCompletionCriteriaIntegration:
         assert (
             task.completion_criteria is None
         ), "design tasks must NOT receive completion_criteria (only implement)"
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_infrastructure_task_does_not_get_completion_criteria(
+        self, parser, constraints
+    ):
+        """Infrastructure tasks must not inherit test-coverage criteria.
+
+        Regression guard for Codex P1 on PR #608: ``_extract_task_type``
+        falls back to ``"implement"`` when a task_id contains no
+        design/implement/test substring (e.g. ``"infra_setup"``,
+        ``"infra_ci_cd"``). Without canonical-type gating, those tasks
+        would receive happy-path / invalid-input criteria they have no
+        business carrying. The gate must consult ``_task_metadata`` and
+        only emit criteria when the canonical type equals
+        ``TASK_TYPE_IMPLEMENTATION``.
+        """
+        # Arrange — infra task_id with no design/implement/test substring,
+        # canonical type stamped as "infrastructure" in _task_metadata.
+        from types import SimpleNamespace
+
+        infra_analysis = SimpleNamespace(
+            functional_requirements=[],
+            non_functional_requirements=[],
+            technical_constraints=[],
+            original_description="Project setup.",
+        )
+        parser._task_metadata = {
+            "infra_setup": {
+                "original_name": "Project Setup",
+                "type": "infrastructure",
+                "epic_id": "epic_infrastructure",
+                "description": "Configure project tooling.",
+            }
+        }
+
+        # Act
+        task = await parser._generate_detailed_task(
+            task_id="infra_setup",
+            epic_id="epic_infrastructure",
+            analysis=infra_analysis,
+            constraints=constraints,
+            sequence=1,
+        )
+
+        # Assert
+        assert task.completion_criteria is None, (
+            "infrastructure tasks must NOT receive test-coverage criteria "
+            "even though _extract_task_type defaults 'infra_setup' to "
+            "'implement' (Codex P1 on #608)"
+        )
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_nfr_task_does_not_get_completion_criteria(self, parser, constraints):
+        """NFR tasks must not inherit per-feature test-coverage criteria.
+
+        Non-functional requirements (performance, security, accessibility)
+        are different in kind from feature implementations and their
+        validation criteria are NFR-specific, not happy-path/invalid-input.
+        Same Codex P1 regression class as the infrastructure case.
+        """
+        # Arrange
+        from types import SimpleNamespace
+
+        nfr_analysis = SimpleNamespace(
+            functional_requirements=[],
+            non_functional_requirements=[
+                {
+                    "id": "performance_requirement",
+                    "name": "Performance Requirement",
+                    "description": "API responds within 200ms.",
+                }
+            ],
+            technical_constraints=[],
+            original_description="A todo app with performance budget.",
+        )
+        parser._task_metadata = {
+            "nfr_performance_requirement": {
+                "original_name": "Performance Requirement",
+                "type": "nfr",
+                "epic_id": "epic_non_functional",
+                "description": "API responds within 200ms.",
+            }
+        }
+
+        # Act
+        task = await parser._generate_detailed_task(
+            task_id="nfr_performance_requirement",
+            epic_id="epic_non_functional",
+            analysis=nfr_analysis,
+            constraints=constraints,
+            sequence=1,
+        )
+
+        # Assert
+        assert task.completion_criteria is None, (
+            "NFR tasks must NOT receive feature-style test-coverage "
+            "criteria (Codex P1 on #608)"
+        )
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_implement_task_without_metadata_does_not_get_criteria(
+        self, parser, analysis, constraints
+    ):
+        """Defensive: task_id resembles an implement but metadata is missing.
+
+        A task whose ID syntactically contains ``"implement"`` but whose
+        canonical type is absent from ``_task_metadata`` should not
+        receive criteria — the gate is strict: canonical metadata must
+        affirmatively declare ``TASK_TYPE_IMPLEMENTATION``. This guards
+        against future code paths that emit implement-looking IDs
+        without the metadata stamp.
+        """
+        # Arrange — no metadata entry; just functional req that matches.
+        parser._task_metadata = {}
+
+        # Act
+        task = await parser._generate_detailed_task(
+            task_id="task_user_login_implement",
+            epic_id="epic_user_login",
+            analysis=analysis,
+            constraints=constraints,
+            sequence=1,
+        )
+
+        # Assert
+        assert task.completion_criteria is None, (
+            "implement-looking task_id without TASK_TYPE_IMPLEMENTATION "
+            "metadata must not receive criteria — gate is canonical, not "
+            "substring-based"
+        )

--- a/tests/unit/ai/test_intelligent_task_patterns.py
+++ b/tests/unit/ai/test_intelligent_task_patterns.py
@@ -5,9 +5,20 @@ This module tests the ability to select appropriate task patterns based on:
 1. Feature complexity (atomic, simple, coordinated, distributed)
 2. Project complexity mode (prototype, standard, enterprise)
 3. Presence of design artifacts requirement
+
+As of issue #607 (step 3), test-task pairing has been rolled up: a separate
+``Test {feature}`` task is no longer emitted. Instead the behaviors that must
+be tested are captured as ``completion_criteria`` on the paired
+``Implement {feature}`` task. TDD is enforced via the worker prompt as a
+project-wide standard, and the runtime validator (``_validate_runtime``)
+remains the enforcement gate that tests exist and pass.
+
+Per the project's CLAUDE.md, all unit tests in tests/unit/ must carry the
+``@pytest.mark.unit`` marker — otherwise they are skipped by ``pytest -m unit``
+in CI. Markers have been added throughout this file.
 """
 
-from unittest.mock import AsyncMock, Mock
+from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 
@@ -22,6 +33,7 @@ class TestAtomicFeaturePatterns:
         """Create parser instance."""
         return AdvancedPRDParser()
 
+    @pytest.mark.unit
     def test_atomic_generates_one_task_prototype(self, parser):
         """Test that atomic features generate 1 task in prototype mode."""
         # Arrange
@@ -39,6 +51,7 @@ class TestAtomicFeaturePatterns:
         assert len(tasks) == 1
         assert tasks[0]["type"] == "implementation"
 
+    @pytest.mark.unit
     def test_atomic_generates_one_task_standard(self, parser):
         """Test that atomic features generate 1 task in standard mode."""
         # Arrange
@@ -55,8 +68,14 @@ class TestAtomicFeaturePatterns:
         assert len(tasks) == 1
         assert tasks[0]["type"] == "implementation"
 
-    def test_atomic_generates_two_tasks_enterprise(self, parser):
-        """Test that atomic features generate 2 tasks in enterprise mode (impl + test)."""
+    @pytest.mark.unit
+    def test_atomic_generates_one_task_enterprise_no_separate_test(self, parser):
+        """Atomic features in enterprise mode get only 1 task.
+
+        Issue #607 step 3 — the paired ``Test {feature}`` task is rolled up
+        into the implement task's completion_criteria; it is no longer a
+        separate board task.
+        """
         # Arrange
         requirement = {
             "id": "green_bg",
@@ -67,10 +86,10 @@ class TestAtomicFeaturePatterns:
         # Act
         tasks = parser._select_task_pattern(requirement, complexity_mode="enterprise")
 
-        # Assert
-        assert len(tasks) == 2
+        # Assert — only implementation; no separate test task
+        assert len(tasks) == 1
         assert tasks[0]["type"] == "implementation"
-        assert tasks[1]["type"] == "testing"
+        assert all(t["type"] != "testing" for t in tasks)
 
 
 class TestSimpleFeaturePatterns:
@@ -81,6 +100,7 @@ class TestSimpleFeaturePatterns:
         """Create parser instance."""
         return AdvancedPRDParser()
 
+    @pytest.mark.unit
     def test_simple_generates_one_task_prototype(self, parser):
         """Test that simple features generate 1 task in prototype mode."""
         # Arrange
@@ -97,8 +117,13 @@ class TestSimpleFeaturePatterns:
         assert len(tasks) == 1
         assert tasks[0]["type"] == "implementation"
 
-    def test_simple_generates_two_tasks_standard(self, parser):
-        """Test that simple features generate 2 tasks in standard mode."""
+    @pytest.mark.unit
+    def test_simple_generates_one_task_standard_no_separate_test(self, parser):
+        """Simple features in standard mode now get only 1 task.
+
+        Previously the standard pattern emitted ``Implement X`` + ``Test X``;
+        after issue #607 step 3 the test behaviors live on the implement task.
+        """
         # Arrange
         requirement = {
             "id": "score_display",
@@ -110,12 +135,13 @@ class TestSimpleFeaturePatterns:
         tasks = parser._select_task_pattern(requirement, complexity_mode="standard")
 
         # Assert
-        assert len(tasks) == 2
+        assert len(tasks) == 1
         assert tasks[0]["type"] == "implementation"
-        assert tasks[1]["type"] == "testing"
+        assert all(t["type"] != "testing" for t in tasks)
 
-    def test_simple_generates_three_tasks_enterprise(self, parser):
-        """Test that simple features generate 3 tasks in enterprise mode."""
+    @pytest.mark.unit
+    def test_simple_generates_two_tasks_enterprise_design_plus_implement(self, parser):
+        """Simple features in enterprise mode get design + implementation only."""
         # Arrange
         requirement = {
             "id": "score_display",
@@ -126,11 +152,11 @@ class TestSimpleFeaturePatterns:
         # Act
         tasks = parser._select_task_pattern(requirement, complexity_mode="enterprise")
 
-        # Assert
-        assert len(tasks) == 3
+        # Assert — design + implementation; the test task is rolled up
+        assert len(tasks) == 2
         assert tasks[0]["type"] == "design"
         assert tasks[1]["type"] == "implementation"
-        assert tasks[2]["type"] == "testing"
+        assert all(t["type"] != "testing" for t in tasks)
 
 
 class TestCoordinatedFeaturePatterns:
@@ -141,8 +167,9 @@ class TestCoordinatedFeaturePatterns:
         """Create parser instance."""
         return AdvancedPRDParser()
 
-    def test_coordinated_generates_two_tasks_prototype(self, parser):
-        """Test that coordinated features generate 2 tasks in prototype mode."""
+    @pytest.mark.unit
+    def test_coordinated_generates_one_task_prototype(self, parser):
+        """Coordinated features in prototype mode get only 1 task (implement)."""
         # Arrange
         requirement = {
             "id": "user_auth",
@@ -155,12 +182,13 @@ class TestCoordinatedFeaturePatterns:
         tasks = parser._select_task_pattern(requirement, complexity_mode="prototype")
 
         # Assert
-        assert len(tasks) == 2
+        assert len(tasks) == 1
         assert tasks[0]["type"] == "implementation"
-        assert tasks[1]["type"] == "testing"
+        assert all(t["type"] != "testing" for t in tasks)
 
-    def test_coordinated_generates_three_tasks_standard(self, parser):
-        """Test that coordinated features generate 3 tasks in standard mode."""
+    @pytest.mark.unit
+    def test_coordinated_generates_two_tasks_standard(self, parser):
+        """Coordinated features in standard mode get design + implementation."""
         # Arrange
         requirement = {
             "id": "user_auth",
@@ -173,13 +201,14 @@ class TestCoordinatedFeaturePatterns:
         tasks = parser._select_task_pattern(requirement, complexity_mode="standard")
 
         # Assert
-        assert len(tasks) == 3
+        assert len(tasks) == 2
         assert tasks[0]["type"] == "design"
         assert tasks[1]["type"] == "implementation"
-        assert tasks[2]["type"] == "testing"
+        assert all(t["type"] != "testing" for t in tasks)
 
-    def test_coordinated_generates_three_tasks_enterprise(self, parser):
-        """Test that coordinated features generate 3 tasks in enterprise mode."""
+    @pytest.mark.unit
+    def test_coordinated_generates_two_tasks_enterprise(self, parser):
+        """Coordinated features in enterprise mode get design + implementation."""
         # Arrange
         requirement = {
             "id": "user_auth",
@@ -192,10 +221,10 @@ class TestCoordinatedFeaturePatterns:
         tasks = parser._select_task_pattern(requirement, complexity_mode="enterprise")
 
         # Assert
-        assert len(tasks) == 3
+        assert len(tasks) == 2
         assert tasks[0]["type"] == "design"
         assert tasks[1]["type"] == "implementation"
-        assert tasks[2]["type"] == "testing"
+        assert all(t["type"] != "testing" for t in tasks)
 
 
 class TestDistributedFeaturePatterns:
@@ -206,8 +235,9 @@ class TestDistributedFeaturePatterns:
         """Create parser instance."""
         return AdvancedPRDParser()
 
-    def test_distributed_generates_two_tasks_prototype(self, parser):
-        """Test that distributed features generate 2 tasks in prototype mode."""
+    @pytest.mark.unit
+    def test_distributed_generates_one_task_prototype(self, parser):
+        """Distributed features in prototype mode get only 1 task."""
         # Arrange
         requirement = {
             "id": "microservices",
@@ -220,12 +250,13 @@ class TestDistributedFeaturePatterns:
         tasks = parser._select_task_pattern(requirement, complexity_mode="prototype")
 
         # Assert
-        assert len(tasks) == 2
+        assert len(tasks) == 1
         assert tasks[0]["type"] == "implementation"
-        assert tasks[1]["type"] == "testing"
+        assert all(t["type"] != "testing" for t in tasks)
 
-    def test_distributed_generates_three_tasks_standard(self, parser):
-        """Test that distributed features generate 3 tasks in standard mode."""
+    @pytest.mark.unit
+    def test_distributed_generates_two_tasks_standard(self, parser):
+        """Distributed features in standard mode get design + implementation."""
         # Arrange
         requirement = {
             "id": "microservices",
@@ -238,13 +269,14 @@ class TestDistributedFeaturePatterns:
         tasks = parser._select_task_pattern(requirement, complexity_mode="standard")
 
         # Assert
-        assert len(tasks) == 3
+        assert len(tasks) == 2
         assert tasks[0]["type"] == "design"
         assert tasks[1]["type"] == "implementation"
-        assert tasks[2]["type"] == "testing"
+        assert all(t["type"] != "testing" for t in tasks)
 
-    def test_distributed_generates_three_tasks_enterprise(self, parser):
-        """Test that distributed features generate 3 tasks in enterprise mode."""
+    @pytest.mark.unit
+    def test_distributed_generates_two_tasks_enterprise(self, parser):
+        """Distributed features in enterprise mode get design + implementation."""
         # Arrange
         requirement = {
             "id": "microservices",
@@ -257,10 +289,10 @@ class TestDistributedFeaturePatterns:
         tasks = parser._select_task_pattern(requirement, complexity_mode="enterprise")
 
         # Assert
-        assert len(tasks) == 3
+        assert len(tasks) == 2
         assert tasks[0]["type"] == "design"
         assert tasks[1]["type"] == "implementation"
-        assert tasks[2]["type"] == "testing"
+        assert all(t["type"] != "testing" for t in tasks)
 
 
 class TestTaskIdGeneration:
@@ -271,6 +303,7 @@ class TestTaskIdGeneration:
         """Create parser instance."""
         return AdvancedPRDParser()
 
+    @pytest.mark.unit
     def test_task_ids_have_correct_format(self, parser):
         """Test that generated task IDs follow naming convention."""
         # Arrange
@@ -283,11 +316,11 @@ class TestTaskIdGeneration:
         # Act
         tasks = parser._select_task_pattern(requirement, complexity_mode="standard")
 
-        # Assert
+        # Assert — coordinated/standard now produces design + implement only
         assert tasks[0]["id"] == "task_user_auth_design"
         assert tasks[1]["id"] == "task_user_auth_implement"
-        assert tasks[2]["id"] == "task_user_auth_test"
 
+    @pytest.mark.unit
     def test_task_names_include_feature_name(self, parser):
         """Test that generated task names include the feature name."""
         # Arrange
@@ -301,9 +334,8 @@ class TestTaskIdGeneration:
         tasks = parser._select_task_pattern(requirement, complexity_mode="standard")
 
         # Assert
-        assert "User Authentication" in tasks[0]["name"]
-        assert "User Authentication" in tasks[1]["name"]
-        assert "User Authentication" in tasks[2]["name"]
+        for task in tasks:
+            assert "User Authentication" in task["name"]
 
 
 class TestBreakDownEpicIntegration:
@@ -324,8 +356,10 @@ class TestBreakDownEpicIntegration:
         """Create mock constraints with standard mode."""
         constraints = Mock()
         constraints.quality_requirements = {"project_size": "standard"}
+        constraints.complexity_mode = "standard"
         return constraints
 
+    @pytest.mark.unit
     @pytest.mark.asyncio
     async def test_break_down_epic_uses_complexity(
         self, parser, mock_analysis, mock_constraints_standard
@@ -348,11 +382,16 @@ class TestBreakDownEpicIntegration:
         assert len(tasks) == 1  # Atomic should only get 1 task in standard mode
         assert tasks[0]["type"] == "implementation"
 
+    @pytest.mark.unit
     @pytest.mark.asyncio
-    async def test_break_down_epic_defaults_to_coordinated_if_no_complexity(
+    async def test_break_down_epic_defaults_for_no_complexity_field(
         self, parser, mock_analysis, mock_constraints_standard
     ):
-        """Test that _break_down_epic defaults to coordinated for backward compatibility."""
+        """Backward compat: requirements without complexity still parse.
+
+        After #607 step 3 the coordinated/standard pattern is design +
+        implementation only (no separate test task).
+        """
         # Arrange
         requirement = {
             "id": "old_feature",
@@ -366,12 +405,11 @@ class TestBreakDownEpicIntegration:
             requirement, mock_analysis, mock_constraints_standard
         )
 
-        # Assert
-        # Should default to coordinated behavior (3 tasks)
-        assert len(tasks) == 3
+        # Assert — defaults to coordinated → 2 tasks (design + implement)
+        assert len(tasks) == 2
         assert tasks[0]["type"] == "design"
         assert tasks[1]["type"] == "implementation"
-        assert tasks[2]["type"] == "testing"
+        assert all(t["type"] != "testing" for t in tasks)
 
 
 class TestComplexityModeEffects:
@@ -382,8 +420,9 @@ class TestComplexityModeEffects:
         """Create parser instance."""
         return AdvancedPRDParser()
 
+    @pytest.mark.unit
     def test_prototype_simplifies_coordinated_features(self, parser):
-        """Test that prototype mode simplifies coordinated features."""
+        """Prototype mode reduces coordinated features to a single implement task."""
         # Arrange
         requirement = {
             "id": "complex_feature",
@@ -394,14 +433,13 @@ class TestComplexityModeEffects:
         # Act
         tasks = parser._select_task_pattern(requirement, complexity_mode="prototype")
 
-        # Assert
-        # Prototype should skip design phase for speed
-        assert len(tasks) == 2
+        # Assert — prototype skips design AND no separate test task
+        assert len(tasks) == 1
         assert tasks[0]["type"] == "implementation"
-        assert tasks[1]["type"] == "testing"
 
+    @pytest.mark.unit
     def test_enterprise_adds_design_to_simple_features(self, parser):
-        """Test that enterprise mode adds design phase to simple features."""
+        """Enterprise mode adds design to simple features (no separate test task)."""
         # Arrange
         requirement = {
             "id": "simple_feature",
@@ -412,15 +450,15 @@ class TestComplexityModeEffects:
         # Act
         tasks = parser._select_task_pattern(requirement, complexity_mode="enterprise")
 
-        # Assert
-        # Enterprise should add design for traceability
-        assert len(tasks) == 3
+        # Assert — design + implement; no testing task
+        assert len(tasks) == 2
         assert tasks[0]["type"] == "design"
         assert tasks[1]["type"] == "implementation"
-        assert tasks[2]["type"] == "testing"
+        assert all(t["type"] != "testing" for t in tasks)
 
+    @pytest.mark.unit
     def test_standard_mode_uses_intelligent_patterns(self, parser):
-        """Test that standard mode uses complexity-based patterns."""
+        """Standard mode uses complexity-based patterns without test pairing."""
         # Arrange
         atomic_req = {"id": "atomic", "name": "Atomic", "complexity": "atomic"}
         simple_req = {"id": "simple", "name": "Simple", "complexity": "simple"}
@@ -443,5 +481,295 @@ class TestComplexityModeEffects:
 
         # Assert
         assert len(atomic_tasks) == 1  # Just implementation
-        assert len(simple_tasks) == 2  # Implementation + test
-        assert len(coordinated_tasks) == 3  # Design + implementation + test
+        assert len(simple_tasks) == 1  # Just implementation (no test pair)
+        assert len(coordinated_tasks) == 2  # Design + implementation
+
+
+class TestNoTestTasksAcrossAllModes:
+    """Issue #607 step 3: separate ``Test {feature}`` tasks are never emitted.
+
+    The test behaviors that previously formed a separate testing task now live
+    on the implement task as ``completion_criteria``. These tests guard the
+    invariant: no path through ``_select_task_pattern`` produces a task whose
+    ``type`` equals ``"testing"``.
+    """
+
+    @pytest.fixture
+    def parser(self):
+        """Create parser instance."""
+        return AdvancedPRDParser()
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize(
+        "complexity_mode",
+        ["prototype", "standard", "enterprise"],
+    )
+    @pytest.mark.parametrize(
+        "complexity",
+        ["atomic", "simple", "coordinated", "distributed"],
+    )
+    def test_no_testing_task_for_any_combination(
+        self, parser, complexity_mode, complexity
+    ):
+        """No task pattern emits a ``testing`` task in any mode/complexity."""
+        # Arrange
+        requirement = {
+            "id": f"feature_{complexity}",
+            "name": f"Feature {complexity}",
+            "complexity": complexity,
+        }
+
+        # Act
+        tasks = parser._select_task_pattern(
+            requirement, complexity_mode=complexity_mode
+        )
+
+        # Assert
+        testing_tasks = [t for t in tasks if t["type"] == "testing"]
+        assert testing_tasks == [], (
+            f"Expected no testing tasks in mode={complexity_mode}, "
+            f"complexity={complexity}; got {testing_tasks}"
+        )
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize(
+        "complexity_mode",
+        ["prototype", "standard", "enterprise"],
+    )
+    @pytest.mark.parametrize(
+        "complexity",
+        ["atomic", "simple", "coordinated", "distributed"],
+    )
+    def test_at_least_one_implementation_task_always_present(
+        self, parser, complexity_mode, complexity
+    ):
+        """Every mode/complexity emits at least one implementation task.
+
+        The implement task is the carrier for the rolled-up test behaviors
+        via its ``completion_criteria``.
+        """
+        # Arrange
+        requirement = {
+            "id": f"feature_{complexity}",
+            "name": f"Feature {complexity}",
+            "complexity": complexity,
+        }
+
+        # Act
+        tasks = parser._select_task_pattern(
+            requirement, complexity_mode=complexity_mode
+        )
+
+        # Assert
+        impl_tasks = [t for t in tasks if t["type"] == "implementation"]
+        assert len(impl_tasks) == 1, (
+            f"Expected exactly one implementation task in "
+            f"mode={complexity_mode}, complexity={complexity}; got {impl_tasks}"
+        )
+
+
+class TestTestCoverageCriteriaGeneration:
+    """Issue #607 step 3: the helper that derives test-coverage criteria.
+
+    ``_generate_test_coverage_criteria`` produces the list of criterion
+    strings that the implement task's ``completion_criteria`` field is
+    populated with. The strings name *behaviors that must be tested*, not
+    test framework or structure (those remain agent choices).
+    """
+
+    @pytest.fixture
+    def parser(self):
+        """Create parser instance."""
+        return AdvancedPRDParser()
+
+    @pytest.mark.unit
+    def test_returns_non_empty_list_of_strings(self, parser):
+        """Helper returns a non-empty list of string criteria."""
+        # Act
+        criteria = parser._generate_test_coverage_criteria(
+            feature_name="User Login",
+            base_description="Users can log in with email and password.",
+        )
+
+        # Assert
+        assert isinstance(criteria, list)
+        assert len(criteria) >= 1
+        assert all(isinstance(c, str) and c.strip() for c in criteria)
+
+    @pytest.mark.unit
+    def test_criteria_mention_feature_name(self, parser):
+        """Generated criteria reference the feature so they read sensibly."""
+        # Act
+        criteria = parser._generate_test_coverage_criteria(
+            feature_name="Mark Complete",
+            base_description="Toggle a todo item's done flag.",
+        )
+
+        # Assert — at least one criterion contains the feature name (any case)
+        flat = " ".join(criteria).lower()
+        assert "mark complete" in flat
+
+    @pytest.mark.unit
+    def test_criteria_name_behaviors_not_implementation_how(self, parser):
+        """Criteria describe what to test, not how to test (no framework names)."""
+        # Act
+        criteria = parser._generate_test_coverage_criteria(
+            feature_name="User Login",
+            base_description="Users can log in.",
+        )
+
+        # Assert — no implementation prescription leaks in
+        joined = " ".join(criteria).lower()
+        forbidden_hows = ["pytest", "unittest", "jest", "mocha", "rspec"]
+        for token in forbidden_hows:
+            assert token not in joined, (
+                f"Criterion accidentally prescribes framework '{token}': " f"{criteria}"
+            )
+
+    @pytest.mark.unit
+    def test_criteria_include_happy_path_and_invalid_input(self, parser):
+        """Default criteria cover both happy path and invalid input behaviors."""
+        # Act
+        criteria = parser._generate_test_coverage_criteria(
+            feature_name="Create Todo",
+            base_description="Create a new todo with a title.",
+        )
+
+        # Assert — must hint at both success and error paths
+        joined = " ".join(criteria).lower()
+        # Heuristic: at least one criterion references valid/normal/happy
+        # AND at least one references invalid/error/edge.
+        has_happy = any(kw in joined for kw in ["valid", "happy", "normal", "success"])
+        has_unhappy = any(kw in joined for kw in ["invalid", "error", "edge", "fail"])
+        assert has_happy, f"No happy-path criterion found: {criteria}"
+        assert has_unhappy, f"No error/edge criterion found: {criteria}"
+
+
+class TestImplementTaskCompletionCriteriaIntegration:
+    """End-to-end: ``_generate_detailed_task`` populates ``completion_criteria``.
+
+    Issue #607 step 3 — the integration check: a requirement that flows
+    through ``_select_task_pattern`` → ``_generate_detailed_task`` ends up
+    with an implement task whose ``completion_criteria`` carries the
+    test-behavior strings.  Design tasks must NOT receive
+    ``completion_criteria`` (they're not implement tasks).
+    """
+
+    @pytest.fixture
+    def parser(self):
+        """Parser with LLM patched out to return a canned description."""
+        with patch(
+            "src.ai.advanced.prd.advanced_parser.LLMAbstraction"
+        ) as mock_llm_class:
+            mock_llm = Mock()
+            mock_llm.analyze = AsyncMock(
+                return_value="Implement the feature per the requirement."
+            )
+            mock_llm_class.return_value = mock_llm
+            p = AdvancedPRDParser()
+            p.llm_client = mock_llm
+            return p
+
+    @pytest.fixture
+    def analysis(self):
+        """Minimal PRDAnalysis-shaped object with one functional requirement.
+
+        Uses ``SimpleNamespace`` rather than ``Mock`` because the parser
+        reads ``analysis.__dict__`` directly when stuffing source_context,
+        and a real ``__dict__`` is much cleaner than fighting with
+        ``Mock``'s auto-attribute behavior.
+        """
+        from types import SimpleNamespace
+
+        return SimpleNamespace(
+            functional_requirements=[
+                {
+                    "id": "user_login",
+                    "name": "User Login",
+                    "description": "Users can log in with email and password.",
+                }
+            ],
+            non_functional_requirements=[],
+            technical_constraints=[],
+            original_description="A simple todo app.",
+        )
+
+    @pytest.fixture
+    def constraints(self):
+        """Minimal ProjectConstraints-shaped object."""
+        from types import SimpleNamespace
+
+        return SimpleNamespace(
+            team_size=1,
+            technical_constraints=[],
+            quality_requirements={},
+            complexity_mode="standard",
+        )
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_implement_task_gets_completion_criteria_populated(
+        self, parser, analysis, constraints
+    ):
+        """The implement task carries test-coverage criteria as a list of strings."""
+        # Arrange — pre-populate _task_metadata as _generate_task_hierarchy would.
+        parser._task_metadata = {
+            "task_user_login_implement": {
+                "original_name": "Implement User Login",
+                "type": "implementation",
+                "epic_id": "epic_user_login",
+                "requirement": analysis.functional_requirements[0],
+            }
+        }
+
+        # Act
+        task = await parser._generate_detailed_task(
+            task_id="task_user_login_implement",
+            epic_id="epic_user_login",
+            analysis=analysis,
+            constraints=constraints,
+            sequence=1,
+        )
+
+        # Assert
+        assert (
+            task.completion_criteria is not None
+        ), "implement tasks must carry completion_criteria after #607 step 3"
+        assert isinstance(task.completion_criteria, list)
+        assert len(task.completion_criteria) >= 1
+        # Live shape is list-of-strings, honored by WorkAnalyzer._extract_criteria
+        # and by sqlite_kanban JSON serialization.
+        assert all(isinstance(c, str) for c in task.completion_criteria)
+        # The criteria reference the feature being implemented.
+        flat = " ".join(task.completion_criteria).lower()
+        assert "user login" in flat
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_design_task_does_not_get_completion_criteria(
+        self, parser, analysis, constraints
+    ):
+        """Design tasks have no completion_criteria — only implement tasks do."""
+        # Arrange
+        parser._task_metadata = {
+            "task_user_login_design": {
+                "original_name": "Design User Login",
+                "type": "design",
+                "epic_id": "epic_user_login",
+                "requirement": analysis.functional_requirements[0],
+            }
+        }
+
+        # Act
+        task = await parser._generate_detailed_task(
+            task_id="task_user_login_design",
+            epic_id="epic_user_login",
+            analysis=analysis,
+            constraints=constraints,
+            sequence=1,
+        )
+
+        # Assert
+        assert (
+            task.completion_criteria is None
+        ), "design tasks must NOT receive completion_criteria (only implement)"

--- a/tests/unit/ai/test_prd_parser_hybrid.py
+++ b/tests/unit/ai/test_prd_parser_hybrid.py
@@ -58,11 +58,14 @@ class TestPRDParserHybridApproach:
 
         tasks = await parser._break_down_epic(req, analysis, mock_constraints)
 
-        assert len(tasks) == 3
+        # Issue #607 step 3: paired Test task is rolled up into the
+        # implement task's completion_criteria; only design + implement
+        # land on the board.
+        assert len(tasks) == 2
         assert tasks[0]["id"] == "task_crud_operations_design"
         assert tasks[0]["name"] == "Design CRUD Operations"
         assert tasks[1]["id"] == "task_crud_operations_implement"
-        assert tasks[2]["id"] == "task_crud_operations_test"
+        assert all(t["type"] != "testing" for t in tasks)
 
     @pytest.mark.unit
     @pytest.mark.asyncio
@@ -95,7 +98,8 @@ class TestPRDParserHybridApproach:
         assert "Expected 'id' field" in caplog.text
 
         # Should still generate correct tasks
-        assert len(tasks) == 3
+        # Issue #607 step 3: design + implement only (no Test task).
+        assert len(tasks) == 2
         assert "task_user_auth_design" in tasks[0]["id"]
 
     @pytest.mark.unit

--- a/tests/unit/ai/test_prd_parser_robustness.py
+++ b/tests/unit/ai/test_prd_parser_robustness.py
@@ -48,11 +48,14 @@ class TestPRDParserRobustness:
         req = {"feature": "CRUD Operations"}
         tasks = await parser._break_down_epic(req, analysis, mock_constraints)
 
-        assert len(tasks) == 3
+        # Issue #607 step 3: the paired Test task is rolled up into the
+        # implement task's completion_criteria; only design + implement
+        # land on the board.
+        assert len(tasks) == 2
         assert tasks[0]["id"] == "task_crud_operations_design"
         assert tasks[0]["name"] == "Design CRUD Operations"
         assert tasks[1]["id"] == "task_crud_operations_implement"
-        assert tasks[2]["id"] == "task_crud_operations_test"
+        assert all(t["type"] != "testing" for t in tasks)
 
     @pytest.mark.unit
     @pytest.mark.asyncio
@@ -76,9 +79,11 @@ class TestPRDParserRobustness:
         req = {"description": "User Authentication"}
         tasks = await parser._break_down_epic(req, analysis, mock_constraints)
 
-        assert len(tasks) == 3
+        # Issue #607 step 3: design + implement only (no Test task).
+        assert len(tasks) == 2
         assert tasks[0]["id"] == "task_user_authentication_design"
         assert tasks[0]["name"] == "Design User Authentication"
+        assert all(t["type"] != "testing" for t in tasks)
 
     @pytest.mark.unit
     @pytest.mark.asyncio
@@ -102,7 +107,8 @@ class TestPRDParserRobustness:
         req = {"feature": "CRUD operations for todos: Create, Read, Update, Delete"}
         tasks = await parser._break_down_epic(req, analysis, mock_constraints)
 
-        assert len(tasks) == 3
+        # Issue #607 step 3: design + implement only (no Test task).
+        assert len(tasks) == 2
         # Should clean up the ID properly
         assert "task_crud_operations_todos_create_read_update_delete" in tasks[0]["id"]
         assert (
@@ -130,7 +136,8 @@ class TestPRDParserRobustness:
         req = {"feature": "User authentication with JWT tokens and OAuth"}
         tasks = await parser._break_down_epic(req, analysis, mock_constraints)
 
-        assert len(tasks) == 3
+        # Issue #607 step 3: design + implement only (no Test task).
+        assert len(tasks) == 2
         # Common words like 'with' and 'and' should be removed
         assert "task_user_authentication_jwt_tokens_oauth" in tasks[0]["id"]
 
@@ -154,7 +161,8 @@ class TestPRDParserRobustness:
         req: dict[str, Any] = {}  # Empty req
         tasks = await parser._break_down_epic(req, analysis, mock_constraints)
 
-        assert len(tasks) == 3
+        # Issue #607 step 3: design + implement only (no Test task).
+        assert len(tasks) == 2
         assert tasks[0]["id"] == "task_req_0_design"
         assert tasks[0]["name"] == "Design feature"
 
@@ -230,7 +238,7 @@ class TestPRDParserRobustness:
         assert "epic_non_functional" in hierarchy
         assert "epic_infrastructure" in hierarchy
 
-        # Each functional epic should have 3 tasks
-        assert len(hierarchy["epic_crud_operations"]) == 3
-        assert len(hierarchy["epic_user_authentication"]) == 3
-        assert len(hierarchy["epic_data_validation"]) == 3
+        # Issue #607 step 3: design + implement only (no Test task) -> 2 tasks each.
+        assert len(hierarchy["epic_crud_operations"]) == 2
+        assert len(hierarchy["epic_user_authentication"]) == 2
+        assert len(hierarchy["epic_data_validation"]) == 2

--- a/tests/unit/experiments/test_spawn_agents.py
+++ b/tests/unit/experiments/test_spawn_agents.py
@@ -535,6 +535,49 @@ class TestWorkerPromptEphemeralContract:
             )
         assert "exit" in prompt
 
+    def test_real_template_enforces_tdd_as_project_standard(
+        self, spawner: Any, agent_config: dict[str, Any]
+    ) -> None:
+        """Issue #607: TDD is a project-wide standard in the worker prompt.
+
+        Step 3 of the decomposition redesign rolls the per-feature Test
+        task up into the Implement task's ``completion_criteria``. The
+        load-bearing complement to that rollup is this directive in the
+        worker prompt: write tests first against the criteria, watch
+        them fail, then make them pass; do not modify tests to fit code.
+
+        This is a project standard (like "all PRs require review"), not
+        a prescription of HOW (framework, file layout, assertion style
+        remain agent choices).
+        """
+        real_template = (
+            Path(spawn_agents.__file__).resolve().parent.parent
+            / "templates"
+            / "agent_prompt.md"
+        )
+        spawner.agent_prompt_template = real_template
+
+        prompt = spawner.create_worker_prompt(agent_config).lower()
+
+        # Project-standard TDD directive must mention all four moves.
+        assert "completion_criteria" in prompt, (
+            "TDD directive must point agents at the implement task's "
+            "completion_criteria (the test behaviors Marcus rolls up)"
+        )
+        assert (
+            "tests first" in prompt or "write the tests first" in prompt
+        ), "TDD directive must order tests FIRST"
+        assert "fail" in prompt, "TDD directive must require watching tests fail"
+        # Reject the most common LLM cheat: retrofit tests to match the code.
+        assert (
+            "do not modify the tests" in prompt
+            or "not modify the tests" in prompt
+            or "not modify tests" in prompt
+        ), "TDD directive must forbid modifying tests to fit the implementation"
+        # Must NOT prescribe a framework — agents pick their own.
+        assert "you must use pytest" not in prompt
+        assert "you must use jest" not in prompt
+
 
 class TestFetchRecommendedAgents:
     """_fetch_recommended_agents queries Marcus MCP HTTP — no LLM relay."""


### PR DESCRIPTION
## What is this system, briefly

**Marcus** is a multi-agent platform. You describe a project; Marcus
**decomposes** the description into a **graph of tasks on a shared kanban
board**; small autonomous AI agents pick tasks up one at a time and build
the thing. Every task costs a fresh agent orientation (reading the repo,
understanding the project, getting going), so the *number* of tasks
Marcus produces matters: too many tasks = too many context-rebuilds = a
lot of wasted compute.

This PR is step 3 of **issue #607** — the broader plan for cutting how
many tasks Marcus emits per project. A controlled 9-run probe in #607
measured Marcus over-decomposing by ~2× at standard complexity and ~3.3×
at enterprise. The probe pinpointed **three** distinct mechanisms; this
PR fixes the smallest, most contained one: the **test-task pairing
explosion**.

## Why (user-visible motivation)

Today every `Implement {feature}` task on the board comes with a paired
`Test {feature}` task. For an enterprise-complexity project with 16–51
implement tasks, that's another 16–51 board tasks whose entire purpose
is "write tests for the thing above me." Each of those test tasks costs
a fresh agent spinup.

A second, sneakier problem: LLM agents are **well-documented liars**
about tests. A separate `Test {feature}` task makes it trivial for an
agent to write a trivial test that just calls the function and asserts
it returned *something*, or to retrofit a passing test to match buggy
code. The pairing wasn't only expensive; it was also a quality hole.

**This PR's fix:** stop emitting the separate `Test {feature}` task.
Move the behaviors that must be tested onto the implement task as
**acceptance criteria**, and make **TDD a project-wide standard** in the
worker prompt (write tests first, watch them fail, then make them
pass; do not modify tests to fit code). The runtime validator
(`_validate_runtime` in `src/ai/validation/work_analyzer.py`) still runs
pytest against the agent's work — that is the enforcement gate.

For a college reader: this is the same kind of rule as *"all PRs require
review."* It governs the order in which the agent works (tests first,
code second), but it does **not** dictate the framework (pytest /
unittest / jest — agent's call), the file layout, or the assertion
style. The agent picks all of those.

## Glossary

| Term | Meaning |
|---|---|
| **Marcus** | The multi-agent product itself, and the name of its MCP server |
| **Decomposer** | The component that turns a project description into a graph of tasks. Lives in `src/ai/advanced/prd/advanced_parser.py` |
| **Implement task** | A board task whose name starts with "Implement" — the carrier of feature work |
| **Test task** | (Going away in this PR) A board task whose name started with "Test" — paired 1:1 with an implement task |
| **`completion_criteria`** | A field on every Task that names the success conditions the agent must hit. Surfaced to agents via `request_next_task`. Field declared on `Task` at `src/core/models.py:273` |
| **`_validate_runtime`** | The function in `src/ai/validation/work_analyzer.py` that runs the agent's tests after task completion. Already exists; unchanged |
| **TDD** | Test-Driven Development: write the tests first, watch them fail, then write the code to make them pass |
| **Complexity mode** | A project-level dial: `prototype` (fast), `standard` (default), or `enterprise` (full traceability). Set on `ProjectConstraints` |

## What changed (technical)

### 1. `src/ai/advanced/prd/advanced_parser.py`

- `_select_task_pattern` (lines ~3247–3325): the three `Test {feature}`
  dict creations (one per mode branch) are **removed**. The function
  now emits `Implement {feature}` only, plus a `Design {feature}` task
  at coordinated/distributed/enterprise complexity, as before.
- `_generate_detailed_task` (line ~2128, branch ~2336): when the task
  being built is an implement task, its `completion_criteria` field is
  now populated with a list of test-coverage criterion strings.
- New helper `_generate_test_coverage_criteria(feature_name,
  base_description)` (added near `_generate_acceptance_criteria` at
  line ~4540): produces the criterion list deterministically — no
  extra LLM call. The criteria name *behaviors to test* (happy path,
  invalid input, edge cases, TDD-order contract), never *how* to test.

### 2. `dev-tools/experiments/templates/agent_prompt.md`

A new `PROJECT STANDARD — TDD FOR IMPLEMENTATION TASKS` block was added
right after `HANDLING "NO TASK AVAILABLE"`. The block tells the agent
to read the task's `completion_criteria`, write the tests first, watch
them fail, then write the implementation to make them pass — and to
**not** modify the tests to fit the implementation. It explicitly says
it does NOT prescribe a framework; the agent still picks pytest /
unittest / jest / etc.

### 3. Tests updated

| File | What changed |
|---|---|
| `tests/unit/ai/test_intelligent_task_patterns.py` | Existing tests reduced their expected count (3 → 2 / 2 → 1, etc.) and now assert "no `testing` type ever appears." **Added `@pytest.mark.unit` markers across the file** — the file was previously skipped by `pytest -m unit` (CI) because of missing markers. Added a new parametrized class (`TestNoTestTasksAcrossAllModes`) that locks in the invariant across all 12 (mode × complexity) combinations. Added `TestTestCoverageCriteriaGeneration` unit tests for the new helper. Added `TestImplementTaskCompletionCriteriaIntegration` end-to-end tests proving `_generate_detailed_task` puts criteria on the implement task and **not** on the design task. |
| `tests/unit/ai/test_prd_parser_robustness.py` | Updated `_break_down_epic` assertions: 3 tasks → 2 tasks (no Test). |
| `tests/unit/ai/test_prd_parser_hybrid.py` | Same. |
| `tests/unit/ai/test_advanced_prd_parser.py` | Same. |
| `tests/unit/experiments/test_spawn_agents.py` | Added `test_real_template_enforces_tdd_as_project_standard` to the existing `TestWorkerPromptEphemeralContract` class. Loads the real prompt template and asserts the four load-bearing TDD phrases are present and no framework is prescribed. |

## How to verify it works

1. **Tests pass.** Run `pytest -m unit tests/unit/ai/
   tests/unit/experiments/test_spawn_agents.py` and confirm zero
   failures.
2. **No `testing` task is produced.** In a Python REPL:
   ```python
   from src.ai.advanced.prd.advanced_parser import AdvancedPRDParser
   p = AdvancedPRDParser()
   tasks = p._select_task_pattern(
       {"id": "x", "name": "X", "complexity": "coordinated"},
       complexity_mode="enterprise",
   )
   assert all(t["type"] != "testing" for t in tasks)
   # Expect: 2 tasks (design + implement). Pre-PR was 3.
   ```
3. **Implement tasks get `completion_criteria`.** Use the integration
   test in `tests/unit/ai/test_intelligent_task_patterns.py::TestImplementTaskCompletionCriteriaIntegration`
   as the canonical end-to-end check.
4. **TDD directive lives in the real worker prompt.** Open
   `dev-tools/experiments/templates/agent_prompt.md` and confirm the
   `PROJECT STANDARD — TDD FOR IMPLEMENTATION TASKS` block is present.
   The unit test `test_real_template_enforces_tdd_as_project_standard`
   guards this.
5. **Decomposition probe re-run (manual, not in CI).** Re-run the
   `/tmp/decomp_granularity_probe.py` script from #607 and confirm the
   means trend toward the divider in the issue
   (prototype ~7, standard ~11, enterprise ~22). Note: this PR alone
   only addresses one of three drivers, so expect partial movement —
   the full divider is hit after #607 steps 4 and 5 land too.

## Test plan

- [ ] `pytest -m unit tests/unit/ai/` passes (298 tests)
- [ ] `pytest -m unit tests/unit/experiments/test_spawn_agents.py` passes (90 tests)
- [ ] `mypy src/ai/advanced/prd/advanced_parser.py` is clean
- [ ] `flake8 --max-line-length=88 src/ai/advanced/prd/advanced_parser.py` is clean
- [ ] Spot-check: `dev-tools/experiments/templates/agent_prompt.md`
      contains "TDD" and "completion_criteria"

## Out of scope (deliberate, future PRs)

- **Gap-fill atomization → criteria** = #607 step 4. The intent-fidelity
  pass currently bolts one extra task per uncovered requirement. That
  will become criteria on the relevant native implement task. Separate PR.
- **Enterprise native-prompt tightening** = #607 step 5. At enterprise
  complexity the native decomposer uncaps and emits 16–51 implements
  per project (same spec, 3× spread). The prompt conflates "complex
  project" with "atomic tasks." Separate PR.
- **The three small bonus fixes** (design-ghost determinism, doubled
  "Implement" word naming bug, near-duplicate dedup at enterprise) —
  each its own tiny PR.
- **`Task.completion_criteria`'s declared type.** The dataclass declares
  `Optional[Dict[str, Any]]` but everywhere in the codebase that reads
  it — `WorkAnalyzer._extract_criteria`, the sqlite kanban serializer,
  the `request_next_task` MCP response, and existing tests — already
  accepts a `List[str]`. This PR honors live usage and writes the list
  form. **Follow-up:** update the type hint to
  `Optional[Union[Dict[str, Any], List[str]]]` in a separate PR rather
  than expanding this diff.

## Where to look in the code first

| File | Purpose |
|---|---|
| `src/ai/advanced/prd/advanced_parser.py` (~3247–3325) | `_select_task_pattern` — the three `Test {feature}` creations are gone |
| `src/ai/advanced/prd/advanced_parser.py` (~2412–2470) | `_generate_detailed_task` — populates `completion_criteria` on implement tasks |
| `src/ai/advanced/prd/advanced_parser.py` (~4540) | New helper `_generate_test_coverage_criteria` |
| `dev-tools/experiments/templates/agent_prompt.md` | New `PROJECT STANDARD — TDD FOR IMPLEMENTATION TASKS` block |
| `tests/unit/ai/test_intelligent_task_patterns.py` | New + updated tests; pytest markers added |
| `src/core/models.py:273` | `Task.completion_criteria` field declaration (unchanged here) |
| `src/marcus_mcp/tools/task.py:1895` | `request_next_task` surfaces `completion_criteria` to agents (unchanged here) |

## Related

- **#607** — parent issue, the decomposition redesign plan
- **#604** — what goes into the foundation contract (tech-stack pinning)
- **#605** — context-delivery in `request_next_task` (merged)
- **#606** — prior PR for #605

🤖 Generated with [Claude Code](https://claude.com/claude-code)