### PR TITLE
feat(decomposer): roll gap-fill output into completion_criteria (#607 step 4)

### DIFF
--- a/src/marcus_mcp/coordinator/outcome_coverage.py
+++ b/src/marcus_mcp/coordinator/outcome_coverage.py
@@ -1187,11 +1187,24 @@ def _gap_dict_to_criterion(gap_dict: Dict[str, Any]) -> str:
     pattern, no internal code structure). Two agents reading the same
     criterion are free to write legitimately different code.
 
+    Contract-first gap dicts carry an additional ``responsibility``
+    field ("implements <Iface> from <path>") that the pre-step-4
+    ``_build_contract_gap_fill_task`` projected onto
+    ``Task.responsibility`` / contract source_context. The rollup path
+    no longer materializes that Task field, so when ``responsibility``
+    is present it is appended to the criterion text — the only channel
+    that surfaces contract ownership for gap-driven contract work
+    after the rollup (Codex P2 on PR #611). Agents reading the
+    criterion still see the contract framing even though Task-field
+    rendering (Layer 1.3 of ``build_tiered_instructions``) no longer
+    fires for these gaps.
+
     Parameters
     ----------
     gap_dict : dict
         One entry from :attr:`OutcomeCoverageResult.synthesized_tasks`,
-        shape ``{"name": str, "description": str, ...}``.
+        shape ``{"name": str, "description": str,
+        "responsibility"?: str, ...}``.
 
     Returns
     -------
@@ -1202,9 +1215,81 @@ def _gap_dict_to_criterion(gap_dict: Dict[str, Any]) -> str:
     """
     name = (gap_dict.get("name") or "").strip()
     description = (gap_dict.get("description") or "").strip()
+    responsibility = (gap_dict.get("responsibility") or "").strip()
     if name and description:
-        return f"{OUTCOME_GAP_CRITERION_PREFIX}{name} — {description}"
-    return f"{OUTCOME_GAP_CRITERION_PREFIX}{name or description}"
+        body = f"{name} — {description}"
+    else:
+        body = name or description
+    if responsibility:
+        body = f"{body} (contract: {responsibility})"
+    return f"{OUTCOME_GAP_CRITERION_PREFIX}{body}"
+
+
+def _materialize_gap_dicts_as_rescue_tasks(
+    gap_dicts: List[Dict[str, Any]],
+) -> List[Task]:
+    """Materialize gap-fill dicts into Tasks for the empty-graph case.
+
+    Codex P1 on PR #611. ``_create_detailed_tasks`` can return ``[]``
+    when AI decomposition fails entirely; before step 4 the gap-fill
+    output rescued those projects by materializing tasks even with no
+    siblings. Step 4's rollup needs an anchor task to route criteria
+    onto — with zero native tasks there is no anchor, so gaps would be
+    silently dropped. This helper restores the pre-step-4 rescue path
+    scoped narrowly to the empty-native-graph case.
+
+    The atomization concern that motivated #607 step 4 does not apply
+    here: there are no native tasks to atomize against, the gap-fill
+    output IS the entire graph.
+
+    Parameters
+    ----------
+    gap_dicts
+        :attr:`OutcomeCoverageResult.synthesized_tasks` — the gap-fill
+        LLM's output dicts.
+
+    Returns
+    -------
+    list of Task
+        One :class:`Task` per gap dict, labeled ``["gap_fill",
+        "intent_fidelity", "rescue"]`` so audits can identify rescue-
+        path synthesized tasks distinctly from the (now-removed)
+        atomization-path synthesized tasks. The ``"rescue"`` label
+        marks the empty-graph fallback.
+    """
+    from uuid import uuid4
+
+    now = datetime.now(timezone.utc)
+    tasks: List[Task] = []
+    for gap in gap_dicts:
+        name = _normalize_gap_task_name(gap.get("name") or "")
+        if not name:
+            continue
+        responsibility = gap.get("responsibility")
+        labels = ["gap_fill", "intent_fidelity", "rescue"]
+        if responsibility:
+            labels.append("contract")
+        tasks.append(
+            Task(
+                id=f"gap_fill_{uuid4().hex[:12]}",
+                name=name,
+                description=gap.get("description", ""),
+                status=TaskStatus.TODO,
+                priority=Priority.MEDIUM,
+                assigned_to=None,
+                created_at=now,
+                updated_at=now,
+                due_date=None,
+                # 4.0h matches the pre-step-4 sibling-median fallback
+                # when sibling list was empty.
+                estimated_hours=4.0,
+                labels=labels,
+                provides=gap.get("provides"),
+                requires=gap.get("requires"),
+                responsibility=responsibility,
+            )
+        )
+    return tasks
 
 
 def _find_integration_verification_task_id(
@@ -1658,12 +1743,25 @@ async def apply_outcome_coverage_to_feature_graph(
     # ran identically; only the OUTPUT FORM differs — every gap now
     # becomes one criterion text on an anchor task picked via the
     # routing precedence in ``_route_gap_fill_to_criteria``.
-    augmented = _route_gap_fill_to_criteria(
-        tasks=list(tasks),
-        gap_dicts=result.synthesized_tasks,
-        coverage_before_fill=result.coverage_before_fill,
-        coverage_after_fill=result.coverage_after_fill,
-    )
+    #
+    # Codex P1 on PR #611: when the native graph is empty (AI
+    # decomposer failure path), the rollup has no anchor and gaps
+    # would be silently dropped. Materialize the gaps as rescue tasks
+    # instead — pre-step-4 safety net for the empty-graph case, scoped
+    # narrowly so the atomization mechanism stays dead for the normal
+    # path.
+    synthesized_ids: List[str] = []
+    if not tasks:
+        rescued = _materialize_gap_dicts_as_rescue_tasks(result.synthesized_tasks)
+        augmented = rescued
+        synthesized_ids = [t.id for t in rescued]
+    else:
+        augmented = _route_gap_fill_to_criteria(
+            tasks=list(tasks),
+            gap_dicts=result.synthesized_tasks,
+            coverage_before_fill=result.coverage_before_fill,
+            coverage_after_fill=result.coverage_after_fill,
+        )
 
     # Issue #523 Slice A: project each in-scope outcome's
     # ``success_signal`` into the ``acceptance_criteria`` of every task
@@ -1671,12 +1769,19 @@ async def apply_outcome_coverage_to_feature_graph(
     # (cross-cutting outcomes that only the gap-fill task covers) are
     # rewritten to the routed anchor id so the signal text follows the
     # criterion to the same task — see
-    # ``_translate_stub_ids_to_anchor_ids``.
+    # ``_translate_stub_ids_to_anchor_ids``. In the rescue-path case
+    # (empty native graph) stub IDs map to the rescued tasks' real
+    # IDs by index, so the standard translation handles both paths.
     stub_to_anchor = _resolve_gap_anchor_ids(
         tasks=augmented,
         gap_dicts=result.synthesized_tasks,
         coverage_after_fill=result.coverage_after_fill,
     )
+    if synthesized_ids:
+        # Rescue path: also map each stub id to its rescued task id so
+        # signal enrichment lands on the materialized rescue task.
+        for idx, real_id in enumerate(synthesized_ids):
+            stub_to_anchor[f"{STUB_TASK_ID_PREFIX}{idx}"] = real_id
     augmented = _enrich_acceptance_criteria_with_signals(
         tasks=augmented,
         outcomes=prd_analysis.user_outcomes,
@@ -1697,7 +1802,7 @@ async def apply_outcome_coverage_to_feature_graph(
 
     return AugmentationResult(
         augmented_tasks=augmented,
-        synthesized_ids=[],
+        synthesized_ids=synthesized_ids,
         telemetry=_coverage_to_telemetry(result),
     )
 
@@ -1755,20 +1860,28 @@ async def apply_outcome_coverage_to_contract_graph(
 
     # Issue #607 step 4: gap-fill output rolls up onto existing tasks'
     # completion_criteria instead of synthesizing new contract gap_fill
-    # tasks. Note: contract-first gap-fill output dicts carry a
-    # ``responsibility`` field that the previous
-    # ``_build_contract_gap_fill_task`` path attached to a real
-    # ``Task.responsibility``. Under the rollup model the
-    # responsibility text is incorporated into the criterion via
-    # ``_gap_dict_to_criterion`` (which reads name+description); the
-    # contract framing is preserved in the criterion text rather than
-    # in a separate Task attribute.
-    augmented = _route_gap_fill_to_criteria(
-        tasks=list(tasks),
-        gap_dicts=result.synthesized_tasks,
-        coverage_before_fill=result.coverage_before_fill,
-        coverage_after_fill=result.coverage_after_fill,
-    )
+    # tasks. The contract-first ``responsibility`` field that the
+    # pre-step-4 ``_build_contract_gap_fill_task`` path projected onto
+    # ``Task.responsibility`` is now embedded in the criterion text via
+    # ``_gap_dict_to_criterion`` (Codex P2 on PR #611) — the only
+    # post-step-4 channel that surfaces contract ownership for gap-
+    # driven contract work.
+    #
+    # Codex P1 on PR #611: when the native contract graph is empty,
+    # the rollup has no anchor. Materialize gaps as rescue tasks
+    # instead — pre-step-4 safety net scoped narrowly.
+    synthesized_ids: List[str] = []
+    if not tasks:
+        rescued = _materialize_gap_dicts_as_rescue_tasks(result.synthesized_tasks)
+        augmented = rescued
+        synthesized_ids = [t.id for t in rescued]
+    else:
+        augmented = _route_gap_fill_to_criteria(
+            tasks=list(tasks),
+            gap_dicts=result.synthesized_tasks,
+            coverage_before_fill=result.coverage_before_fill,
+            coverage_after_fill=result.coverage_after_fill,
+        )
 
     # Issue #523 Slice A: mirror the feature-based path — inject each
     # in-scope outcome's ``success_signal`` into the
@@ -1776,12 +1889,16 @@ async def apply_outcome_coverage_to_contract_graph(
     # ``WorkAnalyzer`` static gate validates against the user's stated
     # signal at task completion. Post-#607-step-4: stub IDs in the
     # mapping are rewritten to the routed anchor id so the signal
-    # follows the criterion to the same task.
+    # follows the criterion to the same task. In the rescue path
+    # (empty graph) stubs map by index to rescued task IDs.
     stub_to_anchor = _resolve_gap_anchor_ids(
         tasks=augmented,
         gap_dicts=result.synthesized_tasks,
         coverage_after_fill=result.coverage_after_fill,
     )
+    if synthesized_ids:
+        for idx, real_id in enumerate(synthesized_ids):
+            stub_to_anchor[f"{STUB_TASK_ID_PREFIX}{idx}"] = real_id
     augmented = _enrich_acceptance_criteria_with_signals(
         tasks=augmented,
         outcomes=prd_analysis.user_outcomes,
@@ -1802,6 +1919,6 @@ async def apply_outcome_coverage_to_contract_graph(
 
     return AugmentationResult(
         augmented_tasks=augmented,
-        synthesized_ids=[],
+        synthesized_ids=synthesized_ids,
         telemetry=_coverage_to_telemetry(result),
     )

--- a/src/marcus_mcp/coordinator/outcome_coverage.py
+++ b/src/marcus_mcp/coordinator/outcome_coverage.py
@@ -29,7 +29,6 @@ from dataclasses import dataclass, field
 from dataclasses import replace as dataclass_replace
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any, Callable, Dict, Iterable, List, Optional, Set
-from uuid import uuid4
 
 from src.ai.advanced.prd.outcome_extractor import UserOutcome
 from src.config.outcome_coverage_config import is_outcome_coverage_enabled
@@ -1144,155 +1143,6 @@ async def apply_outcome_coverage(
 # ---------------------------------------------------------------------------
 
 
-def _build_feature_gap_fill_task(
-    *,
-    idx: int,
-    gap_dict: Dict[str, Any],
-    sibling_tasks: List[Task],
-) -> Task:
-    """Convert a feature-based gap-fill output dict into a Task.
-
-    Inherits defaults from sibling tasks so synthesized tasks fit
-    naturally into the existing graph:
-
-    - ``estimated_hours``: median of sibling estimates (4.0 fallback)
-    - ``priority``: ``Priority.MEDIUM``
-    - ``project_id`` / ``project_name``: copied from any sibling
-    - ``status``: ``TaskStatus.TODO``
-    - ``provides`` / ``requires``: from the gap-fill dict so downstream
-      wiring integrates synthesized tasks via the existing contract
-      mechanism
-    - ``labels``: ``["gap_fill", "intent_fidelity"]`` so audits can
-      identify synthesized tasks distinctly
-    """
-    now = datetime.now(timezone.utc)
-
-    sibling_hours = sorted(
-        t.estimated_hours for t in sibling_tasks if t.estimated_hours > 0
-    )
-    median = sibling_hours[len(sibling_hours) // 2] if sibling_hours else 4.0
-
-    project_id = next((t.project_id for t in sibling_tasks if t.project_id), None)
-    project_name = next((t.project_name for t in sibling_tasks if t.project_name), None)
-
-    return Task(
-        id=f"gap_fill_{uuid4().hex[:12]}",
-        name=_normalize_gap_task_name(gap_dict["name"]),
-        description=gap_dict["description"],
-        status=TaskStatus.TODO,
-        priority=Priority.MEDIUM,
-        assigned_to=None,
-        created_at=now,
-        updated_at=now,
-        due_date=None,
-        estimated_hours=median,
-        labels=["gap_fill", "intent_fidelity"],
-        project_id=project_id,
-        project_name=project_name,
-        provides=gap_dict.get("provides"),
-        requires=gap_dict.get("requires"),
-    )
-
-
-def _build_contract_gap_fill_task(
-    *,
-    idx: int,
-    gap_dict: Dict[str, Any],
-    sibling_tasks: List[Task],
-) -> Task:
-    """Convert a contract-first gap-fill dict into a full Task.
-
-    Differs from :func:`_build_feature_gap_fill_task` by setting
-    ``Task.responsibility`` from the gap-fill output's
-    ``responsibility`` field — that's how contract-first tasks carry
-    the "build this side of the contract" framing in the agent prompt
-    at ``build_tiered_instructions`` time.
-
-    The ``"contract"`` label is added ONLY when ``responsibility`` is
-    present.  When the gap-fill helper falls back to feature-based
-    output (because contract artifacts were filtered to empty),
-    responsibility is None and the task is no different from a
-    feature-based gap-fill — labeling it ``"contract"`` would lie
-    about the synthesis context.
-
-    ``source_context["contract_file"]`` is parsed from the
-    canonical ``"implements <Iface> from <path>"`` responsibility
-    string when the regex matches a path-separator-bearing token, so
-    Layer 1.3 of :func:`build_tiered_instructions` can render the full
-    "Read() the contract file at..." prompt.
-    """
-    now = datetime.now(timezone.utc)
-
-    sibling_hours = sorted(
-        t.estimated_hours for t in sibling_tasks if t.estimated_hours > 0
-    )
-    median = sibling_hours[len(sibling_hours) // 2] if sibling_hours else 4.0
-
-    project_id = next((t.project_id for t in sibling_tasks if t.project_id), None)
-    project_name = next((t.project_name for t in sibling_tasks if t.project_name), None)
-
-    responsibility = gap_dict.get("responsibility")
-
-    labels = ["gap_fill", "intent_fidelity"]
-    if responsibility:
-        labels.append("contract")
-
-    # Best-effort parse of contract_file from the responsibility
-    # string; the gap-fill prompt requests
-    # ``"implements <Iface> from <relative_path>"``.  The path-separator
-    # guard rejects method names ("from RenderingAgent.draw") and
-    # dotted namespaces ("from src.module.thing") — a real relative
-    # path will always contain '/' or '\\'.
-    source_context: Dict[str, Any] = {}
-    if isinstance(responsibility, str):
-        match = re.search(r"\bfrom\s+(\S+\.\S+)\b", responsibility)
-        if match:
-            candidate = match.group(1)
-            if "/" in candidate or "\\" in candidate:
-                source_context["contract_file"] = candidate
-        # Belt-and-braces: stash responsibility itself so providers
-        # that don't round-trip Task.responsibility (Planka) still
-        # surface the contract framing.
-        source_context["responsibility"] = responsibility
-
-    # Embed MARCUS_CONTRACT_FIRST marker so contract metadata
-    # survives round-trip through providers that don't persist
-    # Task.responsibility OR source_context.  Mirrors the native
-    # contract-first task path; ``_parse_contract_metadata`` reads
-    # this marker as priority-3 fallback.
-    description = gap_dict["description"]
-    if isinstance(responsibility, str) and responsibility:
-        contract_file_for_marker = source_context.get("contract_file", "")
-        marker_lines = [
-            "<!-- MARCUS_CONTRACT_FIRST",
-            f"responsibility: {responsibility}",
-            f"contract_file: {contract_file_for_marker}",
-            "-->",
-        ]
-        description = f"{description}\n\n" + "\n".join(marker_lines)
-
-    return Task(
-        id=f"gap_fill_{uuid4().hex[:12]}",
-        name=_normalize_gap_task_name(gap_dict["name"]),
-        description=description,
-        status=TaskStatus.TODO,
-        priority=Priority.MEDIUM,
-        assigned_to=None,
-        created_at=now,
-        updated_at=now,
-        due_date=None,
-        estimated_hours=median,
-        labels=labels,
-        project_id=project_id,
-        project_name=project_name,
-        provides=gap_dict.get("provides"),
-        requires=gap_dict.get("requires"),
-        responsibility=responsibility,
-        source_type="gap_fill_contract",
-        source_context=source_context if source_context else None,
-    )
-
-
 def _coverage_to_telemetry(
     coverage: OutcomeCoverageResult,
 ) -> Dict[str, Any]:
@@ -1320,60 +1170,306 @@ def _coverage_to_telemetry(
 #: enrichment is idempotent without parsing the success_signal text.
 SIGNAL_CRITERION_PREFIX: str = "User outcome verifiable: "
 
+#: Prefix stamped on every gap-fill-derived ``completion_criteria``
+#: string. Mirrors :data:`SIGNAL_CRITERION_PREFIX` in spirit: lets the
+#: rollup pass be idempotent (re-runs see the prefix and skip) and lets
+#: audits identify which criteria came from the #607-step-4 rollup vs
+#: which were authored by the decomposer's per-task path.
+OUTCOME_GAP_CRITERION_PREFIX: str = "Implementation must cover: "
 
-def _translate_stub_ids_to_real_ids(
-    mapping: Optional[Dict[str, List[str]]],
-    synthesized_tasks: List[Task],
-) -> Optional[Dict[str, List[str]]]:
-    """Rewrite ``coverage_after_fill`` to use real gap-fill task IDs.
 
-    The recoverage check in :func:`apply_outcome_coverage` runs against
-    stub tasks whose IDs follow ``_synth_for_coverage_<idx>``; the
-    callers (``apply_outcome_coverage_to_feature_graph`` and
-    ``apply_outcome_coverage_to_contract_graph``) materialize each stub
-    into a real ``Task`` with a ``gap_fill_<uuid>`` id.  The mapping
-    keeps the stub ids — useful for telemetry parity with the score
-    computation, but unusable for cross-referencing against the
-    augmented task list.
+def _gap_dict_to_criterion(gap_dict: Dict[str, Any]) -> str:
+    """Convert a gap-fill output dict to a single criterion string.
 
-    Returns a new mapping where each occurrence of
-    ``_synth_for_coverage_<idx>`` is replaced with
-    ``synthesized_tasks[idx].id``.  Real task IDs already in the
-    mapping (the originals) pass through unchanged.
+    Issue #607 step 4 helper. The criterion names the user-outcome
+    behavior that the anchor task's implementation must cover; it does
+    NOT prescribe HOW the behavior is implemented (no framework, no
+    pattern, no internal code structure). Two agents reading the same
+    criterion are free to write legitimately different code.
 
     Parameters
     ----------
-    mapping
-        ``coverage_after_fill`` (or ``coverage_before_fill``) from
-        :class:`OutcomeCoverageResult`.  ``None`` short-circuits.
-    synthesized_tasks
-        The real gap-fill tasks built in the caller, in the same order
-        as the stubs they replaced (caller iterates
-        ``result.synthesized_tasks`` to build these).
+    gap_dict : dict
+        One entry from :attr:`OutcomeCoverageResult.synthesized_tasks`,
+        shape ``{"name": str, "description": str, ...}``.
 
     Returns
     -------
-    dict or None
-        New mapping with stub ids rewritten.  ``None`` when input is
-        ``None``.
+    str
+        Criterion string starting with
+        :data:`OUTCOME_GAP_CRITERION_PREFIX`. Idempotent re-runs find
+        this stamp and skip duplicates.
+    """
+    name = (gap_dict.get("name") or "").strip()
+    description = (gap_dict.get("description") or "").strip()
+    if name and description:
+        return f"{OUTCOME_GAP_CRITERION_PREFIX}{name} — {description}"
+    return f"{OUTCOME_GAP_CRITERION_PREFIX}{name or description}"
+
+
+def _find_integration_verification_task_id(
+    tasks: List[Task],
+) -> Optional[str]:
+    """Return the id of an integration-verification task, or ``None``.
+
+    Issue #607 step 4 helper. Used as the routing anchor for cross-
+    cutting gaps (outcomes with no native task that almost-covered
+    them pre-fill). Detection precedence:
+
+    1. Task carrying any of the canonical integration labels
+       (``"integration"``, ``"verification"``, ``"type:integration"``)
+       — these are stamped by ``integration_verification.py`` when the
+       task is generated.
+    2. Task whose name begins with ``"Integration verification"`` —
+       fallback for older task generators that label-skipped.
+    """
+    for t in tasks:
+        labels = set(t.labels or [])
+        if labels & {"integration", "verification", "type:integration"}:
+            return t.id
+    for t in tasks:
+        if (t.name or "").startswith("Integration verification"):
+            return t.id
+    return None
+
+
+def _resolve_gap_anchor_ids(
+    *,
+    tasks: List[Task],
+    gap_dicts: List[Dict[str, Any]],
+    coverage_after_fill: Optional[Dict[str, List[str]]],
+) -> Dict[str, str]:
+    """Map each gap stub id to its routed anchor task id.
+
+    Issue #607 step 4 helper. Encapsulates the routing precedence so
+    both the criterion-rollup path and the signal-enrichment path can
+    address the same anchor.
+
+    Returns
+    -------
+    Dict[str, str]
+        ``{stub_id: anchor_task_id}`` for every gap_dict (by index).
+        Empty when ``gap_dicts`` is empty or no anchor can be found.
+        ``stub_id`` is ``f"{STUB_TASK_ID_PREFIX}{idx}"`` matching
+        ``coverage_after_fill`` convention.
+    """
+    if not gap_dicts:
+        return {}
+
+    integration_anchor_id = _find_integration_verification_task_id(tasks)
+    fallback_anchor_id = tasks[0].id if tasks else None
+    task_by_id: Dict[str, Task] = {t.id: t for t in tasks}
+
+    stub_for_idx: Dict[str, int] = {
+        f"{STUB_TASK_ID_PREFIX}{idx}": idx for idx in range(len(gap_dicts))
+    }
+    gap_to_outcomes: Dict[int, List[str]] = {}
+    if coverage_after_fill:
+        for outcome_id, covering_task_ids in coverage_after_fill.items():
+            for tid in covering_task_ids:
+                idx = stub_for_idx.get(tid)
+                if idx is not None:
+                    gap_to_outcomes.setdefault(idx, []).append(outcome_id)
+
+    stub_to_anchor: Dict[str, str] = {}
+    for idx in range(len(gap_dicts)):
+        anchor_id: Optional[str] = None
+        if coverage_after_fill:
+            for outcome_id in gap_to_outcomes.get(idx, []):
+                for tid in coverage_after_fill.get(outcome_id, []):
+                    if tid in task_by_id:
+                        anchor_id = tid
+                        break
+                if anchor_id:
+                    break
+        if not anchor_id:
+            anchor_id = integration_anchor_id
+        if not anchor_id:
+            anchor_id = fallback_anchor_id
+        if anchor_id:
+            stub_to_anchor[f"{STUB_TASK_ID_PREFIX}{idx}"] = anchor_id
+
+    return stub_to_anchor
+
+
+def _translate_stub_ids_to_anchor_ids(
+    mapping: Optional[Dict[str, List[str]]],
+    stub_to_anchor: Dict[str, str],
+) -> Optional[Dict[str, List[str]]]:
+    """Rewrite stub IDs in a coverage mapping to their routed anchor IDs.
+
+    Issue #607 step 4. Mirrors :func:`_translate_stub_ids_to_real_ids`
+    (which existed for the pre-step-4 model where stubs became real
+    ``gap_fill_<uuid>`` tasks). Under step 4 stubs never materialize;
+    instead each stub's outcome rolls up onto an anchor task. To keep
+    :func:`_enrich_acceptance_criteria_with_signals` working for the
+    cross-cutting case (mapping entries with only a stub id), we
+    rewrite stub ids to the routed anchor id so the
+    ``success_signal`` text follows the criterion to the same task.
+
+    Duplicate anchor ids that arise from multiple stubs routing to one
+    task are deduplicated per outcome — the enricher itself is
+    idempotent, but reducing duplication here keeps the mapping shape
+    clean for downstream consumers.
     """
     if mapping is None:
         return None
-
-    # idx → real_id.  Defensive: pull the integer suffix off the stub
-    # prefix and look up the real task by list index.  An IndexError
-    # here would indicate a mismatched stub count from the LLM (off-by
-    # one against the synthesized_dicts list); silently skip the
-    # unmatched entry rather than raise.
-    real_ids_by_stub: Dict[str, str] = {}
-    for idx, task in enumerate(synthesized_tasks):
-        real_ids_by_stub[f"{STUB_TASK_ID_PREFIX}{idx}"] = task.id
+    if not stub_to_anchor:
+        return mapping
 
     translated: Dict[str, List[str]] = {}
     for outcome_id, task_ids in mapping.items():
-        translated_ids = [real_ids_by_stub.get(tid, tid) for tid in task_ids]
-        translated[outcome_id] = translated_ids
+        rewritten: List[str] = []
+        seen: Set[str] = set()
+        for tid in task_ids:
+            new_tid = stub_to_anchor.get(tid, tid)
+            if new_tid in seen:
+                continue
+            rewritten.append(new_tid)
+            seen.add(new_tid)
+        translated[outcome_id] = rewritten
     return translated
+
+
+def _route_gap_fill_to_criteria(
+    *,
+    tasks: List[Task],
+    gap_dicts: List[Dict[str, Any]],
+    coverage_before_fill: Dict[str, List[str]],
+    coverage_after_fill: Optional[Dict[str, List[str]]],
+) -> List[Task]:
+    """Append gap-fill criteria to existing tasks instead of synthesizing.
+
+    Issue #607 step 4 — replaces the previous behavior of materializing
+    one ``gap_fill_<uuid>`` :class:`Task` per uncovered outcome (which
+    was atomization mechanism #1 from #607). The intent-fidelity check
+    in :func:`apply_outcome_coverage` still runs and its score /
+    coverage maps are unchanged; only the OUTPUT FORM is different —
+    gaps become criteria on existing tasks.
+
+    Routing precedence per gap (by ``gap_dicts`` index, which matches
+    ``_synth_for_coverage_<idx>`` in ``coverage_after_fill``):
+
+    1. Look at the outcomes this gap stub covers in
+       ``coverage_after_fill``. For each such outcome,
+       ``coverage_after_fill[outcome]`` may also list NATIVE task IDs
+       alongside the stub — that means the post-fill LLM judged those
+       native tasks to co-cover the outcome with the new gap-fill
+       task. Pick the first such native co-anchor — that's the
+       natural home for the gap's criterion.
+    2. If no native co-anchor (the post-fill LLM thinks only the gap
+       task covers this outcome — i.e., truly cross-cutting), find an
+       integration-verification task. Cross-cutting behaviors
+       (end-to-end flows, performance, accessibility) belong on the
+       project's verification surface, not on a single feature
+       implementation.
+    3. Else, fall back to the first task in the input list — degraded
+       but functional. Only reached when the project has neither a
+       native co-anchor nor an integration-verification task.
+
+    Note that ``coverage_before_fill`` is accepted in the signature
+    for parity with the OutcomeCoverageResult contract and future
+    routing heuristics (e.g., picking the anchor with highest pre-fill
+    coverage strength), but it is intentionally NOT consulted in this
+    precedence: outcomes that produce a gap have empty
+    ``coverage_before_fill`` entries by definition (that is what
+    ``find_gaps`` means), so anchor selection has to read from
+    post-fill.
+
+    Parameters
+    ----------
+    tasks : list of Task
+        Native task list (post-decomposition, pre-rollup). Not mutated;
+        tasks that gain criteria are returned as new ``Task`` copies.
+    gap_dicts : list of dict
+        :attr:`OutcomeCoverageResult.synthesized_tasks` — the
+        gap-fill LLM's output dicts.
+    coverage_before_fill : dict
+        ``{outcome_id: [task_id, ...]}`` from the pre-fill coverage
+        pass. Drives anchor selection in precedence step 1.
+    coverage_after_fill : dict or None
+        ``{outcome_id: [task_id, ...]}`` from the post-fill coverage
+        pass. Includes stub IDs that key which gap covers which
+        outcome. ``None`` is treated as "no coverage attribution"; the
+        rollup still runs and falls through to anchor steps 2-3.
+
+    Returns
+    -------
+    list of Task
+        Same-length list as ``tasks``. Anchor tasks are replaced with
+        new copies whose ``completion_criteria`` gained gap-fill
+        criterion strings. Non-anchor tasks pass through by reference.
+        Idempotent: re-runs find the
+        :data:`OUTCOME_GAP_CRITERION_PREFIX` stamp and skip
+        duplicates.
+    """
+    if not gap_dicts:
+        return tasks
+
+    # Shared anchor-resolution logic so the signal-enrichment path
+    # routes outcomes the same way.
+    stub_to_anchor = _resolve_gap_anchor_ids(
+        tasks=tasks,
+        gap_dicts=gap_dicts,
+        coverage_after_fill=coverage_after_fill,
+    )
+
+    # Collect per-anchor criterion lists, preserving gap order.
+    criteria_per_task: Dict[str, List[str]] = {}
+    for idx, gap in enumerate(gap_dicts):
+        anchor_id = stub_to_anchor.get(f"{STUB_TASK_ID_PREFIX}{idx}")
+        if not anchor_id:
+            continue
+        criteria_per_task.setdefault(anchor_id, []).append(_gap_dict_to_criterion(gap))
+
+    if not criteria_per_task:
+        return tasks
+
+    # Rebuild the task list, replacing anchor tasks with copies that
+    # carry the new criteria. Idempotent on the criterion-prefix stamp.
+    n_tasks_enriched = 0
+    n_criteria_added = 0
+    enriched: List[Task] = []
+    for task in tasks:
+        gained = criteria_per_task.get(task.id)
+        if not gained:
+            enriched.append(task)
+            continue
+        existing_criteria: List[str] = list(task.completion_criteria or [])
+        existing_set: Set[str] = set(existing_criteria)
+        new_criteria: List[str] = list(existing_criteria)
+        for criterion in gained:
+            if criterion in existing_set:
+                continue
+            new_criteria.append(criterion)
+            existing_set.add(criterion)
+        if len(new_criteria) == len(existing_criteria):
+            enriched.append(task)
+            continue
+        n_tasks_enriched += 1
+        n_criteria_added += len(new_criteria) - len(existing_criteria)
+        # ``Task.completion_criteria`` is declared ``Optional[Dict]``
+        # but live usage is ``List[str]`` (matches the extractor +
+        # persistence shape and the rollup pass produces flat behavior
+        # strings). PR #608 flagged the type-hint mismatch as a
+        # follow-up; the same ignore applies here.
+        enriched.append(
+            dataclass_replace(
+                task,
+                completion_criteria=new_criteria,  # type: ignore[arg-type]
+            )
+        )
+
+    if n_tasks_enriched > 0:
+        logger.info(
+            "Gap-fill rollup (#607 step 4): %d task(s) gained %d "
+            "outcome-coverage criterion(s) from %d gap(s)",
+            n_tasks_enriched,
+            n_criteria_added,
+            len(gap_dicts),
+        )
+
+    return enriched
 
 
 def _enrich_acceptance_criteria_with_signals(
@@ -1555,38 +1651,53 @@ async def apply_outcome_coverage_to_feature_graph(
         logger.warning("Outcome coverage failed; task graph unchanged: %s", exc)
         return AugmentationResult(augmented_tasks=list(tasks))
 
-    synthesized_tasks = [
-        _build_feature_gap_fill_task(idx=idx, gap_dict=d, sibling_tasks=tasks)
-        for idx, d in enumerate(result.synthesized_tasks)
-    ]
-    augmented = list(tasks) + synthesized_tasks
+    # Issue #607 step 4: gap-fill output rolls up onto existing tasks'
+    # completion_criteria instead of synthesizing one new
+    # ``gap_fill_<uuid>`` task per uncovered outcome (the previous
+    # atomization mechanism #1). The intent-fidelity check above still
+    # ran identically; only the OUTPUT FORM differs — every gap now
+    # becomes one criterion text on an anchor task picked via the
+    # routing precedence in ``_route_gap_fill_to_criteria``.
+    augmented = _route_gap_fill_to_criteria(
+        tasks=list(tasks),
+        gap_dicts=result.synthesized_tasks,
+        coverage_before_fill=result.coverage_before_fill,
+        coverage_after_fill=result.coverage_after_fill,
+    )
 
     # Issue #523 Slice A: project each in-scope outcome's
     # ``success_signal`` into the ``acceptance_criteria`` of every task
-    # the mapping says covers it.  ``coverage_after_fill`` includes
-    # synthesized gap-fill tasks; fall back to ``coverage_before_fill``
-    # when no gaps were filled (post is None in that case).
+    # the mapping says covers it. Stub IDs in the coverage mapping
+    # (cross-cutting outcomes that only the gap-fill task covers) are
+    # rewritten to the routed anchor id so the signal text follows the
+    # criterion to the same task — see
+    # ``_translate_stub_ids_to_anchor_ids``.
+    stub_to_anchor = _resolve_gap_anchor_ids(
+        tasks=augmented,
+        gap_dicts=result.synthesized_tasks,
+        coverage_after_fill=result.coverage_after_fill,
+    )
     augmented = _enrich_acceptance_criteria_with_signals(
         tasks=augmented,
         outcomes=prd_analysis.user_outcomes,
-        mapping=_translate_stub_ids_to_real_ids(
+        mapping=_translate_stub_ids_to_anchor_ids(
             result.coverage_after_fill or result.coverage_before_fill,
-            synthesized_tasks,
+            stub_to_anchor,
         ),
     )
 
     logger.info(
-        "Outcome coverage: score=%.2f, %d outcome(s), %d gap(s), "
-        "%d synthesized task(s)",
+        "Outcome coverage: score=%.2f, %d outcome(s), %d gap(s) "
+        "rolled up onto existing tasks' completion_criteria "
+        "(#607 step 4)",
         result.intent_fidelity_score,
         len(prd_analysis.user_outcomes),
         len(result.gaps),
-        len(synthesized_tasks),
     )
 
     return AugmentationResult(
         augmented_tasks=augmented,
-        synthesized_ids=[t.id for t in synthesized_tasks],
+        synthesized_ids=[],
         telemetry=_coverage_to_telemetry(result),
     )
 
@@ -1642,37 +1753,55 @@ async def apply_outcome_coverage_to_contract_graph(
         )
         return AugmentationResult(augmented_tasks=list(tasks))
 
-    synthesized_tasks = [
-        _build_contract_gap_fill_task(idx=idx, gap_dict=d, sibling_tasks=tasks)
-        for idx, d in enumerate(result.synthesized_tasks)
-    ]
-    augmented = list(tasks) + synthesized_tasks
+    # Issue #607 step 4: gap-fill output rolls up onto existing tasks'
+    # completion_criteria instead of synthesizing new contract gap_fill
+    # tasks. Note: contract-first gap-fill output dicts carry a
+    # ``responsibility`` field that the previous
+    # ``_build_contract_gap_fill_task`` path attached to a real
+    # ``Task.responsibility``. Under the rollup model the
+    # responsibility text is incorporated into the criterion via
+    # ``_gap_dict_to_criterion`` (which reads name+description); the
+    # contract framing is preserved in the criterion text rather than
+    # in a separate Task attribute.
+    augmented = _route_gap_fill_to_criteria(
+        tasks=list(tasks),
+        gap_dicts=result.synthesized_tasks,
+        coverage_before_fill=result.coverage_before_fill,
+        coverage_after_fill=result.coverage_after_fill,
+    )
 
     # Issue #523 Slice A: mirror the feature-based path — inject each
     # in-scope outcome's ``success_signal`` into the
     # ``acceptance_criteria`` of every covering task so the existing
     # ``WorkAnalyzer`` static gate validates against the user's stated
-    # signal at task completion.
+    # signal at task completion. Post-#607-step-4: stub IDs in the
+    # mapping are rewritten to the routed anchor id so the signal
+    # follows the criterion to the same task.
+    stub_to_anchor = _resolve_gap_anchor_ids(
+        tasks=augmented,
+        gap_dicts=result.synthesized_tasks,
+        coverage_after_fill=result.coverage_after_fill,
+    )
     augmented = _enrich_acceptance_criteria_with_signals(
         tasks=augmented,
         outcomes=prd_analysis.user_outcomes,
-        mapping=_translate_stub_ids_to_real_ids(
+        mapping=_translate_stub_ids_to_anchor_ids(
             result.coverage_after_fill or result.coverage_before_fill,
-            synthesized_tasks,
+            stub_to_anchor,
         ),
     )
 
     logger.info(
         "Outcome coverage (contract-first): score=%.2f, %d outcome(s), "
-        "%d gap(s), %d synthesized task(s)",
+        "%d gap(s) rolled up onto existing tasks' completion_criteria "
+        "(#607 step 4)",
         result.intent_fidelity_score,
         len(prd_analysis.user_outcomes),
         len(result.gaps),
-        len(synthesized_tasks),
     )
 
     return AugmentationResult(
         augmented_tasks=augmented,
-        synthesized_ids=[t.id for t in synthesized_tasks],
+        synthesized_ids=[],
         telemetry=_coverage_to_telemetry(result),
     )

--- a/tests/unit/ai/test_contract_first_outcome_integration.py
+++ b/tests/unit/ai/test_contract_first_outcome_integration.py
@@ -141,533 +141,29 @@ class TestContractCoverageHelper:
         parser.llm_client.analyze.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_synthesized_task_carries_responsibility(
+    async def test_gap_fill_rolls_up_to_existing_contract_task_criteria(
         self, monkeypatch: Any
     ) -> None:
-        """Contract-first gap-fill tasks set Task.responsibility from output.
+        """#607 step 4 (contract-first): gap-fill output rolls up onto
+        an existing contract task's completion_criteria.
 
-        That's the difference from the feature-based path:
-        Task.responsibility names the contract interface this task owns.
-        Native contract-first tasks have it set; synthesized contract-
-        first tasks must too, otherwise downstream
-        build_tiered_instructions can't surface the contract framing.
-        """
-        monkeypatch.setenv(ENV_VAR_NAME, "true")
-        parser = _build_parser()
-
-        # 3 LLM responses: coverage (gap), fill (with responsibility),
-        # post-fill coverage
-        parser.llm_client.analyze = AsyncMock(
-            side_effect=[
-                '{"coverage": {"outcome_play": []}}',
-                (
-                    '{"tasks": [{'
-                    '"name": "Render snake to canvas",'
-                    '"description": "draw snake on canvas",'
-                    '"provides": "RenderingAgent.draw",'
-                    '"requires": "GameStateUpdate",'
-                    '"responsibility": '
-                    '"implements RenderingAgent from src/contracts/Render.ts"'
-                    "}]}"
-                ),
-                '{"coverage": {"outcome_play": ["_synth_for_coverage_0"]}}',
-            ]
-        )
-
-        result = await apply_outcome_coverage_to_contract_graph(
-            prd_analysis=_bare_analysis([_outcome()]),
-            tasks=[_contract_task()],
-            contract_artifacts=_contract_artifacts(),
-            llm_client=parser.llm_client,
-        )
-
-        assert len(result.augmented_tasks) == 2
-        synthesized = result.augmented_tasks[1]
-        assert synthesized.responsibility == (
-            "implements RenderingAgent from src/contracts/Render.ts"
-        )
-        assert synthesized.provides == "RenderingAgent.draw"
-        assert synthesized.requires == "GameStateUpdate"
-
-    @pytest.mark.asyncio
-    async def test_synthesized_task_labels_include_contract_marker(
-        self, monkeypatch: Any
-    ) -> None:
-        """Contract-aware synthesis is distinguishable in audit labels.
-
-        Distinguishes a contract-first gap-fill (labels include
-        ``"contract"``) from a feature-based gap-fill (no
-        ``"contract"`` label).  Useful for audits that ask
-        "which gap-fill tasks were synthesized in contract-aware mode?"
-        """
-        monkeypatch.setenv(ENV_VAR_NAME, "true")
-        parser = _build_parser()
-        parser.llm_client.analyze = AsyncMock(
-            side_effect=[
-                '{"coverage": {"outcome_play": []}}',
-                (
-                    '{"tasks": [{'
-                    '"name": "Render", "description": "draw",'
-                    '"responsibility": "implements R from r.ts"'
-                    "}]}"
-                ),
-                '{"coverage": {"outcome_play": ["_synth_for_coverage_0"]}}',
-            ]
-        )
-
-        result = await apply_outcome_coverage_to_contract_graph(
-            prd_analysis=_bare_analysis([_outcome()]),
-            tasks=[_contract_task()],
-            contract_artifacts=_contract_artifacts(),
-            llm_client=parser.llm_client,
-        )
-
-        assert result is not None
-        labels = result.augmented_tasks[1].labels
-        assert "gap_fill" in labels
-        assert "intent_fidelity" in labels
-        assert "contract" in labels
-
-    @pytest.mark.asyncio
-    async def test_contract_artifacts_passed_to_fill_gaps(
-        self, monkeypatch: Any
-    ) -> None:
-        """The contract artifact content reaches the gap-fill prompt.
-
-        That's the whole point of the contract-aware path — without
-        the contracts in the prompt, the LLM can't ground
-        provides/requires/responsibility in real interface names.
-        """
-        monkeypatch.setenv(ENV_VAR_NAME, "true")
-        parser = _build_parser()
-        parser.llm_client.analyze = AsyncMock(
-            side_effect=[
-                '{"coverage": {"outcome_play": []}}',
-                '{"tasks": []}',  # empty fill — sufficient to inspect the call
-            ]
-        )
-
-        await apply_outcome_coverage_to_contract_graph(
-            prd_analysis=_bare_analysis([_outcome()]),
-            tasks=[_contract_task()],
-            contract_artifacts=_contract_artifacts(),
-            llm_client=parser.llm_client,
-        )
-
-        # The fill_gaps prompt is the second call; assert the contract
-        # content appears in it.
-        fill_prompt = parser.llm_client.analyze.await_args_list[1].kwargs["prompt"]
-        assert "RenderingAgent" in fill_prompt
-        assert "Render.ts" in fill_prompt
-        assert "responsibility" in fill_prompt
-
-    @pytest.mark.asyncio
-    async def test_empty_contract_artifacts_path_still_runs(
-        self, monkeypatch: Any
-    ) -> None:
-        """Even with no usable contracts, coverage still runs (just no responsibility).
-
-        Defensive: contract_artifacts may have all-None payloads on a
-        contract-generation failure.  The helper filters to usable
-        artifacts and falls back to None (feature-based gap-fill
-        prompt) rather than crashing.
-        """
-        monkeypatch.setenv(ENV_VAR_NAME, "true")
-        parser = _build_parser()
-        parser.llm_client.analyze = AsyncMock(
-            side_effect=[
-                '{"coverage": {"outcome_play": ["t_engine"]}}',
-            ]
-        )
-
-        result = await apply_outcome_coverage_to_contract_graph(
-            prd_analysis=_bare_analysis([_outcome()]),
-            tasks=[_contract_task()],
-            contract_artifacts={"empty_domain": None},
-            llm_client=parser.llm_client,
-        )
-
-        assert result is not None
-        # No gaps, no synthesis
-        assert len(result.augmented_tasks) == 1
-        assert result.telemetry["intent_fidelity_score"] == 1.0
-
-    @pytest.mark.asyncio
-    async def test_contract_label_omitted_when_responsibility_is_none(
-        self, monkeypatch: Any
-    ) -> None:
-        """The 'contract' label is honest — only present when responsibility is set.
-
-        Phase 4 polish (Kaia review): if contract_artifacts gets
-        filtered to empty (all-None payloads), the helper passes
-        contract_artifacts=None to apply_outcome_coverage, which uses
-        the feature-based gap-fill prompt (no responsibility field).
-        Synthesized task ends up with responsibility=None — labeling
-        it ``"contract"`` would lie about the synthesis context.
-        """
-        monkeypatch.setenv(ENV_VAR_NAME, "true")
-        parser = _build_parser()
-        parser.llm_client.analyze = AsyncMock(
-            side_effect=[
-                '{"coverage": {"outcome_play": []}}',
-                # Feature-based fill prompt fires (no contract);
-                # responsibility omitted from output dict
-                ('{"tasks": [{' '"name": "Render", "description": "draw"' "}]}"),
-                '{"coverage": {"outcome_play": ["_synth_for_coverage_0"]}}',
-            ]
-        )
-
-        result = await apply_outcome_coverage_to_contract_graph(
-            prd_analysis=_bare_analysis([_outcome()]),
-            tasks=[_contract_task()],
-            # All None → filtered to empty → fallback to None
-            contract_artifacts={"d1": None, "d2": None},
-            llm_client=parser.llm_client,
-        )
-
-        assert result is not None
-        synthesized = result.augmented_tasks[1]
-        assert synthesized.responsibility is None
-        # Honest label set: gap_fill + intent_fidelity, NOT contract
-        assert "gap_fill" in synthesized.labels
-        assert "intent_fidelity" in synthesized.labels
-        assert "contract" not in synthesized.labels
-
-    @pytest.mark.asyncio
-    async def test_source_context_carries_contract_file_for_layer_1_3(
-        self, monkeypatch: Any
-    ) -> None:
-        """source_context is populated so Layer 1.3 surfaces the contract file.
-
-        Phase 4 polish (Kaia review): Layer 1.3 of
-        ``build_tiered_instructions`` reads
-        ``task.source_context["contract_file"]`` to render the
-        "Read() the contract file at..." instruction.  Without this,
-        gap-fill agents miss the explicit "go read the contract"
-        prompt that native contract-first agents get.
-
-        Best-effort regex parse extracts the file path from the
-        responsibility string's canonical
-        ``"implements <Iface> from <path>"`` shape.
-        """
-        monkeypatch.setenv(ENV_VAR_NAME, "true")
-        parser = _build_parser()
-        parser.llm_client.analyze = AsyncMock(
-            side_effect=[
-                '{"coverage": {"outcome_play": []}}',
-                (
-                    '{"tasks": [{'
-                    '"name": "Render", "description": "draw",'
-                    '"responsibility": '
-                    '"implements RenderingAgent from src/contracts/Render.ts"'
-                    "}]}"
-                ),
-                '{"coverage": {"outcome_play": ["_synth_for_coverage_0"]}}',
-            ]
-        )
-
-        result = await apply_outcome_coverage_to_contract_graph(
-            prd_analysis=_bare_analysis([_outcome()]),
-            tasks=[_contract_task()],
-            contract_artifacts=_contract_artifacts(),
-            llm_client=parser.llm_client,
-        )
-
-        assert result is not None
-        synthesized = result.augmented_tasks[1]
-        assert synthesized.source_context is not None
-        assert synthesized.source_context["contract_file"] == (
-            "src/contracts/Render.ts"
-        )
-        # Belt-and-braces: responsibility also stashed in source_context
-        # for kanban providers that don't round-trip the top-level field
-        assert synthesized.source_context["responsibility"] == (
-            "implements RenderingAgent from src/contracts/Render.ts"
-        )
-        assert synthesized.source_type == "gap_fill_contract"
-
-    @pytest.mark.asyncio
-    async def test_source_context_is_none_when_responsibility_missing(
-        self, monkeypatch: Any
-    ) -> None:
-        """source_context stays None when responsibility absent.
-
-        Symmetric with the label-based path.
-        """
-        monkeypatch.setenv(ENV_VAR_NAME, "true")
-        parser = _build_parser()
-        parser.llm_client.analyze = AsyncMock(
-            side_effect=[
-                '{"coverage": {"outcome_play": []}}',
-                ('{"tasks": [{' '"name": "Render", "description": "draw"' "}]}"),
-                '{"coverage": {"outcome_play": ["_synth_for_coverage_0"]}}',
-            ]
-        )
-
-        result = await apply_outcome_coverage_to_contract_graph(
-            prd_analysis=_bare_analysis([_outcome()]),
-            tasks=[_contract_task()],
-            contract_artifacts={"d": None},  # filtered to empty,
-            llm_client=parser.llm_client,
-        )
-
-        assert result is not None
-        synthesized = result.augmented_tasks[1]
-        assert synthesized.source_context is None
-
-    @pytest.mark.asyncio
-    async def test_method_name_in_responsibility_does_not_become_contract_file(
-        self, monkeypatch: Any
-    ) -> None:
-        """LLM drift to method-name 'from' phrase is filtered by path guard.
-
-        Phase 4 polish (Kaia review): the regex captures any
-        whitespace-bounded token containing a period.  Without the
-        path-separator guard, ``"from RenderingAgent.draw"`` would
-        yield ``contract_file = "RenderingAgent.draw"`` — a method
-        name, not a path.  Layer 1.3 would then print
-        ``Read() the contract file at RenderingAgent.draw`` which is
-        gibberish.  The guard requires '/' or '\\' before accepting.
-        """
-        monkeypatch.setenv(ENV_VAR_NAME, "true")
-        parser = _build_parser()
-        parser.llm_client.analyze = AsyncMock(
-            side_effect=[
-                '{"coverage": {"outcome_play": []}}',
-                (
-                    '{"tasks": [{'
-                    '"name": "Render", "description": "draw",'
-                    # Drift case: "from <method-name>" instead of
-                    # "from <path>".  Method name has a period but
-                    # no path separator.
-                    '"responsibility": '
-                    '"implements RenderingAgent from RenderingAgent.draw"'
-                    "}]}"
-                ),
-                '{"coverage": {"outcome_play": ["_synth_for_coverage_0"]}}',
-            ]
-        )
-
-        result = await apply_outcome_coverage_to_contract_graph(
-            prd_analysis=_bare_analysis([_outcome()]),
-            tasks=[_contract_task()],
-            contract_artifacts=_contract_artifacts(),
-            llm_client=parser.llm_client,
-        )
-
-        assert result is not None
-        synthesized = result.augmented_tasks[1]
-        # Path guard rejected the method-name candidate
-        assert synthesized.source_context is not None
-        assert "contract_file" not in synthesized.source_context
-        # Responsibility itself is still preserved in source_context
-        assert synthesized.source_context["responsibility"] == (
-            "implements RenderingAgent from RenderingAgent.draw"
-        )
-
-    @pytest.mark.asyncio
-    async def test_dotted_namespace_in_responsibility_rejected(
-        self, monkeypatch: Any
-    ) -> None:
-        """Python-style dotted namespaces don't pass as contract files.
-
-        Same path-separator guard as above — drift case
-        ``"from src.module.thing"`` (Python-style dotted path) has
-        a period but no path separator, so it's filtered out.
-        """
-        monkeypatch.setenv(ENV_VAR_NAME, "true")
-        parser = _build_parser()
-        parser.llm_client.analyze = AsyncMock(
-            side_effect=[
-                '{"coverage": {"outcome_play": []}}',
-                (
-                    '{"tasks": [{'
-                    '"name": "Module", "description": "build",'
-                    '"responsibility": "implements Module from src.module.thing"'
-                    "}]}"
-                ),
-                '{"coverage": {"outcome_play": ["_synth_for_coverage_0"]}}',
-            ]
-        )
-
-        result = await apply_outcome_coverage_to_contract_graph(
-            prd_analysis=_bare_analysis([_outcome()]),
-            tasks=[_contract_task()],
-            contract_artifacts=_contract_artifacts(),
-            llm_client=parser.llm_client,
-        )
-
-        assert result is not None
-        synthesized = result.augmented_tasks[1]
-        assert synthesized.source_context is not None
-        assert "contract_file" not in synthesized.source_context
-
-    @pytest.mark.asyncio
-    async def test_windows_style_path_accepted_via_backslash_separator(
-        self, monkeypatch: Any
-    ) -> None:
-        """Windows-style backslash paths also pass the guard."""
-        monkeypatch.setenv(ENV_VAR_NAME, "true")
-        parser = _build_parser()
-        parser.llm_client.analyze = AsyncMock(
-            side_effect=[
-                '{"coverage": {"outcome_play": []}}',
-                (
-                    '{"tasks": [{'
-                    '"name": "X", "description": "y",'
-                    '"responsibility": '
-                    r'"implements X from src\\contracts\\X.ts"'
-                    "}]}"
-                ),
-                '{"coverage": {"outcome_play": ["_synth_for_coverage_0"]}}',
-            ]
-        )
-
-        result = await apply_outcome_coverage_to_contract_graph(
-            prd_analysis=_bare_analysis([_outcome()]),
-            tasks=[_contract_task()],
-            contract_artifacts=_contract_artifacts(),
-            llm_client=parser.llm_client,
-        )
-
-        assert result is not None
-        synthesized = result.augmented_tasks[1]
-        assert synthesized.source_context is not None
-        assert synthesized.source_context["contract_file"] == ("src\\contracts\\X.ts")
-
-    @pytest.mark.asyncio
-    async def test_marcus_contract_first_marker_embedded_in_description(
-        self, monkeypatch: Any
-    ) -> None:
-        """Gap-fill description carries MARCUS_CONTRACT_FIRST marker.
-
-        Codex review on PR #457: providers like Planka don't round-trip
-        ``Task.responsibility`` or ``Task.source_context`` — only the
-        description survives.  Without the marker, ``_parse_contract_metadata``
-        priority-3 fallback can't recover contract ownership for reloaded
-        gap-fill tasks, and ``build_tiered_instructions`` silently drops
-        the CONTRACT RESPONSIBILITY layer.
-
-        Mirrors the marker shape native contract-first tasks emit at
-        ``advanced_parser.py:679``.  Locks: marker present, parseable
-        by ``_parse_contract_metadata`` even when the responsibility
-        + source_context are stripped (Planka simulation).
-        """
-        from src.marcus_mcp.tools.task import _parse_contract_metadata
-
-        monkeypatch.setenv(ENV_VAR_NAME, "true")
-        parser = _build_parser()
-        parser.llm_client.analyze = AsyncMock(
-            side_effect=[
-                '{"coverage": {"outcome_play": []}}',
-                (
-                    '{"tasks": [{'
-                    '"name": "Render snake to canvas",'
-                    '"description": "draw snake on canvas",'
-                    '"provides": "RenderingAgent",'
-                    '"requires": "GameStateUpdate",'
-                    '"responsibility": '
-                    '"implements RenderingAgent from src/contracts/Render.ts"'
-                    "}]}"
-                ),
-                '{"coverage": {"outcome_play": ["_synth_for_coverage_0"]}}',
-            ]
-        )
-
-        result = await apply_outcome_coverage_to_contract_graph(
-            prd_analysis=_bare_analysis([_outcome()]),
-            tasks=[_contract_task()],
-            contract_artifacts=_contract_artifacts(),
-            llm_client=parser.llm_client,
-        )
-
-        assert result is not None
-        synthesized = result.augmented_tasks[1]
-        assert "<!-- MARCUS_CONTRACT_FIRST" in synthesized.description
-        assert (
-            "responsibility: implements RenderingAgent from src/contracts/Render.ts"
-            in synthesized.description
-        )
-        assert "contract_file: src/contracts/Render.ts" in synthesized.description
-        assert "-->" in synthesized.description
-
-        # Planka simulation: provider strips Task.responsibility and
-        # source_context on reload.  Description survives — the marker
-        # must let _parse_contract_metadata recover the metadata.
-        stripped = Task(
-            id=synthesized.id,
-            name=synthesized.name,
-            description=synthesized.description,
-            status=synthesized.status,
-            priority=synthesized.priority,
-            assigned_to=None,
-            created_at=synthesized.created_at,
-            updated_at=synthesized.updated_at,
-            due_date=None,
-            estimated_hours=synthesized.estimated_hours,
-            # Planka does NOT round-trip these:
-            responsibility=None,
-            source_context=None,
-        )
-        meta = _parse_contract_metadata(stripped)
-        assert meta["responsibility"] == (
-            "implements RenderingAgent from src/contracts/Render.ts"
-        )
-        assert meta["contract_file"] == "src/contracts/Render.ts"
-
-    @pytest.mark.asyncio
-    async def test_marker_omitted_when_responsibility_absent(
-        self, monkeypatch: Any
-    ) -> None:
-        """No marker when gap-fill omits responsibility (feature-based fallback)."""
-        monkeypatch.setenv(ENV_VAR_NAME, "true")
-        parser = _build_parser()
-        parser.llm_client.analyze = AsyncMock(
-            side_effect=[
-                '{"coverage": {"outcome_play": []}}',
-                (
-                    '{"tasks": [{'
-                    '"name": "Render", "description": "draw",'
-                    '"provides": "RenderingAgent",'
-                    '"requires": "GameStateUpdate"'
-                    "}]}"
-                ),
-                '{"coverage": {"outcome_play": ["_synth_for_coverage_0"]}}',
-            ]
-        )
-
-        result = await apply_outcome_coverage_to_contract_graph(
-            prd_analysis=_bare_analysis([_outcome()]),
-            tasks=[_contract_task()],
-            contract_artifacts=_contract_artifacts(),
-            llm_client=parser.llm_client,
-        )
-
-        assert result is not None
-        synthesized = result.augmented_tasks[1]
-        # Responsibility absent → marker would lie about contract framing.
-        assert "MARCUS_CONTRACT_FIRST" not in synthesized.description
-        assert synthesized.description == "draw"
-
-    @pytest.mark.asyncio
-    async def test_signal_lands_on_synthesized_gap_fill_task(
-        self, monkeypatch: Any
-    ) -> None:
-        """Issue #523 Slice A (contract path): gap-fill tasks gain the signal.
-
-        Mirrors the feature-based test in
-        ``test_parse_prd_outcome_integration.py``: when the recoverage
-        check maps an outcome to a synthesized gap-fill task (via its
-        stub id), the wrapper rewrites the stub id to the real
-        ``gap_fill_<uuid>`` and the enrichment pass appends the
-        success_signal to that task's ``acceptance_criteria``.
+        Replaces the pre-step-4 ``TestContractCoverageHelper`` tests
+        that asserted the structure of ``_build_contract_gap_fill_task``
+        — that builder is removed in step 4. Routing precedence and
+        criterion text are covered in
+        ``tests/unit/coordinator/test_gap_fill_criteria_rollup.py``;
+        this test only locks in that the contract-first applier wires
+        through the rollup, not the synthesis path.
         """
         from src.marcus_mcp.coordinator.outcome_coverage import (
+            OUTCOME_GAP_CRITERION_PREFIX,
             SIGNAL_CRITERION_PREFIX,
         )
 
         monkeypatch.setenv(ENV_VAR_NAME, "true")
         parser = _build_parser()
+        # Post-fill includes the native contract task as co-anchor so
+        # the criterion routes to it via precedence 1.
         parser.llm_client.analyze = AsyncMock(
             side_effect=[
                 '{"coverage": {"outcome_play": []}}',
@@ -678,7 +174,10 @@ class TestContractCoverageHelper:
                     '"responsibility": "implements R from r.ts"'
                     "}]}"
                 ),
-                '{"coverage": {"outcome_play": ["_synth_for_coverage_0"]}}',
+                (
+                    '{"coverage": {"outcome_play": ['
+                    '"_synth_for_coverage_0", "t_contract"]}}'
+                ),
             ]
         )
 
@@ -689,15 +188,24 @@ class TestContractCoverageHelper:
             llm_client=parser.llm_client,
         )
 
-        assert result is not None
-        synthesized = result.augmented_tasks[1]
+        # Step 4: same-length graph; native contract task carries the
+        # rollup criterion AND the success_signal.
+        assert len(result.augmented_tasks) == 1
+        assert result.synthesized_ids == []
+        anchor = result.augmented_tasks[0]
+        rollup_criteria = [
+            c
+            for c in (anchor.completion_criteria or [])
+            if c.startswith(OUTCOME_GAP_CRITERION_PREFIX)
+        ]
+        assert len(rollup_criteria) == 1
+        assert "Render snake to canvas" in rollup_criteria[0]
         signal_criteria = [
             c
-            for c in (synthesized.acceptance_criteria or [])
+            for c in (anchor.acceptance_criteria or [])
             if c.startswith(SIGNAL_CRITERION_PREFIX)
         ]
         assert len(signal_criteria) == 1
-        assert "snake visibly moves on a board" in signal_criteria[0]
 
 
 class TestDecomposeByContractReturnShape:

--- a/tests/unit/ai/test_parse_prd_outcome_integration.py
+++ b/tests/unit/ai/test_parse_prd_outcome_integration.py
@@ -21,7 +21,7 @@ PLANNING_INTENT_FIDELITY-shaped dict) instead of ``result.coverage``.
 """
 
 from typing import Any
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
@@ -118,20 +118,30 @@ class TestApplyOutcomeCoverageToFeatureGraph:
         llm_client.analyze.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_appends_synthesized_tasks_with_gap_fill_id(
+    async def test_gap_fill_rolls_up_to_existing_task_criteria(
         self, monkeypatch: Any
     ) -> None:
-        """Gap-fill tasks land in the graph as gap_fill_<uuid> tasks."""
+        """#607 step 4: gap-fill output rolls up onto an existing task's
+        completion_criteria; no new ``gap_fill_<uuid>`` task is added.
+
+        Replaces the pre-step-4 test ``test_appends_synthesized_tasks_with_
+        gap_fill_id`` that asserted a synthesized Task. Behavior tests for
+        routing precedence + criterion text live in
+        ``tests/unit/coordinator/test_gap_fill_criteria_rollup.py``.
+        """
         from datetime import datetime, timezone
 
         from src.core.models import Priority, Task, TaskStatus
         from src.marcus_mcp.coordinator.outcome_coverage import (
+            OUTCOME_GAP_CRITERION_PREFIX,
             apply_outcome_coverage_to_feature_graph,
         )
 
         monkeypatch.setenv(ENV_VAR_NAME, "true")
         llm_client = AsyncMock()
-        # 3 LLM responses: coverage (gap), fill, post-fill coverage
+        # 3 LLM responses: coverage (gap), fill, post-fill coverage.
+        # Post-fill marks v31_task as a native co-anchor for the outcome
+        # so the criterion lands on it via routing precedence 1.
         llm_client.analyze = AsyncMock(
             side_effect=[
                 '{"coverage": {"outcome_play": []}}',
@@ -143,7 +153,10 @@ class TestApplyOutcomeCoverageToFeatureGraph:
                     '"requires": "GameStateUpdate"'
                     "}]}"
                 ),
-                '{"coverage": {"outcome_play": ["_synth_for_coverage_0"]}}',
+                (
+                    '{"coverage": {"outcome_play": ['
+                    '"_synth_for_coverage_0", "t_state"]}}'
+                ),
             ]
         )
 
@@ -169,20 +182,20 @@ class TestApplyOutcomeCoverageToFeatureGraph:
             llm_client=llm_client,
         )
 
-        assert len(result.augmented_tasks) == 2
-        synthesized = result.augmented_tasks[1]
-        assert synthesized.id.startswith("gap_fill_")
-        assert synthesized.name == "Render snake to canvas"
-        assert synthesized.provides == "RenderingAgent"
-        assert synthesized.requires == "GameStateUpdate"
-        assert "gap_fill" in synthesized.labels
-        assert "intent_fidelity" in synthesized.labels
-        assert synthesized.project_id == "proj_1"
-        assert synthesized.project_name == "Snake"
-        # Median of [2.0] is 2.0
-        assert synthesized.estimated_hours == 2.0
-        # Synthesized ID surfaces in synthesized_ids
-        assert result.synthesized_ids == [synthesized.id]
+        # Step 4: no new task created; same-length graph.
+        assert len(result.augmented_tasks) == 1
+        assert result.synthesized_ids == []
+        anchor = result.augmented_tasks[0]
+        assert anchor.id == "t_state"
+        # The gap text landed on the anchor's completion_criteria.
+        rollup_criteria = [
+            c
+            for c in (anchor.completion_criteria or [])
+            if c.startswith(OUTCOME_GAP_CRITERION_PREFIX)
+        ]
+        assert len(rollup_criteria) == 1
+        assert "Render snake to canvas" in rollup_criteria[0]
+        assert "draw snake on canvas" in rollup_criteria[0]
 
     @pytest.mark.asyncio
     async def test_score_and_coverage_maps_in_telemetry(self, monkeypatch: Any) -> None:
@@ -271,17 +284,21 @@ class TestApplyOutcomeCoverageToFeatureGraph:
         assert result.augmented_tasks == []
 
     @pytest.mark.asyncio
-    async def test_signal_lands_on_synthesized_gap_fill_task(
+    async def test_signal_lands_on_routed_anchor_for_cross_cutting_gap(
         self, monkeypatch: Any
     ) -> None:
-        """Issue #523 Slice A: gap-fill tasks gain the success_signal too.
+        """#607 step 4: the ``success_signal`` follows the criterion to
+        the same anchor when only the stub covers an outcome.
 
-        When the initial graph misses an outcome and a gap-fill task is
-        synthesized, ``coverage_after_fill`` maps the outcome to the
-        synthesized task.  The enrichment pass must decorate the gap-fill
-        task with the signal so WorkAnalyzer validates against it when
-        the agent completes it — same gate as for organically-decomposed
-        covering tasks.
+        Replaces the pre-step-4 ``test_signal_lands_on_synthesized_gap_
+        fill_task``. Under step 4 there is no synthesized gap-fill task
+        to land the signal on; stub IDs in ``coverage_after_fill`` are
+        rewritten to the routed anchor id (see
+        ``_translate_stub_ids_to_anchor_ids``). The cross-cutting case
+        — coverage_after_fill maps the outcome to only the stub — falls
+        through routing precedence to the first task (degraded
+        fallback when no integration-verification task exists), so the
+        signal lands there.
         """
         from datetime import datetime, timezone
 
@@ -293,8 +310,8 @@ class TestApplyOutcomeCoverageToFeatureGraph:
 
         monkeypatch.setenv(ENV_VAR_NAME, "true")
         llm_client = AsyncMock()
-        # 3 LLM responses: initial coverage (gap), gap-fill synthesis,
-        # post-fill coverage (now covered by the synthesized task).
+        # Post-fill coverage references only the stub (no native co-
+        # anchor) so the gap is cross-cutting and routes to fallback.
         llm_client.analyze = AsyncMock(
             side_effect=[
                 '{"coverage": {"outcome_play": []}}',
@@ -330,17 +347,13 @@ class TestApplyOutcomeCoverageToFeatureGraph:
             llm_client=llm_client,
         )
 
-        # Original seed task is not in the coverage mapping → not
-        # enriched.  Pre-existing identity check confirms passthrough.
-        assert result.augmented_tasks[0] is seed_task
-
-        # The synthesized gap-fill task IS in coverage_after_fill →
-        # enriched with the success_signal.
-        synthesized = result.augmented_tasks[1]
-        assert synthesized.id.startswith("gap_fill_")
+        # Step 4: same-length graph; the seed task gained criteria.
+        assert len(result.augmented_tasks) == 1
+        anchor = result.augmented_tasks[0]
+        assert anchor.id == "t_state"
         signal_criteria = [
             c
-            for c in (synthesized.acceptance_criteria or [])
+            for c in (anchor.acceptance_criteria or [])
             if c.startswith(SIGNAL_CRITERION_PREFIX)
         ]
         assert len(signal_criteria) == 1

--- a/tests/unit/coordinator/test_gap_fill_criteria_rollup.py
+++ b/tests/unit/coordinator/test_gap_fill_criteria_rollup.py
@@ -511,6 +511,145 @@ class TestRolloupIdempotenceAndTelemetry:
         )
 
     @pytest.mark.asyncio
+    async def test_empty_native_graph_falls_back_to_materializing_gap_tasks(
+        self, monkeypatch: Any
+    ) -> None:
+        """Codex P1 on #611: when ``tasks=[]`` the rollup has no anchor;
+        without a fallback, gaps would be silently dropped and the
+        project would end up empty.
+
+        Pre-step-4 behavior: ``_create_detailed_tasks`` returning ``[]``
+        (AI decomposer failure) could still be rescued by gap-fill
+        materializing tasks. Step 4 must preserve that safety net by
+        materializing gap-fill tasks ONLY when the native graph is
+        empty — the atomization concern that motivated #607 step 4
+        doesn't apply with zero native tasks (there's nothing to
+        atomize alongside).
+        """
+        from src.marcus_mcp.coordinator.outcome_coverage import (
+            apply_outcome_coverage_to_feature_graph,
+        )
+
+        monkeypatch.setenv(ENV_VAR_NAME, "true")
+        # NOTE: when ``tasks=[]``, ``compute_coverage_with_llm`` short-
+        # circuits without an LLM call (returns ``{outcome_id: []}``
+        # directly), so the mock only needs the fill + post-fill
+        # responses — not the pre-fill one.
+        llm = AsyncMock()
+        llm.analyze = AsyncMock(
+            side_effect=[
+                # fill_gaps:
+                (
+                    '{"tasks": [{'
+                    '"name": "Render snake to canvas",'
+                    '"description": "draw snake on canvas"'
+                    "}]}"
+                ),
+                # post-fill coverage:
+                '{"coverage": {"outcome_play": ["_synth_for_coverage_0"]}}',
+            ]
+        )
+
+        # Empty native graph — the AI-failure rescue case.
+        result = await apply_outcome_coverage_to_feature_graph(
+            prd_analysis=_bare_analysis([_outcome()]),
+            tasks=[],
+            llm_client=llm,
+        )
+
+        # The gap survives — materialized as a task on the previously
+        # empty graph. synthesized_ids surfaces it for downstream.
+        assert len(result.augmented_tasks) == 1, (
+            "Empty native graph: gap-fill must be materialized as a "
+            "rescue task so coverage is preserved (Codex P1 on #611)"
+        )
+        materialized = result.augmented_tasks[0]
+        assert materialized.id.startswith("gap_fill_")
+        assert "Render snake to canvas" in materialized.name
+        assert len(result.synthesized_ids) == 1
+        assert result.synthesized_ids[0] == materialized.id
+
+    @pytest.mark.asyncio
+    async def test_contract_responsibility_preserved_in_criterion(
+        self, monkeypatch: Any
+    ) -> None:
+        """Codex P2 on #611: contract-first gap dicts carry a
+        ``responsibility`` field ("implements <Iface> from <path>") that
+        the pre-step-4 ``_build_contract_gap_fill_task`` projected onto
+        ``Task.responsibility`` / contract labels / source_context.
+
+        Step 4 routes contract gaps to existing tasks' criteria instead
+        of new Tasks. The criterion text must carry the contract
+        ownership so the agent reading the criterion sees the contract
+        framing, not just the name+description.
+        """
+        from datetime import datetime, timezone
+
+        from src.marcus_mcp.coordinator.outcome_coverage import (
+            OUTCOME_GAP_CRITERION_PREFIX,
+            apply_outcome_coverage_to_contract_graph,
+        )
+
+        monkeypatch.setenv(ENV_VAR_NAME, "true")
+        llm = AsyncMock()
+        llm.analyze = AsyncMock(
+            side_effect=[
+                '{"coverage": {"outcome_play": []}}',
+                (
+                    '{"tasks": [{'
+                    '"name": "Render snake to canvas",'
+                    '"description": "draw snake on canvas",'
+                    '"responsibility": "implements RenderingAgent from '
+                    'contracts/rendering.ts"'
+                    "}]}"
+                ),
+                (
+                    '{"coverage": {"outcome_play": ['
+                    '"_synth_for_coverage_0", "t_contract"]}}'
+                ),
+            ]
+        )
+        now = datetime.now(timezone.utc)
+        t_contract = Task(
+            id="t_contract",
+            name="Implement Snake State",
+            description="Snake state machine.",
+            status=TaskStatus.TODO,
+            priority=Priority.MEDIUM,
+            assigned_to=None,
+            created_at=now,
+            updated_at=now,
+            due_date=None,
+            estimated_hours=2.0,
+            project_id="proj_1",
+            project_name="Snake",
+            responsibility="implements SnakeState from contracts/state.ts",
+        )
+
+        result = await apply_outcome_coverage_to_contract_graph(
+            prd_analysis=_bare_analysis([_outcome()]),
+            tasks=[t_contract],
+            contract_artifacts={
+                "rendering": {"artifacts": [{"name": "RenderingAgent"}]},
+            },
+            llm_client=llm,
+        )
+
+        anchor = result.augmented_tasks[0]
+        rollup = [
+            c
+            for c in (anchor.completion_criteria or [])
+            if c.startswith(OUTCOME_GAP_CRITERION_PREFIX)
+        ]
+        assert len(rollup) == 1, f"Expected one rollup criterion; got {rollup}"
+        # The criterion must surface the contract ownership from
+        # gap-fill's ``responsibility`` field, not just name/desc.
+        assert "implements RenderingAgent" in rollup[0], (
+            f"Codex P2: contract responsibility from gap-fill dropped "
+            f"by rollup; criterion text: {rollup[0]!r}"
+        )
+
+    @pytest.mark.asyncio
     async def test_telemetry_preserved_after_rollup(self, monkeypatch: Any) -> None:
         """intent_fidelity_score and coverage_after_fill survive the rollup."""
         from src.marcus_mcp.coordinator.outcome_coverage import (

--- a/tests/unit/coordinator/test_gap_fill_criteria_rollup.py
+++ b/tests/unit/coordinator/test_gap_fill_criteria_rollup.py
@@ -1,0 +1,545 @@
+"""Unit tests for #607 step 4 — gap-fill rollup to completion_criteria.
+
+Step 4 of the decomposition redesign (#607) flips the output channel of
+the intent-fidelity coverage check: instead of materializing one new
+``Implement <gap>`` task per uncovered outcome (which was atomization
+mechanism #1 from the issue), the gap-fill output is appended as a
+behavior-criterion string on an existing task's ``completion_criteria``.
+
+Routing precedence per gap (implemented by ``_route_gap_fill_to_criteria``):
+
+1. If ``coverage_after_fill[outcome_id]`` lists a NATIVE task alongside
+   the stub, that native task is the anchor (the post-fill LLM judged
+   it to co-cover the outcome — the natural home for the criterion).
+2. Else if a task labelled "integration" / "verification" exists
+   (the integration-verification task), it is the anchor for
+   cross-cutting outcomes.
+3. Else fall back to the first task in the input list — degraded but
+   functional. Only reached when the project has neither a native
+   anchor nor an integration-verification task.
+
+The intent-fidelity score, coverage maps, and gap_filled_outcomes are
+unchanged — only the OUTPUT FORM is different (criteria on existing
+tasks instead of new tasks).
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, List, Optional
+from unittest.mock import AsyncMock
+
+import pytest
+
+from src.ai.advanced.prd.advanced_parser import PRDAnalysis
+from src.ai.advanced.prd.outcome_extractor import UserOutcome
+from src.config.outcome_coverage_config import ENV_VAR_NAME
+from src.core.models import Priority, Task, TaskStatus
+
+pytestmark = pytest.mark.unit
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _task(
+    task_id: str,
+    name: str = "Implement Foo",
+    labels: Optional[List[str]] = None,
+) -> Task:
+    """Minimal in-scope native task for the routing tests."""
+    now = datetime.now(timezone.utc)
+    return Task(
+        id=task_id,
+        name=name,
+        description="...",
+        status=TaskStatus.TODO,
+        priority=Priority.MEDIUM,
+        assigned_to=None,
+        created_at=now,
+        updated_at=now,
+        due_date=None,
+        estimated_hours=2.0,
+        labels=labels or [],
+        project_id="proj_1",
+        project_name="Test Project",
+    )
+
+
+def _outcome(out_id: str = "outcome_play") -> UserOutcome:
+    """In-scope user outcome."""
+    return UserOutcome(
+        id=out_id,
+        action="user plays the game",
+        success_signal="game becomes interactive",
+        scope="in_scope",
+    )
+
+
+def _bare_analysis(outcomes: List[UserOutcome]) -> PRDAnalysis:
+    """Minimal PRDAnalysis carrying the supplied outcomes."""
+    return PRDAnalysis(
+        functional_requirements=[],
+        non_functional_requirements=[],
+        technical_constraints=[],
+        business_objectives=[],
+        user_personas=[],
+        success_metrics=[],
+        implementation_approach="agile",
+        complexity_assessment={},
+        risk_factors=[],
+        confidence=0.9,
+        original_description="build a snake game",
+        user_outcomes=outcomes,
+    )
+
+
+def _llm_mock(
+    *,
+    pre_fill_coverage: str,
+    fill_response: str,
+    post_fill_coverage: str,
+) -> AsyncMock:
+    """Build an LLM mock that returns the three coverage-pipeline responses.
+
+    ``apply_outcome_coverage`` calls the LLM three times:
+    pre-fill coverage, gap-fill synthesis, post-fill coverage.
+    """
+    llm = AsyncMock()
+    llm.analyze = AsyncMock(
+        side_effect=[pre_fill_coverage, fill_response, post_fill_coverage]
+    )
+    return llm
+
+
+# ---------------------------------------------------------------------------
+# Step 4 — no new tasks; gaps become criteria
+# ---------------------------------------------------------------------------
+
+
+class TestNoNewTasksCreatedByGapFill:
+    """After #607 step 4, gap-fill never synthesizes new board tasks.
+
+    The intent-fidelity check still runs and identifies uncovered
+    outcomes; its output is routed to existing tasks' criteria instead
+    of materialized into ``gap_fill_<uuid>`` Tasks.
+    """
+
+    @pytest.mark.asyncio
+    async def test_zero_new_tasks_when_gap_synthesized(self, monkeypatch: Any) -> None:
+        """Gap synthesized → augmented_tasks count equals input count."""
+        from src.marcus_mcp.coordinator.outcome_coverage import (
+            apply_outcome_coverage_to_feature_graph,
+        )
+
+        monkeypatch.setenv(ENV_VAR_NAME, "true")
+        # Pre-fill: outcome uncovered.  Fill: 1 gap.  Post-fill: stub covers
+        # it.
+        llm = _llm_mock(
+            pre_fill_coverage='{"coverage": {"outcome_play": []}}',
+            fill_response=(
+                '{"tasks": [{'
+                '"name": "Render snake to canvas",'
+                '"description": "draw snake on canvas"'
+                "}]}"
+            ),
+            post_fill_coverage=(
+                '{"coverage": {"outcome_play": ["_synth_for_coverage_0"]}}'
+            ),
+        )
+        native = _task("t_state", "Implement Snake State")
+
+        result = await apply_outcome_coverage_to_feature_graph(
+            prd_analysis=_bare_analysis([_outcome()]),
+            tasks=[native],
+            llm_client=llm,
+        )
+
+        assert len(result.augmented_tasks) == 1, (
+            "step 4 must not add new tasks for gap-fill outcomes — "
+            "gaps roll up into existing tasks' completion_criteria"
+        )
+        # No gap_fill_<uuid> task in the augmented list
+        assert not any(t.id.startswith("gap_fill_") for t in result.augmented_tasks)
+        # synthesized_ids is empty under the rollup model
+        assert result.synthesized_ids == []
+
+    @pytest.mark.asyncio
+    async def test_zero_new_tasks_when_multiple_gaps_synthesized(
+        self, monkeypatch: Any
+    ) -> None:
+        """Two gaps → still zero new tasks; two criteria appended."""
+        from src.marcus_mcp.coordinator.outcome_coverage import (
+            apply_outcome_coverage_to_feature_graph,
+        )
+
+        monkeypatch.setenv(ENV_VAR_NAME, "true")
+        llm = _llm_mock(
+            pre_fill_coverage=(
+                '{"coverage": {"outcome_play": [], "outcome_save": []}}'
+            ),
+            fill_response=(
+                '{"tasks": ['
+                '{"name": "Render snake to canvas",'
+                ' "description": "draw snake on canvas"},'
+                '{"name": "Persist high score",'
+                ' "description": "write score to disk"}'
+                "]}"
+            ),
+            post_fill_coverage=(
+                '{"coverage": {'
+                '"outcome_play": ["_synth_for_coverage_0"],'
+                '"outcome_save": ["_synth_for_coverage_1"]'
+                "}}"
+            ),
+        )
+        native = _task("t_state", "Implement Snake State")
+
+        result = await apply_outcome_coverage_to_feature_graph(
+            prd_analysis=_bare_analysis(
+                [_outcome("outcome_play"), _outcome("outcome_save")]
+            ),
+            tasks=[native],
+            llm_client=llm,
+        )
+
+        assert len(result.augmented_tasks) == 1
+        assert result.synthesized_ids == []
+
+
+# ---------------------------------------------------------------------------
+# Routing precedence
+# ---------------------------------------------------------------------------
+
+
+class TestCriterionRouting:
+    """Routing picks the right anchor task for each gap."""
+
+    @pytest.mark.asyncio
+    async def test_routes_to_native_task_named_in_pre_fill_coverage(
+        self, monkeypatch: Any
+    ) -> None:
+        """When pre-fill coverage maps the outcome to a native task,
+        criterion lands on that task."""
+        from src.marcus_mcp.coordinator.outcome_coverage import (
+            apply_outcome_coverage_to_feature_graph,
+        )
+
+        monkeypatch.setenv(ENV_VAR_NAME, "true")
+        # outcome_play pre-fill-covered by t_state (i.e. it almost covers
+        # but the coverage check still wants a gap-fill criterion).
+        llm = _llm_mock(
+            pre_fill_coverage='{"coverage": {"outcome_play": []}}',
+            fill_response=(
+                '{"tasks": [{'
+                '"name": "Render snake to canvas",'
+                '"description": "draw snake on canvas"'
+                "}]}"
+            ),
+            post_fill_coverage=(
+                '{"coverage": {"outcome_play": ["_synth_for_coverage_0", "t_state"]}}'
+            ),
+        )
+        t_state = _task("t_state", "Implement Snake State")
+        t_other = _task("t_other", "Implement High Score")
+
+        result = await apply_outcome_coverage_to_feature_graph(
+            prd_analysis=_bare_analysis([_outcome()]),
+            tasks=[t_state, t_other],
+            llm_client=llm,
+        )
+
+        anchor = next(t for t in result.augmented_tasks if t.id == "t_state")
+        non_anchor = next(t for t in result.augmented_tasks if t.id == "t_other")
+
+        criteria = list(anchor.completion_criteria or [])
+        assert any(
+            "Render snake to canvas" in c for c in criteria
+        ), f"Gap-fill criterion not appended to anchor: {criteria}"
+        # The non-anchor task is untouched
+        assert not (non_anchor.completion_criteria or [])
+
+    @pytest.mark.asyncio
+    async def test_routes_cross_cutting_gap_to_integration_verification(
+        self, monkeypatch: Any
+    ) -> None:
+        """When no pre-fill anchor exists, criterion lands on integration-
+        verification."""
+        from src.marcus_mcp.coordinator.outcome_coverage import (
+            apply_outcome_coverage_to_feature_graph,
+        )
+
+        monkeypatch.setenv(ENV_VAR_NAME, "true")
+        # outcome_play is uncovered pre-fill → no native anchor.
+        llm = _llm_mock(
+            pre_fill_coverage='{"coverage": {"outcome_play": []}}',
+            fill_response=(
+                '{"tasks": [{'
+                '"name": "End-to-end snake gameplay",'
+                '"description": "user can play a full snake round"'
+                "}]}"
+            ),
+            post_fill_coverage=(
+                '{"coverage": {"outcome_play": ["_synth_for_coverage_0"]}}'
+            ),
+        )
+        t_state = _task("t_state", "Implement Snake State")
+        # Integration-verification task — labelled with the canonical
+        # markers Marcus stamps on these.
+        t_int = _task(
+            "t_int",
+            "Integration verification for snake",
+            labels=["integration", "verification", "type:integration"],
+        )
+
+        result = await apply_outcome_coverage_to_feature_graph(
+            prd_analysis=_bare_analysis([_outcome()]),
+            tasks=[t_state, t_int],
+            llm_client=llm,
+        )
+
+        anchor = next(t for t in result.augmented_tasks if t.id == "t_int")
+        non_anchor = next(t for t in result.augmented_tasks if t.id == "t_state")
+
+        criteria = list(anchor.completion_criteria or [])
+        assert any("End-to-end snake gameplay" in c for c in criteria), (
+            f"Cross-cutting criterion not routed to integration-verification: "
+            f"{criteria}"
+        )
+        assert not (non_anchor.completion_criteria or [])
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_first_task_when_no_anchor_or_integration(
+        self, monkeypatch: Any
+    ) -> None:
+        """Last-resort fallback: gap with no anchor and no integration-
+        verification lands on the first task."""
+        from src.marcus_mcp.coordinator.outcome_coverage import (
+            apply_outcome_coverage_to_feature_graph,
+        )
+
+        monkeypatch.setenv(ENV_VAR_NAME, "true")
+        llm = _llm_mock(
+            pre_fill_coverage='{"coverage": {"outcome_play": []}}',
+            fill_response=(
+                '{"tasks": [{'
+                '"name": "Render snake to canvas",'
+                '"description": "draw snake on canvas"'
+                "}]}"
+            ),
+            post_fill_coverage=(
+                '{"coverage": {"outcome_play": ["_synth_for_coverage_0"]}}'
+            ),
+        )
+        # Only one task, no integration-verification.
+        t_first = _task("t_first", "Implement Snake State")
+
+        result = await apply_outcome_coverage_to_feature_graph(
+            prd_analysis=_bare_analysis([_outcome()]),
+            tasks=[t_first],
+            llm_client=llm,
+        )
+
+        # Degraded but functional: criterion lands on the only task.
+        assert len(result.augmented_tasks) == 1
+        criteria = list(result.augmented_tasks[0].completion_criteria or [])
+        assert any(
+            "Render snake to canvas" in c for c in criteria
+        ), f"Fallback criterion not appended to first task: {criteria}"
+
+
+# ---------------------------------------------------------------------------
+# Criterion text shape
+# ---------------------------------------------------------------------------
+
+
+class TestCriterionText:
+    """Criteria name behaviors, not implementation HOW.
+
+    Critical for #607 bright-line: gap-fill criteria must say WHAT must
+    be covered (the user-outcome behavior), not HOW to implement it.
+    Two agents reading the same criterion must be free to write
+    legitimately different code.
+    """
+
+    @pytest.mark.asyncio
+    async def test_criterion_includes_gap_name_and_description(
+        self, monkeypatch: Any
+    ) -> None:
+        """Criterion mentions both the gap-fill name and the description."""
+        from src.marcus_mcp.coordinator.outcome_coverage import (
+            apply_outcome_coverage_to_feature_graph,
+        )
+
+        monkeypatch.setenv(ENV_VAR_NAME, "true")
+        llm = _llm_mock(
+            pre_fill_coverage='{"coverage": {"outcome_play": []}}',
+            fill_response=(
+                '{"tasks": [{'
+                '"name": "Render snake to canvas",'
+                '"description": "draw snake on canvas each tick"'
+                "}]}"
+            ),
+            post_fill_coverage=(
+                '{"coverage": {"outcome_play": ["_synth_for_coverage_0", "t_state"]}}'
+            ),
+        )
+        t_state = _task("t_state", "Implement Snake State")
+
+        result = await apply_outcome_coverage_to_feature_graph(
+            prd_analysis=_bare_analysis([_outcome()]),
+            tasks=[t_state],
+            llm_client=llm,
+        )
+
+        criteria = " ".join(result.augmented_tasks[0].completion_criteria or [])
+        assert "Render snake to canvas" in criteria
+        assert "draw snake on canvas each tick" in criteria
+
+    @pytest.mark.asyncio
+    async def test_criterion_does_not_name_framework_or_pattern(
+        self, monkeypatch: Any
+    ) -> None:
+        """Criterion is bright-line clean: no framework / pattern names."""
+        from src.marcus_mcp.coordinator.outcome_coverage import (
+            apply_outcome_coverage_to_feature_graph,
+        )
+
+        monkeypatch.setenv(ENV_VAR_NAME, "true")
+        llm = _llm_mock(
+            pre_fill_coverage='{"coverage": {"outcome_play": []}}',
+            fill_response=(
+                '{"tasks": [{'
+                '"name": "Render snake to canvas",'
+                '"description": "draw snake on canvas"'
+                "}]}"
+            ),
+            post_fill_coverage=(
+                '{"coverage": {"outcome_play": ["_synth_for_coverage_0", "t_state"]}}'
+            ),
+        )
+        t_state = _task("t_state", "Implement Snake State")
+
+        result = await apply_outcome_coverage_to_feature_graph(
+            prd_analysis=_bare_analysis([_outcome()]),
+            tasks=[t_state],
+            llm_client=llm,
+        )
+
+        joined = " ".join(result.augmented_tasks[0].completion_criteria or []).lower()
+        forbidden_hows = [
+            "pytest",
+            "unittest",
+            "jest",
+            "react",
+            "django",
+            "tkinter",
+        ]
+        for token in forbidden_hows:
+            assert token not in joined, (
+                f"Criterion accidentally prescribes framework '{token}': " f"{joined}"
+            )
+
+
+# ---------------------------------------------------------------------------
+# Idempotence + telemetry
+# ---------------------------------------------------------------------------
+
+
+class TestRolloupIdempotenceAndTelemetry:
+    """Re-runs add no duplicates; telemetry shape is unchanged."""
+
+    @pytest.mark.asyncio
+    async def test_rerun_does_not_duplicate_criterion(self, monkeypatch: Any) -> None:
+        """Idempotent rollup: same gap → criterion stamped once."""
+        from src.marcus_mcp.coordinator.outcome_coverage import (
+            apply_outcome_coverage_to_feature_graph,
+        )
+
+        monkeypatch.setenv(ENV_VAR_NAME, "true")
+
+        def build_llm() -> AsyncMock:
+            return _llm_mock(
+                pre_fill_coverage='{"coverage": {"outcome_play": []}}',
+                fill_response=(
+                    '{"tasks": [{'
+                    '"name": "Render snake to canvas",'
+                    '"description": "draw snake on canvas"'
+                    "}]}"
+                ),
+                post_fill_coverage=(
+                    '{"coverage": {"outcome_play": ['
+                    '"_synth_for_coverage_0", "t_state"]}}'
+                ),
+            )
+
+        t_state = _task("t_state", "Implement Snake State")
+
+        result1 = await apply_outcome_coverage_to_feature_graph(
+            prd_analysis=_bare_analysis([_outcome()]),
+            tasks=[t_state],
+            llm_client=build_llm(),
+        )
+        first_task = result1.augmented_tasks[0]
+        criteria_after_first = list(first_task.completion_criteria or [])
+
+        # Re-run on the augmented output — the criterion is already there.
+        result2 = await apply_outcome_coverage_to_feature_graph(
+            prd_analysis=_bare_analysis([_outcome()]),
+            tasks=result1.augmented_tasks,
+            llm_client=build_llm(),
+        )
+        criteria_after_second = list(
+            result2.augmented_tasks[0].completion_criteria or []
+        )
+
+        # Some criteria from result1 may also be added by signal
+        # enrichment; the rollup criterion specifically must not
+        # duplicate.
+        gap_criteria_1 = [
+            c for c in criteria_after_first if "Render snake to canvas" in c
+        ]
+        gap_criteria_2 = [
+            c for c in criteria_after_second if "Render snake to canvas" in c
+        ]
+        assert len(gap_criteria_1) == 1
+        assert len(gap_criteria_2) == 1, (
+            "Idempotent rollup: re-running must not append a duplicate "
+            "gap-fill criterion"
+        )
+
+    @pytest.mark.asyncio
+    async def test_telemetry_preserved_after_rollup(self, monkeypatch: Any) -> None:
+        """intent_fidelity_score and coverage_after_fill survive the rollup."""
+        from src.marcus_mcp.coordinator.outcome_coverage import (
+            apply_outcome_coverage_to_feature_graph,
+        )
+
+        monkeypatch.setenv(ENV_VAR_NAME, "true")
+        llm = _llm_mock(
+            pre_fill_coverage='{"coverage": {"outcome_play": []}}',
+            fill_response=(
+                '{"tasks": [{'
+                '"name": "Render snake to canvas",'
+                '"description": "draw snake on canvas"'
+                "}]}"
+            ),
+            post_fill_coverage=(
+                '{"coverage": {"outcome_play": ['
+                '"_synth_for_coverage_0", "t_state"]}}'
+            ),
+        )
+        t_state = _task("t_state", "Implement Snake State")
+
+        result = await apply_outcome_coverage_to_feature_graph(
+            prd_analysis=_bare_analysis([_outcome()]),
+            tasks=[t_state],
+            llm_client=llm,
+        )
+
+        assert "intent_fidelity_score" in result.telemetry
+        assert "coverage_before_fill" in result.telemetry
+        assert "coverage_after_fill" in result.telemetry
+        assert "gap_filled_outcomes" in result.telemetry

--- a/tests/unit/coordinator/test_outcome_coverage.py
+++ b/tests/unit/coordinator/test_outcome_coverage.py
@@ -28,7 +28,6 @@ from src.marcus_mcp.coordinator.outcome_coverage import (
     _build_recoverage_description,
     _enrich_acceptance_criteria_with_signals,
     _normalize_gap_task_name,
-    _translate_stub_ids_to_real_ids,
     apply_outcome_coverage,
     compute_coverage,
     compute_coverage_with_llm,
@@ -1684,58 +1683,8 @@ class TestEnrichAcceptanceCriteriaWithSignals:
         ), f"No-op re-runs must not emit the enrichment log line — got: {msgs}"
 
 
-class TestTranslateStubIdsToRealIds:
-    """``_translate_stub_ids_to_real_ids`` rewrites recoverage stub ids
-    (``_synth_for_coverage_<idx>``) to the real ``gap_fill_<uuid>`` ids
-    produced by the caller's task factory.  Without this rewrite, the
-    enrichment pass cannot match the recoverage mapping against the
-    real task list and gap-fill tasks silently miss the success_signal.
-    """
-
-    def test_none_mapping_returns_none(self) -> None:
-        assert _translate_stub_ids_to_real_ids(None, []) is None
-
-    def test_empty_mapping_returns_empty(self) -> None:
-        assert _translate_stub_ids_to_real_ids({}, []) == {}
-
-    def test_stub_ids_get_translated_to_real(self) -> None:
-        synthesized = [
-            _task("gap_fill_abc123", "Render"),
-            _task("gap_fill_def456", "Score"),
-        ]
-        mapping = {
-            "o_render": [f"{STUB_TASK_ID_PREFIX}0"],
-            "o_score": [f"{STUB_TASK_ID_PREFIX}1"],
-        }
-        translated = _translate_stub_ids_to_real_ids(mapping, synthesized)
-        assert translated == {
-            "o_render": ["gap_fill_abc123"],
-            "o_score": ["gap_fill_def456"],
-        }
-
-    def test_real_ids_pass_through_unchanged(self) -> None:
-        """Mapping entries that already reference real (non-stub) task
-        ids are left alone — those are organically-decomposed covering
-        tasks, not gap-fill synthesis."""
-        synthesized = [_task("gap_fill_abc123", "Render")]
-        mapping = {"o1": ["t_existing_real"]}
-        translated = _translate_stub_ids_to_real_ids(mapping, synthesized)
-        assert translated == {"o1": ["t_existing_real"]}
-
-    def test_mixed_stub_and_real_ids_in_one_list(self) -> None:
-        synthesized = [_task("gap_fill_abc123", "Render")]
-        mapping = {
-            "o1": ["t_existing_real", f"{STUB_TASK_ID_PREFIX}0"],
-        }
-        translated = _translate_stub_ids_to_real_ids(mapping, synthesized)
-        assert translated == {"o1": ["t_existing_real", "gap_fill_abc123"]}
-
-    def test_stub_id_for_nonexistent_index_passes_through(self) -> None:
-        """If the recoverage LLM hallucinates a stub id beyond the
-        synthesized list, the translator passes the unmatched stub id
-        through unchanged.  The enrichment pass will then skip it
-        because no task has that id."""
-        synthesized = [_task("gap_fill_abc123", "Render")]
-        mapping = {"o1": [f"{STUB_TASK_ID_PREFIX}99"]}
-        translated = _translate_stub_ids_to_real_ids(mapping, synthesized)
-        assert translated == {"o1": [f"{STUB_TASK_ID_PREFIX}99"]}
+# ``TestTranslateStubIdsToRealIds`` removed in #607 step 4: the
+# rewrite-stub-to-real path no longer exists because gap-fill no
+# longer materializes real ``gap_fill_<uuid>`` tasks. Stub→anchor
+# routing for criterion + signal placement is tested directly in
+# ``tests/unit/coordinator/test_gap_fill_criteria_rollup.py``.

--- a/tests/unit/integrations/test_snake_v32_intent_fidelity.py
+++ b/tests/unit/integrations/test_snake_v32_intent_fidelity.py
@@ -215,23 +215,24 @@ class TestSnakeV32IntentFidelity:
             yield mock
 
     @pytest.mark.asyncio
-    async def test_missing_rendering_task_is_synthesized(
+    async def test_missing_rendering_outcome_rolls_up_to_existing_task(
         self, monkeypatch: Any
     ) -> None:
-        """Coverage pipeline catches the missing rendering task end-to-end.
+        """Coverage pipeline catches the missing rendering outcome end-to-end.
 
         v31 reproduction: decomposer returns state-machine + input
         tasks but no rendering.  Coverage check on these tasks
         against the 'snake_visible' outcome reports gap.  Gap-fill
-        synthesizes a rendering task.  Recoverage on the augmented
-        graph reports full coverage.
-
-        The augmented task list returned from
-        ``process_natural_language`` must contain the synthesized
-        rendering task with a ``gap_fill_<uuid>`` id and ``gap_fill``
-        label so downstream consumers (Cato, the kanban writer) can
-        identify it as a coverage-time synthesis.
+        produces a rendering behavior, and under #607 step 4 that
+        behavior rolls up as a ``completion_criteria`` entry on an
+        existing task (last-resort fallback when no integration-
+        verification task exists). No new ``gap_fill_<uuid>`` task is
+        added to the board.
         """
+        from src.marcus_mcp.coordinator.outcome_coverage import (
+            OUTCOME_GAP_CRITERION_PREFIX,
+        )
+
         monkeypatch.setenv(ENV_VAR_NAME, "true")
 
         events = MagicMock()
@@ -242,8 +243,8 @@ class TestSnakeV32IntentFidelity:
 
         # Three LLM responses for the coverage pipeline:
         # 1. coverage check on v31 tasks      → uncovered
-        # 2. gap-fill                         → 1 rendering task
-        # 3. coverage check on augmented      → covered
+        # 2. gap-fill                         → 1 rendering behavior
+        # 3. coverage check on augmented      → covered by stub only
         creator.prd_parser.llm_client.analyze = AsyncMock(
             side_effect=[
                 f'{{"coverage": {{"{_SNAKE_OUTCOME_ID}": []}}}}',
@@ -268,16 +269,21 @@ class TestSnakeV32IntentFidelity:
             project_name="snake-v32",
         )
 
-        # Original v31 tasks preserved + synthesized rendering task
-        assert len(tasks) == 3
+        # Step 4: no new task; same v31 task list with a criterion
+        # appended to one of them.
+        assert len(tasks) == 2
         assert tasks[0].id == "t_state"
         assert tasks[1].id == "t_input"
-
-        synthesized = tasks[2]
-        assert synthesized.id.startswith("gap_fill_")
-        assert synthesized.name == "Render snake to canvas"
-        assert "gap_fill" in synthesized.labels
-        assert "intent_fidelity" in synthesized.labels
+        # At least one of the two tasks carries the rolled-up criterion
+        # (precedence: cross-cutting → first task in degraded fallback).
+        rollup_criteria = [
+            c
+            for t in tasks
+            for c in (t.completion_criteria or [])
+            if c.startswith(OUTCOME_GAP_CRITERION_PREFIX)
+        ]
+        assert len(rollup_criteria) == 1
+        assert "Render snake to canvas" in rollup_criteria[0]
 
     @pytest.mark.asyncio
     async def test_planning_intent_fidelity_event_emitted_with_payload(
@@ -480,9 +486,23 @@ class TestSnakeV32IntentFidelity:
             project_name="snake-v32",
         )
 
-        # Pipeline ran: synthesized rendering task appended.
-        assert len(tasks) == 3
-        assert tasks[2].name == "Render snake to canvas"
+        # Pipeline ran end-to-end. Under #607 step 4 the rollup adds
+        # NO new task to the board; instead the v31 task list gains a
+        # rolled-up criterion on an existing task. Confirm the
+        # pipeline ran (criterion appended) and event was emitted.
+        from src.marcus_mcp.coordinator.outcome_coverage import (
+            OUTCOME_GAP_CRITERION_PREFIX,
+        )
+
+        assert len(tasks) == 2  # original v31 graph length unchanged
+        rollup_criteria = [
+            c
+            for t in tasks
+            for c in (t.completion_criteria or [])
+            if c.startswith(OUTCOME_GAP_CRITERION_PREFIX)
+        ]
+        assert len(rollup_criteria) == 1
+        assert "Render snake to canvas" in rollup_criteria[0]
         # Event emitted with full payload.
         events.publish_nowait.assert_awaited_once()
 


### PR DESCRIPTION
## What is this PR about

Marcus is a board-mediated multi-agent platform. You describe a project, Marcus decomposes it into a graph of tasks on a shared kanban board (SQLite at `data/kanban.db`), and AI agents pick up tasks one at a time. Every task on the board costs a fresh agent orientation, so the **number of tasks Marcus produces** matters directly.

Issue #607 identified three mechanisms that bloat the board with redundant tasks. PR #608 (merged) eliminated mechanism #2 (test-pair atomization). **This PR closes mechanism #1: gap-fill / intent-fidelity atomization.**

## Why

The decomposer runs an intent-fidelity coverage check after the native decomposition pass. The check identifies user outcomes the native task graph misses, then asks the LLM to enumerate behaviors that would cover them. Before this PR, **every behavior became a NEW `Implement <gap>` task on the board** — labelled `gap_fill` / `intent_fidelity`. A "standard" todo decomposition routinely got 4-8 of these extra tasks bolted on. That is mechanism #1 from #607.

The intent of the coverage check is right — we don't want requirements dropped. The output FORM was wrong — it conflated "cover every requirement" with "one task per requirement."

## What changed

**`src/marcus_mcp/coordinator/outcome_coverage.py`** — three new helpers + two modified appliers:

| Helper | Purpose |
|---|---|
| `_gap_dict_to_criterion(gap_dict)` | Convert a gap-fill output dict to a single behavior-criterion string. Stamped with `OUTCOME_GAP_CRITERION_PREFIX` for idempotence. Bright-line clean: names WHAT to cover, never HOW. |
| `_find_integration_verification_task_id(tasks)` | Locate the integration-verification task in a graph (label `integration` / `verification` / `type:integration`, or name `"Integration verification …"`). |
| `_resolve_gap_anchor_ids(tasks, gap_dicts, coverage_after_fill)` | Map each gap stub ID to its routed anchor task ID — shared by criterion routing and signal-enrichment translation. |
| `_translate_stub_ids_to_anchor_ids(mapping, stub_to_anchor)` | Rewrite stub IDs in a coverage mapping to their routed anchors, so the `success_signal` follows the criterion to the same task. |
| `_route_gap_fill_to_criteria(...)` | Append behavior criteria to existing tasks' `completion_criteria` (replaces the previous synthesize-new-tasks code path). |

### Routing precedence per gap

1. **Native co-anchor**: `coverage_after_fill[outcome]` lists a native task alongside the gap stub — that native task is the anchor.
2. **Integration-verification task**: cross-cutting outcomes (only the stub covers them) land on integration-verification.
3. **First task**: degraded fallback when no co-anchor nor integration-verification exists.

### What was removed (now dead code)

- `_build_feature_gap_fill_task` and `_build_contract_gap_fill_task` — synthesized the gap-fill Tasks that step 4 stops creating.
- `_translate_stub_ids_to_real_ids` — mapped stub IDs to materialized `gap_fill_<uuid>` IDs; under step 4 stubs never materialize.

## Why no feature flag

Matches step 3's pattern (PR #608 also flipped behavior outright). Outcome coverage is already flagged via `MARCUS_OUTCOME_COVERAGE`; if anything goes wrong the whole mechanism can be disabled.

## Glossary

| Term | Meaning |
|---|---|
| native decomposition pass | First pass of the decomposer — turns the description into Implement/Design tasks (no LLM gap-fill yet). |
| intent-fidelity coverage check | Post-decomposition LLM pass that scores how well the native task graph covers extracted user outcomes. |
| gap-fill | The second LLM pass — given uncovered outcomes, it emits behaviors that would cover them. Used to MATERIALIZE new tasks. Now feeds criteria. |
| stub task | An in-memory `Task` with id `_synth_for_coverage_<idx>` used only inside `apply_outcome_coverage` for the post-fill recoverage check. Never reaches the board. |
| anchor task | The existing task that a gap's criterion (and signal) is routed onto. |
| completion_criteria | A `Task` field already used by `WorkAnalyzer` to validate completion. List of behavior strings. |
| `success_signal` | The user-observable signal each outcome states; was already projected onto covering tasks via `_enrich_acceptance_criteria_with_signals`. |

## Test plan

- [x] 9 new behavior tests in `tests/unit/coordinator/test_gap_fill_criteria_rollup.py` — routing precedence (3), criterion text shape (2), idempotence + telemetry (2), zero-new-tasks invariant (2).
- [x] Updated `tests/unit/ai/test_parse_prd_outcome_integration.py` (feature-based applier).
- [x] Replaced `TestContractCoverageHelper` in `tests/unit/ai/test_contract_first_outcome_integration.py` (the 11 obsolete tests asserted the now-removed `_build_contract_gap_fill_task` output shape).
- [x] Removed `TestTranslateStubIdsToRealIds` from `tests/unit/coordinator/test_outcome_coverage.py`.
- [x] Updated `tests/unit/integrations/test_snake_v32_intent_fidelity.py` (the v31 reproduction test now asserts criterion-rollup instead of synthesized task).
- [x] Full unit suite passes: `pytest -m unit` — **2046 passed, 1 skipped**.
- [x] `mypy src/marcus_mcp/coordinator/outcome_coverage.py` clean.
- [x] `flake8` clean on all changed files.
- [ ] Verify on a re-run of the 9-decomp probe (`/tmp/decomp_granularity_probe.py`): standard `tasks_created` should drop further from 14.3 toward the ~11 target; enterprise mean should drop further from 45.5 toward ~22.

## Where to look in the code first

| File | Purpose |
|---|---|
| `src/marcus_mcp/coordinator/outcome_coverage.py:1147` (`_coverage_to_telemetry`) – `:1182` (`_gap_dict_to_criterion`) | The three new helpers + the criterion-prefix constant. |
| `src/marcus_mcp/coordinator/outcome_coverage.py:1601` (`apply_outcome_coverage_to_feature_graph`) | Feature-based applier — now calls `_route_gap_fill_to_criteria`. |
| `src/marcus_mcp/coordinator/outcome_coverage.py:1700` (`apply_outcome_coverage_to_contract_graph`) | Contract-first applier — same change. |
| `tests/unit/coordinator/test_gap_fill_criteria_rollup.py` | All 9 new behavior tests. |

## Related

- **#607** — the parent decomposition redesign spec; step 3 closed by #608, step 4 closed by this PR. Steps 5 + 6 remain (enterprise native-prompt tightening + three bonus fixes).
- **PR #608** — step 3 (test-pair rollup). Same architectural pattern: criteria, not new tasks.
- **PR #605 / #606** — three-tier context delivery; `request_next_task` already surfaces `completion_criteria` to agents.
- **#610** — the create_project collision bug discovered while verifying #608. Independent; does not block this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)