### PR TITLE
fix(persist): build_task_data was silently dropping Task.completion_criteria

### DIFF
--- a/src/integrations/nlp_task_utils.py
+++ b/src/integrations/nlp_task_utils.py
@@ -215,6 +215,17 @@ class TaskBuilder:
             "original_id": task.id,
             # Include acceptance criteria if available
             "acceptance_criteria": getattr(task, "acceptance_criteria", []),
+            # Include completion criteria — list of behavior strings
+            # populated by #607 step 3 (test-coverage criteria) and
+            # step 4 (gap-fill rollup). Without this line both steps'
+            # output was silently dropped before kanban persistence,
+            # making the field empty for every task in the DB and
+            # both PRs functionally inert in production despite
+            # passing unit tests. Persisted by sqlite_kanban as a
+            # JSON blob; the persistence path gates on truthiness,
+            # so passing ``None`` here is the right "no criteria"
+            # signal for non-feature tasks (design / NFR / infra).
+            "completion_criteria": getattr(task, "completion_criteria", None),
             # Include subtasks if available
             "subtasks": getattr(task, "subtasks", []),
             # Additional fields that might be needed

--- a/tests/unit/integrations/test_build_task_data_completion_criteria.py
+++ b/tests/unit/integrations/test_build_task_data_completion_criteria.py
@@ -1,0 +1,123 @@
+"""Tests for the Task → kanban task_data conversion of completion_criteria.
+
+This file pins a bug found by inspection of post-#608/#611 kanban data:
+``TaskBuilder.build_task_data`` at ``src/integrations/nlp_task_utils.py``
+copied ``acceptance_criteria`` from the in-memory ``Task`` object but
+never copied ``completion_criteria``. Steps 3 and 4 of #607 populated
+``Task.completion_criteria`` correctly, but the field was silently
+dropped at the conversion to ``task_data`` before kanban persistence.
+
+The unit tests for #608 + #611 passed because they asserted on the
+in-memory ``Task`` object — they never went through the persistence
+chain.
+
+Tests:
+
+1. ``build_task_data`` carries ``completion_criteria`` from the Task
+   into the result dict (the missing-line bug).
+2. The list-of-strings shape matches what the SQLite persistence
+   layer expects.
+3. Empty / None ``completion_criteria`` is handled gracefully
+   (matches the pre-fix behavior for tasks without criteria).
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import List, Optional
+
+import pytest
+
+from src.core.models import Priority, Task, TaskStatus
+from src.integrations.nlp_task_utils import TaskBuilder
+
+pytestmark = pytest.mark.unit
+
+
+def _make_task(
+    *,
+    completion_criteria: Optional[List[str]] = None,
+    acceptance_criteria: Optional[List[str]] = None,
+) -> Task:
+    """Minimal Task with optional completion / acceptance criteria."""
+    now = datetime.now(timezone.utc)
+    return Task(
+        id="t_test",
+        name="Implement User Login",
+        description="Login flow.",
+        status=TaskStatus.TODO,
+        priority=Priority.HIGH,
+        assigned_to=None,
+        created_at=now,
+        updated_at=now,
+        due_date=None,
+        estimated_hours=2.0,
+        labels=["implement"],
+        completion_criteria=completion_criteria,
+        acceptance_criteria=acceptance_criteria or [],
+    )
+
+
+class TestBuildTaskDataCompletionCriteria:
+    """Bug pin: build_task_data must carry completion_criteria into
+    the persisted task_data dict.
+
+    Without this, every gap-fill criterion (#607 step 4) and test-
+    coverage criterion (#607 step 3) was silently dropped before
+    kanban persistence — making both PRs functionally inert in
+    production despite passing unit tests.
+    """
+
+    def test_populated_completion_criteria_appears_in_result_dict(self) -> None:
+        """The bug: build_task_data dropped completion_criteria silently.
+
+        After the fix, a Task with non-empty completion_criteria must
+        produce a task_data dict that carries the same list.
+        """
+        criteria = [
+            "Implementation must cover: User Login — email + password",
+            "Tests cover the happy path for User Login with valid input.",
+        ]
+        task = _make_task(completion_criteria=criteria)
+
+        result = TaskBuilder.build_task_data(task)
+
+        assert "completion_criteria" in result, (
+            "build_task_data must include 'completion_criteria' in the "
+            "result dict — without it the sqlite_kanban persistence "
+            "layer at line ~470 silently drops every gap-fill and test-"
+            "coverage criterion produced by #607 step 3 + step 4."
+        )
+        assert result["completion_criteria"] == criteria
+
+    def test_none_completion_criteria_passes_through_as_none(self) -> None:
+        """Tasks without criteria (design, infra, NFR) carry None.
+
+        ``Task.completion_criteria`` is ``Optional[List[str]]`` so non-
+        feature tasks have ``None``. The conversion must preserve that
+        rather than coercing to an empty list — the SQLite write path
+        uses ``if task_data.get("completion_criteria")`` to decide
+        whether to write the field, and None matches that gate.
+        """
+        task = _make_task(completion_criteria=None)
+        result = TaskBuilder.build_task_data(task)
+        assert "completion_criteria" in result
+        assert result["completion_criteria"] is None
+
+    def test_empty_list_completion_criteria_passes_through(self) -> None:
+        """Empty list is distinct from None and must survive."""
+        task = _make_task(completion_criteria=[])
+        result = TaskBuilder.build_task_data(task)
+        assert "completion_criteria" in result
+        assert result["completion_criteria"] == []
+
+    def test_acceptance_criteria_still_carried_unchanged(self) -> None:
+        """Regression guard: the existing acceptance_criteria copy must
+        still work alongside the new completion_criteria copy."""
+        task = _make_task(
+            completion_criteria=["criterion-1"],
+            acceptance_criteria=["acc-1", "acc-2"],
+        )
+        result = TaskBuilder.build_task_data(task)
+        assert result["acceptance_criteria"] == ["acc-1", "acc-2"]
+        assert result["completion_criteria"] == ["criterion-1"]


### PR DESCRIPTION
## What this PR is about

Marcus is a board-mediated multi-agent platform. After it decomposes a project into tasks, each ``Task`` Python object is converted to a plain ``task_data`` dict and then serialized to the SQLite kanban DB. Agents read those rows back via ``request_next_task`` and see the criteria they need to satisfy.

This PR fixes a silent persistence bug that made two recently-merged PRs (#608 + #611) functionally inert in production, even though their unit tests pass.

## The bug

``TaskBuilder.build_task_data`` at ``src/integrations/nlp_task_utils.py:174`` is the Task → dict converter. It copied ``acceptance_criteria`` (line 217) but **never copied ``completion_criteria``**. Steps 3 and 4 of issue #607 populated ``Task.completion_criteria`` correctly in memory, but the field was silently dropped at this conversion step before reaching the kanban DB.

The unit tests for #608 + #611 asserted on the in-memory ``Task`` object — they never went through the persistence chain. So the bug hid through two PRs and a full session of post-merge probe work.

## Direct evidence

Querying the kanban DB grouped by day:

| Day | Tasks with non-empty completion_criteria | Total tasks |
|---|---|---|
| 2026-05-20 | **0** | 118 |
| 2026-05-21 | **0** | 176 |
| 2026-05-22 (PR #608 + #611 merged this day) | **0** | 613 |
| 2026-05-23 | **0** | 583 |

Spot check on an Implement-task that should have carried both criterion types (todo3cf-enterprise-1 → ``Implement Create Todo Item``):

- ``completion_criteria``: **0 entries**
- ``acceptance_criteria``: 5 template-authored + 1 ``#523 Slice A`` success-signal entry

The success-signal entry shows that ``#523 Slice A`` (which writes to ``acceptance_criteria``) is working. ``completion_criteria`` is the field that was silently dropped.

## What PRs were broken

| PR | Intended effect | Actual effect (pre-this-PR) |
|---|---|---|
| #608 (#607 step 3) | Test-coverage criteria on every Implement task | ``Test {feature}`` parent tasks removed ✅; replacement criteria **dropped** ❌ |
| #611 (#607 step 4) | Gap-fill outcomes roll up to existing tasks' completion_criteria | New ``gap_fill_<uuid>`` tasks no longer created ✅; rollup criteria **dropped** ❌ |

Both PRs achieved their "delete the noise" goal but lost their "preserve the signal" goal because the signal couldn't reach the DB.

## What changed

**``src/integrations/nlp_task_utils.py``** (+10 lines): added the missing field copy in ``TaskBuilder.build_task_data``:

```python
"completion_criteria": getattr(task, "completion_criteria", None),
```

``None`` is preserved for non-feature tasks (design, NFR, infrastructure) because the SQLite persistence path at ``sqlite_kanban.py:470`` gates on truthiness — passing ``None`` is the right "no criteria" signal.

**``tests/unit/integrations/test_build_task_data_completion_criteria.py``** (new, +124 lines): 4 regression tests pinning the bug shut:

1. Populated list survives the conversion.
2. ``None`` passes through as ``None``.
3. Empty list passes through as empty list (distinct from ``None``).
4. Existing ``acceptance_criteria`` copy still works (regression guard).

## Test plan

- [x] 4 new tests in ``test_build_task_data_completion_criteria.py`` — all pass.
- [x] Full unit suite: ``pytest -m unit`` — **2055 passed** (was 2051).
- [x] ``mypy src/integrations/nlp_task_utils.py`` — clean.
- [ ] Verify end-to-end: create a fresh project after this merges; query the kanban DB for an Implement-task; confirm ``completion_criteria`` is non-empty and contains both gap-fill and test-coverage entries.

## Why no test on the existing test file (``test_task_creation_cascade.py``)

That file's ``test_acceptance_criteria_list_stored_and_retrieved`` test creates a ``task_data`` dict by hand (bypassing ``build_task_data``) and asserts the SQLite layer round-trips it. Useful for catching DB-side bugs, but it doesn't exercise the Task → dict converter where this bug lives. The new test file pins ``build_task_data`` directly.

## Glossary

| Term | Meaning |
|---|---|
| ``Task`` | The in-memory Python dataclass for a kanban-board task. |
| ``task_data`` | A plain dict that ``sqlite_kanban.create_task`` knows how to serialize to the DB. |
| ``TaskBuilder.build_task_data`` | The Task → task_data converter; lives in ``nlp_task_utils.py``. |
| ``completion_criteria`` | A list of behavior strings: what the implementation must cover (e.g. ``"Tests cover the happy path for X..."``). Read by ``WorkAnalyzer`` at task-completion time. |
| ``acceptance_criteria`` | A parallel list of criteria, the older field. Already carried correctly through the converter. |

## Where to look in the code first

| File | Purpose |
|---|---|
| ``src/integrations/nlp_task_utils.py:217`` | The added line — ``completion_criteria`` now copies through. |
| ``src/integrations/providers/sqlite_kanban.py:470`` | The SQLite write path that consumes ``task_data["completion_criteria"]`` if truthy. |
| ``src/marcus_mcp/tools/task.py`` | Where ``request_next_task`` reads ``completion_criteria`` back off the persisted task and surfaces it to agents. |
| ``tests/unit/integrations/test_build_task_data_completion_criteria.py`` | The 4 new regression tests. |

## Related

- **PR #608** (#607 step 3) — produced ``completion_criteria`` on the Task object. Worked in memory; dropped at persistence.
- **PR #611** (#607 step 4) — same.
- **PR #612** — fixed ``Task.completion_criteria`` type hint to ``Optional[List[str]]``.
- **#607** — parent decomposition redesign spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)