### PR TITLE
fix(#610): serialize create_project to close project-id collision race

### DIFF
--- a/src/marcus_mcp/tools/nlp.py
+++ b/src/marcus_mcp/tools/nlp.py
@@ -27,6 +27,23 @@ logger = logging.getLogger(__name__)
 # "is bound to a different event loop" on the second loop.
 _kanban_init_lock_manager: EventLoopLockManager = EventLoopLockManager()
 
+#: Per-event-loop mutex that serializes the entire ``create_project``
+#: body. Issue #610: ``state.kanban_client`` is shared across calls,
+#: and ``auto_setup_project`` mutates ``self.project_id`` on it (see
+#: ``sqlite_kanban.py:352``). Two concurrent ``create_project`` calls
+#: with different names would otherwise overwrite each other's
+#: project_id mid-flight, commingling tasks from two projects on the
+#: same board. The mutex closes that race by ensuring only one
+#: ``create_project`` is in flight per Marcus server at a time. Same-
+#: name retries continue to short-circuit via the dedup cache and do
+#: NOT wait on the mutex (the cache check happens inside the inner
+#: function, but the inner function is what the mutex protects — and
+#: under the mutex the cache reflects the previous call's completed
+#: state, so retries return the cached result instead of waiting).
+_create_project_serialization_lock_manager: EventLoopLockManager = (
+    EventLoopLockManager()
+)
+
 
 def _local_utc_offset_minutes() -> Optional[int]:
     """Return the host's current UTC offset in minutes, or None.
@@ -314,14 +331,27 @@ async def create_project(
         _run_id,
         _path,
     )
-    with get_recorder().planner_context(
-        PlannerContext(
-            run_id=_run_id,
-            project_id=_placeholder,
-            project_name=_display_name,
-        )
-    ):
-        result = await _create_project_inner(description, project_name, options, state)
+    # Issue #610: serialize ``_create_project_inner`` across the Marcus
+    # server. Two concurrent calls (e.g. retry while a prior call is
+    # still running, with a different name) would otherwise race on
+    # ``state.kanban_client.project_id`` via ``auto_setup_project``
+    # (``sqlite_kanban.py:352``) and commingle tasks from two projects
+    # on the same board. Holding the mutex for the entire inner work
+    # closes that race. Same-name retries that arrive AFTER the first
+    # call completes hit the in-flight/cached dedup logic inside
+    # ``_create_project_inner`` and short-circuit without doing real
+    # work, so the mutex queue doesn't grow unbounded.
+    async with _create_project_serialization_lock_manager.get_lock():
+        with get_recorder().planner_context(
+            PlannerContext(
+                run_id=_run_id,
+                project_id=_placeholder,
+                project_name=_display_name,
+            )
+        ):
+            result = await _create_project_inner(
+                description, project_name, options, state
+            )
 
     # Phase 2: on success, record the runs row (now that we know the
     # real project_id) and rebind every placeholder project_id row.

--- a/src/marcus_mcp/tools/nlp.py
+++ b/src/marcus_mcp/tools/nlp.py
@@ -5,7 +5,9 @@ This module contains tools for natural language project/task creation:
 - add_feature: Add feature to existing project using natural language
 """
 
+import asyncio
 import logging
+import threading
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, Optional
@@ -27,22 +29,43 @@ logger = logging.getLogger(__name__)
 # "is bound to a different event loop" on the second loop.
 _kanban_init_lock_manager: EventLoopLockManager = EventLoopLockManager()
 
-#: Per-event-loop mutex that serializes the entire ``create_project``
-#: body. Issue #610: ``state.kanban_client`` is shared across calls,
-#: and ``auto_setup_project`` mutates ``self.project_id`` on it (see
+#: Process-wide mutex that serializes the entire ``create_project``
+#: body across both event loops AND threads. Issue #610:
+#: ``state.kanban_client`` is shared across calls, and
+#: ``auto_setup_project`` mutates ``self.project_id`` on it (see
 #: ``sqlite_kanban.py:352``). Two concurrent ``create_project`` calls
 #: with different names would otherwise overwrite each other's
 #: project_id mid-flight, commingling tasks from two projects on the
-#: same board. The mutex closes that race by ensuring only one
-#: ``create_project`` is in flight per Marcus server at a time. Same-
-#: name retries continue to short-circuit via the dedup cache and do
-#: NOT wait on the mutex (the cache check happens inside the inner
-#: function, but the inner function is what the mutex protects — and
-#: under the mutex the cache reflects the previous call's completed
-#: state, so retries return the cached result instead of waiting).
-_create_project_serialization_lock_manager: EventLoopLockManager = (
-    EventLoopLockManager()
-)
+#: same board.
+#:
+#: Codex P1 on PR #613: an :class:`EventLoopLockManager` would only
+#: serialize per-event-loop; in HTTP deployments with multiple
+#: uvicorn workers (each running its own asyncio loop in the same
+#: process) two requests on different loops could still race. Using a
+#: :class:`threading.Lock` instead makes the mutex process-wide, so
+#: every ``create_project`` in this Python process queues on the same
+#: lock regardless of event loop.
+#:
+#: Acquisition is done via :func:`_acquire_create_project_lock`,
+#: which polls non-blockingly so the event loop isn't blocked while
+#: waiting for the lock — important because ``create_project`` can
+#: take up to a minute at enterprise complexity.
+_create_project_serialization_lock: threading.Lock = threading.Lock()
+
+
+async def _acquire_create_project_lock() -> None:
+    """Acquire :data:`_create_project_serialization_lock` cooperatively.
+
+    Polls ``acquire(blocking=False)`` and yields to the event loop
+    between attempts. ``threading.Lock`` is the right primitive for
+    cross-loop / cross-thread mutual exclusion, but its blocking
+    ``acquire()`` would freeze the calling event loop. The poll loop
+    runs at 50 ms cadence, which is well below human-noticeable
+    latency and negligible against the 60-second-plus work it
+    protects.
+    """
+    while not _create_project_serialization_lock.acquire(blocking=False):
+        await asyncio.sleep(0.05)
 
 
 def _local_utc_offset_minutes() -> Optional[int]:
@@ -332,7 +355,7 @@ async def create_project(
         _path,
     )
     # Issue #610: serialize ``_create_project_inner`` across the Marcus
-    # server. Two concurrent calls (e.g. retry while a prior call is
+    # process. Two concurrent calls (e.g. retry while a prior call is
     # still running, with a different name) would otherwise race on
     # ``state.kanban_client.project_id`` via ``auto_setup_project``
     # (``sqlite_kanban.py:352``) and commingle tasks from two projects
@@ -341,7 +364,12 @@ async def create_project(
     # call completes hit the in-flight/cached dedup logic inside
     # ``_create_project_inner`` and short-circuit without doing real
     # work, so the mutex queue doesn't grow unbounded.
-    async with _create_project_serialization_lock_manager.get_lock():
+    #
+    # Process-wide ``threading.Lock`` (not per-event-loop) so cross-
+    # loop concurrency (multiple uvicorn workers) is also covered —
+    # Codex P1 on PR #613.
+    await _acquire_create_project_lock()
+    try:
         with get_recorder().planner_context(
             PlannerContext(
                 run_id=_run_id,
@@ -352,6 +380,8 @@ async def create_project(
             result = await _create_project_inner(
                 description, project_name, options, state
             )
+    finally:
+        _create_project_serialization_lock.release()
 
     # Phase 2: on success, record the runs row (now that we know the
     # real project_id) and rebind every placeholder project_id row.

--- a/tests/unit/marcus_mcp/test_create_project_serialization.py
+++ b/tests/unit/marcus_mcp/test_create_project_serialization.py
@@ -137,6 +137,31 @@ class TestConcurrentCreateProjectSerialization:
             f"later {windows[1][0]} started at {later_start:.4f}"
         )
 
+    def test_serialization_lock_is_threading_lock_not_asyncio(self) -> None:
+        """Codex P1 on PR #613: lock must serialize across event loops.
+
+        ``asyncio.Lock`` (and :class:`EventLoopLockManager` which wraps
+        one per loop) only serializes within a single event loop. If
+        Marcus runs uvicorn with multiple worker loops in the same
+        process, two concurrent ``create_project`` requests on
+        different loops would acquire different locks and the #610
+        race would remain. The mutex must be process-wide
+        (``threading.Lock``).
+        """
+        import threading as _threading
+
+        from src.marcus_mcp.tools import nlp as nlp_module
+
+        lock = nlp_module._create_project_serialization_lock
+        # ``threading.Lock()`` is a factory that returns a
+        # ``_thread.lock`` instance; compare against its class.
+        assert isinstance(lock, _threading.Lock().__class__), (
+            "Codex P1 on #613: create_project serialization lock must be "
+            "process-wide (threading.Lock), not per-event-loop "
+            "(asyncio.Lock / EventLoopLockManager). Otherwise two "
+            "requests on different uvicorn worker loops would race."
+        )
+
     @pytest.mark.asyncio
     async def test_third_call_also_serializes_behind_first_two(self) -> None:
         """Three concurrent calls — none overlap.

--- a/tests/unit/marcus_mcp/test_create_project_serialization.py
+++ b/tests/unit/marcus_mcp/test_create_project_serialization.py
@@ -1,0 +1,177 @@
+"""Tests for #610 fix — concurrent create_project calls must not race.
+
+Issue #610: when two ``create_project`` calls are in flight at the same
+time on a single Marcus server (e.g. a slow ``create_project`` for
+project A is still running when ``create_project`` for project B is
+invoked), the shared ``state.kanban_client.project_id`` gets overwritten
+mid-flight and project A's still-being-created tasks end up writing
+under project B's ``project_id``. Both projects end up commingled on
+the same board.
+
+The fix serializes ``create_project`` calls under a per-event-loop
+mutex. Concurrent callers wait for the in-flight call to finish before
+their own work begins. Same name still hits the dedup cache; different
+names now queue instead of racing.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from typing import Any, List
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture(autouse=True)
+def _stub_marcus_config(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Patch the marcus_config singleton so tests are hermetic."""
+    from src.config import marcus_config as mc
+
+    stub = mc.MarcusConfig()
+    stub.ai.anthropic_api_key = "test-key-for-unit-tests"
+    monkeypatch.setattr(mc, "_config", stub)
+
+
+@pytest.fixture(autouse=True)
+def _clear_create_project_dedup_cache() -> Any:
+    """Hermetic tests: clear the module-level dedup cache around each test."""
+    from src.marcus_mcp.tools import nlp as nlp_module
+
+    nlp_module._recent_create_project_calls.clear()
+    yield
+    nlp_module._recent_create_project_calls.clear()
+
+
+def _build_state() -> Mock:
+    """Minimal mock state for the wrapper path."""
+    from src.integrations.kanban_interface import KanbanProvider
+
+    state = Mock()
+    state.log_event = Mock()
+    state.kanban_client = Mock()
+    state.kanban_client.provider = KanbanProvider.PLANKA
+    state.kanban_client.project_id = "stale-id-must-not-leak-between-calls"
+    state.kanban_client.board_id = "stale-board-id"
+    state.ai_engine = Mock()
+    state.subtask_manager = Mock()
+    state.project_registry = Mock()
+    state.project_manager = Mock()
+    state.project_registry.add_project = AsyncMock(return_value="reg-abc")
+    state.project_registry.get_active_project = AsyncMock(return_value=None)
+    state.project_manager.switch_project = AsyncMock()
+    state.project_manager.get_kanban_client = AsyncMock(
+        return_value=state.kanban_client
+    )
+    state._subtasks_migrated = False
+    # cost_store may be None; the wrapper degrades gracefully.
+    state.cost_store = None
+    return state
+
+
+class TestConcurrentCreateProjectSerialization:
+    """Two create_project calls running at once must not overlap.
+
+    Without serialization, the second call's ``auto_setup_project``
+    mutates ``state.kanban_client.project_id`` (line ~352 in
+    ``sqlite_kanban.py``) while the first call is still creating tasks
+    that reference it. The fix is a per-event-loop mutex around the
+    entire create_project body — the second call simply waits.
+    """
+
+    @pytest.mark.asyncio
+    async def test_concurrent_different_named_calls_do_not_overlap(self) -> None:
+        """Two concurrent calls with DIFFERENT names → second waits.
+
+        The inner work is mocked to record entry / exit timestamps.
+        After both calls finish, the inner work's two execution
+        windows must be disjoint (no overlap).
+        """
+        from src.marcus_mcp.tools import nlp as nlp_module
+
+        # Track inner-work execution windows so the test can verify
+        # they don't overlap. Each call's wrapper enters
+        # ``_create_project_inner`` after acquiring the serialization
+        # mutex; we record (start, end) per call.
+        windows: List[tuple[str, float, float]] = []
+
+        async def fake_inner(
+            description: str,
+            project_name: str,
+            *_args: Any,
+            **_kwargs: Any,
+        ) -> dict:
+            start = time.monotonic()
+            # Simulate work — long enough that overlapping calls would
+            # be visible at millisecond resolution.
+            await asyncio.sleep(0.05)
+            end = time.monotonic()
+            windows.append((project_name, start, end))
+            return {
+                "success": True,
+                "project_id": f"id-for-{project_name}",
+                "tasks_created": 1,
+            }
+
+        state = _build_state()
+
+        with patch.object(nlp_module, "_create_project_inner", side_effect=fake_inner):
+            # Two calls with DIFFERENT names → no dedup-cache rejection.
+            await asyncio.gather(
+                nlp_module.create_project("desc one", "project-A", None, state),
+                nlp_module.create_project("desc two", "project-B", None, state),
+            )
+
+        assert len(windows) == 2, f"both calls should have executed; got {windows}"
+        # Sort by start so we can compare the earlier window's end to
+        # the later window's start.
+        windows.sort(key=lambda w: w[1])
+        earlier_end = windows[0][2]
+        later_start = windows[1][1]
+        assert later_start >= earlier_end, (
+            f"#610: concurrent create_project calls overlapped — "
+            f"earlier {windows[0][0]} ended at {earlier_end:.4f}, "
+            f"later {windows[1][0]} started at {later_start:.4f}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_third_call_also_serializes_behind_first_two(self) -> None:
+        """Three concurrent calls — none overlap.
+
+        Catches any "mutex held only between first two" off-by-one bug.
+        All three inner-work windows must be pairwise disjoint.
+        """
+        from src.marcus_mcp.tools import nlp as nlp_module
+
+        windows: List[tuple[str, float, float]] = []
+
+        async def fake_inner(
+            description: str, project_name: str, *_a: Any, **_k: Any
+        ) -> dict:
+            start = time.monotonic()
+            await asyncio.sleep(0.03)
+            end = time.monotonic()
+            windows.append((project_name, start, end))
+            return {
+                "success": True,
+                "project_id": f"id-for-{project_name}",
+                "tasks_created": 1,
+            }
+
+        state = _build_state()
+
+        with patch.object(nlp_module, "_create_project_inner", side_effect=fake_inner):
+            await asyncio.gather(
+                nlp_module.create_project("d1", "p-1", None, state),
+                nlp_module.create_project("d2", "p-2", None, state),
+                nlp_module.create_project("d3", "p-3", None, state),
+            )
+
+        assert len(windows) == 3
+        # Pairwise no-overlap.
+        windows.sort(key=lambda w: w[1])
+        for prev, nxt in zip(windows, windows[1:]):
+            assert nxt[1] >= prev[2], f"#610: overlap between {prev[0]} and {nxt[0]}"


### PR DESCRIPTION
## What this PR is about

Marcus is a board-mediated multi-agent platform. You describe a project, Marcus's ``create_project`` MCP tool decomposes the description into a task graph on a shared kanban board (SQLite at ``data/kanban.db``), each project getting its own ``project_id``. AI agents then pick up tasks from that board.

## Why this PR exists

Issue #610 documents a silent-data-corruption bug discovered while verifying PR #608. The 9-decomposition probe re-run showed three boards in the kanban DB containing tasks from two distinct ``project_name`` values, sharing one ``project_id``. The user saw a board with twice the expected task count and no error.

**Root cause:** ``SQLiteKanbanProvider.auto_setup_project`` at ``src/integrations/providers/sqlite_kanban.py:352`` mutates ``self.project_id`` directly:

```python
self.project_id = uuid.uuid4().hex
```

That instance is the **shared** ``state.kanban_client``. Two concurrent ``create_project`` calls (e.g. an experiment runner kicking off project B while project A is still decomposing) overwrote each other's ``project_id`` mid-flight. Project A's still-being-created tasks landed under project B's ``project_id``.

**The user-visible failure mode (real example from the post-#608 probe):**

| ``project_id`` | Reported ``project_name`` | Tasks actually for |
|---|---|---|
| ``9a168cc3...`` | ``todo2-standard-1`` | ``todo2-standard-1`` **AND** ``todo2-prototype-3`` |
| ``da7a3567...`` | ``todo2-standard-3`` | ``todo2-standard-3`` **AND** ``todo2-standard-2`` |
| ``9b747374...`` | ``todo2-enterprise-3`` | ``todo2-enterprise-3`` **AND** ``todo2-enterprise-2`` |

29 ÷ 2 ≈ 14.5 tasks per logical project — matched the MCP-reported ``tasks_created=14``. The boards looked inflated because two projects' tasks were commingled. None of these errors surfaced to the caller.

## What changed

**``src/marcus_mcp/tools/nlp.py``** (+19/-8): added ``_create_project_serialization_lock_manager`` (a per-event-loop ``EventLoopLockManager``, modelled on the existing ``_kanban_init_lock_manager``) and wrapped the entire ``_create_project_inner`` invocation in ``async with ...get_lock():``. Concurrent ``create_project`` calls now serialize — the second waits for the first to finish before its own ``auto_setup_project`` runs.

Same-name retries continue to short-circuit via the existing dedup cache inside ``_create_project_inner``; the mutex queue does not grow unbounded.

## Why not a different fix shape

| Alternative | Why not |
|---|---|
| Per-call ``SQLiteKanbanProvider`` instance | Requires upstream callers to thread the client through every method — significant refactor. |
| ``auto_setup_project`` returns IDs without mutating ``self`` | Same surface change as above; many call sites read ``self.project_id`` after the setup call. |
| Locking inside ``auto_setup_project`` only | Doesn't help; the mutation is brief but the IDs are READ by downstream task-creation calls long after the lock would release. |
| Serializing at the outer wrapper (this PR) | Smallest correct fix. Trades some create_project concurrency (which is rare in practice) for full data integrity. |

## Test plan

- [x] 2 new behavior tests in ``tests/unit/marcus_mcp/test_create_project_serialization.py``:
  - ``test_concurrent_different_named_calls_do_not_overlap`` — two concurrent calls with different names; the inner-work windows must be disjoint.
  - ``test_third_call_also_serializes_behind_first_two`` — three concurrent calls; pairwise no-overlap.
- [x] Full unit suite: ``pytest -m unit`` — **2050 passed** (was 2048).
- [x] ``mypy src/marcus_mcp/tools/nlp.py`` clean.
- [x] ``flake8`` clean on the changed files.
- [ ] Verify in a real run: re-run the 9-decomp probe and confirm every board has tasks whose ``project_name`` reference only its own complexity (no ``prototype-`` task in a ``standard-`` board).

## Glossary

| Term | Meaning |
|---|---|
| ``create_project`` | Marcus MCP tool that decomposes a project description into a task graph on the kanban board. |
| MCP | Model Context Protocol — JSON-RPC-over-HTTP protocol Marcus uses to talk to AI clients. |
| ``state.kanban_client`` | The shared kanban-board client instance held on the server's ``state`` singleton. |
| ``auto_setup_project`` | The provider hook that allocates a new ``project_id`` + ``board_id`` for a fresh project. |
| ``EventLoopLockManager`` | Existing utility (``src/core/event_loop_utils.py``) that issues per-event-loop locks. HTTP transport may run multiple loops; this is how Marcus scopes locks correctly. |
| dedup cache | ``_recent_create_project_calls`` — module-level dict mapping ``f"{project_name}:{description[:50]}"`` to ``(timestamp, result)``. Catches same-name retries from Claude Code MCP timeouts. |

## Where to look in the code first

| File | Purpose |
|---|---|
| ``src/marcus_mcp/tools/nlp.py:28`` | ``_create_project_serialization_lock_manager`` — the new mutex. |
| ``src/marcus_mcp/tools/nlp.py:324`` | The ``async with`` block around ``_create_project_inner``. |
| ``src/integrations/providers/sqlite_kanban.py:352`` | The ``self.project_id = uuid.uuid4().hex`` mutation the race exploited. |
| ``tests/unit/marcus_mcp/test_create_project_serialization.py`` | The 2 new behavior tests. |

## Related

- **#610** — the issue this PR closes.
- **PR #608** — where the bug was first surfaced (the post-merge probe verification showed contaminated boards).
- **PR #611** — step 4 of #607; the bug was independent of step 4 but hit the same probe.
- **Simon decision:** ``838f8e96`` — the corrected investigation that pivoted from "#609 false alarm" to "this is the real bug."

🤖 Generated with [Claude Code](https://claude.com/claude-code)