### PR TITLE
feat(decomposer): tighten enterprise native prompt (#607 step 5)

### DIFF
--- a/src/ai/advanced/prd/advanced_parser.py
+++ b/src/ai/advanced/prd/advanced_parser.py
@@ -1345,25 +1345,61 @@ Return ONLY the JSON object. Do not include commentary.
         - Include basic error handling and validation
         - Example "User Auth": "Login, signup, password reset, session management"
 
-        ENTERPRISE MODE - Production-ready system (15-30+ features):
+        ENTERPRISE MODE - Production-ready system (8-12 broad feature areas):
         FEATURE BREADTH:
-        - Include everything in STANDARD plus production readiness:
-          * Observability: Monitoring, structured logging, alerting, health checks
-          * Security: Comprehensive auth, RBAC, audit trails, rate limiting
-          * Resilience: Retry logic, circuit breakers, graceful degradation
-          * Data Operations: Backup/restore, migration scripts, data archival
-          * Admin Tooling: Admin dashboard, user management, feature flags
-          * Quality: Comprehensive testing, performance monitoring
-        - Example "twitter clone": All standard features + monitoring, admin UI,
-          content moderation, analytics dashboard, rate limiting, audit logs
+        - Cover the same production-readiness scope as before (auth,
+          observability, resilience, data ops, admin, quality) but
+          CONSOLIDATE related concerns into 8-12 BROAD feature areas,
+          NOT 15-30 narrow ones (#607 step 5).
+        - Each enterprise feature area must BUNDLE related concerns
+          into a single requirement that an agent implements as a
+          coordinated unit. Coarser tasks + richer descriptions, never
+          many narrow tasks.
+        - Example "twitter clone" enterprise as 8-12 areas, NOT 20-30:
+          * Tweet lifecycle: CRUD + content moderation (one area)
+          * Social graph: following, feed, profiles (one area)
+          * Authentication and account: signup, login, password reset,
+            MFA, OAuth, account recovery, audit (one area, not six)
+          * Observability stack: monitoring, structured logging,
+            alerting, health checks (one area, not four)
+          * Security operations: audit logs, rate limiting, RBAC
+            (one area, not three)
+          * Data operations: backup/restore, migration scripts,
+            archival (one area, not three)
+          * Admin tooling: admin dashboard, user management, feature
+            flags (one area, not three)
+          * Quality and performance: comprehensive testing,
+            performance monitoring (one area)
 
-        IMPLEMENTATION DEPTH:
-        - Include comprehensive implementation details in descriptions
-        - Use complexity: "coordinated" or "distributed"
-        - Include security hardening, error recovery, edge cases, audit trails
-        - Example "User Auth": "Login, signup, password reset, session management,
-          MFA, account lockout, password policies, OAuth integration, audit logging,
-          rate limiting, account recovery workflows"
+        IMPLEMENTATION DEPTH (the load-bearing change at enterprise):
+        - Each feature description must be RICH and CONCRETE: list the
+          specific capabilities, sub-flows, security hardening, error
+          recovery, and edge cases that the feature must cover. The
+          agent reading the description sees the FULL SCOPE, not a
+          one-liner. The breadth comes from rich descriptions, not
+          from splitting a feature into many requirements.
+        - Use complexity: "coordinated" or "distributed".
+        - Example "Authentication" description (one requirement,
+          rich description — NOT split into six requirements):
+          "Implement complete authentication: signup with email
+          verification, login with password + optional MFA, session
+          management with refresh tokens, password reset flow with
+          rate-limited token issuance, OAuth integration for Google
+          and GitHub, account recovery workflow, audit logging of all
+          auth events, rate limiting on login + password reset,
+          account lockout after N failed attempts."
+
+        CRITICAL ENTERPRISE GUIDANCE (#607 step 5):
+        - A complex enterprise project is NOT the same as MANY narrow
+          tasks. Coarser tasks + richer descriptions > more tasks +
+          thinner descriptions.
+        - Target: 8-12 functional requirements. If you find yourself
+          producing more than 12, CONSOLIDATE cross-cutting concerns
+          (auth, observability, security ops, data ops, admin) into
+          broader feature areas.
+        - Do NOT split a feature into login / signup / password reset
+          as separate requirements; those are sub-flows that belong
+          in the description of a single "Authentication" requirement.
 
         CRITICAL: User exclusions ALWAYS override complexity mode defaults!
         - If user says "no authentication", omit it even in enterprise mode
@@ -1576,10 +1612,10 @@ Return ONLY the JSON object. Do not include commentary.
                     f"Standard mode expects 8-15 features, but AI generated "
                     f"{feature_count}. Project may be incomplete."
                 )
-            elif constraints.complexity_mode == "enterprise" and feature_count < 15:
+            elif constraints.complexity_mode == "enterprise" and feature_count < 8:
                 logger.warning(
-                    f"Enterprise mode expects 15-30+ features, but AI generated "
-                    f"{feature_count}. Project may be incomplete."
+                    f"Enterprise mode expects 8-12 broad feature areas, but AI "
+                    f"generated {feature_count}. Project may be incomplete."
                 )
 
             # Issue #449: extract user-visible outcomes when the

--- a/tests/unit/ai/test_complexity_aware_generation.py
+++ b/tests/unit/ai/test_complexity_aware_generation.py
@@ -209,10 +209,19 @@ class TestComplexityAwareGeneration:
         call_args = mock_llm_client.analyze.call_args
         prompt = call_args.kwargs["prompt"]
 
-        assert "ENTERPRISE MODE - Production-ready system (15-30+ features)" in prompt
-        assert "Observability: Monitoring, structured logging" in prompt
-        assert "Security: Comprehensive auth, RBAC, audit trails" in prompt
-        assert "Admin Tooling: Admin dashboard" in prompt
+        # #607 step 5: enterprise prompt was retargeted from
+        # "15-30+ features" to "8-12 broad feature areas" with rich
+        # per-feature descriptions instead of many narrow features.
+        assert (
+            "ENTERPRISE MODE - Production-ready system (8-12 broad feature areas)"
+            in prompt
+        )
+        # The same production-readiness scope is still covered; the
+        # categories now live inside richer descriptions and the
+        # example uses one-area-per-concern phrasing.
+        assert "auth," in prompt and "observability," in prompt
+        assert "audit logs" in prompt
+        assert "admin dashboard" in prompt.lower()
 
     @pytest.mark.unit
     @pytest.mark.asyncio
@@ -233,9 +242,18 @@ class TestComplexityAwareGeneration:
         call_args = mock_llm_client.analyze.call_args
         prompt = call_args.kwargs["prompt"]
 
-        assert "Include comprehensive implementation details" in prompt
-        assert 'Use complexity: "coordinated" or "distributed"' in prompt
-        assert "security hardening, error recovery, edge cases" in prompt
+        # #607 step 5: depth guidance kept but moved into the new
+        # IMPLEMENTATION DEPTH block of the enterprise section. The
+        # wording changed; pin the key concepts that remain. Normalize
+        # whitespace because the prompt-template f-string wraps long
+        # lines on its own indentation, splitting some compound terms
+        # ("error recovery", "edge cases") across lines.
+        normalized = " ".join(prompt.split()).lower()
+        assert "rich and concrete" in normalized
+        assert 'use complexity: "coordinated" or "distributed"' in normalized
+        assert "security hardening" in normalized
+        assert "error recovery" in normalized
+        assert "edge cases" in normalized
 
     @pytest.mark.unit
     @pytest.mark.asyncio

--- a/tests/unit/ai/test_enterprise_prompt_tightening.py
+++ b/tests/unit/ai/test_enterprise_prompt_tightening.py
@@ -1,0 +1,188 @@
+"""Unit tests for #607 step 5 — enterprise native-prompt tightening.
+
+The pre-step-5 enterprise prompt at
+``src/ai/advanced/prd/advanced_parser.py`` asked the LLM for
+"15-30+ features", which trained the model to atomize a complex
+enterprise project into 15-50 narrow functional requirements (and
+therefore 16-51 ``Implement`` tasks on the board). Mechanism #3 from
+issue #607.
+
+Step 5 tightens the prompt so an enterprise project is described as
+8-12 BROAD feature areas, each with a rich, concrete description that
+bundles related concerns. The agent sees the full scope on a coarser
+task instead of the scope being shredded across many narrow tasks.
+
+These tests pin the prompt-template contract: a future edit that
+re-introduces the "15-30+" language or drops the consolidation
+guidance fails these tests.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+
+from src.ai.advanced.prd.advanced_parser import (
+    AdvancedPRDParser,
+    ProjectConstraints,
+)
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture
+def parser() -> AdvancedPRDParser:
+    """Parser with mocked LLM dependencies."""
+    with (
+        patch("src.ai.advanced.prd.advanced_parser.LLMAbstraction"),
+        patch("src.ai.advanced.prd.advanced_parser.HybridDependencyInferer"),
+    ):
+        p = AdvancedPRDParser()
+        p.llm_client = Mock()
+        p.llm_client.analyze = AsyncMock(return_value="{}")
+        return p
+
+
+async def _capture_prompt(parser: AdvancedPRDParser, complexity_mode: str) -> str:
+    """Run ``_analyze_prd_deeply`` and capture the LLM prompt argument."""
+    captured: dict[str, str] = {}
+
+    async def fake_structured_call(
+        *,
+        llm: Any,
+        prompt: str,
+        operation: str,
+        initial_max_tokens: int = 16384,
+    ) -> dict:
+        captured["prompt"] = prompt
+        # Minimal valid PRD analysis response so the caller proceeds.
+        return json.loads(
+            '{"functional_requirements": [], "non_functional_requirements": [], '
+            '"technical_constraints": [], "business_objectives": [], '
+            '"user_personas": [], "success_metrics": [], '
+            '"implementation_approach": "agile", "complexity_assessment": {}, '
+            '"risk_factors": [], "confidence": 0.9, "domain": "other", '
+            '"structuralCategory": "other"}'
+        )
+
+    constraints = ProjectConstraints(
+        team_size=3,
+        available_skills=["Python"],
+        technology_constraints=[],
+        complexity_mode=complexity_mode,
+    )
+    with patch(
+        "src.utils.structured_llm.safe_structured_call",
+        side_effect=fake_structured_call,
+    ):
+        await parser._analyze_prd_deeply("a todo app", constraints)
+    return captured.get("prompt", "")
+
+
+class TestEnterprisePromptCoarserFeatureCount:
+    """#607 step 5: enterprise must ask for FEWER, COARSER features."""
+
+    @pytest.mark.asyncio
+    async def test_enterprise_does_not_request_15_to_30_plus_features(
+        self, parser: AdvancedPRDParser
+    ) -> None:
+        """The legacy "15-30+ features" target trained over-decomposition."""
+        prompt = await _capture_prompt(parser, "enterprise")
+        # The legacy string must be gone from the enterprise guidance.
+        assert "15-30+ features" not in prompt, (
+            "#607 step 5: prompt still asks for '15-30+ features' at "
+            "enterprise — this is mechanism #3 of over-decomposition. "
+            "Should target a tighter band with richer descriptions."
+        )
+
+    @pytest.mark.asyncio
+    async def test_enterprise_targets_coarser_feature_band(
+        self, parser: AdvancedPRDParser
+    ) -> None:
+        """Replacement target band must be visibly in the prompt.
+
+        Implementation must use a band like "8-12" or similar coarser
+        count and identify it as the enterprise target. The exact
+        wording can vary; what's tested is that the LLM sees an
+        explicit numeric target lower than the legacy 15-30+.
+        """
+        prompt = await _capture_prompt(parser, "enterprise")
+        # Some band-like phrasing in the enterprise section anchors
+        # the LLM to a smaller count. We accept any range whose UPPER
+        # bound is <= 15 (vs the legacy 30+).
+        # Searching the enterprise section specifically.
+        enterprise_idx = prompt.find("ENTERPRISE MODE")
+        assert enterprise_idx >= 0, "ENTERPRISE MODE section missing"
+        ent_section = prompt[enterprise_idx : enterprise_idx + 2000]
+        # The new band must include an upper bound of 12-15 (not 30+).
+        # Allow flexibility in the exact wording; pin only the band.
+        import re
+
+        bands = re.findall(
+            r"(\d+)\s*[-–]\s*(\d+)\s+(?:features|broad|feature)", ent_section
+        )
+        assert bands, (
+            f"No feature-count band found in enterprise section; "
+            f"section excerpt: {ent_section[:300]!r}"
+        )
+        # At least one band's upper bound must be <= 15.
+        upper_bounds = [int(hi) for _lo, hi in bands]
+        assert min(upper_bounds) <= 15, (
+            f"#607 step 5: enterprise feature-count band's upper bound is "
+            f"{upper_bounds} — should be <= 15 to drive coarser features. "
+            f"Bands found: {bands}"
+        )
+
+
+class TestEnterprisePromptRichDescriptionsGuidance:
+    """The enterprise prompt must direct the LLM to RICHER descriptions,
+    not MORE features.
+    """
+
+    @pytest.mark.asyncio
+    async def test_enterprise_prompt_warns_against_more_narrower_features(
+        self, parser: AdvancedPRDParser
+    ) -> None:
+        """Explicit guidance: coarser tasks + richer descriptions, not
+        many narrow tasks.
+        """
+        prompt = await _capture_prompt(parser, "enterprise")
+        # The guidance can be phrased many ways; check for the key
+        # concept words.
+        enterprise_idx = prompt.find("ENTERPRISE MODE")
+        ent_section = prompt[enterprise_idx : enterprise_idx + 3000].lower()
+        # Must mention "consolidate" or "bundle" or "coarser" — the
+        # consolidation discipline that prevents over-decomposition.
+        assert (
+            "consolidate" in ent_section
+            or "bundle" in ent_section
+            or "coarser" in ent_section
+            or "broader" in ent_section
+        ), (
+            "Enterprise section must direct the LLM to CONSOLIDATE / "
+            "BUNDLE / use COARSER features instead of splitting widely. "
+            f"Section excerpt: {ent_section[:400]!r}"
+        )
+
+
+class TestProtoTypeAndStandardPromptsUnchanged:
+    """Step 5 only retargets ENTERPRISE; prototype + standard guidance
+    untouched.
+    """
+
+    @pytest.mark.asyncio
+    async def test_prototype_band_unchanged(self, parser: AdvancedPRDParser) -> None:
+        """Prototype still targets 3-5 core features."""
+        prompt = await _capture_prompt(parser, "prototype")
+        assert "PROTOTYPE MODE" in prompt
+        assert "3-5 core features" in prompt or "(3-5 " in prompt
+
+    @pytest.mark.asyncio
+    async def test_standard_band_unchanged(self, parser: AdvancedPRDParser) -> None:
+        """Standard still targets 8-15 features."""
+        prompt = await _capture_prompt(parser, "standard")
+        assert "STANDARD MODE" in prompt
+        assert "8-15 features" in prompt or "(8-15 " in prompt


### PR DESCRIPTION
## What this PR is about

Marcus is a board-mediated multi-agent platform. ``create_project`` calls Marcus's PRD-analysis LLM to extract a list of functional requirements from the user's project description; each requirement becomes one or more tasks on the kanban board. The PRD-analysis prompt is the load-bearing input to the LLM at decomposition time.

Issue #607 identified three mechanisms that bloated the board with redundant tasks. This PR closes mechanism #3: the prompt at enterprise complexity asked the LLM for "15-30+ features", training it to atomize a complex project into 15-50 narrow functional requirements (and therefore 16-51 ``Implement`` parent tasks on the board, with 3x spread for the same spec across reps).

## Why

A complex enterprise project is NOT the same thing as MANY narrow tasks. The pre-step-5 prompt conflated those two ideas. Empirical evidence from this session's 9-decomposition probe (``"a todo app"`` at enterprise × 3 reps):

| Era | Enterprise mean tasks_created | Notes |
|---|---|---|
| Pre-PR-608 baseline | **66.3** | (3 reps, range 35-107) |
| Post-#608 (test-pair rollup) | 45.5 | (2 reps) |
| Post-#611 (gap-fill rollup) | 40.3 | (3 reps) |
| #607 target | **~22** | The divider for enterprise |

#608 + #611 reduced #1 + #2 mechanisms; #3 (this PR) was the remaining gap.

## What changed

**``src/ai/advanced/prd/advanced_parser.py``** — the enterprise section of the PRD-analysis prompt rewritten:

- **Before**: "ENTERPRISE MODE - Production-ready system (15-30+ features)". Listed 6 categories of features to include (observability, security, resilience, data ops, admin tooling, quality).
- **After**: "ENTERPRISE MODE - Production-ready system (8-12 broad feature areas)". Same 6 production-readiness categories, but the LLM is directed to CONSOLIDATE them into broader feature areas, each with a rich, concrete description that bundles related concerns.

Concrete worked example for "twitter clone" enterprise:

| Concern | Pre-step-5 (narrow) | Post-step-5 (broad) |
|---|---|---|
| Authentication | 6 requirements: signup / login / password reset / MFA / OAuth / account recovery | 1 requirement: "Authentication and account" with all 6 in the description |
| Observability | 4 requirements: monitoring / structured logging / alerting / health checks | 1 requirement: "Observability stack" with all 4 in the description |
| Security operations | 3 requirements: audit logs / rate limiting / RBAC | 1 requirement: "Security operations" with all 3 in the description |

A new CRITICAL ENTERPRISE GUIDANCE block tells the LLM: "If you find yourself producing more than 12, CONSOLIDATE cross-cutting concerns into broader feature areas."

The post-extraction warning at line 1615 was also updated from "expects 15-30+ features" to "expects 8-12 broad feature areas".

## Bright line preserved

The richer descriptions name WHAT must be covered ("signup with email verification, session management with refresh tokens, ...") — they do NOT prescribe HOW. No framework, no pattern, no internal code structure. Two agents on the same requirement still produce legitimately different implementations. This satisfies Marcus's Invariant #2: Marcus says WHAT and WHY, agents own HOW.

## Test plan

- [x] 5 new behavior tests in ``tests/unit/ai/test_enterprise_prompt_tightening.py`` — pin the prompt-template contract:
  - No legacy "15-30+ features" string in the enterprise section
  - An explicit feature-count band with upper bound ≤ 15 visible in the enterprise section
  - "consolidate / bundle / coarser / broader" guidance present
  - Prototype + standard sections unchanged
- [x] 2 existing enterprise-prompt tests in ``test_complexity_aware_generation.py`` updated to match the new wording.
- [x] Full unit suite: ``pytest -m unit`` — **2060 passed** (was 2055).
- [x] ``mypy src/ai/advanced/prd/advanced_parser.py`` clean.
- [x] ``flake8`` clean on all changed files.
- [ ] Verify via 9-decomp probe re-run: enterprise mean must drop from ~40 toward the ~22 target.

## Why no test on the actual LLM output

The prompt is what we control; the LLM's response to the prompt is non-deterministic. We can't unit-test that the LLM actually produces 8-12 requirements — that's verified empirically via the post-merge probe. The unit tests pin the PROMPT CONTRACT (the thing the LLM sees), which is the leverage point we own.

## Glossary

| Term | Meaning |
|---|---|
| PRD-analysis prompt | The LLM prompt that turns a project description into a structured list of functional / non-functional requirements. Lives at ``advanced_parser.py:1212`` (``_analyze_prd_deeply``). |
| complexity_mode | One of ``prototype`` / ``standard`` / ``enterprise``. The prompt's behavior changes per mode. |
| Marcus Invariant #2 | Marcus says WHAT, agents own HOW. Foundational to the Multi-Agency proclamation. |
| 9-decomp probe | Verification harness at ``/tmp/decomp_granularity_probe.py`` — 3 modes × 3 reps × ``"a todo app"``. |

## Where to look in the code first

| File | Purpose |
|---|---|
| ``src/ai/advanced/prd/advanced_parser.py`` | The PRD-analysis prompt template + the warning threshold. Search for "ENTERPRISE MODE" to find the section. |
| ``tests/unit/ai/test_enterprise_prompt_tightening.py`` | The 5 new behavior tests. |
| ``tests/unit/ai/test_complexity_aware_generation.py`` | The 2 existing tests updated for the new wording. |

## Related

- **#607** — parent decomposition redesign spec; step 3 closed by #608, step 4 by #611, step 5 by this PR.
- **PR #608** — step 3 (test-pair rollup). Same architectural pattern: less atomization, more discipline.
- **PR #611** — step 4 (gap-fill rollup).
- **PR #614** — fixed the persistence bug that was making #608 + #611 inert. Step 5 measurement depends on that fix landing first.
- **#615** — contract_first cross-contract type-consistency bug. Independent of step 5; step 5 only touches the feature_based prompt path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)