### PR TITLE
perf(context): cache foundation contract for get_task_context MCP tool

### DIFF
--- a/src/marcus_mcp/server.py
+++ b/src/marcus_mcp/server.py
@@ -988,6 +988,22 @@ class MarcusServer:
                         f"preserved {len(existing_subtasks)} subtasks"
                     )
 
+                # v0.3.8.post1: invalidate the foundation-contract cache
+                # whenever project_tasks is reassigned from kanban —
+                # the foundation task set might have changed and the
+                # cache would otherwise serve stale content for up to
+                # the TTL. Best-effort: never block project refresh on
+                # cache miss.
+                try:
+                    from src.marcus_mcp.tools.context import (
+                        invalidate_foundation_contract_cache,
+                    )
+
+                    _pid = getattr(self, "current_project_id", None)
+                    invalidate_foundation_contract_cache(str(_pid) if _pid else None)
+                except Exception:  # noqa: BLE001 - never break refresh
+                    pass
+
                 # Re-apply recovery_info to refreshed tasks
                 if recovery_info_map:
                     restored = 0

--- a/src/marcus_mcp/tools/attachment.py
+++ b/src/marcus_mcp/tools/attachment.py
@@ -292,6 +292,28 @@ async def log_artifact(
 
         state.task_artifacts[task_id].append(artifact_entry)
 
+        # v0.3.8.post1: invalidate the foundation-contract cache when an
+        # artifact is logged to a foundation task. Without this, agents
+        # would see a stale (up to TTL-seconds) foundation contract that
+        # is missing the just-logged artifact.
+        try:
+            task = next(
+                (t for t in (state.project_tasks or []) if t.id == task_id),
+                None,
+            )
+            if (
+                task is not None
+                and getattr(task, "source_type", None) == "pre_fork_synthesis"
+            ):
+                from src.marcus_mcp.tools.context import (
+                    invalidate_foundation_contract_cache,
+                )
+
+                pid = getattr(state, "current_project_id", None)
+                invalidate_foundation_contract_cache(str(pid) if pid else None)
+        except Exception:  # noqa: BLE001 - never break log_artifact on cache miss
+            pass
+
         # Add a comment to the task if kanban is available
         if state.kanban_client and description:
             try:

--- a/src/marcus_mcp/tools/context.py
+++ b/src/marcus_mcp/tools/context.py
@@ -5,6 +5,7 @@ This module contains tools for context management:
 - get_task_context: Get context for a specific task
 """
 
+import copy
 import logging
 import time
 from typing import Any, Dict, List, Optional, Set
@@ -486,13 +487,19 @@ async def _collect_foundation_contract(
     task) should call :func:`invalidate_foundation_contract_cache`.
     """
     # Cache check — return cached entry within TTL.
+    #
+    # Deep-copy the cached contract on read so callers can mutate
+    # their returned dict without corrupting the shared cache entry
+    # for subsequent readers. The contract is small (typically <10
+    # artifacts), so the copy cost is negligible vs the ~13s of work
+    # this saves on a cache hit.
     cache_key = _foundation_contract_cache_key(state)
     if cache_key is not None:
         cached = _foundation_contract_cache.get(cache_key)
         if cached is not None:
             cached_at, cached_contract = cached
             if (time.monotonic() - cached_at) < _FOUNDATION_CONTRACT_CACHE_TTL_SECONDS:
-                return cached_contract
+                return copy.deepcopy(cached_contract)
 
     foundation_tasks = [
         t
@@ -500,7 +507,20 @@ async def _collect_foundation_contract(
         if getattr(t, "source_type", None) == "pre_fork_synthesis"
     ]
     if not foundation_tasks:
-        return {"artifacts": [], "decisions": []}
+        # Cache the empty-foundation result too. Otherwise projects
+        # without foundation tasks (prototypes that don't pre-fork,
+        # NFR-only projects) re-scan ``state.project_tasks`` on every
+        # ``request_next_task`` call.
+        empty_contract: Dict[str, List[Dict[str, Any]]] = {
+            "artifacts": [],
+            "decisions": [],
+        }
+        if cache_key is not None:
+            _foundation_contract_cache[cache_key] = (
+                time.monotonic(),
+                empty_contract,
+            )
+        return copy.deepcopy(empty_contract)
 
     foundation_task_ids = {t.id for t in foundation_tasks}
 
@@ -586,11 +606,16 @@ async def _collect_foundation_contract(
 
     contract = {"artifacts": artifacts, "decisions": decisions}
 
-    # Write to cache when a key is available. Skipping when no
-    # current_project_id is set keeps the helper degrade-safe for
-    # partially-initialized state and unit-test mocks.
+    # Write to cache when a key is available. Store a deep copy so
+    # caller-side mutations of the returned dict don't corrupt the
+    # cache. Skip caching when no current_project_id is set — that
+    # keeps the helper degrade-safe for partially-initialized state
+    # and unit-test mocks.
     if cache_key is not None:
-        _foundation_contract_cache[cache_key] = (time.monotonic(), contract)
+        _foundation_contract_cache[cache_key] = (
+            time.monotonic(),
+            copy.deepcopy(contract),
+        )
 
     return contract
 

--- a/src/marcus_mcp/tools/context.py
+++ b/src/marcus_mcp/tools/context.py
@@ -75,6 +75,29 @@ async def log_decision(
             agent_id=agent_id, task_id=task_id, what=what, why=why, impact=impact
         )
 
+        # v0.3.8.post1 (Codex P2 on PR #625): invalidate the
+        # foundation-contract cache when a decision is logged against
+        # a foundation task. The cached contract includes
+        # foundation-task decisions; without this invalidation an
+        # agent calling ``get_task_context`` right after a foundation
+        # decision lands would see the stale pre-decision contract
+        # for up to ``_FOUNDATION_CONTRACT_CACHE_TTL_SECONDS`` and
+        # build the wrong architecture guidance into its work.
+        # Best-effort: never break log_decision on cache-miss.
+        try:
+            task = next(
+                (t for t in (state.project_tasks or []) if t.id == task_id),
+                None,
+            )
+            if (
+                task is not None
+                and getattr(task, "source_type", None) == "pre_fork_synthesis"
+            ):
+                pid = getattr(state, "current_project_id", None)
+                invalidate_foundation_contract_cache(str(pid) if pid else None)
+        except Exception:  # noqa: BLE001 - never break log_decision on cache miss
+            pass
+
         # Add comment to task if kanban is available
         if state.kanban_client:
             try:

--- a/src/marcus_mcp/tools/context.py
+++ b/src/marcus_mcp/tools/context.py
@@ -6,7 +6,8 @@ This module contains tools for context management:
 """
 
 import logging
-from typing import Any, Dict, List, Set
+import time
+from typing import Any, Dict, List, Optional, Set
 
 from src.core.project_history import Decision as HistoryDecision
 from src.core.project_history import (
@@ -324,6 +325,63 @@ _FOUNDATION_USAGE_GUIDANCE = (
 )
 
 
+#: Per-project cache for ``_collect_foundation_contract`` output.
+#:
+#: v0.3.8.post1 perf hotfix. Pre-cache the helper was invoked on every
+#: ``request_next_task`` call. With 3 foundation tasks per project,
+#: each call re-walked ``state.task_artifacts`` AND made 3 fresh
+#: kanban ``get_attachments`` queries — context_building dominated by
+#: that work at ~12 seconds per call against the snake-completion-1
+#: probe board. Multiplied by ephemeral agents each polling, the
+#: server appears hung.
+#:
+#: Cache is keyed by ``state.current_project_id`` and TTL-bound. The
+#: foundation contract is intentionally cheap to invalidate: it only
+#: changes when (a) the active project changes, (b) a new artifact is
+#: logged to a foundation task, or (c) a board attachment is added.
+#: We bound staleness with a TTL rather than tracking change events,
+#: because the cost of a stale read (one cycle of slightly-old
+#: foundation data) is much smaller than the cost of a missed
+#: invalidation (agents permanently miss new foundation content).
+#:
+#: Shape: ``{project_id: (computed_at_monotonic, contract_dict)}``.
+_FOUNDATION_CONTRACT_CACHE_TTL_SECONDS: float = 60.0
+_foundation_contract_cache: Dict[str, tuple[float, Dict[str, List[Dict[str, Any]]]]] = (
+    {}
+)
+
+
+def _foundation_contract_cache_key(state: Any) -> Optional[str]:
+    """Return the cache key for the current project, or None to skip caching.
+
+    Returns ``None`` when ``state.current_project_id`` is missing —
+    the caller will compute fresh every time, never crashing. This is
+    the safe degrade path for unit-test mocks or partially-initialized
+    state.
+    """
+    pid = getattr(state, "current_project_id", None)
+    return str(pid) if pid else None
+
+
+def invalidate_foundation_contract_cache(project_id: Optional[str] = None) -> None:
+    """Drop the foundation-contract cache entry for one project (or all).
+
+    Call when an artifact is logged to a foundation task or an attachment
+    is added — the cache MUST be invalidated so the next
+    ``_collect_foundation_contract`` call sees the new content.
+
+    Parameters
+    ----------
+    project_id : Optional[str]
+        Drop only this project's entry. When ``None``, drop everything
+        (used during full state resets / project switches).
+    """
+    if project_id is None:
+        _foundation_contract_cache.clear()
+    else:
+        _foundation_contract_cache.pop(project_id, None)
+
+
 def _inject_usage_guidance(
     artifact: Dict[str, Any],
     is_design_dep: bool,
@@ -417,7 +475,25 @@ async def _collect_foundation_contract(
         architectural artifacts and decisions produced by every
         foundation task in the project. Both lists are empty when there
         is no foundation work or the backing state is unavailable.
+
+    Caching (v0.3.8.post1 perf hotfix). The result is cached per
+    ``state.current_project_id`` for
+    :data:`_FOUNDATION_CONTRACT_CACHE_TTL_SECONDS`. Cache invalidation
+    is TTL-only — the cost of a 60-second-stale read is negligible
+    relative to the per-call latency this avoids (12+ seconds on
+    multi-foundation projects). Callers that need to invalidate
+    explicitly (e.g. when a new artifact is logged to a foundation
+    task) should call :func:`invalidate_foundation_contract_cache`.
     """
+    # Cache check — return cached entry within TTL.
+    cache_key = _foundation_contract_cache_key(state)
+    if cache_key is not None:
+        cached = _foundation_contract_cache.get(cache_key)
+        if cached is not None:
+            cached_at, cached_contract = cached
+            if (time.monotonic() - cached_at) < _FOUNDATION_CONTRACT_CACHE_TTL_SECONDS:
+                return cached_contract
+
     foundation_tasks = [
         t
         for t in (getattr(state, "project_tasks", None) or [])
@@ -508,7 +584,15 @@ async def _collect_foundation_contract(
             if getattr(decision, "task_id", None) in foundation_task_ids:
                 decisions.append(decision.to_dict())
 
-    return {"artifacts": artifacts, "decisions": decisions}
+    contract = {"artifacts": artifacts, "decisions": decisions}
+
+    # Write to cache when a key is available. Skipping when no
+    # current_project_id is set keeps the helper degrade-safe for
+    # partially-initialized state and unit-test mocks.
+    if cache_key is not None:
+        _foundation_contract_cache[cache_key] = (time.monotonic(), contract)
+
+    return contract
 
 
 async def _collect_task_artifacts(

--- a/tests/unit/mcp/test_get_task_context_project_contract.py
+++ b/tests/unit/mcp/test_get_task_context_project_contract.py
@@ -489,3 +489,102 @@ class TestFoundationContractCaching:
         c1 = await _collect_foundation_contract(state)
         c2 = await _collect_foundation_contract(state)
         assert c1["artifacts"] and c2["artifacts"]
+
+
+class TestCachePostMergeFixes:
+    """Three correctness fixes applied post-Kaia-self-review on PR #625:
+
+    1. Cache hit returns a DEEP COPY so caller mutations don't corrupt
+       the shared cache entry.
+    2. Empty-foundation result is cached too, so projects without
+       foundation tasks don't re-scan ``state.project_tasks`` per
+       request.
+    3. Cache invalidation hook fires on ``state.project_tasks``
+       reassignment from the kanban refresh path (verified separately
+       in ``test_server_refresh_state.py``; here we only verify the
+       cache helper exposes the ``invalidate_foundation_contract_cache``
+       API the refresh path calls).
+    """
+
+    @pytest.mark.asyncio
+    async def test_cache_hit_returns_independent_copy(self, state: _MockState) -> None:
+        """Caller mutation of the returned dict must NOT corrupt the
+        cached entry (deep-copy on hit)."""
+        from unittest.mock import AsyncMock
+
+        state.project_tasks = [_task("f1", source_type="pre_fork_synthesis")]
+        state.task_artifacts["f1"] = [
+            {"filename": "tsconfig.json", "artifact_type": "specification"}
+        ]
+        state.kanban_client = AsyncMock()
+        state.kanban_client.get_attachments = AsyncMock(
+            return_value={"success": True, "data": []}
+        )
+        state.current_project_id = "proj-copy-1"
+
+        # First call: computes + caches.
+        contract1 = await _collect_foundation_contract(state)
+        original_artifact_count = len(contract1["artifacts"])
+
+        # Corrupt the returned dict.
+        contract1["artifacts"].append({"filename": "MUTATED.txt"})
+        contract1["decisions"].append({"task_id": "MUTATED"})
+
+        # Second call: should NOT see the mutations from contract1.
+        contract2 = await _collect_foundation_contract(state)
+        assert len(contract2["artifacts"]) == original_artifact_count, (
+            f"Cache returned a SHARED reference: caller-mutation of "
+            f"contract1 leaked into the cached entry. "
+            f"contract2 artifacts: {contract2['artifacts']}"
+        )
+        assert not any(
+            a.get("filename") == "MUTATED.txt" for a in contract2["artifacts"]
+        )
+        assert not any(d.get("task_id") == "MUTATED" for d in contract2["decisions"])
+
+    @pytest.mark.asyncio
+    async def test_empty_foundation_result_is_cached(self, state: _MockState) -> None:
+        """No-foundation projects must NOT re-scan project_tasks per call.
+
+        Tracked at the helper level by ensuring the second call to
+        ``_collect_foundation_contract`` does NOT iterate
+        ``state.project_tasks`` again — verified by setting
+        ``project_tasks`` to a list that tracks iteration.
+        """
+        state.current_project_id = "proj-empty-1"
+
+        scan_count = [0]
+
+        class _CountingList(list):
+            def __iter__(self):
+                scan_count[0] += 1
+                return list.__iter__(self)
+
+        state.project_tasks = _CountingList()  # empty, but counts iterations
+
+        # First call: misses cache, scans (empty) project_tasks once.
+        await _collect_foundation_contract(state)
+        first_scans = scan_count[0]
+
+        # Second call: should hit cache, NOT scan again.
+        await _collect_foundation_contract(state)
+        second_scans = scan_count[0]
+
+        assert second_scans == first_scans, (
+            f"Empty-foundation result was not cached: project_tasks "
+            f"got iterated {second_scans - first_scans} extra times "
+            f"on second call."
+        )
+
+    def test_invalidate_cache_api_is_exposed(self) -> None:
+        """The ``invalidate_foundation_contract_cache`` function must
+        be importable and callable — the kanban-refresh path in
+        ``server.py`` depends on it."""
+        from src.marcus_mcp.tools.context import (
+            invalidate_foundation_contract_cache,
+        )
+
+        # Both signatures must work: with a project_id and without.
+        invalidate_foundation_contract_cache("proj-X")
+        invalidate_foundation_contract_cache(None)
+        invalidate_foundation_contract_cache()  # default = clear all

--- a/tests/unit/mcp/test_get_task_context_project_contract.py
+++ b/tests/unit/mcp/test_get_task_context_project_contract.py
@@ -394,3 +394,98 @@ class TestCodexFixesOnProjectContract:
 
         # Logged artifact still delivered; kanban error swallowed.
         assert [a["filename"] for a in contract["artifacts"]] == ["tsconfig.json"]
+
+
+class TestFoundationContractCaching:
+    """v0.3.8.post1 perf hotfix: foundation contract must be cached per
+    project so ``request_next_task`` doesn't re-walk SQLite + re-fetch
+    kanban attachments on every call.
+
+    Pre-cache observed: context_building took 12-15 seconds per call
+    against snake-completion-1 (3 foundation tasks × ~4s kanban attachment
+    query). Goal: <100ms after first call.
+    """
+
+    @pytest.mark.asyncio
+    async def test_cache_hit_skips_kanban_fetch_on_second_call(
+        self, state: _MockState
+    ) -> None:
+        """Same project_id within TTL → cached contract, no second
+        kanban fetch."""
+        from unittest.mock import AsyncMock
+
+        state.project_tasks = [_task("f1", source_type="pre_fork_synthesis")]
+        state.task_artifacts["f1"] = [
+            {"filename": "tsconfig.json", "artifact_type": "specification"}
+        ]
+        state.kanban_client = AsyncMock()
+        state.kanban_client.get_attachments = AsyncMock(
+            return_value={"success": True, "data": []}
+        )
+        state.current_project_id = "proj-perf-test-1"
+
+        # First call: computes + caches.
+        contract1 = await _collect_foundation_contract(state)
+        assert contract1["artifacts"]
+        first_call_count = state.kanban_client.get_attachments.call_count
+
+        # Second call: should hit cache, NOT re-call kanban.
+        contract2 = await _collect_foundation_contract(state)
+        second_call_count = state.kanban_client.get_attachments.call_count
+
+        assert second_call_count == first_call_count, (
+            f"Foundation contract cache miss: kanban.get_attachments "
+            f"called {second_call_count - first_call_count} extra times "
+            f"on second call. Cache MUST hit when project_id is unchanged."
+        )
+        # Same content returned.
+        assert contract1 == contract2
+
+    @pytest.mark.asyncio
+    async def test_different_project_id_rebuilds_cache(self, state: _MockState) -> None:
+        """Switching project_id triggers a fresh compute."""
+        from unittest.mock import AsyncMock
+
+        state.project_tasks = [_task("f1", source_type="pre_fork_synthesis")]
+        state.task_artifacts["f1"] = [
+            {"filename": "tsconfig.json", "artifact_type": "specification"}
+        ]
+        state.kanban_client = AsyncMock()
+        state.kanban_client.get_attachments = AsyncMock(
+            return_value={"success": True, "data": []}
+        )
+        state.current_project_id = "proj-A"
+
+        await _collect_foundation_contract(state)
+        calls_after_A = state.kanban_client.get_attachments.call_count
+
+        # Switch project_id; cache must NOT serve cross-project.
+        state.current_project_id = "proj-B"
+        await _collect_foundation_contract(state)
+        calls_after_B = state.kanban_client.get_attachments.call_count
+
+        assert calls_after_B > calls_after_A, (
+            "Foundation contract cache must NOT serve cross-project; "
+            "switching project_id should trigger a fresh compute."
+        )
+
+    @pytest.mark.asyncio
+    async def test_no_project_id_does_not_break(self, state: _MockState) -> None:
+        """Defensive: if state has no current_project_id, helper still
+        works (no cache, computed fresh every call) — never crashes."""
+        from unittest.mock import AsyncMock
+
+        state.project_tasks = [_task("f1", source_type="pre_fork_synthesis")]
+        state.task_artifacts["f1"] = [
+            {"filename": "tsconfig.json", "artifact_type": "specification"}
+        ]
+        state.kanban_client = AsyncMock()
+        state.kanban_client.get_attachments = AsyncMock(
+            return_value={"success": True, "data": []}
+        )
+        # Explicitly NOT setting state.current_project_id.
+
+        # Both calls should succeed without raising.
+        c1 = await _collect_foundation_contract(state)
+        c2 = await _collect_foundation_contract(state)
+        assert c1["artifacts"] and c2["artifacts"]

--- a/tests/unit/mcp/test_get_task_context_project_contract.py
+++ b/tests/unit/mcp/test_get_task_context_project_contract.py
@@ -576,6 +576,117 @@ class TestCachePostMergeFixes:
             f"on second call."
         )
 
+    @pytest.mark.asyncio
+    async def test_log_decision_on_foundation_task_invalidates_cache(
+        self, state: _MockState
+    ) -> None:
+        """Codex P2 on PR #625: ``log_decision`` against a foundation
+        task must invalidate the foundation-contract cache.
+
+        Without this, decisions logged on foundation tasks are hidden
+        from the next ``get_task_context`` for up to
+        ``_FOUNDATION_CONTRACT_CACHE_TTL_SECONDS``, and agents building
+        against the foundation see stale architecture guidance for that
+        window. Mirrors the existing ``log_artifact`` invalidation hook.
+        """
+        from unittest.mock import AsyncMock
+
+        from src.marcus_mcp.tools.context import log_decision
+
+        foundation = _task("f1", source_type="pre_fork_synthesis")
+        state.project_tasks = [foundation]
+        state.task_artifacts["f1"] = []
+        state.kanban_client = None  # skip kanban-comment path
+        state.current_project_id = "proj-decision-invalidation"
+
+        # Pre-cache the foundation contract by calling once.
+        await _collect_foundation_contract(state)
+
+        # Mock ``state.context.log_decision`` so we can drive the
+        # function without a real Context subsystem.
+        class _LoggedDecision:
+            decision_id = "dec-1"
+
+            def to_dict(self) -> Dict[str, Any]:
+                return {"id": "dec-1"}
+
+        async def fake_log(**kwargs: Any) -> _LoggedDecision:
+            # Side-effect: append the decision to state.context.decisions
+            # so a recompute would see it.
+            state.context.decisions.append(_MockDecision("f1", "use TypeScript"))
+            return _LoggedDecision()
+
+        state.context.log_decision = AsyncMock(  # type: ignore[attr-defined]
+            side_effect=fake_log
+        )
+
+        # Log a decision against the foundation task.
+        result = await log_decision("agent-1", "f1", "use TypeScript", state)
+        assert result["success"] is True
+
+        # Next call must see the new decision (cache invalidated).
+        contract = await _collect_foundation_contract(state)
+        assert any(d.get("what") == "use TypeScript" for d in contract["decisions"]), (
+            "Codex P2: log_decision on a foundation task must "
+            "invalidate the foundation-contract cache so the next "
+            "get_task_context sees the new decision."
+        )
+
+    @pytest.mark.asyncio
+    async def test_log_decision_on_NON_foundation_task_does_not_invalidate(
+        self, state: _MockState
+    ) -> None:
+        """Cache invalidation must be SCOPED to foundation tasks only.
+
+        A decision on a regular implement-task should NOT bust the
+        foundation-contract cache; otherwise the cache is useless
+        because every agent decision triggers a recompute.
+        """
+        from unittest.mock import AsyncMock
+
+        from src.marcus_mcp.tools.context import (
+            _foundation_contract_cache,
+            log_decision,
+        )
+
+        # Foundation task + a non-foundation task; only the latter
+        # gets the decision.
+        foundation = _task("f1", source_type="pre_fork_synthesis")
+        regular = _task("impl1")  # no source_type → not foundation
+        state.project_tasks = [foundation, regular]
+        state.task_artifacts["f1"] = [
+            {"filename": "tsconfig.json", "artifact_type": "specification"}
+        ]
+        state.kanban_client = None
+        state.current_project_id = "proj-scope-test"
+
+        # Warm the cache.
+        await _collect_foundation_contract(state)
+        assert "proj-scope-test" in _foundation_contract_cache
+
+        class _LoggedDecision:
+            decision_id = "dec-1"
+
+            def to_dict(self) -> Dict[str, Any]:
+                return {"id": "dec-1"}
+
+        async def fake_log(**kwargs: Any) -> _LoggedDecision:
+            return _LoggedDecision()
+
+        state.context.log_decision = AsyncMock(  # type: ignore[attr-defined]
+            side_effect=fake_log
+        )
+
+        # Log a decision against the NON-foundation task.
+        await log_decision("agent-1", "impl1", "use vanilla JS", state)
+
+        # Cache entry for proj-scope-test must STILL be present
+        # (decision was on regular task, not foundation).
+        assert "proj-scope-test" in _foundation_contract_cache, (
+            "Cache was invalidated for a non-foundation decision; "
+            "invalidation must be scoped to foundation tasks only."
+        )
+
     def test_invalidate_cache_api_is_exposed(self) -> None:
         """The ``invalidate_foundation_contract_cache`` function must
         be importable and callable — the kanban-refresh path in


### PR DESCRIPTION
## What this PR is, in plain English

Marcus delivers a project-wide **foundation contract** — a bundle of artifacts and decisions
from the synthesized pre-fork tasks — to every agent that asks for one. There are two
delivery paths today:

1. **Inline (the hot path):** `request_next_task` always returns the foundation contract
   inside the assigned task response. Issue #605.
2. **On demand (the cold path):** an agent can also call `get_task_context(task_id)` to
   fetch the same bundle by itself. This is the optional tool path.

Before this PR, both paths re-walked `state.project_tasks`, re-filtered for
`pre_fork_synthesis` tasks, and re-queried kanban attachments **every single call**.

This PR caches the result of `_collect_foundation_contract` per project for 60 seconds,
with explicit invalidation when board state changes (new artifacts, new decisions, or a
fresh project-state refresh).

## Honest scope correction

When this PR was first written it was titled a v0.3.8.post1 **hotfix** for the
`request_next_task` perf regression (18-22s latency observed by the user). After
shipping the code and running a verification project (`perf-verify-1`), the per-phase
timings show:

| Phase | ms (still) |
|---|---|
| `context_building` | **13,000-15,000 ms** (unchanged) |
| `instruction_generation` | 4,000-6,000 ms |
| `assemble_task_context` (foundation contract) | **~4 ms** |

`_collect_foundation_contract` was not the dominant cost on the `request_next_task`
hot path. The real cost lives in `state.context.analyze_dependencies()` — see new
issue (linked below) — which calls Claude for ambiguous dependency pairs on every
request. **That fix is a separate PR.**

This PR is still a net win on the **`get_task_context` cold path**: that tool was
also paying the same 13-14s on each call. Agents using it (e.g. the optional
"check dependencies before starting work" pattern in `request_next_task`'s
instruction prompt) now hit the cache.

## Where to look in the code

| File | Purpose |
|---|---|
| `src/marcus_mcp/tools/context.py` | `_collect_foundation_contract` (lines ~449-643), `_foundation_contract_cache`, `invalidate_foundation_contract_cache` |
| `src/marcus_mcp/tools/attachment.py` | Invalidate on `log_artifact` for foundation tasks |
| `src/marcus_mcp/server.py` (~line 969) | Invalidate on `state.project_tasks` reassignment (kanban refresh) |
| `src/marcus_mcp/tools/context.py` (`log_decision`) | Invalidate on `log_decision` against a foundation task (Codex P2 fix) |

## Cache semantics

- **Key:** `state.current_project_id` (falls back to no-cache if absent — safe for unit-test mocks)
- **TTL:** 60 seconds
- **Read:** `copy.deepcopy` on hit so callers can mutate their returned dict
- **Write:** `copy.deepcopy` on store so the cache holds an immutable snapshot
- **Invalidation:** explicit, on every state-changing operation that touches a foundation task

## Verification

- All CI passes (unit + internal integration + pre-commit + claude-review)
- Manual: re-ran `get_task_context` against a project with foundation tasks. First call
  ~13s (cache miss); subsequent calls within TTL ~10ms (cache hit on deep-copy path)

## Related

- Issue #595 (foundation contract delivery)
- PR #605/#606 (deliver context in `request_next_task` — the change that introduced
  the regression by removing the ">5 TODO tasks" skip guard)
- New v0.3.9 issue: cache `analyze_dependencies` result — that is the real
  `request_next_task` perf fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)