### PR TITLE
feat(verification): Phase A + Phase B soft rollout — Marcus authors verifications, gate prefers them, falls back to agent (#636)

### DIFF
--- a/src/ai/advanced/prd/verification_command_generator.py
+++ b/src/ai/advanced/prd/verification_command_generator.py
@@ -1,0 +1,334 @@
+"""
+Setup-time generation of verification commands per :class:`UserOutcome`.
+
+Background
+----------
+Issue #636: Marcus's integration verifier ships unplayable apps when the
+agent authors its own verification commands. The agent has retry pressure
+to keep weakening the command until exit=0; the command that finally
+passes may not actually test the user-facing behavior. Project test58
+(purple-dot-snake-game) shipped without keyboard input because the
+agent's verification for ``outcome_control_snake`` was a trivial check
+that didn't simulate a keypress.
+
+Invariant #2 v2 (CLAUDE.md MULTIAGENCY_PROCLAMATION) moved verification
+ownership from the agent to Marcus's setup-time pipeline. The agent
+still owns implementation (HOW to build the feature); Marcus owns the
+contract (WHAT to build AND HOW to verify it was built correctly).
+This is the contract-net protocol pattern from 1980s MAS literature.
+
+This module is the setup-time piece: given the project's
+:class:`UserOutcome` records (extracted from the spec), it generates a
+:class:`ContractVerification` per outcome — a shell command Marcus runs
+to demonstrate the outcome's ``success_signal`` against the deliverable.
+
+The smoke gate at completion time (issue #636 Phase B, separate PR) will
+prefer these contract-authored commands over agent-supplied ones.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional
+
+from src.ai.advanced.prd.outcome_extractor import UserOutcome
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class ContractVerification:
+    """A setup-time-authored verification command for one user outcome.
+
+    Marcus generates one per in-scope :class:`UserOutcome` during Phase A
+    and stamps the list onto the integration task's
+    ``source_context["contract_verifications"]``. At completion time the
+    smoke gate runs each command as a subprocess.
+
+    Attributes
+    ----------
+    signal_id : str
+        The ``UserOutcome.id`` this verification observes. Required so
+        the smoke gate's coverage check can match verifications to
+        in-scope outcomes (issue #523 Slice B).
+    command : str
+        Shell command Marcus runs as a subprocess in the project's
+        composed ``implementation/`` directory. Exit 0 iff the outcome
+        was demonstrated; non-zero rejects completion.
+    description : str
+        Short human label used in smoke-gate log lines and the blocker
+        message when the verification fails. Helps operators
+        understand which outcome the verifier was observing.
+    readiness_probe : Optional[str]
+        Optional probe command for long-running server-mode commands.
+        When provided, Marcus runs ``command`` in the background and
+        polls ``readiness_probe`` (exit 0 = ready) for up to 15s
+        before killing the background process. Absent => ``command``
+        is one-shot; must exit 0 within 60s.
+    """
+
+    signal_id: str
+    command: str
+    description: str
+    readiness_probe: Optional[str] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Serialize for storage on ``source_context``.
+
+        Returns
+        -------
+        Dict[str, Any]
+            JSON-safe dict matching the existing schema used by the
+            agent-authored verifications in ``report_task_progress``.
+            Compatibility with that schema is intentional: the smoke
+            gate can treat contract-authored and agent-authored entries
+            interchangeably at the run-as-subprocess layer (issue #636
+            Phase B will add the precedence logic above this layer).
+        """
+        d: Dict[str, Any] = {
+            "signal_id": self.signal_id,
+            "command": self.command,
+            "description": self.description,
+        }
+        if self.readiness_probe is not None:
+            d["readiness_probe"] = self.readiness_probe
+        return d
+
+    @classmethod
+    def from_dict(cls, d: Dict[str, Any]) -> "ContractVerification":
+        """Reconstruct from a dict produced by :meth:`to_dict`.
+
+        Raises
+        ------
+        ValueError
+            When required fields are missing or non-string. Matches
+            the strict-validation style of :class:`UserOutcome` —
+            malformed records never enter the pipeline.
+        """
+        for required in ("signal_id", "command", "description"):
+            value = d.get(required)
+            if not isinstance(value, str) or not value.strip():
+                raise ValueError(
+                    f"ContractVerification: field {required!r} must be a "
+                    f"non-empty string, got {value!r}"
+                )
+
+        readiness = d.get("readiness_probe")
+        if readiness is not None and not isinstance(readiness, str):
+            raise ValueError(
+                f"ContractVerification: 'readiness_probe' must be a string "
+                f"or None, got {readiness!r}"
+            )
+
+        return cls(
+            signal_id=d["signal_id"],
+            command=d["command"],
+            description=d["description"],
+            readiness_probe=readiness,
+        )
+
+
+_GENERATION_PROMPT_TEMPLATE = """\
+You are generating a SHELL COMMAND that Marcus will run as a subprocess
+to verify that a user-visible outcome was achieved by a built software
+project.
+
+Outcome ID: {outcome_id}
+User Action: {action}
+Success Signal: {success_signal}
+
+Project description (for tech-stack context):
+{project_description}
+
+The command must satisfy ALL of these requirements:
+
+1. Exit 0 if and only if the Success Signal was demonstrated by the
+   running deliverable. Non-zero exit means the outcome was not
+   demonstrated and the build is incomplete.
+
+2. Actually EXERCISE the user-facing behavior described by the Success
+   Signal. Do NOT just check that files exist or modules can be
+   imported — those checks pass even when the user-facing behavior is
+   broken (the test58 failure mode).
+
+3. Use ONLY tools the project's tech stack already provides. Infer the
+   stack from the project description. If the outcome cannot be
+   verified using tools the stack already includes, return null for
+   the command field — Marcus will surface the gap rather than ship a
+   broken verification.
+
+4. Be runnable as a subprocess from the project's root directory. Use
+   relative paths or paths starting from the project root.
+
+5. Be idempotent: re-running must not leave state behind (no /tmp
+   pollution, no zombie processes, no orphaned databases).
+
+6. For long-running processes (web server, dev server), provide a
+   ``readiness_probe`` — a second shell command Marcus polls until it
+   exits 0, before declaring the process ready. Marcus always kills
+   the background process when the probe is done.
+
+Return strict JSON of the form:
+
+{{
+  "command": "<shell command>" or null,
+  "readiness_probe": "<optional probe command>" or null,
+  "description": "<short human label for log lines>"
+}}
+
+Respond with ONLY the JSON object — no preamble, no markdown fences.
+"""
+
+
+async def generate_verification_command(
+    outcome: UserOutcome,
+    project_description: str,
+    llm_client: Any,
+    max_tokens: int = 800,
+) -> Optional[ContractVerification]:
+    """Generate one :class:`ContractVerification` for a single outcome.
+
+    Calls the LLM once to translate the outcome's ``success_signal``
+    into a runnable shell command. Returns ``None`` when the LLM
+    indicates the outcome cannot be verified with the project's
+    available tooling — caller decides whether to flag the gap, drop
+    the outcome, or raise.
+
+    Parameters
+    ----------
+    outcome : UserOutcome
+        The outcome to generate a verification for. Both in-scope and
+        out-of-scope outcomes are accepted; callers decide whether to
+        skip out-of-scope ones before calling.
+    project_description : str
+        The original project specification, used as tech-stack context
+        in the prompt. The LLM infers from this what tools are
+        available.
+    llm_client : Any
+        Any client exposing ``async analyze(prompt, context)`` and
+        returning a string. Mocked in unit tests.
+    max_tokens : int, optional
+        Token budget for the LLM call. Default 800 — verification
+        commands are short.
+
+    Returns
+    -------
+    Optional[ContractVerification]
+        A populated :class:`ContractVerification`, or ``None`` when
+        the LLM reports the outcome cannot be verified with the
+        available tech stack.
+
+    Raises
+    ------
+    ValueError
+        When the LLM returns malformed JSON, missing required fields,
+        or non-string values in required fields. Strict-fail mirrors
+        :func:`extract_user_outcomes` so malformed records don't
+        silently corrupt the contract.
+    """
+    prompt = _GENERATION_PROMPT_TEMPLATE.format(
+        outcome_id=outcome.id,
+        action=outcome.action,
+        success_signal=outcome.success_signal,
+        project_description=project_description,
+    )
+
+    from src.utils.structured_llm import safe_structured_call
+
+    try:
+        payload = await safe_structured_call(
+            llm=llm_client,
+            prompt=prompt,
+            operation="generate_verification_command",
+            initial_max_tokens=max_tokens,
+        )
+    except (ValueError, json.JSONDecodeError) as exc:
+        raise ValueError(
+            f"Verification-command generator: LLM returned malformed JSON "
+            f"for outcome {outcome.id!r}: {exc}"
+        ) from exc
+
+    command = payload.get("command")
+    if command is None:
+        # LLM explicitly declined — tech stack can't verify this
+        # outcome. Caller surfaces the gap (don't silently drop).
+        logger.info(
+            "Verification-command generator: LLM returned null command for "
+            "outcome %r — tech stack cannot verify this outcome. "
+            "Returning None.",
+            outcome.id,
+        )
+        return None
+
+    if not isinstance(command, str) or not command.strip():
+        raise ValueError(
+            f"Verification-command generator: 'command' must be a "
+            f"non-empty string or null for outcome {outcome.id!r}, got "
+            f"{command!r}"
+        )
+
+    description = payload.get("description") or outcome.success_signal
+    if not isinstance(description, str):
+        raise ValueError(
+            f"Verification-command generator: 'description' must be a "
+            f"string for outcome {outcome.id!r}, got {description!r}"
+        )
+
+    readiness_probe = payload.get("readiness_probe")
+    if readiness_probe is not None and not isinstance(readiness_probe, str):
+        raise ValueError(
+            f"Verification-command generator: 'readiness_probe' must be "
+            f"a string or null for outcome {outcome.id!r}, got "
+            f"{readiness_probe!r}"
+        )
+
+    return ContractVerification(
+        signal_id=outcome.id,
+        command=command.strip(),
+        description=description.strip(),
+        readiness_probe=readiness_probe.strip() if readiness_probe else None,
+    )
+
+
+async def generate_verification_commands(
+    outcomes: List[UserOutcome],
+    project_description: str,
+    llm_client: Any,
+) -> List[ContractVerification]:
+    """Generate verifications for many outcomes concurrently.
+
+    Fans out N LLM calls via ``asyncio.gather`` so total Phase A
+    latency is dominated by the slowest single call, not the sum
+    (Kaia review M4 on PR spec). Outcomes for which the LLM declined
+    to author a command (returned ``None``) are dropped from the
+    result; caller surfaces the gap separately.
+
+    Parameters
+    ----------
+    outcomes : List[UserOutcome]
+        Outcomes to generate verifications for. Caller is responsible
+        for filtering to in-scope outcomes before passing.
+    project_description : str
+        Tech-stack context — passed through to every per-outcome call.
+    llm_client : Any
+        Any client exposing ``async analyze(prompt, context)``.
+
+    Returns
+    -------
+    List[ContractVerification]
+        Successfully-generated verifications, in the input outcome
+        order. May be shorter than ``len(outcomes)`` when some
+        outcomes are unverifiable on the current stack.
+    """
+    if not outcomes:
+        return []
+
+    coroutines = [
+        generate_verification_command(o, project_description, llm_client)
+        for o in outcomes
+    ]
+    results = await asyncio.gather(*coroutines)
+    return [v for v in results if v is not None]

--- a/src/ai/advanced/prd/verification_command_generator.py
+++ b/src/ai/advanced/prd/verification_command_generator.py
@@ -302,9 +302,19 @@ async def generate_verification_commands(
 
     Fans out N LLM calls via ``asyncio.gather`` so total Phase A
     latency is dominated by the slowest single call, not the sum
-    (Kaia review M4 on PR spec). Outcomes for which the LLM declined
-    to author a command (returned ``None``) are dropped from the
-    result; caller surfaces the gap separately.
+    (Kaia review M4 on PR spec).
+
+    Two categories of per-outcome failure are isolated rather than
+    poisoning the whole batch (Kaia P2-2 on PR #642):
+
+    1. The LLM declined the outcome (``generate_verification_command``
+       returned ``None``) — drop the outcome silently. The tech stack
+       cannot verify it; Phase B will surface the gap when it tries
+       to enforce coverage.
+    2. The per-outcome call raised an exception — log a WARNING with
+       the outcome id and the exception, then drop that outcome. The
+       remaining N-1 results still ship. Without ``return_exceptions=True``
+       a single bad LLM response would lose ALL N verifications.
 
     Parameters
     ----------
@@ -321,7 +331,8 @@ async def generate_verification_commands(
     List[ContractVerification]
         Successfully-generated verifications, in the input outcome
         order. May be shorter than ``len(outcomes)`` when some
-        outcomes are unverifiable on the current stack.
+        outcomes are unverifiable on the current stack OR when their
+        per-outcome generator call raised.
     """
     if not outcomes:
         return []
@@ -330,5 +341,22 @@ async def generate_verification_commands(
         generate_verification_command(o, project_description, llm_client)
         for o in outcomes
     ]
-    results = await asyncio.gather(*coroutines)
-    return [v for v in results if v is not None]
+    results = await asyncio.gather(*coroutines, return_exceptions=True)
+
+    verifications: List[ContractVerification] = []
+    for outcome, result in zip(outcomes, results):
+        if isinstance(result, ContractVerification):
+            verifications.append(result)
+        elif isinstance(result, BaseException):
+            # Per-outcome failure — log and drop. Keeps the rest of
+            # the batch alive (P2-2 fix). Failing the whole batch on
+            # any single bad LLM response converts an 11% per-project
+            # partial-failure rate into a 11% complete-loss rate
+            # (assuming ~2% per-call failure, 6 outcomes).
+            logger.warning(
+                "Verification-command generator failed for outcome %r: %s",
+                outcome.id,
+                result,
+            )
+        # else: result is None — LLM declined; gap surfaced by Phase B
+    return verifications

--- a/src/integrations/integration_verification.py
+++ b/src/integrations/integration_verification.py
@@ -194,7 +194,15 @@ class IntegrationTaskGenerator:
             # Invariant #2 v2 (CLAUDE.md MULTIAGENCY_PROCLAMATION).
             # Until Phase B lands the field is present but unused at
             # runtime — keeps this PR fully backwards-compatible.
-            if contract_verifications:
+            #
+            # ``is not None`` (not a truthy check) so an empty list
+            # round-trips: it means "generation ran but the LLM could
+            # not author commands for any in-scope outcome on this
+            # tech stack." Phase B needs to distinguish that from
+            # "generation never happened" (caller is None) to decide
+            # between failing loudly and falling back to legacy
+            # agent-authored verifications. Codex P2 on PR #642.
+            if contract_verifications is not None:
                 source_context["contract_verifications"] = [
                     cv.to_dict() for cv in contract_verifications
                 ]

--- a/src/integrations/integration_verification.py
+++ b/src/integrations/integration_verification.py
@@ -31,6 +31,9 @@ if TYPE_CHECKING:
     # integration layer free of upward dependencies on
     # ``src.ai.advanced.prd``.
     from src.ai.advanced.prd.outcome_extractor import UserOutcome
+    from src.ai.advanced.prd.verification_command_generator import (
+        ContractVerification,
+    )
 
 logger = logging.getLogger(__name__)
 
@@ -61,6 +64,7 @@ class IntegrationTaskGenerator:
         project_name: str = "Project",
         contract_file: Optional[str] = None,
         outcomes: Optional[List["UserOutcome"]] = None,
+        contract_verifications: Optional[List["ContractVerification"]] = None,
     ) -> Optional[Task]:
         """
         Create an integration verification task.
@@ -183,6 +187,17 @@ class IntegrationTaskGenerator:
             source_context = {
                 "in_scope_outcome_ids": [o.id for o in in_scope_outcomes],
             }
+            # Issue #636 Phase A: stash Marcus-authored verification
+            # commands alongside the outcome IDs. Phase B (separate PR)
+            # will wire the smoke gate to prefer these over agent-
+            # supplied ``verifications`` at completion time, per
+            # Invariant #2 v2 (CLAUDE.md MULTIAGENCY_PROCLAMATION).
+            # Until Phase B lands the field is present but unused at
+            # runtime — keeps this PR fully backwards-compatible.
+            if contract_verifications:
+                source_context["contract_verifications"] = [
+                    cv.to_dict() for cv in contract_verifications
+                ]
 
         task = Task(
             id=f"integration_verify_{uuid.uuid4().hex[:8]}",
@@ -956,6 +971,7 @@ def enhance_project_with_integration(
     contract_file: Optional[str] = None,
     functional_requirements: Optional[List[Dict[str, Any]]] = None,
     outcomes: Optional[List["UserOutcome"]] = None,
+    contract_verifications: Optional[List["ContractVerification"]] = None,
 ) -> List[Task]:
     """
     Add integration verification task to project if appropriate.
@@ -1005,7 +1021,11 @@ def enhance_project_with_integration(
         return tasks
 
     task = IntegrationTaskGenerator.create_integration_task(
-        tasks, project_name, contract_file=contract_file, outcomes=outcomes
+        tasks,
+        project_name,
+        contract_file=contract_file,
+        outcomes=outcomes,
+        contract_verifications=contract_verifications,
     )
 
     if task:

--- a/src/integrations/nlp_tools.py
+++ b/src/integrations/nlp_tools.py
@@ -1696,10 +1696,18 @@ class NaturalLanguageProjectCreator(NaturalLanguageTaskCreator):
                                     self.ai_engine,
                                 )
                             )
-                            logger.info(
-                                f"Generated "
-                                f"{len(contract_verifications_list)} "
-                                f"contract verification(s) for "
+                            # WARNING when the empty-list case fires
+                            # (Kaia P3 on PR #642). "We tried to verify
+                            # N outcomes and the tech stack supported
+                            # zero of them" is exactly the operator-
+                            # visible event the Codex P2 fix made
+                            # representable; burying it at INFO defeats
+                            # the point.
+                            _gen_count = len(contract_verifications_list)
+                            _log = logger.warning if _gen_count == 0 else logger.info
+                            _log(
+                                f"Generated {_gen_count} contract "
+                                f"verification(s) for "
                                 f"{len(in_scope_for_verification)} "
                                 f"in-scope outcome(s)"
                             )

--- a/src/integrations/nlp_tools.py
+++ b/src/integrations/nlp_tools.py
@@ -1675,11 +1675,31 @@ class NaturalLanguageProjectCreator(NaturalLanguageTaskCreator):
                 # BEFORE creating the integration task. The list gets
                 # stamped onto the integration task's source_context
                 # so Phase B's smoke-gate change can run them at
-                # completion time (per Invariant #2 v2). Field is
-                # unused at runtime until Phase B; this PR ships the
-                # contract-side wiring only.
+                # completion time (per Invariant #2 v2).
+                #
+                # Eligibility gate (Codex P2 on PR #642):
+                # ``enhance_project_with_integration`` calls
+                # ``should_add_integration_task`` and early-returns
+                # for demo / POC / prototype projects — running the
+                # generator before that check would spend N LLM calls
+                # whose output gets discarded. Mirror the predicate
+                # here so the wasted-call path is closed.
+                from src.integrations.integration_verification import (
+                    IntegrationTaskGenerator,
+                )
+
                 contract_verifications_list = None
-                if stashed_outcomes:
+                integration_eligible = (
+                    IntegrationTaskGenerator.should_add_integration_task(description)
+                )
+                if not integration_eligible:
+                    logger.info(
+                        "Skipping contract verification generation — "
+                        "project doesn't qualify for integration verification "
+                        "(demo / POC / prototype shape per "
+                        "should_add_integration_task)"
+                    )
+                elif stashed_outcomes:
                     from src.ai.advanced.prd.verification_command_generator import (
                         generate_verification_commands,
                     )

--- a/src/integrations/nlp_tools.py
+++ b/src/integrations/nlp_tools.py
@@ -1669,6 +1669,55 @@ class NaturalLanguageProjectCreator(NaturalLanguageTaskCreator):
                 # based wiring is a follow-up — the snake-game class
                 # of failure ships via contract_first, the default.
                 stashed_outcomes = getattr(self, "_contract_first_user_outcomes", None)
+
+                # Issue #636 Phase A: generate Marcus-authored
+                # verification commands for the in-scope outcomes
+                # BEFORE creating the integration task. The list gets
+                # stamped onto the integration task's source_context
+                # so Phase B's smoke-gate change can run them at
+                # completion time (per Invariant #2 v2). Field is
+                # unused at runtime until Phase B; this PR ships the
+                # contract-side wiring only.
+                contract_verifications_list = None
+                if stashed_outcomes:
+                    from src.ai.advanced.prd.verification_command_generator import (
+                        generate_verification_commands,
+                    )
+
+                    in_scope_for_verification = [
+                        o for o in stashed_outcomes if o.scope == "in_scope"
+                    ]
+                    if in_scope_for_verification and self.ai_engine is not None:
+                        try:
+                            contract_verifications_list = (
+                                await generate_verification_commands(
+                                    in_scope_for_verification,
+                                    description,
+                                    self.ai_engine,
+                                )
+                            )
+                            logger.info(
+                                f"Generated "
+                                f"{len(contract_verifications_list)} "
+                                f"contract verification(s) for "
+                                f"{len(in_scope_for_verification)} "
+                                f"in-scope outcome(s)"
+                            )
+                        except Exception as gen_err:  # noqa: BLE001
+                            # Never block project creation on
+                            # verification-command generation failure.
+                            # Falling through leaves the integration
+                            # task's contract_verifications unset, and
+                            # Phase B will fall back to agent-supplied
+                            # (legacy path).
+                            logger.warning(
+                                f"Failed to generate contract "
+                                f"verifications, integration task will "
+                                f"fall back to agent-supplied "
+                                f"verifications at completion time: "
+                                f"{gen_err}"
+                            )
+
                 safe_tasks = enhance_project_with_integration(
                     safe_tasks,
                     description,
@@ -1676,6 +1725,7 @@ class NaturalLanguageProjectCreator(NaturalLanguageTaskCreator):
                     contract_file=contract_file_for_integration,
                     functional_requirements=stashed_requirements,
                     outcomes=stashed_outcomes,
+                    contract_verifications=contract_verifications_list,
                 )
                 logger.info(
                     "After integration enhancement: " f"{len(safe_tasks)} tasks"

--- a/src/marcus_mcp/tools/task.py
+++ b/src/marcus_mcp/tools/task.py
@@ -582,6 +582,100 @@ async def _run_product_smoke_gate(
     required_outcome_ids_for_task: List[str] = (
         list(raw_required) if isinstance(raw_required, list) else []
     )
+
+    # Issue #636 Phase B (soft rollout): if Marcus authored
+    # verification commands at setup time, prefer those over the
+    # agent's. Per Invariant #2 v2 (CLAUDE.md MULTIAGENCY_PROCLAMATION),
+    # the agent owns implementation HOW but not self-verification HOW
+    # — the verification commands are part of the task contract.
+    #
+    # Soft rollout means: contract is TRIED first; agent-supplied is
+    # the FALLBACK. The fallback fires when (a) the contract is
+    # absent / empty, (b) the contract has incomplete coverage of
+    # in-scope outcomes, or (c) the contract path runs but any
+    # verification fails. Each fallback fires a WARNING log so
+    # operators can iterate on the generator prompt over time. Once
+    # the contract is empirically reliable (failure rate well below
+    # the legacy path's), a future PR can promote this to a hard
+    # cutover — but until then the fallback prevents Phase B from
+    # being WORSE than the legacy path.
+    raw_contract = (task.source_context or {}).get("contract_verifications")
+    contract_list: List[Dict[str, Any]] = (
+        list(raw_contract) if isinstance(raw_contract, list) else []
+    )
+    if contract_list:
+        # Build VerificationSpec records from the contract.
+        contract_specs = [
+            VerificationSpec(
+                signal_id=str(v.get("signal_id", "")),
+                command=str(v.get("command", "")),
+                description=str(v.get("description", "") or ""),
+                readiness_probe=(
+                    str(v["readiness_probe"]) if v.get("readiness_probe") else None
+                ),
+            )
+            for v in contract_list
+        ]
+        # Coverage check on the contract: every in-scope outcome
+        # must have a contract verification before we even try
+        # running it. If coverage is incomplete, fall through to
+        # the agent-supplied path rather than partial-verify.
+        contract_signal_ids: set[str] = {
+            spec.signal_id for spec in contract_specs if spec.signal_id
+        }
+        contract_missing = [
+            oid
+            for oid in required_outcome_ids_for_task
+            if oid not in contract_signal_ids
+        ]
+        if contract_missing:
+            logger.warning(
+                "PRODUCT SMOKE GATE: contract has incomplete coverage "
+                "for task %s — missing %d in-scope outcome(s): %s. "
+                "Falling back to agent-supplied verifications.",
+                task.id,
+                len(contract_missing),
+                contract_missing,
+            )
+        else:
+            logger.info(
+                "PRODUCT SMOKE GATE: Running %d contract-authored "
+                "verification(s) for integration task %s at %s",
+                len(contract_specs),
+                task.id,
+                project_root_path,
+            )
+            contract_result = await verify_verification_specs(
+                specs=contract_specs,
+                cwd=project_root_path,
+            )
+            if contract_result.success:
+                logger.info(
+                    "PRODUCT SMOKE GATE: All %d contract "
+                    "verification(s) passed for task %s",
+                    len(contract_specs),
+                    task.id,
+                )
+                return None  # accept via contract
+            logger.warning(
+                "PRODUCT SMOKE GATE: contract verification FAILED for "
+                "task %s — %s. Falling back to agent-supplied "
+                "verifications (Phase B soft rollout).",
+                task.id,
+                contract_result.failure_summary or "(unknown failure)",
+            )
+    elif isinstance(raw_contract, list):
+        # Empty list — generation ran but produced nothing for any
+        # in-scope outcome. Codex P2 distinguished this from
+        # "generation never happened" (raw_contract is None); the
+        # gate logs it explicitly so the operator sees the gap.
+        logger.warning(
+            "PRODUCT SMOKE GATE: contract_verifications is empty for "
+            "task %s — generation ran but the LLM could not author "
+            "commands for any in-scope outcome. Falling back to "
+            "agent-supplied verifications.",
+            task.id,
+        )
     if required_outcome_ids_for_task and not verifications:
         logger.warning(
             "PRODUCT SMOKE GATE: Integration task %s has %d in-scope "

--- a/tests/unit/ai/test_verification_command_generator.py
+++ b/tests/unit/ai/test_verification_command_generator.py
@@ -349,30 +349,42 @@ class TestGenerateVerificationCommands:
         assert result[0].signal_id == "verifiable"
 
     @pytest.mark.asyncio
-    async def test_partial_llm_failure_propagates_via_gather(self):
-        """If one LLM call's payload fails validation, the gather raises.
+    async def test_partial_llm_failure_is_isolated_per_outcome(self, caplog):
+        """One bad LLM call drops that outcome but keeps the rest (P2-2).
 
-        ``asyncio.gather`` with the default ``return_exceptions=False``
-        propagates the first exception. We deliberately don't swallow
-        per-outcome failures inside the generator — the caller in
-        ``nlp_tools.py`` wraps the whole call in try/except so project
-        creation isn't blocked. (The bypass uses a post-parse validation
-        failure rather than a parse failure, because the LLM layer
-        retries on parse errors and we don't want to test that here.)
+        Pre-P2-2, ``asyncio.gather`` defaulted to ``return_exceptions=False``
+        and a single bad LLM response would raise out of the whole batch
+        — losing ALL N verifications because the caller in nlp_tools.py
+        caught the exception and fell back to ``None``. With
+        ``return_exceptions=True``, failures are per-outcome: log a
+        warning and drop just the failing one.
         """
+        import logging
+
         # First call: well-formed. Second: parses but fails validation
-        # (non-string command → strict-fail in generator).
+        # (non-string command → strict-fail in single-outcome generator).
         responses = [
             json.dumps({"command": "ok"}),
             json.dumps({"command": 42}),
         ]
         llm = MagicMock()
         llm.analyze = AsyncMock(side_effect=responses)
-        outcomes = [_outcome(id_="a"), _outcome(id_="b")]
+        outcomes = [_outcome(id_="good"), _outcome(id_="bad")]
 
-        with pytest.raises(ValueError, match="command"):
-            await generate_verification_commands(
+        with caplog.at_level(logging.WARNING):
+            result = await generate_verification_commands(
                 outcomes=outcomes,
                 project_description="x",
                 llm_client=llm,
             )
+
+        # The good outcome survived; the bad one was dropped.
+        assert len(result) == 1
+        assert result[0].signal_id == "good"
+
+        # And the failing outcome's id appears in a warning log line so
+        # operators can see WHY a contract is incomplete.
+        assert any(
+            "bad" in rec.message and rec.levelno == logging.WARNING
+            for rec in caplog.records
+        )

--- a/tests/unit/ai/test_verification_command_generator.py
+++ b/tests/unit/ai/test_verification_command_generator.py
@@ -1,0 +1,378 @@
+"""
+Unit tests for :mod:`src.ai.advanced.prd.verification_command_generator`.
+
+Background
+----------
+Issue #636 Phase A: Marcus generates verification commands per
+:class:`UserOutcome` at setup time so the smoke gate can run
+contract-authored commands at completion time instead of trusting
+agent-authored ones (Invariant #2 v2 in ``CLAUDE.md``).
+
+These tests cover the generator module:
+
+- :class:`ContractVerification` dataclass serialization round-trips
+- :func:`generate_verification_command` LLM contract (success, null,
+  malformed JSON, missing fields)
+- :func:`generate_verification_commands` fan-out semantics (parallelism,
+  partial-failure handling)
+"""
+
+from __future__ import annotations
+
+import json
+from typing import List
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from src.ai.advanced.prd.outcome_extractor import UserOutcome
+from src.ai.advanced.prd.verification_command_generator import (
+    ContractVerification,
+    generate_verification_command,
+    generate_verification_commands,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _outcome(
+    id_: str = "outcome_play",
+    action: str = "user can play the game",
+    success_signal: str = "snake responds to arrow keys",
+    scope: str = "in_scope",
+) -> UserOutcome:
+    """Build a UserOutcome with defaults sufficient for generator tests."""
+    return UserOutcome(
+        id=id_,
+        action=action,
+        success_signal=success_signal,
+        scope=scope,
+    )
+
+
+def _stub_llm(response: str) -> MagicMock:
+    """Return a mock LLM client that yields ``response`` from ``analyze``.
+
+    Mirrors the contract :func:`safe_structured_call` expects: an async
+    ``analyze(prompt, context)`` method returning a string.
+    """
+    client = MagicMock()
+    client.analyze = AsyncMock(return_value=response)
+    return client
+
+
+# ---------------------------------------------------------------------------
+# ContractVerification dataclass — round-trips and validation
+# ---------------------------------------------------------------------------
+
+
+class TestContractVerification:
+    """Round-trip + validation semantics for the dataclass."""
+
+    def test_to_dict_includes_required_fields(self):
+        """``to_dict`` always emits the three required fields."""
+        cv = ContractVerification(
+            signal_id="outcome_play",
+            command="npm test",
+            description="run the test suite",
+        )
+        d = cv.to_dict()
+        assert d == {
+            "signal_id": "outcome_play",
+            "command": "npm test",
+            "description": "run the test suite",
+        }
+
+    def test_to_dict_omits_readiness_probe_when_none(self):
+        """``readiness_probe`` is absent from the dict when not provided.
+
+        Matches the existing agent-authored verification schema where
+        the probe is opt-in.
+        """
+        cv = ContractVerification(
+            signal_id="a",
+            command="x",
+            description="y",
+            readiness_probe=None,
+        )
+        assert "readiness_probe" not in cv.to_dict()
+
+    def test_to_dict_includes_readiness_probe_when_provided(self):
+        """When the probe is set, it appears in the serialized dict."""
+        cv = ContractVerification(
+            signal_id="a",
+            command="vite dev",
+            description="dev server",
+            readiness_probe="curl -f http://localhost:5173",
+        )
+        assert cv.to_dict()["readiness_probe"] == "curl -f http://localhost:5173"
+
+    def test_from_dict_round_trips(self):
+        """``from_dict(to_dict(x)) == x`` for any valid record."""
+        original = ContractVerification(
+            signal_id="outcome_a",
+            command="npm test",
+            description="run tests",
+            readiness_probe="curl -f http://localhost:3000",
+        )
+        round_tripped = ContractVerification.from_dict(original.to_dict())
+        assert round_tripped == original
+
+    def test_from_dict_rejects_missing_required_field(self):
+        """Missing a required field raises ValueError, not silent default."""
+        with pytest.raises(ValueError, match="signal_id"):
+            ContractVerification.from_dict({"command": "x", "description": "y"})
+
+    def test_from_dict_rejects_non_string_required_field(self):
+        """Required fields must be strings; ints / None raise ValueError."""
+        with pytest.raises(ValueError, match="command"):
+            ContractVerification.from_dict(
+                {"signal_id": "a", "command": 42, "description": "y"}
+            )
+
+    def test_from_dict_rejects_empty_string_required_field(self):
+        """Empty strings are rejected — they're a malformed contract."""
+        with pytest.raises(ValueError, match="description"):
+            ContractVerification.from_dict(
+                {"signal_id": "a", "command": "x", "description": "   "}
+            )
+
+    def test_from_dict_rejects_non_string_readiness_probe(self):
+        """A non-string probe value is rejected; None is allowed."""
+        with pytest.raises(ValueError, match="readiness_probe"):
+            ContractVerification.from_dict(
+                {
+                    "signal_id": "a",
+                    "command": "x",
+                    "description": "y",
+                    "readiness_probe": 99,
+                }
+            )
+
+
+# ---------------------------------------------------------------------------
+# generate_verification_command — single-outcome LLM contract
+# ---------------------------------------------------------------------------
+
+
+class TestGenerateVerificationCommand:
+    """The single-outcome generator's LLM contract."""
+
+    @pytest.mark.asyncio
+    async def test_returns_populated_verification_on_well_formed_llm_response(self):
+        """The happy path: LLM returns a valid JSON object → ContractVerification."""
+        llm = _stub_llm(
+            json.dumps(
+                {
+                    "command": "npm test -- --grep arrow-keys",
+                    "readiness_probe": None,
+                    "description": "exercise keyboard input",
+                }
+            )
+        )
+        result = await generate_verification_command(
+            _outcome(),
+            project_description="A snake game built with vanilla JavaScript and Vite.",
+            llm_client=llm,
+        )
+        assert result is not None
+        assert isinstance(result, ContractVerification)
+        assert result.signal_id == "outcome_play"
+        assert result.command == "npm test -- --grep arrow-keys"
+        assert result.description == "exercise keyboard input"
+        assert result.readiness_probe is None
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_llm_returns_null_command(self):
+        """LLM signals 'cannot verify with the available stack' → None."""
+        llm = _stub_llm(
+            json.dumps(
+                {
+                    "command": None,
+                    "readiness_probe": None,
+                    "description": "skipped",
+                }
+            )
+        )
+        result = await generate_verification_command(
+            _outcome(), project_description="bare-bones project", llm_client=llm
+        )
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_strips_whitespace_from_command_and_description(self):
+        """Leading/trailing whitespace in LLM output is normalized away."""
+        llm = _stub_llm(
+            json.dumps(
+                {
+                    "command": "   npm test   ",
+                    "description": "  run tests  ",
+                }
+            )
+        )
+        result = await generate_verification_command(
+            _outcome(), project_description="x", llm_client=llm
+        )
+        assert result is not None
+        assert result.command == "npm test"
+        assert result.description == "run tests"
+
+    @pytest.mark.asyncio
+    async def test_includes_readiness_probe_when_llm_provides_one(self):
+        """Server-mode commands carry the probe through to the dataclass."""
+        llm = _stub_llm(
+            json.dumps(
+                {
+                    "command": "vite dev",
+                    "readiness_probe": "curl -f http://localhost:5173",
+                    "description": "boot dev server",
+                }
+            )
+        )
+        result = await generate_verification_command(
+            _outcome(), project_description="vite app", llm_client=llm
+        )
+        assert result is not None
+        assert result.readiness_probe == "curl -f http://localhost:5173"
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_success_signal_when_description_absent(self):
+        """A missing description field uses the outcome's success_signal."""
+        llm = _stub_llm(json.dumps({"command": "x"}))
+        result = await generate_verification_command(
+            _outcome(success_signal="snake responds to arrows"),
+            project_description="x",
+            llm_client=llm,
+        )
+        assert result is not None
+        assert result.description == "snake responds to arrows"
+
+    @pytest.mark.asyncio
+    async def test_rejects_empty_string_command(self):
+        """Empty command is malformed — strict-fail with ValueError."""
+        llm = _stub_llm(json.dumps({"command": "   "}))
+        with pytest.raises(ValueError, match="command"):
+            await generate_verification_command(
+                _outcome(), project_description="x", llm_client=llm
+            )
+
+    @pytest.mark.asyncio
+    async def test_rejects_non_string_command(self):
+        """Non-string command is malformed — strict-fail with ValueError."""
+        llm = _stub_llm(json.dumps({"command": 42}))
+        with pytest.raises(ValueError, match="command"):
+            await generate_verification_command(
+                _outcome(), project_description="x", llm_client=llm
+            )
+
+    @pytest.mark.asyncio
+    async def test_rejects_non_string_readiness_probe(self):
+        """Non-string readiness_probe — strict-fail with ValueError."""
+        llm = _stub_llm(json.dumps({"command": "x", "readiness_probe": 99}))
+        with pytest.raises(ValueError, match="readiness_probe"):
+            await generate_verification_command(
+                _outcome(), project_description="x", llm_client=llm
+            )
+
+    @pytest.mark.asyncio
+    async def test_rejects_malformed_llm_json(self):
+        """Garbage from the LLM raises ValueError with outcome id in message."""
+        llm = _stub_llm("not json at all")
+        with pytest.raises(ValueError, match="outcome_play"):
+            await generate_verification_command(
+                _outcome(), project_description="x", llm_client=llm
+            )
+
+
+# ---------------------------------------------------------------------------
+# generate_verification_commands — fan-out semantics
+# ---------------------------------------------------------------------------
+
+
+class TestGenerateVerificationCommands:
+    """Fan-out generator's parallelism + partial-failure handling."""
+
+    @pytest.mark.asyncio
+    async def test_empty_input_returns_empty_list_without_llm_call(self):
+        """No outcomes → no LLM calls fired."""
+        llm = MagicMock()
+        llm.analyze = AsyncMock(side_effect=AssertionError("must not call"))
+        result = await generate_verification_commands(
+            outcomes=[], project_description="x", llm_client=llm
+        )
+        assert result == []
+        llm.analyze.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_generates_one_verification_per_outcome(self):
+        """N outcomes → N LLM calls → N verifications when all succeed."""
+        # Each call returns the same shape; test asserts the count.
+        llm = _stub_llm(json.dumps({"command": "npm test", "description": "tests"}))
+        outcomes = [
+            _outcome(id_=f"outcome_{i}", action=f"do thing {i}") for i in range(3)
+        ]
+        result = await generate_verification_commands(
+            outcomes=outcomes,
+            project_description="any",
+            llm_client=llm,
+        )
+        assert len(result) == 3
+        assert llm.analyze.call_count == 3
+        assert [v.signal_id for v in result] == [
+            "outcome_0",
+            "outcome_1",
+            "outcome_2",
+        ]
+
+    @pytest.mark.asyncio
+    async def test_drops_outcomes_for_which_llm_returns_null_command(self):
+        """LLM-null command for one outcome → that outcome is omitted."""
+        # First call returns null; second returns a real command.
+        responses = [
+            json.dumps({"command": None}),
+            json.dumps({"command": "npm test", "description": "tests"}),
+        ]
+        llm = MagicMock()
+        llm.analyze = AsyncMock(side_effect=responses)
+
+        outcomes = [
+            _outcome(id_="unverifiable"),
+            _outcome(id_="verifiable"),
+        ]
+        result = await generate_verification_commands(
+            outcomes=outcomes,
+            project_description="x",
+            llm_client=llm,
+        )
+
+        assert len(result) == 1
+        assert result[0].signal_id == "verifiable"
+
+    @pytest.mark.asyncio
+    async def test_partial_llm_failure_propagates_via_gather(self):
+        """If one LLM call's payload fails validation, the gather raises.
+
+        ``asyncio.gather`` with the default ``return_exceptions=False``
+        propagates the first exception. We deliberately don't swallow
+        per-outcome failures inside the generator — the caller in
+        ``nlp_tools.py`` wraps the whole call in try/except so project
+        creation isn't blocked. (The bypass uses a post-parse validation
+        failure rather than a parse failure, because the LLM layer
+        retries on parse errors and we don't want to test that here.)
+        """
+        # First call: well-formed. Second: parses but fails validation
+        # (non-string command → strict-fail in generator).
+        responses = [
+            json.dumps({"command": "ok"}),
+            json.dumps({"command": 42}),
+        ]
+        llm = MagicMock()
+        llm.analyze = AsyncMock(side_effect=responses)
+        outcomes = [_outcome(id_="a"), _outcome(id_="b")]
+
+        with pytest.raises(ValueError, match="command"):
+            await generate_verification_commands(
+                outcomes=outcomes,
+                project_description="x",
+                llm_client=llm,
+            )

--- a/tests/unit/integrations/test_integration_verification.py
+++ b/tests/unit/integrations/test_integration_verification.py
@@ -1411,3 +1411,106 @@ class TestIntegrationTaskOutcomesWiring:
         assert (integration_task.source_context or {}).get("in_scope_outcome_ids") == [
             "outcome_play"
         ]
+
+    # ------------------------------------------------------------------
+    # Issue #636 Phase A: contract_verifications parameter
+    # ------------------------------------------------------------------
+
+    def test_contract_verifications_absent_when_parameter_not_passed(
+        self, sample_tasks: list[Task]
+    ) -> None:
+        """No ``contract_verifications`` kwarg → field not stamped."""
+        from src.integrations.integration_verification import (
+            IntegrationTaskGenerator,
+        )
+
+        outcomes = [_user_outcome("outcome_play", "user can play", "snake moves")]
+        task = IntegrationTaskGenerator.create_integration_task(
+            sample_tasks, project_name="Snake", outcomes=outcomes
+        )
+        assert task is not None
+        # in_scope_outcome_ids is present (existing Slice B behavior),
+        # but contract_verifications is absent — distinguishes
+        # "generation never happened" from later cases.
+        assert (task.source_context or {}).get("contract_verifications") is None
+
+    def test_contract_verifications_absent_when_parameter_is_none(
+        self, sample_tasks: list[Task]
+    ) -> None:
+        """``contract_verifications=None`` → field not stamped."""
+        from src.integrations.integration_verification import (
+            IntegrationTaskGenerator,
+        )
+
+        outcomes = [_user_outcome("outcome_play", "user can play", "snake moves")]
+        task = IntegrationTaskGenerator.create_integration_task(
+            sample_tasks,
+            project_name="Snake",
+            outcomes=outcomes,
+            contract_verifications=None,
+        )
+        assert task is not None
+        assert (task.source_context or {}).get("contract_verifications") is None
+
+    def test_contract_verifications_empty_list_is_stamped(
+        self, sample_tasks: list[Task]
+    ) -> None:
+        """Empty list round-trips intact (Codex P2 on PR #642).
+
+        An empty list means "generation ran but the LLM could not
+        author commands for any in-scope outcome on this tech stack."
+        Phase B's gate must distinguish that from "generation never
+        happened" (which is ``None``) — the former should surface the
+        gap; the latter should fall back to legacy agent-authored
+        verifications.
+        """
+        from src.ai.advanced.prd.verification_command_generator import (
+            ContractVerification,
+        )
+        from src.integrations.integration_verification import (
+            IntegrationTaskGenerator,
+        )
+
+        outcomes = [_user_outcome("outcome_play", "user can play", "snake moves")]
+        empty_verifications: list[ContractVerification] = []
+        task = IntegrationTaskGenerator.create_integration_task(
+            sample_tasks,
+            project_name="Snake",
+            outcomes=outcomes,
+            contract_verifications=empty_verifications,
+        )
+        assert task is not None
+        assert (task.source_context or {}).get("contract_verifications") == []
+
+    def test_contract_verifications_populated_list_is_stamped(
+        self, sample_tasks: list[Task]
+    ) -> None:
+        """Non-empty list stamps the dict-serialized records."""
+        from src.ai.advanced.prd.verification_command_generator import (
+            ContractVerification,
+        )
+        from src.integrations.integration_verification import (
+            IntegrationTaskGenerator,
+        )
+
+        outcomes = [_user_outcome("outcome_play", "user can play", "snake moves")]
+        verifications = [
+            ContractVerification(
+                signal_id="outcome_play",
+                command="npm test -- --grep arrow-keys",
+                description="exercise keyboard input",
+            ),
+        ]
+        task = IntegrationTaskGenerator.create_integration_task(
+            sample_tasks,
+            project_name="Snake",
+            outcomes=outcomes,
+            contract_verifications=verifications,
+        )
+        assert task is not None
+        cv_list = (task.source_context or {}).get("contract_verifications")
+        assert cv_list is not None
+        assert len(cv_list) == 1
+        assert cv_list[0]["signal_id"] == "outcome_play"
+        assert cv_list[0]["command"] == "npm test -- --grep arrow-keys"
+        assert cv_list[0]["description"] == "exercise keyboard input"

--- a/tests/unit/marcus_mcp/test_integration_smoke_gate.py
+++ b/tests/unit/marcus_mcp/test_integration_smoke_gate.py
@@ -1136,3 +1136,288 @@ class TestVerificationsRequiredWhenOutcomesDeclared:
         # Legacy path ran successfully.
         assert response is None
         mock_legacy.assert_awaited_once()
+
+
+def _make_integration_task_with_contract(
+    *,
+    in_scope_outcome_ids: list[str],
+    contract_verifications: list[dict] | None,
+    task_id: str = "int-soft",
+) -> Task:
+    """Build an integration task carrying contract verifications.
+
+    ``contract_verifications=None`` means the field is absent from
+    source_context (Phase A generator never ran). ``[]`` means
+    generation ran but produced nothing (Codex P2 case). Both are
+    valid input states for the soft-rollout test cases below.
+    """
+    src_ctx: dict = {"in_scope_outcome_ids": in_scope_outcome_ids}
+    if contract_verifications is not None:
+        src_ctx["contract_verifications"] = contract_verifications
+    return Task(
+        id=task_id,
+        name="Integration verification for Soft-Rollout Project",
+        description="Build and verify",
+        status=TaskStatus.IN_PROGRESS,
+        priority=Priority.HIGH,
+        assigned_to="agent-001",
+        created_at=datetime.now(timezone.utc),
+        updated_at=datetime.now(timezone.utc),
+        due_date=None,
+        estimated_hours=1.0,
+        labels=["integration", "verification", "type:integration"],
+        source_context=src_ctx,
+    )
+
+
+class TestPhaseBSoftRollout:
+    """Phase B (#636): prefer Marcus-authored contract verifications;
+    fall back to agent-supplied on absence, empty, incomplete coverage,
+    or any failure. Fallback is the safety net while the LLM-based
+    generator (PR #642 Phase A) is being hardened.
+    """
+
+    @pytest.mark.asyncio
+    async def test_contract_accept_skips_agent_path(self, tmp_path: Path) -> None:
+        """Contract present with full coverage and all pass ->
+        accept via contract; the agent-supplied path is not run.
+        """
+        from src.integrations.product_smoke import VerificationsResult
+
+        task = _make_integration_task_with_contract(
+            in_scope_outcome_ids=["o1"],
+            contract_verifications=[
+                {
+                    "signal_id": "o1",
+                    "command": "true",
+                    "description": "demonstrates o1",
+                }
+            ],
+        )
+        state = _make_state(task, project_root=str(tmp_path))
+
+        contract_pass = VerificationsResult(success=True, spec_results=[])
+        with patch(
+            "src.integrations.product_smoke.verify_verification_specs",
+            new_callable=AsyncMock,
+            return_value=contract_pass,
+        ) as mock_specs:
+            response = await _run_product_smoke_gate(
+                task=task,
+                agent_id="agent-001",
+                state=state,
+                start_command=None,
+                readiness_probe=None,
+                # Agent supplied a parallel set — but contract wins,
+                # so this list is never consulted.
+                verifications=[
+                    {"signal_id": "o1", "command": "false", "description": "x"}
+                ],
+            )
+
+        assert response is None
+        # Called exactly once — with the contract specs, not the
+        # agent-supplied ones.
+        mock_specs.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_contract_failure_falls_back_to_agent_supplied(
+        self, tmp_path: Path
+    ) -> None:
+        """Contract verification fails -> WARNING logged, fall through
+        to agent-supplied path. If agent's verifications pass, the
+        completion is accepted (legacy gameability preserved as the
+        fallback safety net — strict M3 will close this later)."""
+        from src.integrations.product_smoke import VerificationsResult
+
+        task = _make_integration_task_with_contract(
+            in_scope_outcome_ids=["o1"],
+            contract_verifications=[
+                {"signal_id": "o1", "command": "false", "description": "fails"}
+            ],
+        )
+        state = _make_state(task, project_root=str(tmp_path))
+
+        # First call (contract) fails; second call (agent) passes.
+        contract_fail = VerificationsResult(
+            success=False,
+            spec_results=[],
+            failure_summary="contract command failed",
+        )
+        agent_pass = VerificationsResult(success=True, spec_results=[])
+
+        with patch(
+            "src.integrations.product_smoke.verify_verification_specs",
+            new_callable=AsyncMock,
+            side_effect=[contract_fail, agent_pass],
+        ) as mock_specs:
+            response = await _run_product_smoke_gate(
+                task=task,
+                agent_id="agent-001",
+                state=state,
+                start_command=None,
+                readiness_probe=None,
+                verifications=[
+                    {"signal_id": "o1", "command": "true", "description": "ok"}
+                ],
+            )
+
+        # Accepted via the fallback.
+        assert response is None
+        # Verifier was called twice: once for contract, once for agent.
+        assert mock_specs.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_contract_incomplete_coverage_falls_back_to_agent(
+        self, tmp_path: Path
+    ) -> None:
+        """Contract missing coverage for one in-scope outcome ->
+        WARNING, fall through to agent-supplied. Don't partial-verify."""
+        from src.integrations.product_smoke import VerificationsResult
+
+        task = _make_integration_task_with_contract(
+            in_scope_outcome_ids=["o1", "o2"],
+            # Contract only covers o1; o2 is missing
+            contract_verifications=[
+                {"signal_id": "o1", "command": "true", "description": "ok"}
+            ],
+        )
+        state = _make_state(task, project_root=str(tmp_path))
+
+        agent_pass = VerificationsResult(success=True, spec_results=[])
+        with patch(
+            "src.integrations.product_smoke.verify_verification_specs",
+            new_callable=AsyncMock,
+            return_value=agent_pass,
+        ) as mock_specs:
+            response = await _run_product_smoke_gate(
+                task=task,
+                agent_id="agent-001",
+                state=state,
+                start_command=None,
+                readiness_probe=None,
+                verifications=[
+                    {"signal_id": "o1", "command": "true", "description": "ok"},
+                    {"signal_id": "o2", "command": "true", "description": "ok"},
+                ],
+            )
+
+        assert response is None
+        # Only the agent-supplied call ran; contract was skipped
+        # entirely because coverage was incomplete.
+        mock_specs.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_contract_empty_list_falls_back_to_agent(
+        self, tmp_path: Path
+    ) -> None:
+        """Contract is ``[]`` (Codex P2 case — generation ran but the
+        LLM declined every outcome) -> WARNING, fall through to agent-
+        supplied. Empty list IS distinguishable from absent (semantics
+        from Codex P2 fix on PR #642)."""
+        from src.integrations.product_smoke import VerificationsResult
+
+        task = _make_integration_task_with_contract(
+            in_scope_outcome_ids=["o1"],
+            contract_verifications=[],  # empty, not None
+        )
+        state = _make_state(task, project_root=str(tmp_path))
+
+        agent_pass = VerificationsResult(success=True, spec_results=[])
+        with patch(
+            "src.integrations.product_smoke.verify_verification_specs",
+            new_callable=AsyncMock,
+            return_value=agent_pass,
+        ) as mock_specs:
+            response = await _run_product_smoke_gate(
+                task=task,
+                agent_id="agent-001",
+                state=state,
+                start_command=None,
+                readiness_probe=None,
+                verifications=[
+                    {"signal_id": "o1", "command": "true", "description": "ok"}
+                ],
+            )
+
+        assert response is None
+        # Agent-supplied was the only path that ran.
+        mock_specs.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_contract_absent_uses_legacy_agent_path(self, tmp_path: Path) -> None:
+        """Contract field absent (Phase A never ran for this project) ->
+        existing agent-supplied behavior unchanged. This is the
+        backwards-compatible path for projects created before Phase A
+        shipped."""
+        from src.integrations.product_smoke import VerificationsResult
+
+        task = _make_integration_task_with_contract(
+            in_scope_outcome_ids=["o1"],
+            contract_verifications=None,  # field absent
+        )
+        state = _make_state(task, project_root=str(tmp_path))
+
+        agent_pass = VerificationsResult(success=True, spec_results=[])
+        with patch(
+            "src.integrations.product_smoke.verify_verification_specs",
+            new_callable=AsyncMock,
+            return_value=agent_pass,
+        ) as mock_specs:
+            response = await _run_product_smoke_gate(
+                task=task,
+                agent_id="agent-001",
+                state=state,
+                start_command=None,
+                readiness_probe=None,
+                verifications=[
+                    {"signal_id": "o1", "command": "true", "description": "ok"}
+                ],
+            )
+
+        assert response is None
+        mock_specs.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_contract_failure_with_no_agent_supplied_rejects(
+        self, tmp_path: Path
+    ) -> None:
+        """Contract fails AND agent did not supply -> the existing
+        escape-hatch rejection fires (in-scope outcomes + no
+        verifications). Soft rollout does not bypass the existing
+        gate when neither path can verify."""
+        from src.integrations.product_smoke import VerificationsResult
+
+        task = _make_integration_task_with_contract(
+            in_scope_outcome_ids=["o1"],
+            contract_verifications=[
+                {"signal_id": "o1", "command": "false", "description": "fails"}
+            ],
+        )
+        state = _make_state(task, project_root=str(tmp_path))
+
+        contract_fail = VerificationsResult(
+            success=False,
+            spec_results=[],
+            failure_summary="contract command failed",
+        )
+        with patch(
+            "src.integrations.product_smoke.verify_verification_specs",
+            new_callable=AsyncMock,
+            return_value=contract_fail,
+        ):
+            response = await _run_product_smoke_gate(
+                task=task,
+                agent_id="agent-001",
+                state=state,
+                start_command=None,
+                readiness_probe=None,
+                verifications=None,  # agent didn't supply
+            )
+
+        # Escape-hatch fires: in_scope outcomes set + no agent
+        # verifications. The existing Slice B rejection path runs
+        # AFTER the contract path falls through.
+        assert response is not None
+        assert response.get("success") is False
+        assert response.get("error") == "verifications_required_but_missing"


### PR DESCRIPTION
**Bundle of Phase A + Phase B for issue #636.** Implements
Invariant #2 v2 (CLAUDE.md MULTIAGENCY_PROCLAMATION, PR #639):
verification command authorship moves from the integration agent
to Marcus's setup-time pipeline; the runtime smoke gate prefers
contract-authored commands and falls back to agent-supplied on
absence, empty, incomplete coverage, or runtime failure.

## What this PR does, in plain English

Marcus today builds software by spawning AI agents in parallel.
After they all finish, an integration-verifier agent confirms the
system works. Until now the agent **chose what verification commands
to run** — and because the agent has retry pressure to keep weakening
commands until exit 0, they ended up shipping commands that
technically passed without actually testing the user-facing
behavior. Project test58 (purple-dot-snake-game) shipped unplayable
because the agent's verification for the "keyboard input" outcome
never simulated a keypress.

This PR moves verification authorship to Marcus. At project setup
(Phase A), Marcus generates one shell command per in-scope user
outcome via an LLM call. At completion (Phase B), Marcus's smoke
gate prefers those contract-authored commands over the agent's.

**Soft rollout:** if Marcus's command is wrong (absent, broken,
incomplete coverage), the gate falls back to the agent's verifications.
Each fallback fires a WARNING log so operators can iterate on the
generator prompt over time. Once the contract path is empirically
reliable, a future PR will promote to a hard cutover.

## Why soft rollout, not hard cutover

The hard-cutover plan was "contract present -> trust absolutely."
Pre-merge Kaia review pushed back: without #643's scaffold-stack
enforcement, Phase A's LLM-generated commands will reference
unavailable tools, wrong paths, vacuous checks. A buggy contract
under hard cutover blocks ALL completions; under soft rollout it
loses to the agent-supplied fallback with a WARNING that lets us
iterate.

Honest trade-off: Phase B does NOT eliminate the gameability that
motivated #636. It makes the gameability the FALLBACK instead of
the default. As contract reliability grows (via #643), the fallback
fires less.

## What changed

| File | Change |
|---|---|
| `src/ai/advanced/prd/verification_command_generator.py` (new) | `ContractVerification` typed dataclass + per-outcome LLM generator + parallelized fan-out via `asyncio.gather(return_exceptions=True)` for per-outcome isolation |
| `src/integrations/integration_verification.py` | `create_integration_task` + `enhance_project_with_integration` accept `contract_verifications` parameter; stamps `source_context["contract_verifications"]` (preserves empty list per Codex P2) |
| `src/integrations/nlp_tools.py` (`create_project_from_description`) | Fans out the generator on in-scope outcomes before creating the integration task; wraps in try/except so generation failure never blocks project creation; WARNING log when generated count is 0 |
| `src/marcus_mcp/tools/task.py::_run_product_smoke_gate` | NEW: contract-first try-then-fall-through block BEFORE the existing Slice B escape-hatch. Each fallback case fires WARNING. |
| `tests/unit/ai/test_verification_command_generator.py` (new) | 21 tests: dataclass round-trip, single-outcome generator, fan-out isolation under partial failure |
| `tests/unit/integrations/test_integration_verification.py` | 4 new tests: `contract_verifications` parameter (absent / None / empty list / populated) |
| `tests/unit/marcus_mcp/test_integration_smoke_gate.py` | `TestPhaseBSoftRollout` class with 6 tests covering all fallback modes |

## Commit chain

| Commit | What |
|---|---|
| `302a5809` | Phase A: generator module + integration-task parameter + caller wiring + 21 tests |
| `87d7fed1` | Codex P2 fix: preserve `[]` (distinct from `None`) on `source_context` |
| `7c44b187` | Kaia P2-2 + P3: `asyncio.gather(return_exceptions=True)` isolation + WARNING-level log on empty result |
| `ba1fde95` | Phase B: smoke-gate contract-first soft rollout + 6 new tests |

## How the contract flows (worked example)

Project ``test58`` style — 6 in-scope outcomes:

1. **Phase A** runs at project creation:
   ```
   asyncio.gather(
       generate_verification_command(outcome_play_snake, ...),
       generate_verification_command(outcome_control_snake, ...),
       ... 6 in parallel ...
   )
   ```
   N LLM calls, ~5s wall-clock total. Maybe 4 succeed, 1 LLM returns
   null (tech stack can't verify that outcome), 1 raises. Result: 4
   ContractVerification objects.

2. **Integration task** carries `source_context["contract_verifications"]`
   with those 4 dicts (Codex P2 preservation: even if the list were
   empty, it round-trips intact).

3. **Phase B** at agent completion:
   - Gate reads `source_context["contract_verifications"]` — 4 entries
   - Coverage check: 6 in_scope outcomes, only 4 covered -> incomplete
   - WARNING: "contract has incomplete coverage for task X — missing
     2 in-scope outcome(s)"
   - Fall through to agent-supplied path (existing Slice B behavior)
   - If agent supplied verifications and they pass: accept (fallback)
   - If agent didn't supply: existing rejection fires

In the happy-path case (all 6 LLM calls succeed AND all 6 commands
pass at runtime), the agent's path is never consulted — completion
is accepted via contract.

## Glossary

| Term | Meaning |
|---|---|
| **Phase A** | Marcus's setup-time pipeline. Adds `generate_verification_command` LLM call per in-scope `UserOutcome`. |
| **Phase B** | Runtime completion gate. Reads contract verifications; falls back to agent-supplied on failure. |
| **`UserOutcome`** | User-visible capability the spec promises (`id`, `action`, `success_signal`, `scope`). Extracted by `outcome_extractor.py`. |
| **`ContractVerification`** | New dataclass added in this PR. Pairs `signal_id` (`UserOutcome.id`) with the shell `command` Marcus runs. |
| **Soft rollout** | Contract preferred at runtime; agent-supplied is fallback. As opposed to hard cutover (contract absolute, agent dead). |
| **Contract-net protocol** | 1980s MAS pattern: manager specifies WHAT + HOW-TO-VERIFY; bidder implements. Preserves bidder autonomy on implementation. |

## How to verify it works

### Unit tests
```bash
python -m pytest tests/unit/ai/test_verification_command_generator.py tests/unit/integrations/test_integration_verification.py tests/unit/marcus_mcp/test_integration_smoke_gate.py -v
```
Expected: all pass. Currently 21 + 4 + 33 = **58 tests in scope, all passing**.

### Production smoke
1. Run a /marcus project end-to-end on this branch
2. After project creation, inspect the kanban for the integration
   task's `source_context["contract_verifications"]`
3. **Expected:** the field is populated with one dict per in-scope
   outcome the LLM didn't decline
4. Wait for the integration agent to complete the run
5. Grep the Marcus log for `PRODUCT SMOKE GATE`:
   - **Happy path:** "Running N contract-authored verification(s)..."
     followed by "All N contract verification(s) passed for task X"
   - **Fallback path:** "contract verification FAILED" or
     "contract has incomplete coverage" WARNING, followed by the
     existing Slice B agent-supplied flow
6. The first batch of real projects will reveal how reliable the
   generator is — fallback frequency tells us how much #643's
   scaffold-stack work is needed.

## Test plan

- [ ] CI green (unit, internal integration, pre-commit, claude-review)
- [ ] All 58 in-scope tests pass
- [ ] No regressions in broader unit suite
- [ ] mypy clean for all 4 changed source files
- [ ] Production smoke: a real /marcus project shows contract verifications
      on the integration task's source_context
- [ ] Production smoke: Marcus log shows either "contract passed" or
      "fall back to agent-supplied" with WARNING — never a silent
      regression

## Related

- Issue #636 — umbrella
- PR #639 — Invariant #2 v2 doc landed first
- #643 — scaffold-stack constraint follow-up (will reduce fallback frequency)
- #644 — Cato cost-tracking: verification group
- #645 — Epictetus multi-agent transcript refactor
- Simon decisions: `b8599a52` (philosophy), thoughts `77ade35a` + `a4219ac9` (Kaia reviews)

🤖 Generated with [Claude Code](https://claude.com/claude-code)