### PR TITLE
refactor(models): declare Task.completion_criteria as Optional[List[str]]

### DIFF
--- a/src/ai/advanced/prd/advanced_parser.py
+++ b/src/ai/advanced/prd/advanced_parser.py
@@ -2426,18 +2426,10 @@ Create design artifacts such as:
         # Issue #607 step 3 — test-pair rollup. The implement task carries
         # the test-coverage criteria that previously lived on a separate
         # ``Test {feature}`` task. Surfaced to the agent via
-        # ``request_next_task`` (see ``src/marcus_mcp/tools/task.py`` and
-        # consumed by ``WorkAnalyzer._extract_criteria``, which already
-        # supports list-of-strings shape — see
-        # ``tests/unit/ai/test_criteria_extraction.py``).
+        # ``request_next_task`` (see ``src/marcus_mcp/tools/task.py``) and
+        # consumed by ``WorkAnalyzer._extract_criteria``, which reads the
+        # list-of-strings shape declared on the ``Task`` dataclass.
         #
-        # Shape note: the dataclass declares
-        # ``completion_criteria: Optional[Dict[str, Any]]`` but live usage
-        # (extractor + persistence + tests) accepts a ``List[str]``. We
-        # populate the list form here because the criteria are flat
-        # behavior strings and the extractor preserves them as-is. The
-        # type-hint mismatch is flagged as a follow-up rather than fixed
-        # in this PR to keep the diff focused.
         # Codex P1 (PR #608 review): _extract_task_type defaults unknown
         # task IDs to "implement" (with a logged warning) — so non-feature
         # tasks like ``infra_setup`` / ``infra_ci_cd`` / NFR requirement
@@ -2480,7 +2472,7 @@ Create design artifacts such as:
             dependencies=[],  # Will be filled by dependency inference
             labels=labels,
             acceptance_criteria=acceptance_criteria,
-            completion_criteria=completion_criteria,  # type: ignore[arg-type]
+            completion_criteria=completion_criteria,
             # Store context for reference
             source_type="nlp_project",
             source_context={

--- a/src/core/models.py
+++ b/src/core/models.py
@@ -270,7 +270,9 @@ class Task:
     # Fields for generalization support
     source_type: Optional[str] = None  # "nlp_project", "predefined", "github_issue"
     source_context: Optional[Dict[str, Any]] = None  # Original context data
-    completion_criteria: Optional[Dict[str, Any]] = None  # Success conditions
+    completion_criteria: Optional[List[str]] = (
+        None  # Success conditions (#607 step 3+4: flat behavior strings)
+    )
     acceptance_criteria: List[str] = field(default_factory=list)  # Checklist items
     validation_spec: Optional[str] = None  # How to validate completion
 

--- a/src/marcus_mcp/coordinator/outcome_coverage.py
+++ b/src/marcus_mcp/coordinator/outcome_coverage.py
@@ -1533,17 +1533,7 @@ def _route_gap_fill_to_criteria(
             continue
         n_tasks_enriched += 1
         n_criteria_added += len(new_criteria) - len(existing_criteria)
-        # ``Task.completion_criteria`` is declared ``Optional[Dict]``
-        # but live usage is ``List[str]`` (matches the extractor +
-        # persistence shape and the rollup pass produces flat behavior
-        # strings). PR #608 flagged the type-hint mismatch as a
-        # follow-up; the same ignore applies here.
-        enriched.append(
-            dataclass_replace(
-                task,
-                completion_criteria=new_criteria,  # type: ignore[arg-type]
-            )
-        )
+        enriched.append(dataclass_replace(task, completion_criteria=new_criteria))
 
     if n_tasks_enriched > 0:
         logger.info(


### PR DESCRIPTION
## What is this PR about

Marcus is a board-mediated multi-agent platform: you describe a project, Marcus decomposes it into tasks on a shared kanban board, and AI agents pick up tasks one at a time. Each ``Task`` is a Python dataclass with several fields including ``completion_criteria`` — a list of behaviors the implementation must cover, surfaced to agents at task-assignment time so they know what "done" looks like.

## Why this PR exists

Issue #607 step 3 (PR #608) introduced the use of ``completion_criteria`` as a list of behavior strings. Step 4 (PR #611) doubled down by routing gap-fill outcomes onto the same field. Both stored ``List[str]``. Both ran fine. But the original dataclass declaration at ``src/core/models.py:273`` said:

```python
completion_criteria: Optional[Dict[str, Any]] = None  # Success conditions
```

That's `Dict`, not `List`. The two PRs each carried a ``# type: ignore[arg-type]`` comment to suppress mypy and a 7-line "Shape note" comment explaining the lie. Every subsequent step that touches the field compounds the workaround.

Five-minute cleanup PR: align the type hint with reality.

## What changed

| File | Change |
|---|---|
| `src/core/models.py:273` | Type hint: ``Optional[Dict[str, Any]]`` → ``Optional[List[str]]``. Comment updated to reference #607. |
| `src/ai/advanced/prd/advanced_parser.py:2483` | Removed ``# type: ignore[arg-type]``. Removed the "Shape note" disclaimer comment block. |
| `src/marcus_mcp/coordinator/outcome_coverage.py:1544` | Removed ``# type: ignore[arg-type]``. Removed the inline comment explaining the mismatch. |

## What did NOT change

No behavior change. The persistence layer (``sqlite_kanban.py:1635``) uses ``json.loads()``, which is schema-agnostic — any pre-existing kanban-DB rows continue to round-trip unchanged. All producers and consumers were already treating the field as ``List[str]``.

## Test plan

- [x] ``python -m mypy src/core/models.py src/marcus_mcp/coordinator/outcome_coverage.py src/ai/advanced/prd/advanced_parser.py`` — clean (no errors in 3 source files).
- [x] ``python -m pytest tests/unit -m unit`` — **2048 passed, 1 skipped**.

## Glossary

| Term | Meaning |
|---|---|
| ``Task.completion_criteria`` | A field on the ``Task`` dataclass holding a list of behavior strings (e.g. ``"Tests cover happy path for User Login..."``). Agents read these from the ``request_next_task`` MCP response. |
| ``WorkAnalyzer._extract_criteria`` | Reads ``completion_criteria`` at task-completion time and validates against the listed behaviors. Already expects ``List[str]``. |
| ``sqlite_kanban`` | Marcus's SQLite-backed kanban-board persistence layer. Stores ``completion_criteria`` as a JSON blob, so it's type-agnostic. |

## Where to look in the code

| File | Purpose |
|---|---|
| ``src/core/models.py:273`` | The corrected type hint. |
| ``src/ai/advanced/prd/advanced_parser.py:2483`` | One producer that #608 added — now without the ignore. |
| ``src/marcus_mcp/coordinator/outcome_coverage.py:1544`` | The #611 producer — now without the ignore. |
| ``src/integrations/providers/sqlite_kanban.py:1635`` | Where the field is deserialized via ``json.loads`` — no type assumption, no change. |

## Related

- **PR #608** (#607 step 3) — introduced ``completion_criteria`` usage with the first ``# type: ignore``.
- **PR #611** (#607 step 4) — added the second ``# type: ignore``. Kaia flagged the compounding "ignore tax" during review.
- **#607** — parent decomposition redesign spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)