### PR TITLE
fix(context): Codex P1 + P2 on #622 release PR

### DIFF
--- a/src/marcus_mcp/tools/context.py
+++ b/src/marcus_mcp/tools/context.py
@@ -449,12 +449,22 @@ async def _collect_foundation_contract(
     # pass the filter — but apply the filter anyway for symmetry with
     # the logged-artifact path and to future-proof against attachments
     # being stamped with a non-architectural type.
+    #
+    # Interface contract per ``src/integrations/kanban_interface.py``:
+    # ``get_attachments(task_id: str)`` returns
+    # ``{"success": bool, "data": [{"id", "filename", "url",
+    # "content_type", "size", "created_at", "created_by"}, ...]}``.
+    # The keys are normalized; do NOT use Planka-style raw keys
+    # (``name`` / ``userId`` / ``createdAt``) — they would all read
+    # as ``None`` against the canonical provider output (Codex P2
+    # follow-up on PR #623). The same bug exists in
+    # ``_collect_task_artifacts`` and is tracked separately; this
+    # fix is foundation-collector only.
     kanban_client = getattr(state, "kanban_client", None)
     if kanban_client is not None:
         for t in foundation_tasks:
-            card_id = getattr(t, "kanban_card_id", None) or t.id
             try:
-                result = await kanban_client.get_attachments(card_id=card_id)
+                result = await kanban_client.get_attachments(task_id=t.id)
             except Exception as exc:  # noqa: BLE001
                 # Don't fail the whole context-delivery path if the
                 # kanban backend is unavailable or transient-errors.
@@ -468,16 +478,23 @@ async def _collect_foundation_contract(
             if not result.get("success", False):
                 continue
             for attachment in result.get("data") or []:
+                filename = attachment.get("filename")
+                # Prefer the provider's canonical ``url`` (real
+                # filepath / served URL); fall back to a synthetic
+                # ``./attachments/<id>/<filename>`` only when the
+                # provider didn't populate ``url``.
+                location = attachment.get("url") or (
+                    f"./attachments/{attachment.get('id')}/{filename}"
+                    if filename
+                    else None
+                )
                 attach_artifact: Dict[str, Any] = {
-                    "filename": attachment.get("name"),
-                    "location": (
-                        f"./attachments/{attachment.get('id')}/"
-                        f"{attachment.get('name')}"
-                    ),
+                    "filename": filename,
+                    "location": location,
                     "storage_type": "attachment",
                     "artifact_type": "reference",
-                    "created_by": attachment.get("userId"),
-                    "created_at": attachment.get("createdAt"),
+                    "created_by": attachment.get("created_by"),
+                    "created_at": attachment.get("created_at"),
                     "description": (f"Foundation attachment from task {t.id}"),
                     "usage_guidance": _FOUNDATION_USAGE_GUIDANCE,
                 }

--- a/src/marcus_mcp/tools/context.py
+++ b/src/marcus_mcp/tools/context.py
@@ -205,7 +205,9 @@ async def get_task_context(task_id: str, state: Any) -> Dict[str, Any]:
                 # #595 Fix 2: the foundation contract is project-global —
                 # every task, including subtasks, receives it regardless
                 # of dependency-graph position.
-                context_dict["project_contract"] = _collect_foundation_contract(state)
+                context_dict["project_contract"] = await _collect_foundation_contract(
+                    state
+                )
 
                 # Add parent task's context if Context system is available
                 if hasattr(state, "context") and state.context and parent_task:
@@ -243,7 +245,7 @@ async def get_task_context(task_id: str, state: Any) -> Dict[str, Any]:
         # #595 Fix 2: the foundation contract is project-global. Unlike
         # `artifacts` (scoped to direct dependencies), it is returned to
         # every task regardless of dependency-graph position.
-        context_dict["project_contract"] = _collect_foundation_contract(state)
+        context_dict["project_contract"] = await _collect_foundation_contract(state)
 
         # Add recovery information if present
         if task.recovery_info:
@@ -362,7 +364,9 @@ def _inject_usage_guidance(
         artifact.setdefault("usage_guidance", _COORDINATION_REFERENCE_GUIDANCE)
 
 
-def _collect_foundation_contract(state: Any) -> Dict[str, List[Dict[str, Any]]]:
+async def _collect_foundation_contract(
+    state: Any,
+) -> Dict[str, List[Dict[str, Any]]]:
     """
     Collect the project-global foundation contract (issue #595 Fix 2).
 
@@ -379,37 +383,106 @@ def _collect_foundation_contract(state: Any) -> Dict[str, List[Dict[str, Any]]]:
     marker. This deliberately excludes domain-specific design artifacts,
     whose 1-hop dependency scoping is correct.
 
+    Sources of artifacts (Codex P1 on PR #622):
+
+    1. ``state.task_artifacts[fid]`` — artifacts logged via
+       :func:`log_artifact`.
+    2. Kanban-board attachments on each foundation task — fetched via
+       ``state.kanban_client.get_attachments(card_id=...)``. Without
+       this second source, foundation documents attached to the board
+       directly (not logged through ``log_artifact``) would be silently
+       dropped, because the dependency-traversal path also skips
+       ``pre_fork_synthesis`` tasks.
+
+    All artifacts from both sources are filtered through
+    :func:`_is_architectural_artifact` (Codex P2 on PR #622). The
+    project_contract is broadcast to every task, so non-architectural
+    artifacts (temporary or code-like) would be project-wide noise and
+    cross the bright line by leaking implementation HOW into a
+    coordination channel. Other tiers (dependency / transitive) already
+    enforce this filter; foundation now matches.
+
     Parameters
     ----------
     state : Any
-        Marcus server state. ``project_tasks``, ``task_artifacts`` and
-        ``context`` are each consulted defensively and treated as
-        optional, so the helper degrades to empty results rather than
-        raising when a subsystem is unavailable.
+        Marcus server state. ``project_tasks``, ``task_artifacts``,
+        ``kanban_client`` and ``context`` are each consulted defensively
+        and treated as optional, so the helper degrades to empty results
+        rather than raising when a subsystem is unavailable.
 
     Returns
     -------
     Dict[str, List[Dict[str, Any]]]
         ``{"artifacts": [...], "decisions": [...]}`` — the union of
-        artifacts and architectural decisions produced by every
+        architectural artifacts and decisions produced by every
         foundation task in the project. Both lists are empty when there
         is no foundation work or the backing state is unavailable.
     """
-    foundation_task_ids = {
-        t.id
+    foundation_tasks = [
+        t
         for t in (getattr(state, "project_tasks", None) or [])
         if getattr(t, "source_type", None) == "pre_fork_synthesis"
-    }
-    if not foundation_task_ids:
+    ]
+    if not foundation_tasks:
         return {"artifacts": [], "decisions": []}
+
+    foundation_task_ids = {t.id for t in foundation_tasks}
 
     artifacts: List[Dict[str, Any]] = []
     task_artifacts = getattr(state, "task_artifacts", None) or {}
+
+    # Source 1: artifacts logged via log_artifact, filtered to
+    # architectural types only.
     for fid in foundation_task_ids:
         for raw in task_artifacts.get(fid, []):
+            if not _is_architectural_artifact(raw):
+                continue
             artifact = dict(raw)
             artifact.setdefault("usage_guidance", _FOUNDATION_USAGE_GUIDANCE)
             artifacts.append(artifact)
+
+    # Source 2: Kanban-board attachments on each foundation task.
+    # Without this, foundation documents attached to the board (not
+    # logged through log_artifact) are silently dropped (Codex P1 on
+    # PR #622). Kanban attachments are stamped
+    # ``artifact_type: "reference"`` which is architectural, so they
+    # pass the filter — but apply the filter anyway for symmetry with
+    # the logged-artifact path and to future-proof against attachments
+    # being stamped with a non-architectural type.
+    kanban_client = getattr(state, "kanban_client", None)
+    if kanban_client is not None:
+        for t in foundation_tasks:
+            card_id = getattr(t, "kanban_card_id", None) or t.id
+            try:
+                result = await kanban_client.get_attachments(card_id=card_id)
+            except Exception as exc:  # noqa: BLE001
+                # Don't fail the whole context-delivery path if the
+                # kanban backend is unavailable or transient-errors.
+                logger.warning(
+                    "Foundation contract: failed to fetch attachments "
+                    "for task %s: %s",
+                    t.id,
+                    exc,
+                )
+                continue
+            if not result.get("success", False):
+                continue
+            for attachment in result.get("data") or []:
+                attach_artifact: Dict[str, Any] = {
+                    "filename": attachment.get("name"),
+                    "location": (
+                        f"./attachments/{attachment.get('id')}/"
+                        f"{attachment.get('name')}"
+                    ),
+                    "storage_type": "attachment",
+                    "artifact_type": "reference",
+                    "created_by": attachment.get("userId"),
+                    "created_at": attachment.get("createdAt"),
+                    "description": (f"Foundation attachment from task {t.id}"),
+                    "usage_guidance": _FOUNDATION_USAGE_GUIDANCE,
+                }
+                if _is_architectural_artifact(attach_artifact):
+                    artifacts.append(attach_artifact)
 
     decisions: List[Dict[str, Any]] = []
     context = getattr(state, "context", None)
@@ -796,7 +869,7 @@ async def assemble_task_context(task_id: str, task: Any, state: Any) -> Dict[str
         "transitive_context": {...}}``. Each field degrades to an empty
         value rather than raising when a subsystem is unavailable.
     """
-    project_contract = _collect_foundation_contract(state)
+    project_contract = await _collect_foundation_contract(state)
 
     direct_artifacts = await _collect_task_artifacts(task_id, task, state)
     # PR #606 review P2: _collect_task_artifacts also returns the

--- a/tests/unit/mcp/test_get_task_context_project_contract.py
+++ b/tests/unit/mcp/test_get_task_context_project_contract.py
@@ -277,7 +277,14 @@ class TestCodexFixesOnProjectContract:
         state.project_tasks = [_task("f1", source_type="pre_fork_synthesis")]
         state.task_artifacts["f1"] = []  # no logged artifacts
 
-        # Mock kanban_client.get_attachments to return a board attachment.
+        # Mock kanban_client.get_attachments — return CANONICAL
+        # provider shape per ``src/integrations/kanban_interface.py``:
+        # ``{"id", "filename", "url", "content_type", "size",
+        # "created_at", "created_by"}``. Codex P2 follow-up on PR
+        # #623 caught the earlier mock used Planka-style raw keys
+        # (``name`` / ``userId`` / ``createdAt``) which masked a
+        # real field-mapping bug — the code would have read None
+        # against the canonical interface.
         state.kanban_client = AsyncMock()
         state.kanban_client.get_attachments = AsyncMock(
             return_value={
@@ -285,15 +292,24 @@ class TestCodexFixesOnProjectContract:
                 "data": [
                     {
                         "id": "att-1",
-                        "name": "foundation-contract.md",
-                        "userId": "user-1",
-                        "createdAt": "2026-05-23T12:00:00Z",
+                        "filename": "foundation-contract.md",
+                        "url": "/storage/foundation-contract.md",
+                        "content_type": "text/markdown",
+                        "size": 1024,
+                        "created_by": "user-1",
+                        "created_at": "2026-05-23T12:00:00Z",
                     }
                 ],
             }
         )
 
         contract = await _collect_foundation_contract(state)
+
+        # Verify the foundation collector calls ``get_attachments``
+        # with the canonical ``task_id=`` keyword — NOT Planka-style
+        # ``card_id=`` which would TypeError against the documented
+        # interface (Codex P1 follow-up on PR #623).
+        state.kanban_client.get_attachments.assert_called_once_with(task_id="f1")
 
         assert any(
             a.get("filename") == "foundation-contract.md" for a in contract["artifacts"]
@@ -312,6 +328,14 @@ class TestCodexFixesOnProjectContract:
         )
         assert attach.get("artifact_type") == "reference"
         assert attach.get("storage_type") == "attachment"
+        # Provider's canonical ``url`` field is preserved as
+        # ``location`` — not overwritten with a synthetic path when
+        # the real one is available.
+        assert attach.get("location") == "/storage/foundation-contract.md"
+        # Canonical-key reads land on the right keys: ``created_by``
+        # / ``created_at`` (NOT Planka raw ``userId`` / ``createdAt``).
+        assert attach.get("created_by") == "user-1"
+        assert attach.get("created_at") == "2026-05-23T12:00:00Z"
 
     @pytest.mark.asyncio
     async def test_p2_non_architectural_artifacts_are_filtered_out(

--- a/tests/unit/mcp/test_get_task_context_project_contract.py
+++ b/tests/unit/mcp/test_get_task_context_project_contract.py
@@ -122,18 +122,24 @@ def state() -> _MockState:
 class TestCollectFoundationContract:
     """_collect_foundation_contract gathers only foundation-task output."""
 
-    def test_collects_artifacts_from_foundation_tasks(self, state: _MockState) -> None:
+    @pytest.mark.asyncio
+    async def test_collects_artifacts_from_foundation_tasks(
+        self, state: _MockState
+    ) -> None:
         """Artifacts from pre_fork_synthesis tasks are returned."""
         state.project_tasks = [_task("f1", source_type="pre_fork_synthesis")]
         state.task_artifacts["f1"] = [
             {"filename": "tsconfig.json", "artifact_type": "specification"}
         ]
 
-        contract = _collect_foundation_contract(state)
+        contract = await _collect_foundation_contract(state)
 
         assert [a["filename"] for a in contract["artifacts"]] == ["tsconfig.json"]
 
-    def test_collects_decisions_from_foundation_tasks(self, state: _MockState) -> None:
+    @pytest.mark.asyncio
+    async def test_collects_decisions_from_foundation_tasks(
+        self, state: _MockState
+    ) -> None:
         """Decisions made on a foundation task are returned."""
         state.project_tasks = [_task("f1", source_type="pre_fork_synthesis")]
         state.context.decisions = [
@@ -141,31 +147,37 @@ class TestCollectFoundationContract:
             _MockDecision("other", "unrelated decision"),
         ]
 
-        contract = _collect_foundation_contract(state)
+        contract = await _collect_foundation_contract(state)
 
         assert [d["what"] for d in contract["decisions"]] == ["Public API surface"]
 
-    def test_excludes_non_foundation_task_artifacts(self, state: _MockState) -> None:
+    @pytest.mark.asyncio
+    async def test_excludes_non_foundation_task_artifacts(
+        self, state: _MockState
+    ) -> None:
         """Artifacts from ordinary (non-foundation) tasks are not global."""
         state.project_tasks = [
             _task("f1", source_type="pre_fork_synthesis"),
             _task("impl1", source_type="pre_fork_synthesis_NOT"),
             _task("design1"),  # no source_type
         ]
-        state.task_artifacts["f1"] = [{"filename": "package.json"}]
+        state.task_artifacts["f1"] = [
+            {"filename": "package.json", "artifact_type": "specification"}
+        ]
         state.task_artifacts["impl1"] = [{"filename": "feature.ts"}]
         state.task_artifacts["design1"] = [{"filename": "design.md"}]
 
-        contract = _collect_foundation_contract(state)
+        contract = await _collect_foundation_contract(state)
 
         assert [a["filename"] for a in contract["artifacts"]] == ["package.json"]
 
-    def test_empty_when_no_foundation_tasks(self, state: _MockState) -> None:
+    @pytest.mark.asyncio
+    async def test_empty_when_no_foundation_tasks(self, state: _MockState) -> None:
         """No foundation tasks yields empty artifact and decision lists."""
         state.project_tasks = [_task("impl1")]
         state.task_artifacts["impl1"] = [{"filename": "feature.ts"}]
 
-        contract = _collect_foundation_contract(state)
+        contract = await _collect_foundation_contract(state)
 
         assert contract == {"artifacts": [], "decisions": []}
 
@@ -235,4 +247,126 @@ class TestGetTaskContextProjectContract:
         assert result["success"] is True
         assert result["context"]["is_subtask"] is True
         contract = result["context"]["project_contract"]
+        assert [a["filename"] for a in contract["artifacts"]] == ["tsconfig.json"]
+
+
+class TestCodexFixesOnProjectContract:
+    """Codex P1 + P2 regression guards on PR #622.
+
+    Two issues flagged on the develop -> main release PR:
+
+    - P1: skipping ``pre_fork_synthesis`` deps in the direct-dependency
+      path dropped Kanban-board attachments (not just logged artifacts).
+      ``_collect_foundation_contract`` must compensate by reading both
+      ``state.task_artifacts`` AND ``state.kanban_client.get_attachments``
+      for each foundation task.
+    - P2: foundation artifacts must be filtered by
+      ``_is_architectural_artifact`` like the other context tiers do,
+      since the project_contract is broadcast to every task. Non-
+      architectural (temporary / code-like) artifacts would otherwise
+      leak project-wide.
+    """
+
+    @pytest.mark.asyncio
+    async def test_p1_pulls_kanban_attachments_from_foundation_tasks(
+        self, state: _MockState
+    ) -> None:
+        """Board-attached foundation docs must reach project_contract."""
+        from unittest.mock import AsyncMock
+
+        state.project_tasks = [_task("f1", source_type="pre_fork_synthesis")]
+        state.task_artifacts["f1"] = []  # no logged artifacts
+
+        # Mock kanban_client.get_attachments to return a board attachment.
+        state.kanban_client = AsyncMock()
+        state.kanban_client.get_attachments = AsyncMock(
+            return_value={
+                "success": True,
+                "data": [
+                    {
+                        "id": "att-1",
+                        "name": "foundation-contract.md",
+                        "userId": "user-1",
+                        "createdAt": "2026-05-23T12:00:00Z",
+                    }
+                ],
+            }
+        )
+
+        contract = await _collect_foundation_contract(state)
+
+        assert any(
+            a.get("filename") == "foundation-contract.md" for a in contract["artifacts"]
+        ), (
+            "Codex P1: Kanban-board attachments on foundation tasks "
+            "must appear in project_contract. Without this, foundation "
+            "documents attached on the board (not logged via "
+            "log_artifact) are silently dropped."
+        )
+        # Stamped with the architectural type so future filter changes
+        # don't accidentally exclude them.
+        attach = next(
+            a
+            for a in contract["artifacts"]
+            if a.get("filename") == "foundation-contract.md"
+        )
+        assert attach.get("artifact_type") == "reference"
+        assert attach.get("storage_type") == "attachment"
+
+    @pytest.mark.asyncio
+    async def test_p2_non_architectural_artifacts_are_filtered_out(
+        self, state: _MockState
+    ) -> None:
+        """Temporary / code-like artifacts must NOT reach project_contract.
+
+        Other tiers (dependency, transitive) already filter to
+        architectural types via :func:`_is_architectural_artifact`. The
+        project_contract is broadcast to every task, so it must apply
+        the same filter — otherwise non-architectural artifacts leak
+        project-wide.
+        """
+        state.project_tasks = [_task("f1", source_type="pre_fork_synthesis")]
+        state.task_artifacts["f1"] = [
+            {"filename": "tsconfig.json", "artifact_type": "specification"},
+            {"filename": "scratch.py", "artifact_type": "temporary"},
+            {"filename": "snippet.ts", "artifact_type": "source_code"},
+        ]
+
+        contract = await _collect_foundation_contract(state)
+
+        filenames = {a["filename"] for a in contract["artifacts"]}
+        assert "tsconfig.json" in filenames
+        assert "scratch.py" not in filenames, (
+            "Codex P2: non-architectural artifact 'temporary' leaked "
+            "into project_contract."
+        )
+        assert "snippet.ts" not in filenames, (
+            "Codex P2: non-architectural artifact 'source_code' leaked "
+            "into project_contract."
+        )
+
+    @pytest.mark.asyncio
+    async def test_kanban_attachment_failure_does_not_crash_contract(
+        self, state: _MockState
+    ) -> None:
+        """Graceful degrade when kanban backend errors fetching attachments.
+
+        The context-delivery hot path must NEVER raise on a transient
+        kanban error — degrade to logged-artifacts only, log a warning.
+        """
+        from unittest.mock import AsyncMock
+
+        state.project_tasks = [_task("f1", source_type="pre_fork_synthesis")]
+        state.task_artifacts["f1"] = [
+            {"filename": "tsconfig.json", "artifact_type": "specification"}
+        ]
+        state.kanban_client = AsyncMock()
+        state.kanban_client.get_attachments = AsyncMock(
+            side_effect=RuntimeError("kanban transient error")
+        )
+
+        # Must NOT raise.
+        contract = await _collect_foundation_contract(state)
+
+        # Logged artifact still delivered; kanban error swallowed.
         assert [a["filename"] for a in contract["artifacts"]] == ["tsconfig.json"]


### PR DESCRIPTION
## What this PR is about

Marcus delivers a three-tier context bundle to every task: ``project_contract`` (foundation, global), ``dependency_artifacts`` (direct deps, one-hop), ``transitive_context`` (past one-hop). The foundation collector ``_collect_foundation_contract`` in ``src/marcus_mcp/tools/context.py`` builds the project-wide tier from each foundation task's artifacts and decisions.

Codex's review on PR #622 (the v0.3.8 release promotion) flagged two issues in that collector. Both real, both worth fixing **before tagging v0.3.8**.

## P1 — Kanban board attachments are dropped

The direct-dependency traversal at ``context.py:497`` skips ``pre_fork_synthesis`` deps entirely (so foundation content flows through the project-wide channel, not 1-hop). But ``_collect_foundation_contract`` only read ``state.task_artifacts`` (artifacts logged via ``log_artifact``). **Attachments placed directly on the kanban board for foundation tasks were silently dropped** — they had reached dependents via the dep traversal pre-#606, and now they reach nothing.

**Worked example:** a user attaches ``api-contract.yaml`` directly to a foundation kanban card. Pre-#606, downstream tasks saw it via dep-traversal. Post-#606, the foundation collector doesn't fetch board attachments, and the dep traversal skips foundation tasks. The file is invisible to every downstream agent — a real coordination break.

## P2 — Foundation artifacts must be filtered to architectural types

The ``project_contract`` is broadcast to **every** task in the project. The other tiers (dependency, transitive) filter through ``_is_architectural_artifact`` so non-architectural artifacts (``temporary``, ``source_code``, etc.) never leak. The foundation tier didn't — so a foundation task with a stray ``temporary`` artifact would broadcast that artifact to every other task in the project. Crosses the bright line (potential implementation HOW leakage) and inflates token cost.

## What changed

``src/marcus_mcp/tools/context.py``:

1. ``_collect_foundation_contract`` is now ``async def``.
2. It fetches ``state.kanban_client.get_attachments(card_id=...)`` for each foundation task and adds each attachment as an ``artifact_type: "reference"`` artifact (mirrors the pattern in ``_collect_task_artifacts``). Graceful degrade on kanban errors via try/except — never crashes the context hot path.
3. Both logged artifacts AND kanban attachments are filtered through ``_is_architectural_artifact`` (same filter used by direct-dependency and transitive tiers).
4. 3 callers (``get_task_context`` × 2 paths, ``assemble_task_context``) updated to ``await``.

``tests/unit/mcp/test_get_task_context_project_contract.py``:

- 4 existing ``TestCollectFoundationContract`` tests converted to async (calls were sync).
- 3 new regression tests in ``TestCodexFixesOnProjectContract``:
  - ``test_p1_pulls_kanban_attachments_from_foundation_tasks``
  - ``test_p2_non_architectural_artifacts_are_filtered_out``
  - ``test_kanban_attachment_failure_does_not_crash_contract`` — pin the graceful-degrade contract.

## Test plan

- [x] 10 tests in ``test_get_task_context_project_contract.py`` pass (4 existing async-converted + 3 GetTaskContext + 3 new regression).
- [x] Full unit suite: ``pytest -m unit`` — **2063 passed** (was 2060).
- [x] ``mypy src/marcus_mcp/tools/context.py`` clean.

## Why this matters NOW

This is a fix to code that's already on develop. PR #622 (the develop → main release for v0.3.8) is currently open and includes the bug. Merging this PR to develop first lets the release PR pick it up before main tagging.

## Where to look in the code first

| File | Purpose |
|---|---|
| ``src/marcus_mcp/tools/context.py:365`` (``_collect_foundation_contract``) | The async-converted, attachment-fetching, filter-applying foundation collector. |
| ``src/marcus_mcp/tools/context.py:497`` | The direct-dependency traversal that skips ``pre_fork_synthesis`` — context for why P1 mattered. |
| ``src/marcus_mcp/tools/context.py:275`` (``_is_architectural_artifact``) | The reused filter. |

## Related

- **PR #622** — the v0.3.8 release promotion (develop → main); this PR fixes its Codex findings.
- **PR #605/#606** — original three-tier context delivery.
- **#595 Fix 2** — foundation contract as project-global concept.

🤖 Generated with [Claude Code](https://claude.com/claude-code)