### PR TITLE
fix(runner): spawn-counter uses in_flight_tasks not tmux pane count (#632)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -8,14 +8,18 @@ This roadmap synthesizes our planning documents
 [Implementation Plans](docs/implementation/)) and research-driven features from
 GitHub issues.
 
-> **Status note (2026-04):** Current shipped release is **v0.3.6**. The
-> v0.2.x checklist is now complete and v0.3.x is largely complete — Epictetus
-> is integrated, board health monitoring lives in the Cato dashboard, and
-> parallel multi-instance experiments shipped on `develop` (the v0.4.0 work).
-> The biggest unrepresented gain since this roadmap was last edited is
-> **parallel experiment isolation** (per-instance SQLite kanban DBs +
-> env-var MCP URLs), which lets multiple independent Marcus instances run
-> at once without colliding. See *Phase 1 → v0.4.0-dev* below.
+> **Status note (2026-05):** Current shipped release is **v0.3.8** (2026-05-22).
+> One-agent-per-task lifecycle (#600) + decomposition redesign (#605, #607)
+> shipped this milestone.
+>
+> The **12-month sprint plan** below (2026-05-23 → 2027-05-23) pulls
+> **MFP/federation forward** from the "post-12 months" deferral in the
+> earlier Playbook triage. The v0.5.0 flagship is now **MFP v0.1**
+> (#476) with Board Rewind (#593) as a feature inside the protocol.
+> Federation production (v0.7.0) is a Q3 commitment, not a post-Year-1
+> aspiration. Marketplace + Brownfield sit in Sprint 4 (final 3 months).
+>
+> The arc: **Reliability → Open Protocol (MFP) → Federation → Commercial Surface.**
 
 ---
 
@@ -138,35 +142,114 @@ reliably after every experiment, and a remote-monitoring channel
 
 ---
 
-## Next Queue — Post-v0.4.0
+## 12-Month Sprint Plan — *2026-05-23 → 2027-05-23*
 
-The active queue, in order. Anything below is concrete, scoped, and on
-the near-term path. Issues exist for each.
+The active 12-month plan, broken into four sprints + a 2-month buffer.
+Each sprint maps to specific milestones. The arc:
+**Reliability → Open Protocol (MFP) → Federation → Commercial Surface.**
 
-### #414 — SQLite migration for all data streams
-Replace seven file-based streams (JSONL/JSON under `logs/conversations/`)
-with a unified SQLite store. Goal: queryable, multi-root safe, no
-full-file scans. **Unblocks Cato multi-path work** and makes Posidonius
-multi-instance cleaner. Blocking dependency for several other items.
+### Sprint 1 — Reliability *(2026-05-23 → 2026-07-23, 2 months)*
+**Goal:** A 9-task project completes cleanly end-to-end. No integration
+scrambles, no perf tax, no invariant leaks.
 
-### #416 — PostHog telemetry (PyCon 2026 sprint)
-Opt-in anonymized usage analytics across all Marcus runners (MCP Direct,
-`/marcus`, Posidonius). Surfaces in a PostHog dashboard. **PyCon sprint
-participants get first pick** — flag this issue before working on it
-solo so a sprinter doesn't get blocked.
+Pairs two milestones:
+- **v0.3.9** (13 issues) — decomposer correctness (#604, #615, #617,
+  #618, #619, #620), perf cache for `analyze_dependencies` (#626),
+  `request_task_redo` MCP tool (#627), ephemeral worker worktree
+  cleanup (#603), `_collect_task_artifacts` bug (#624),
+  `recommended_agents` bug (#462), decomposer auto-select (#382),
+  subtask spawning explosion (#628), integration partial-done bug
+  (#629), composition test triage (#630).
+- **v0.4.0 — Trustworthy Coordination** (15 issues) — observability
+  primitives (#447, #196, #284), god-file splits (#422, #423, #424),
+  `with_retry` dedup (#448), context system performance (#219, #222,
+  #223), CPM autoscale (#465), the integration-verifier-must-fix
+  invariant (#296), soft/hard dep support (#156), design/planning
+  validation (#205), project deletion UI (#256).
 
-### #363 — God-files refactor
-20 modules exceed 1000 lines (`advanced_parser.py` is 4505 lines). Each
-has a subissue with a concrete split plan. Cross-file deduplication
-(two `with_retry` implementations, etc.) is bundled in.
+### Sprint 2 — Open Protocol (MFP v0.1) *(2026-07-23 → 2026-09-23, 2 months)*
+**Goal:** MFP v0.1 published as a versioned, language-agnostic
+coordination protocol. Marcus is the *reference implementation*. Cato
+consumes MFP read API instead of filesystem coupling. Conformance test
+suite passes.
 
-### #442 — Track 2: per-session project isolation (deferred post-PyCon)
-The real fix for parallel experiments — one Marcus instance on `:4298`
-handles N experiments simultaneously, isolated by MCP session ID.
-Currently requires N separate Marcus processes on N ports. Blast
-radius: **80+ locations across 15+ files**, requires
-`contextvars.ContextVar`, threading `session_id` through all 50+ tool
-implementations. Deliberately held until after PyCon sprints.
+Milestone: **v0.5.0 — MFP v0.1 + Board Rewind** (8 issues).
+
+Headline: **#476** — MFP v0.1 spec + JSON Schemas + OpenAPI + conformance
+test suite. Defines the eight core artifact schemas (`AgentRegistration`,
+`Task`, `TaskContext`, `TaskProgress`, `Decision`, `ArtifactMetadata`,
+`BlockerReport`, `BoardEvent`) and the seven MCP tool RPC contracts.
+
+Co-flagship: **#593** — Board Rewind. Naturally enabled by MFP's
+immutable event log. Reconstruct board state at any prior task, edit
+that task's spec, re-execute only the tail. A 27-task run with a bad
+task 14 currently costs a full re-run; rewind makes it cost only tasks
+14–27.
+
+Also ships in v0.5.0:
+- **#414** — SQLite migration (unblocker; the schema must support
+  immutable branch lineage and the new `editing`/`pending_review`
+  task states from the start, or rewind forces a re-migration)
+- **#592** — `pending_review` task state (sibling gate machinery
+  for rewind)
+- **#299** — Domain-agnostic coordination (remove software-engineering
+  assumptions from core protocol; required for MFP scope)
+- **#594** — Richer agent capability profiles (MFP's
+  `AgentCapability` schema)
+- **#298** — Marcus Agent Protocol (MAP); rolled into MFP v0.1
+
+### Sprint 3 — Federation v1 *(2026-09-23 → 2026-12-23, 3 months)*
+**Goal:** Two Marcus instances discover each other, exchange
+capabilities, delegate tasks across the wire, sync reputation,
+auth/identity hardened. Private federation production-ready.
+
+Pairs two milestones:
+- **v0.6.0 — The Learning Coordinator** (16 issues) — per-experiment
+  outcome→adaptation loop (#176), backprop blame attribution (#255),
+  signal persistence for ML forecasting (#546), foundation-task
+  decision-compliance metrics (#468, #469, #471), audit-log duration
+  metrics (#228), foundations for federated reputation.
+  Spec-generation improvements feed off the rewind+edit diffs from
+  Sprint 2.
+- **v0.7.0 — Federation** (5 issues) — instance discovery, cross-instance
+  task delegation, reputation portability, payment routing skeleton,
+  cross-instance Build Kit licensing primitives.
+
+### Sprint 4 — Commercial Surface *(2026-12-23 → 2027-03-23, 3 months)*
+**Goal:** Brownfield + Build Kits + Stripe + agent hiring marketplace.
+Public agent economy launch.
+
+Pairs two milestones:
+- **v0.8.0 — Marketplace Foundation** — brownfield project ingestion
+  (RAG over existing repos), Build Kit format + 10 seed kits, Stripe
+  Connect for creators, Jira kanban provider (#241) for enterprise
+  adoption.
+- **v1.0.0 — The Agent Economy** — public marketplace launch, agent
+  hiring + escrow + reputation + dispute resolution, multi-dimensional
+  trust scoring.
+
+### Buffer *(2027-03-23 → 2027-05-23, 2 months)*
+Slip absorption, production hardening, polish. If unused, becomes
+growth/marketing/PMF time before v1.0.0 GA.
+
+---
+
+## Why the Reordering vs the Earlier Playbook
+
+The Playbook (2026-04 triage) deferred MFP, Federation, and Marketplace
+past 12 months in favor of "research-first" milestones. This roadmap
+flips that — **MFP earns its keep when federation lands on top, and
+federation cannot land cleanly without MFP**. The longer Marcus runs
+in production with implicit data shapes, the more expensive MFP
+becomes. Ship the protocol first while the surface area is small.
+
+**Marketplace stays in Sprint 4** because payment infrastructure
+without paying users is a sunk cost. Build Kits + Stripe Connect ship
+only after federation proves a network exists worth monetizing.
+
+**Reliability stays Sprint 1** because nothing compounds if every
+completion test still produces an integration scramble. Trust is the
+foundation everything else stacks on.
 
 ---
 

--- a/dev-tools/experiments/runners/spawn_agents.py
+++ b/dev-tools/experiments/runners/spawn_agents.py
@@ -1940,7 +1940,13 @@ echo "=========================================="
                     )
                     desired = int(signal.get("desired_agent_count", 0))
                     unclaimed = int(signal.get("unclaimed_tasks", 0))
-                    to_spawn = compute_spawn_count(desired, live, unclaimed)
+                    # #632: spawn decision uses Marcus's IN_PROGRESS count
+                    # (the right "who is covering an unclaimed task" signal
+                    # under the ephemeral lifecycle), not the runner's
+                    # tmux-pane count. The pane count is still computed
+                    # above for teardown logic and stall reasoning.
+                    in_flight = int(signal.get("in_flight_tasks", 0))
+                    to_spawn = compute_spawn_count(desired, in_flight, unclaimed)
 
                     # Tell the user, once, how much parallelism the graph
                     # actually offers — and warn when it offers almost
@@ -1965,8 +1971,9 @@ echo "=========================================="
                     _emit(
                         f"tasks {done}/{total} done "
                         f"({in_progress} in-progress, {blocked} blocked) | "
-                        f"live={live} desired={desired} "
-                        f"unclaimed={unclaimed} -> spawn {to_spawn}"
+                        f"live={live} in_flight={in_flight} "
+                        f"desired={desired} unclaimed={unclaimed} "
+                        f"-> spawn {to_spawn}"
                     )
 
                     for _ in range(to_spawn):

--- a/dev-tools/experiments/runners/spawn_controller.py
+++ b/dev-tools/experiments/runners/spawn_controller.py
@@ -15,30 +15,49 @@ from typing import Optional, Tuple
 
 def compute_spawn_count(
     desired_agent_count: int,
-    live_agents: int,
+    in_flight_tasks: int,
     unclaimed_tasks: int,
 ) -> int:
     """
     Decide how many ephemeral agents to spawn this control cycle.
 
-    The formula is ``max(0, min(desired_agent_count - live_agents,
+    The formula is ``max(0, min(desired_agent_count - in_flight_tasks,
     unclaimed_tasks))``:
 
-    - ``desired_agent_count - live_agents`` is the staffing gap.
+    - ``desired_agent_count - in_flight_tasks`` is the staffing gap:
+      how many MORE active claimers the active layer needs.
     - The ``unclaimed_tasks`` cap prevents spawning an agent for which no
       claimable task exists — such an agent would receive "no task" and
       idle, the cost Fix 3 removes.
     - The ``max(0, ...)`` clamp handles a layer boundary: ``desired``
-      drops as the graph narrows while a just-finished agent is still
-      being reaped, so the gap can be momentarily negative.
+      drops as the graph narrows while a just-finished assignment is
+      still being reaped, so the gap can be momentarily negative.
+
+    Why ``in_flight_tasks`` instead of ``live_agents`` (issue #632)
+    --------------------------------------------------------------
+    Pre-#632 this formula used a runner-side count of alive tmux panes
+    as the staffing variable. That count answers the question "how many
+    processes exist?" which is the same as "how many agents will claim
+    the next unclaimed task?" only under the old long-lived agent model.
+    Under the ephemeral lifecycle (PR #600) an agent does EXACTLY ONE
+    task and exits — so a pane that's still alive after the agent
+    finished its task will never claim more work. Counting it as
+    "staffing" stalls the run for any hangover task.
+
+    The right question is "how many tasks have an agent actively working
+    on them?" — which Marcus answers directly via the IN_PROGRESS count
+    in the active layer. The runner reads it from
+    ``get_desired_agent_count``'s response.
 
     Parameters
     ----------
     desired_agent_count : int
         Active-layer width capped at ``max_agents`` (from Marcus's
         ``get_desired_agent_count``).
-    live_agents : int
-        Agents the runner currently has alive.
+    in_flight_tasks : int
+        IN_PROGRESS tasks in the active layer (from
+        ``get_desired_agent_count``). Replaces the pre-#632 ``live_agents``
+        pane count.
     unclaimed_tasks : int
         TODO tasks in the active layer (from ``get_desired_agent_count``).
 
@@ -47,7 +66,7 @@ def compute_spawn_count(
     int
         Number of ephemeral agents to spawn now; never negative.
     """
-    gap = desired_agent_count - live_agents
+    gap = desired_agent_count - in_flight_tasks
     return max(0, min(gap, unclaimed_tasks))
 
 

--- a/src/marcus_mcp/coordinator/scheduler.py
+++ b/src/marcus_mcp/coordinator/scheduler.py
@@ -562,15 +562,16 @@ class ActiveLayerSignal:
     """
     Live layered-spawning signal for the runner controller (issue #595 Fix 3).
 
-    Both fields describe the *active layer* — the earliest DAG layer with
-    incomplete work. The runner's spawn formula combines them with its own
-    live-agent count::
+    All four fields describe the *active layer* — the earliest DAG layer
+    with incomplete work — except ``max_layer_width`` which is whole-graph.
+    The runner's spawn formula uses three of them::
 
-        spawn = max(0, min(desired_agent_count - live_agents, unclaimed_tasks))
+        spawn = max(0, min(desired_agent_count - in_flight_tasks,
+                           unclaimed_tasks))
 
     The ``max(0, ...)`` clamp matters: ``desired_agent_count`` drops at a
     layer boundary while a just-finished agent is still being reaped, so
-    ``desired_agent_count - live_agents`` can briefly go negative.
+    ``desired_agent_count - in_flight_tasks`` can briefly go negative.
 
     Attributes
     ----------
@@ -581,6 +582,13 @@ class ActiveLayerSignal:
     unclaimed_tasks : int
         TODO tasks in the active layer — claimable work the runner may
         still spawn agents for. 0 when all work is DONE.
+    in_flight_tasks : int
+        IN_PROGRESS tasks in the active layer — tasks Marcus has already
+        assigned to an agent and is waiting on. The runner uses this as
+        the "coverage" signal in place of its old tmux-pane count, which
+        was wrong under the ephemeral lifecycle (issue #632): an alive
+        pane is not the same as an agent still about to claim work, and
+        a hung post-completion agent would block spawning indefinitely.
     max_layer_width : int
         Width of the *widest* DAG layer across the whole project — the
         most parallelism the graph can ever offer. A small value means a
@@ -589,6 +597,7 @@ class ActiveLayerSignal:
 
     desired_agent_count: int
     unclaimed_tasks: int
+    in_flight_tasks: int
     max_layer_width: int
 
 
@@ -634,15 +643,16 @@ def compute_active_layer_signal(
     layers = compute_dag_layers(tasks)
     max_layer_width = max((len(layer) for layer in layers), default=0)
 
-    def _signal(desired: int, unclaimed: int) -> ActiveLayerSignal:
+    def _signal(desired: int, unclaimed: int, in_flight: int) -> ActiveLayerSignal:
         return ActiveLayerSignal(
             desired_agent_count=desired,
             unclaimed_tasks=unclaimed,
+            in_flight_tasks=in_flight,
             max_layer_width=max_layer_width,
         )
 
     if max_agents is not None and max_agents <= 0:
-        return _signal(0, 0)
+        return _signal(0, 0, 0)
 
     active: Optional[List[Task]] = None
     for layer in layers:
@@ -650,12 +660,18 @@ def compute_active_layer_signal(
             active = layer
             break
     if active is None:
-        return _signal(0, 0)
+        return _signal(0, 0, 0)
 
     width = len(active)
     desired = width if max_agents is None else min(max_agents, width)
     unclaimed = sum(1 for task in active if task.status == TaskStatus.TODO)
-    return _signal(desired, unclaimed)
+    # Count by status alone, not status + assigned_to. An IN_PROGRESS
+    # task without an ``assigned_to`` is an orphan from a different bug
+    # (lease expiration should reset it to TODO). Filtering on both
+    # fields would couple this signal to "every IN_PROGRESS write sets
+    # assigned_to" — a wider invariant we don't want to audit here.
+    in_flight = sum(1 for task in active if task.status == TaskStatus.IN_PROGRESS)
+    return _signal(desired, unclaimed, in_flight)
 
 
 def compute_desired_agent_count(

--- a/src/marcus_mcp/tools/scheduling.py
+++ b/src/marcus_mcp/tools/scheduling.py
@@ -107,10 +107,12 @@ async def get_desired_agent_count(
     Return the layered-spawning signal for the runner controller (#595 Fix 3).
 
     Returns ``desired_agent_count`` (the width of the earliest DAG layer
-    with incomplete work) and ``unclaimed_tasks`` (TODO tasks in that
-    layer). The runner's spawn formula is
-    ``max(0, min(desired_agent_count - live_agents, unclaimed_tasks))``.
-    Both are 0 when every task is DONE.
+    with incomplete work), ``unclaimed_tasks`` (TODO tasks in that
+    layer), and ``in_flight_tasks`` (IN_PROGRESS tasks in that layer —
+    the runner's coverage signal under the ephemeral lifecycle, issue
+    #632). The runner's spawn formula is
+    ``max(0, min(desired_agent_count - in_flight_tasks,
+    unclaimed_tasks))``. All three are 0 when every task is DONE.
 
     Recomputed from live board state on every call (no cursor — survives
     a rewind). Unlike ``get_optimal_agent_count`` (a one-shot whole-project
@@ -155,6 +157,7 @@ async def get_desired_agent_count(
             "success": True,
             "desired_agent_count": signal.desired_agent_count,
             "unclaimed_tasks": signal.unclaimed_tasks,
+            "in_flight_tasks": signal.in_flight_tasks,
             "max_layer_width": signal.max_layer_width,
             "max_agents": max_agents,
             "total_tasks": len(tasks),

--- a/tests/unit/coordinator/test_layered_spawning.py
+++ b/tests/unit/coordinator/test_layered_spawning.py
@@ -406,3 +406,64 @@ class TestComputeActiveLayerSignal:
 
         assert signal.desired_agent_count == 0
         assert signal.unclaimed_tasks == 0
+
+    def test_reports_in_flight_tasks_in_active_layer(self) -> None:
+        """in_flight_tasks counts IN_PROGRESS tasks in the active layer (#632).
+
+        The active layer here is ``[a, b, c]``: a (DONE) is in a prior
+        layer; b (TODO) and c (IN_PROGRESS) are at the next level. Of
+        the two unsettled tasks, one is IN_PROGRESS — that is the
+        ``in_flight_tasks`` value the runner needs to compute the
+        spawn gap.
+        """
+        tasks = [
+            _task("a", status=TaskStatus.DONE),
+            _task("b", dependencies=["a"], status=TaskStatus.TODO),
+            _task("c", dependencies=["a"], status=TaskStatus.IN_PROGRESS),
+        ]
+
+        signal = compute_active_layer_signal(tasks)
+
+        assert signal.in_flight_tasks == 1
+        assert signal.unclaimed_tasks == 1
+        assert signal.desired_agent_count == 2
+
+    def test_in_flight_zero_when_no_in_progress_in_active_layer(self) -> None:
+        """in_flight_tasks is 0 when the active layer has no IN_PROGRESS work."""
+        tasks = [_task("a", status=TaskStatus.TODO)]
+
+        signal = compute_active_layer_signal(tasks)
+
+        assert signal.in_flight_tasks == 0
+
+    def test_in_flight_zero_when_all_done(self) -> None:
+        """in_flight_tasks is 0 when every task is settled."""
+        signal = compute_active_layer_signal(
+            [_task("a", status=TaskStatus.DONE)], max_agents=5
+        )
+
+        assert signal.in_flight_tasks == 0
+
+    def test_in_flight_counts_only_active_layer_not_prior_in_progress(self) -> None:
+        """Symmetry with desired/unclaimed: in_flight is scoped to the active layer.
+
+        Construct a graph where the active layer contains IN_PROGRESS
+        work but a prior layer also has IN_PROGRESS (a stuck task from
+        an earlier layer that — under the active-layer cursor — should
+        still pin layer 0 as the active layer). The in_flight count
+        should reflect IN_PROGRESS tasks in the layer the runner is
+        actually spawning agents for.
+        """
+        tasks = [
+            _task("l0_a", status=TaskStatus.DONE),
+            _task("l0_b", status=TaskStatus.IN_PROGRESS),
+            _task("l1_a", dependencies=["l0_a", "l0_b"], status=TaskStatus.TODO),
+        ]
+
+        signal = compute_active_layer_signal(tasks)
+
+        # Active layer is [l0_a, l0_b] (l0_b not settled). l1_a is in
+        # the next layer; not counted here. in_flight == 1 (l0_b).
+        assert signal.desired_agent_count == 2
+        assert signal.in_flight_tasks == 1
+        assert signal.unclaimed_tasks == 0

--- a/tests/unit/experiments/test_spawn_controller.py
+++ b/tests/unit/experiments/test_spawn_controller.py
@@ -23,40 +23,100 @@ pytestmark = pytest.mark.unit
 
 
 class TestComputeSpawnCount:
-    """compute_spawn_count = max(0, min(desired - live, unclaimed))."""
+    """compute_spawn_count = max(0, min(desired - in_flight, unclaimed)).
+
+    Issue #632: the formula's coverage variable is now ``in_flight_tasks``
+    (Marcus's IN_PROGRESS count for the active layer), not the runner's
+    tmux-pane count. The shape of the formula is unchanged.
+    """
 
     def test_spawns_to_fill_the_gap(self) -> None:
-        """desired 5, live 2, plenty unclaimed -> spawn 3."""
+        """desired 5, in_flight 2, plenty unclaimed -> spawn 3."""
         assert (
-            compute_spawn_count(desired_agent_count=5, live_agents=2, unclaimed_tasks=5)
+            compute_spawn_count(
+                desired_agent_count=5, in_flight_tasks=2, unclaimed_tasks=5
+            )
             == 3
         )
 
     def test_gated_by_unclaimed_tasks(self) -> None:
         """Never spawn more agents than there are claimable tasks."""
         assert (
-            compute_spawn_count(desired_agent_count=5, live_agents=0, unclaimed_tasks=1)
+            compute_spawn_count(
+                desired_agent_count=5, in_flight_tasks=0, unclaimed_tasks=1
+            )
             == 1
         )
 
-    def test_clamped_at_zero_when_live_exceeds_desired(self) -> None:
-        """At a layer boundary live can transiently exceed desired -> 0."""
+    def test_clamped_at_zero_when_in_flight_exceeds_desired(self) -> None:
+        """At a layer boundary in_flight can transiently exceed desired -> 0."""
         assert (
-            compute_spawn_count(desired_agent_count=2, live_agents=3, unclaimed_tasks=5)
+            compute_spawn_count(
+                desired_agent_count=2, in_flight_tasks=3, unclaimed_tasks=5
+            )
             == 0
         )
 
     def test_zero_when_no_unclaimed_work(self) -> None:
         """A vacancy with no claimable task spawns nothing (no idle agent)."""
         assert (
-            compute_spawn_count(desired_agent_count=5, live_agents=2, unclaimed_tasks=0)
+            compute_spawn_count(
+                desired_agent_count=5, in_flight_tasks=2, unclaimed_tasks=0
+            )
             == 0
         )
 
     def test_zero_when_fully_staffed(self) -> None:
-        """live == desired -> spawn nothing."""
+        """in_flight == desired -> spawn nothing."""
         assert (
-            compute_spawn_count(desired_agent_count=4, live_agents=4, unclaimed_tasks=4)
+            compute_spawn_count(
+                desired_agent_count=4, in_flight_tasks=4, unclaimed_tasks=4
+            )
+            == 0
+        )
+
+    def test_spawns_for_unclaimed_task_when_no_in_flight_work(self) -> None:
+        """Hung-pane regression (#632).
+
+        Pre-#632 a hung tmux pane gave ``live_agents=1`` and the formula
+        decided ``spawn=0`` against an unclaimed task — the test58 stall.
+        Post-#632 the runner reads ``in_flight_tasks`` from Marcus, which
+        correctly reports 0 (no task is IN_PROGRESS because the hung
+        agent's task already reached DONE). The formula should spawn 1
+        agent for the unclaimed task.
+        """
+        assert (
+            compute_spawn_count(
+                desired_agent_count=1, in_flight_tasks=0, unclaimed_tasks=1
+            )
+            == 1
+        )
+
+    def test_residual_integration_hang_does_not_spawn(self) -> None:
+        """Documented trade-off (#632 / #634).
+
+        If the LAST in-flight task is the one that's hung (e.g., the
+        integration verifier hanging in post-completion cleanup), the
+        active layer has ``in_flight=1, unclaimed=0`` — formula spawns
+        0 (correct, no other work). With ``unclaimed=1`` (hangover task
+        like a README that depends on the hung task) we still spawn 0
+        — because ``desired=1`` and ``in_flight=1``. This residual case
+        is bug #634's responsibility (kill the hang); this fix
+        deliberately does not paper over it by over-spawning.
+        """
+        # No other work — correct to spawn 0.
+        assert (
+            compute_spawn_count(
+                desired_agent_count=1, in_flight_tasks=1, unclaimed_tasks=0
+            )
+            == 0
+        )
+        # Hangover task with the last in-flight slot occupied by a hang
+        # — still spawn 0; #634 must resolve the underlying hang.
+        assert (
+            compute_spawn_count(
+                desired_agent_count=1, in_flight_tasks=1, unclaimed_tasks=1
+            )
             == 0
         )
 


### PR DESCRIPTION
Closes #632.

## What this PR does, in plain English

Marcus's ``/marcus`` skill uses a long-lived **runner** process that
polls Marcus every 30 seconds and spawns short-lived **worker agents**
(Claude processes inside tmux panes) to claim tasks from the kanban.
Each agent does exactly one task and exits — that's the **ephemeral
lifecycle** PR #600 shipped.

The runner decides how many fresh agents to spawn each cycle by
asking: "do we already have enough agents covering the available
work?" The formula compares ``desired`` (how many agents the active
layer of work needs) against a coverage count, gated by
``unclaimed`` (claimable tasks remaining).

The bug: the **coverage count was wrong**. The runner was using a
count of alive tmux panes. Under the old long-lived agent model that
meant "agents that will claim the next unclaimed task." Under the
ephemeral lifecycle it doesn't — an alive pane after an agent
finished its one task will never claim more work.

This PR replaces pane-counting with ``in_flight_tasks`` (a count of
IN_PROGRESS tasks on the kanban active layer), which is the signal
that actually answers "how many tasks have an agent working on them
right now?"

## Why this matters — the real stall

Project ``test58`` (purple-dot-snake-game) on 2026-05-23 reached
10/11 tasks DONE. The integration verifier finished at 20:47 and
hung in some post-completion step (separate bug #634). Its tmux
pane stayed alive. The runner logged every 30s for 19 minutes::

    tasks 10/11 done (0 in-progress, 0 blocked) | live=1 desired=1 unclaimed=1 -> spawn 0
    tasks 10/11 done (0 in-progress, 0 blocked) | live=1 desired=1 unclaimed=1 -> spawn 0
    ...
    STALL: no task-count change for 20 min — tearing down

The README task sat unclaimed because the runner thought a phantom
claimer (the hung-but-alive integration verifier pane) was covering
it. With this fix, the runner would have seen ``in_flight=0`` (the
integration verifier's task was already DONE), the formula would
have computed ``spawn=1``, and the README would have been claimed
within 30s.

## What changed

| File | Change |
|---|---|
| ``src/marcus_mcp/coordinator/scheduler.py`` | ``ActiveLayerSignal`` dataclass gains ``in_flight_tasks: int``. ``compute_active_layer_signal`` counts IN_PROGRESS tasks in the active layer (symmetric with how it counts TODO tasks for ``unclaimed_tasks``). |
| ``src/marcus_mcp/tools/scheduling.py`` | ``get_desired_agent_count`` MCP tool response includes the new ``in_flight_tasks`` field. Additive change — existing consumers ignore it. |
| ``dev-tools/experiments/runners/spawn_controller.py`` | ``compute_spawn_count`` parameter renamed ``live_agents`` → ``in_flight_tasks``. Formula shape unchanged: ``max(0, min(desired - in_flight, unclaimed))``. Extensive docstring explaining why the old name was wrong under ephemeral lifecycle. |
| ``dev-tools/experiments/runners/spawn_agents.py`` | Runner reads ``signal["in_flight_tasks"]`` and passes it to ``compute_spawn_count``. Log line now shows both ``live=`` (pane count, for observability) and ``in_flight=`` (the actual coverage signal). ``_count_live_worker_panes`` is KEPT for teardown logic — only removed from the spawn decision. |
| ``tests/unit/experiments/test_spawn_controller.py`` | 5 existing tests renamed for the new parameter; 2 new tests for the hung-pane regression + integration-hang trade-off acceptance. |
| ``tests/unit/coordinator/test_layered_spawning.py`` | 4 new tests for ``in_flight_tasks`` computation including a prior-layer scope check. |

## Why count by status alone (not status + assigned_to)

The proposed fix originally filtered on
``status == IN_PROGRESS and assigned_to is not None`` to be defensive.
Kaia's review (Simon decision ``6c1a0a4a``) pushed back: filtering on
both fields couples this signal to "every IN_PROGRESS write also sets
``assigned_to``" — a wider invariant not worth auditing for this fix.
An IN_PROGRESS task with no ``assigned_to`` is already an orphan from
another bug (lease expiration should reset it to TODO). Counting by
status alone matches Marcus's existing usage of IN_PROGRESS
throughout the codebase.

## Trade-off explicitly accepted

This PR does NOT solve the case where the LAST in-flight task is
itself hung (e.g., the integration verifier hanging in
post-completion cleanup). With ``in_flight=1`` forever and
``unclaimed=0`` (no other work), the formula says ``spawn=0`` —
which is correct, there's no sibling work to cover. With
``unclaimed=1`` (a hangover task that depends on the hung task),
the formula still says ``spawn=0`` because ``desired=1`` and
``in_flight=1``.

The residual hang is bug #634's responsibility. This fix and #634
together ensure: (a) sibling tasks always get coverage despite an
unrelated hang (this fix), and (b) hung tasks eventually fail or
recover so the in_flight count drops (#634). For the test58 symptom
that motivated this work — README task hung behind an already-completed
integration verifier whose pane was lingering — **this fix alone
is sufficient** (in_flight=0 because the integration verifier's
task was already DONE).

This trade-off is enshrined in
``test_residual_integration_hang_does_not_spawn`` so future
reviewers see why the formula doesn't paper over the hang case.

## Where to look in the code first

| File | Purpose |
|---|---|
| ``src/marcus_mcp/coordinator/scheduler.py`` (~lines 560-660) | ``ActiveLayerSignal`` dataclass + ``compute_active_layer_signal`` — the source of truth for the spawn signal |
| ``src/marcus_mcp/tools/scheduling.py`` (~lines 100-165) | The MCP tool that exposes the signal to the runner |
| ``dev-tools/experiments/runners/spawn_controller.py`` | ``compute_spawn_count`` — the formula itself |
| ``dev-tools/experiments/runners/spawn_agents.py`` (~lines 1930-1975) | Runner loop that calls the formula and emits the per-poll log line |

## Glossary

| Term | Meaning |
|---|---|
| **Runner** | Long-lived ``/marcus`` harness process that spawns ephemeral worker agents |
| **Ephemeral agent** | A worker process that exits after one task completion (PR #600) |
| **Active layer** | The earliest DAG layer of the project that still has unsettled (not DONE / not BLOCKED) work |
| **In-flight task** | A task on the kanban with status IN_PROGRESS — an agent is actively working on it |
| **Live agent (old)** | Pre-#632 runner concept: a tmux pane the runner has spawned that still exists. Now used only for teardown reasoning, not for the spawn decision. |
| **Stall detector** | The watchdog at ``StallWatchdog`` that tears down a run when task counts haven't changed for N polls (default 20 min) |

## How to verify it works

### Unit tests

```bash
python -m pytest tests/unit/experiments/test_spawn_controller.py tests/unit/coordinator/test_layered_spawning.py -v
```

Expected: 51/51 pass.

### Production smoke

1. Run a /marcus project on this branch end-to-end
2. When the integration verifier completes, manually freeze its
   Claude process (e.g. ``kill -STOP <pid>``) to simulate the
   test58 hang
3. **Expected (before fix):** README task sits unclaimed; runner
   says ``live=1 in_flight=0 -> spawn 0``; project stalls at 20 min
4. **Expected (after fix):** README task is claimed within 30s by
   a fresh agent (``live=1 in_flight=0 -> spawn 1``); project
   completes to 11/11

The log line shape now shows both ``live=`` (pane count, unchanged)
and ``in_flight=`` (the new coverage signal) so operators can
diagnose either side of a stall.

## Test plan

- [ ] CI green (unit, internal integration, pre-commit, claude-review)
- [ ] All 51 in-scope unit tests pass locally
- [ ] No regressions in broader unit suite (2077 pass, was 2071, +6 new)
- [ ] mypy clean for all 4 changed source files
- [ ] Production smoke: a hung integration verifier no longer stalls
      sibling work

## Related

- Issue #632 — the bug this fixes (the test58 stall root cause)
- Issue #633 — ``/marcus resume`` (sibling recovery primitive for
  cases where this fix isn't enough)
- Issue #634 — integration verifier post-completion hang (the bug
  that triggered the test58 hang; complementary to this fix)
- PR #600 — ephemeral one-agent-per-task lifecycle (the change that
  made the live-pane assumption wrong)
- PR #595 — the long-lived runner architecture this controller
  lives in
- Simon decision ``6c1a0a4a`` — Kaia's pre-PR architectural review
  approving this direction

🤖 Generated with [Claude Code](https://claude.com/claude-code)