### PR TITLE
perf(instrument): phase timing for report_task_progress + create_project

### DIFF
--- a/src/core/perf_instrumentation.py
+++ b/src/core/perf_instrumentation.py
@@ -1,0 +1,154 @@
+"""
+Lightweight phase-by-phase wall-clock instrumentation helpers.
+
+Background
+----------
+``src/marcus_mcp/tools/task.py::request_next_task`` already has an
+inline ``_mark`` timing pattern that emits a structured log line per
+call. This module factors that pattern into a small reusable helper so
+other Marcus entry points (``report_task_progress``,
+``create_project_from_description``, etc.) can adopt the same shape
+without copying the boilerplate.
+
+The goal is observability of where Marcus spends time per task
+lifecycle, so a single "task takes 4 minutes" observation can be
+decomposed into:
+
+- ``request_next_task`` (assignment cost)
+- ``report_task_progress`` (per-progress + completion processing)
+- ``create_project_from_description`` (one-time setup)
+
+Plus the agent's actual execution time, which Marcus does not control.
+
+Usage
+-----
+>>> import logging
+>>> logger = logging.getLogger(__name__)
+>>> async def some_entry_point(agent_id, task_id):
+...     async with async_phase_timer(
+...         "some_entry_point", logger,
+...         agent_id=agent_id, task_id=task_id,
+...     ) as timer:
+...         # ... work ...
+...         timer.mark("phase_a")
+...         # ... more work ...
+...         timer.mark("phase_b")
+...         return {"ok": True}
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from contextlib import asynccontextmanager
+from typing import Any, AsyncIterator, Dict
+
+
+class PhaseTimer:
+    """Phase-by-phase wall-clock timer.
+
+    A new instance starts the wall clock on construction. Call
+    :meth:`mark` at each phase boundary; the marks are cumulative
+    milliseconds since construction. :meth:`to_phase_durations`
+    converts them to per-phase deltas at log time.
+
+    Attributes
+    ----------
+    None public; use :meth:`mark`, :meth:`to_phase_durations`,
+    :meth:`total_ms`.
+    """
+
+    def __init__(self) -> None:
+        """Start the wall clock immediately."""
+        self._start = time.perf_counter()
+        self._marks: Dict[str, float] = {}
+
+    def mark(self, name: str) -> None:
+        """Record a cumulative timestamp under ``name``.
+
+        Parameters
+        ----------
+        name
+            Phase identifier. Must be unique within this timer; later
+            marks with the same name overwrite earlier ones.
+        """
+        self._marks[name] = (time.perf_counter() - self._start) * 1000.0
+
+    def to_phase_durations(self) -> Dict[str, float]:
+        """Convert cumulative marks to per-phase deltas in ms.
+
+        Returns
+        -------
+        Dict[str, float]
+            Ordered mapping of phase name to elapsed ms since the
+            previous mark. The first mark is measured against the
+            timer's construction time.
+        """
+        items = list(self._marks.items())
+        out: Dict[str, float] = {}
+        for i, (name, cumulative) in enumerate(items):
+            prev = items[i - 1][1] if i > 0 else 0.0
+            out[name] = round(cumulative - prev, 2)
+        return out
+
+    def total_ms(self) -> float:
+        """Return the cumulative ms recorded under the ``"total"`` mark.
+
+        Returns
+        -------
+        float
+            Cumulative ms, or ``0.0`` if ``"total"`` was never marked.
+        """
+        return round(self._marks.get("total", 0.0), 2)
+
+
+@asynccontextmanager
+async def async_phase_timer(
+    operation: str,
+    log: logging.Logger,
+    **context: Any,
+) -> AsyncIterator[PhaseTimer]:
+    """Async context manager that logs phase timings on exit.
+
+    Wraps a :class:`PhaseTimer` so the timing log fires even when the
+    wrapped block raises. Each exit also marks ``"total"`` so callers
+    don't have to.
+
+    Parameters
+    ----------
+    operation
+        Identifier used as the log line prefix (e.g.,
+        ``"report_task_progress"``).
+    log
+        Logger to emit on exit.
+    **context
+        Free-form context fields to include in the log line (e.g.,
+        ``agent_id=...``, ``task_id=...``). Values are formatted with
+        ``repr`` so strings keep their quotes.
+
+    Yields
+    ------
+    PhaseTimer
+        The timer; call ``.mark(name)`` at each phase boundary.
+
+    Notes
+    -----
+    The log format matches the pre-existing inline pattern in
+    :func:`src.marcus_mcp.tools.task.request_next_task` so all Marcus
+    timing log lines can be grepped together::
+
+        operation timing: key1=val1 key2=val2 total_ms=N phases={...}
+    """
+    timer = PhaseTimer()
+    try:
+        yield timer
+    finally:
+        timer.mark("total")
+        ctx_str = " ".join(f"{k}={v!r}" for k, v in context.items())
+        log.info(
+            "%s timing: %s total_ms=%s phases=%s",
+            operation,
+            ctx_str,
+            timer.total_ms(),
+            timer.to_phase_durations(),
+        )

--- a/src/integrations/nlp_tools.py
+++ b/src/integrations/nlp_tools.py
@@ -1438,6 +1438,14 @@ class NaturalLanguageProjectCreator(NaturalLanguageTaskCreator):
 
         Uses the base class implementation for common functionality.
         """
+        # Phase timing for performance monitoring (where does the
+        # 30-60s project-creation cost come from?). Mirrors the inline
+        # _mark pattern in ``src/marcus_mcp/tools/task.py`` so all
+        # Marcus timing log lines can be grepped together. Marks fire
+        # on the success path only — error returns skip the log.
+        from src.core.perf_instrumentation import PhaseTimer
+
+        _timer = PhaseTimer()
         try:
             _planning_started_at = datetime.now(timezone.utc)
             # Initialise deferred-write state so the except block can write
@@ -1547,6 +1555,8 @@ class NaturalLanguageProjectCreator(NaturalLanguageTaskCreator):
                         logger.error(f"Failed to create new project: {e}")
                         raise
 
+            _timer.mark("kanban_setup")
+
             # Parse tasks
             from src.core.error_framework import ErrorContext, error_context
 
@@ -1603,6 +1613,8 @@ class NaturalLanguageProjectCreator(NaturalLanguageTaskCreator):
                         },
                     ),
                 )
+
+            _timer.mark("natural_language_processing")
 
             # Apply safety checks using base class
             with error_context(
@@ -1723,6 +1735,8 @@ class NaturalLanguageProjectCreator(NaturalLanguageTaskCreator):
                 if _is_design_task(task):
                     task.assigned_to = "Marcus"
 
+            _timer.mark("augmentation")
+
             # Create tasks on board using base class (this also triggers decomposition)
             with error_context(
                 "kanban_task_creation",
@@ -1733,6 +1747,8 @@ class NaturalLanguageProjectCreator(NaturalLanguageTaskCreator):
             ):
                 created_tasks = await self.create_tasks_on_board(safe_tasks)
                 logger.info(f"Created {len(created_tasks)} tasks on board")
+                _timer.mark("kanban_persist")
+
                 # Planning phase ends: board is populated, agents can now
                 # self-select work.  Log JSONL event (debugging) and persist
                 # to marcus.db so Cato renders a "Marcus Planning" swim lane
@@ -2125,6 +2141,15 @@ class NaturalLanguageProjectCreator(NaturalLanguageTaskCreator):
             except asyncio.TimeoutError:
                 logger.warning("Cleanup timed out after 5.0s, continuing anyway")
 
+            _timer.mark("finalize")
+            _timer.mark("total")
+            logger.info(
+                "create_project_from_description timing: "
+                f"project_name={project_name!r} "
+                f"task_count={len(safe_tasks) if 'safe_tasks' in locals() else 0} "
+                f"total_ms={_timer.total_ms()} "
+                f"phases={_timer.to_phase_durations()}"
+            )
             return result
 
         except Exception as e:

--- a/src/marcus_mcp/tools/task.py
+++ b/src/marcus_mcp/tools/task.py
@@ -2715,8 +2715,18 @@ async def report_task_progress(
     Dict[str, Any]
         Dict with success status
     """
+    # Phase timing for performance monitoring (issue: where does the
+    # 4-min-per-task cost come from?). Mirrors the inline _mark
+    # pattern in ``request_next_task`` so all Marcus timing log lines
+    # can be grepped together. Marks fire on the success path only —
+    # error returns skip the log, matching ``request_next_task``.
+    from src.core.perf_instrumentation import PhaseTimer
+
+    _timer = PhaseTimer()
+
     # Get project/board context
     project_context = await get_project_board_context(state)
+    _timer.mark("ctx_setup")
 
     # Log progress update
     conversation_logger.log_worker_message(
@@ -2750,6 +2760,7 @@ async def report_task_progress(
     try:
         # Initialize kanban if needed
         await state.initialize_kanban()
+        _timer.mark("kanban_init")
 
         # Log Marcus thinking
         log_thinking(
@@ -2855,6 +2866,8 @@ async def report_task_progress(
                             f"— request your next task to continue."
                         ),
                     }
+
+        _timer.mark("stale_guard")
 
         # Update task in kanban
         update_data: Dict[str, Any] = {"progress": progress}
@@ -3018,6 +3031,8 @@ async def report_task_progress(
                         f"for task {task_id}: {smoke_err}"
                     )
                     logger.exception("Smoke verification exception details:")
+
+        _timer.mark("validation")
 
         # Sentinel: holds a failed merge result to be returned AFTER the
         # kanban update. The task must always be finalized on the board
@@ -3288,6 +3303,7 @@ async def report_task_progress(
 
         # Update Kanban card
         await state.kanban_client.update_task(task_id, update_data)
+        _timer.mark("kanban_update")
 
         # Update task progress (including checklist items)
         await state.kanban_client.update_task_progress(
@@ -3416,6 +3432,15 @@ async def report_task_progress(
             )
             fire_task_completed(completed_task)
 
+        _timer.mark("completion_processing")
+        _timer.mark("total")
+        logger.info(
+            "report_task_progress timing: "
+            f"agent={agent_id} task_id={task_id} status={status} "
+            f"progress={progress} "
+            f"total_ms={_timer.total_ms()} "
+            f"phases={_timer.to_phase_durations()}"
+        )
         return {"success": True, "message": "Progress updated successfully"}
 
     except Exception as e:

--- a/tests/unit/core/test_perf_instrumentation.py
+++ b/tests/unit/core/test_perf_instrumentation.py
@@ -1,0 +1,125 @@
+"""
+Unit tests for ``src.core.perf_instrumentation``.
+
+The helper exists to factor the inline ``_mark`` pattern from
+``request_next_task`` so other Marcus entry points can adopt the same
+shape. These tests verify the contract: marks are cumulative, deltas
+are computed correctly, and the async context manager logs even when
+the wrapped block raises.
+"""
+
+from __future__ import annotations
+
+import logging
+from unittest.mock import MagicMock
+
+import pytest
+
+from src.core.perf_instrumentation import PhaseTimer, async_phase_timer
+
+
+class TestPhaseTimer:
+    """Direct unit tests for ``PhaseTimer``."""
+
+    def test_marks_accumulate_in_insertion_order(self):
+        """Marks recorded in the order they were called."""
+        timer = PhaseTimer()
+        timer.mark("a")
+        timer.mark("b")
+        timer.mark("c")
+        keys = list(timer.to_phase_durations().keys())
+        assert keys == ["a", "b", "c"]
+
+    def test_to_phase_durations_returns_deltas_not_cumulative(self):
+        """Each phase value is the elapsed ms since the previous mark.
+
+        Construct a timer, monkey-patch its internal start time, and
+        write three known cumulative marks; verify the deltas come out
+        as the differences between consecutive marks.
+        """
+        timer = PhaseTimer()
+        # Bypass real time.monotonic by writing cumulative ms directly.
+        timer._marks = {
+            "phase_a": 100.0,
+            "phase_b": 250.0,
+            "phase_c": 400.0,
+        }
+        deltas = timer.to_phase_durations()
+        assert deltas == {
+            "phase_a": 100.0,
+            "phase_b": 150.0,
+            "phase_c": 150.0,
+        }
+
+    def test_total_ms_reads_total_mark_when_present(self):
+        """``total_ms`` returns the cumulative value at the ``"total"`` mark."""
+        timer = PhaseTimer()
+        timer._marks = {"phase_a": 50.0, "total": 200.0}
+        assert timer.total_ms() == 200.0
+
+    def test_total_ms_returns_zero_when_total_never_marked(self):
+        """Without a ``"total"`` mark, ``total_ms`` defaults to ``0.0``."""
+        timer = PhaseTimer()
+        timer._marks = {"phase_a": 50.0}
+        assert timer.total_ms() == 0.0
+
+    def test_mark_overwrites_previous_value_for_same_name(self):
+        """Re-marking the same name overwrites the earlier timestamp."""
+        timer = PhaseTimer()
+        timer._marks = {"phase_a": 50.0}
+        timer.mark("phase_a")
+        # Real mark recorded; previous synthetic value is gone.
+        assert timer._marks["phase_a"] != 50.0
+
+
+class TestAsyncPhaseTimer:
+    """Tests for the ``async_phase_timer`` context manager."""
+
+    @pytest.mark.asyncio
+    async def test_logs_on_normal_exit(self):
+        """On clean exit, the timer logs operation + total_ms + phases."""
+        log = MagicMock(spec=logging.Logger)
+        async with async_phase_timer("op_name", log, agent="x") as timer:
+            timer.mark("phase_a")
+        assert log.info.called
+        args = log.info.call_args.args
+        # First arg is the format string; subsequent args are the
+        # positional values fed into it.
+        assert args[0] == "%s timing: %s total_ms=%s phases=%s"
+        assert args[1] == "op_name"
+        assert "agent='x'" in args[2]
+
+    @pytest.mark.asyncio
+    async def test_logs_even_when_wrapped_block_raises(self):
+        """A raising block still triggers the timing log via finally."""
+        log = MagicMock(spec=logging.Logger)
+        with pytest.raises(RuntimeError):
+            async with async_phase_timer("op_name", log) as timer:
+                timer.mark("phase_a")
+                raise RuntimeError("boom")
+        assert log.info.called
+
+    @pytest.mark.asyncio
+    async def test_marks_total_automatically_on_exit(self):
+        """``async_phase_timer`` records a ``"total"`` mark on exit.
+
+        Callers do not need to call ``timer.mark("total")`` explicitly.
+        """
+        log = MagicMock(spec=logging.Logger)
+        captured: list[PhaseTimer] = []
+        async with async_phase_timer("op_name", log) as timer:
+            captured.append(timer)
+        assert "total" in captured[0]._marks
+
+    @pytest.mark.asyncio
+    async def test_context_kwargs_appear_in_log_line(self):
+        """All ``**context`` kwargs are formatted into the log line."""
+        log = MagicMock(spec=logging.Logger)
+        async with async_phase_timer(
+            "op_name", log, agent_id="a1", task_id="t1", status="completed"
+        ):
+            pass
+        ctx_str = log.info.call_args.args[2]
+        assert "agent_id='a1'" in ctx_str
+        assert "task_id='t1'" in ctx_str
+        assert "status='completed'" in ctx_str


### PR DESCRIPTION
## What this PR does, in plain English

Marcus's ``/marcus`` skill produces software from natural-language
descriptions by coordinating multiple AI agents (Claude, GPT, Gemini)
through a shared kanban board. End-to-end, a single task takes
~4 minutes wall-clock. Where does that 4 minutes go?

Today, only one Marcus entry point logs its phase timings:
``request_next_task`` (the per-task pickup call). The two other major
entry points — ``create_project_from_description`` (Phase A: domain
discovery, contract generation, decomposition) and
``report_task_progress`` (per-progress updates and task completion) —
emit no structured timing.

This PR adds per-phase wall-clock instrumentation to those two entry
points, using a small shared helper. After this lands, every Marcus
log file will have three families of timing lines we can grep and
sum, so we can answer "where does the 4-minute task go" without
guessing.

## Why now

The v0.3.9 reliability sprint is a coordination-tax investigation. We
already shipped one optimization (PR #631 / #635: caching
``analyze_dependencies`` so the LLM call doesn't fire on every poll,
saving 13-15s per ``request_next_task``). Several more optimizations
are queued (#636 verification ownership, #637 decomposer redundant
gap-fill, #638 composition orphan detection). Each one we ship,
we need to measure whether the wall-clock per task actually dropped
— and how much.

Without coverage on ``report_task_progress`` and
``create_project_from_description``, we have a measurement blind spot
in two of the three Marcus entry points. This PR closes that blind
spot.

## What changed

| File | Change |
|---|---|
| ``src/core/perf_instrumentation.py`` (new) | New module with ``PhaseTimer`` class + ``async_phase_timer`` async context manager. Factors the existing inline ``_mark`` pattern from ``request_next_task`` so other entry points can adopt without duplicating boilerplate. |
| ``src/marcus_mcp/tools/task.py::report_task_progress`` | Instrumented with phase marks: ``ctx_setup``, ``kanban_init``, ``stale_guard``, ``validation`` (the LLM-based completion check), ``kanban_update``, ``completion_processing``, ``total``. Marks fire on the success-return path only, matching ``request_next_task``'s existing pattern. |
| ``src/integrations/nlp_tools.py::create_project_from_description`` | Instrumented with phase marks: ``kanban_setup``, ``natural_language_processing`` (Phase A pipeline — domain discovery, decomposition, contract generation), ``augmentation`` (safety + integration/documentation augmenter chain), ``kanban_persist`` (writing tasks to kanban), ``finalize``, ``total``. |
| ``tests/unit/core/test_perf_instrumentation.py`` (new) | 9 unit tests covering ``PhaseTimer`` semantics (mark order, delta computation, total_ms read, overwrite-on-remark) and ``async_phase_timer`` behavior (logs on normal exit, logs on exception, auto-marks total, context kwargs in log). |

## How to read the data after this lands

Grep the Marcus log:

```bash
grep "timing:" /Users/lwgray/dev/marcus/logs/marcus_<timestamp>.log
```

You'll see three families of structured lines:

```
request_next_task timing:                  agent=... task=... total_ms=N phases={...}
report_task_progress timing:               agent=... task_id=... status=... total_ms=N phases={...}
create_project_from_description timing:    project_name=... task_count=N total_ms=N phases={...}
```

Each carries ``total_ms`` and a per-phase delta dict. Sum the per-task
overhead (one ``request_next_task`` + one ``report_task_progress``
in_progress + one ``report_task_progress`` completed) across the
task lifetime and compare to wall-clock to quantify where time is
spent.

## Where to look in the code first

| File | Purpose |
|---|---|
| ``src/core/perf_instrumentation.py`` | The new helper — read this first; it's small (154 LOC including docstrings) |
| ``src/marcus_mcp/tools/task.py`` (~line 2625-3420) | ``report_task_progress`` with marks inline at phase boundaries |
| ``src/integrations/nlp_tools.py`` (~line 1430-2130) | ``create_project_from_description`` with marks inline |
| ``src/marcus_mcp/tools/task.py`` (~line 1519-1990) | Existing ``request_next_task`` inline ``_mark`` pattern (the model we're matching) |

## Glossary

| Term | Meaning |
|---|---|
| **Phase timer** | Lightweight wall-clock timer that records named timestamps cumulatively, then converts them to per-phase deltas at log time |
| **``request_next_task``** | MCP tool agents call to pull their next task |
| **``report_task_progress``** | MCP tool agents call to report progress / mark a task complete |
| **``create_project_from_description``** | Top-level entry point that decomposes a project description into a task DAG and writes tasks to the kanban |
| **Phase A** | The setup-time LLM pipeline that runs inside ``create_project_from_description`` — domain discovery, contract generation, decomposition, outcome coverage, scaffold generation |
| **Marcus log file** | ``/Users/lwgray/dev/marcus/logs/marcus_<timestamp>.log`` |

## Behavior change

None at runtime. This PR only ADDS log lines; no existing behavior is
modified. Marks fire on the success-return paths only, matching the
existing pattern in ``request_next_task``. Error returns skip the
log (acceptable — we care about happy-path timings for the cost-tax
question).

## How to verify it works

### Unit tests

```bash
python -m pytest tests/unit/core/test_perf_instrumentation.py -v
```

Expected: 9/9 pass.

### Production smoke

1. Merge this PR
2. Restart Marcus on develop
3. Run a /marcus project end-to-end
4. Grep the log:
   ```bash
   grep "timing:" /Users/lwgray/dev/marcus/logs/marcus_<timestamp>.log
   ```
5. **Expected:** at least one log line of each of the three families
   per completed task; per-phase ``phases={...}`` dicts present and
   summing to ``total_ms`` per line

## Test plan

- [ ] CI green (unit, internal integration, pre-commit, claude-review)
- [ ] All 9 new unit tests pass locally
- [ ] No regressions in broader unit suite
- [ ] mypy clean for all 3 changed source files
- [ ] Production smoke: a full /marcus project produces the three
      timing-line families with sensible numbers

## Related

- PR #631 — perf cache for ``analyze_dependencies`` (the optimization
  that motivated wanting better measurement coverage)
- PR #635 — runner spawn-counter fix (the bug that ate one of our
  recent runs; better instrumentation helps diagnose the next one
  faster)
- Issue #636 — composition+verify pipeline ships unplayable apps
  (the upcoming work that this instrumentation will measure)
- Issue #449 — UserOutcome design (Phase A artifact that this
  instrumentation will help measure)

🤖 Generated with [Claude Code](https://claude.com/claude-code)