### PR TITLE
fix(#649): trivial-spec baseline — domain floor + spec_coverage skip + tech-stack honoring + composer build gate

### DIFF
--- a/src/ai/advanced/prd/advanced_parser.py
+++ b/src/ai/advanced/prd/advanced_parser.py
@@ -484,7 +484,9 @@ class AdvancedPRDParser:
         # Fallback to default
         return default_minutes
 
-    def _build_augmenter_chain(self) -> Sequence[GraphAugmenter]:
+    def _build_augmenter_chain(
+        self, complexity_mode: Optional[str] = None
+    ) -> Sequence[GraphAugmenter]:
         """Build the canonical pre-inference augmenter chain.
 
         Single source of truth for the chain order, used by both
@@ -494,6 +496,14 @@ class AdvancedPRDParser:
         ``OutcomeCoverageAugmenter`` so it sees any outcome gap-fill
         tasks when scoring spec feature coverage (locked by
         ``test_second_augmenter_sees_first_augmenter_tasks``).
+
+        Parameters
+        ----------
+        complexity_mode : Optional[str]
+            Forwarded to :class:`SpecCoverageAugmenter` so prototype
+            projects skip spec_coverage's redundant keyword-based
+            gap-fill (bug #649 root cause 4).  ``None`` preserves the
+            legacy behavior for non-prototype runs.
 
         Returns
         -------
@@ -505,7 +515,7 @@ class AdvancedPRDParser:
         """
         return [
             OutcomeCoverageAugmenter(llm_client=self.llm_client),
-            SpecCoverageAugmenter(),
+            SpecCoverageAugmenter(complexity_mode=complexity_mode),
         ]
 
     async def parse_prd_to_tasks(
@@ -558,7 +568,7 @@ class AdvancedPRDParser:
         # feature-based outcome-coverage path; spec_coverage ignores
         # the parameter (operates on spec text, not contracts).
         augmenter_result = await run_augmenter_chain(
-            self._build_augmenter_chain(),
+            self._build_augmenter_chain(complexity_mode=constraints.complexity_mode),
             prd_analysis=prd_analysis,
             tasks=tasks,
             contract_artifacts=None,
@@ -1057,7 +1067,7 @@ class AdvancedPRDParser:
         # empty telemetry on flag off / no outcomes / LLM error.
         chain_input_tasks = list(pre_existing_tasks or []) + tasks
         return await run_augmenter_chain(
-            self._build_augmenter_chain(),
+            self._build_augmenter_chain(complexity_mode=constraints.complexity_mode),
             prd_analysis=prd_analysis,
             tasks=chain_input_tasks,
             contract_artifacts=contract_artifacts,
@@ -1706,7 +1716,9 @@ Return ONLY the JSON object. Do not include commentary.
             raise ai_error
 
     async def _discover_domains(
-        self, functional_requirements: List[Dict[str, Any]]
+        self,
+        functional_requirements: List[Dict[str, Any]],
+        complexity_mode: Optional[str] = None,
     ) -> Dict[str, List[str]]:
         """
         Use AI to discover natural domain groupings from functional requirements.
@@ -1715,6 +1727,15 @@ Return ONLY the JSON object. Do not include commentary.
         ----------
         functional_requirements : List[Dict[str, Any]]
             List of functional requirements with id, name, description, etc.
+        complexity_mode : Optional[str]
+            Project complexity mode: ``"prototype"``, ``"standard"``,
+            or ``"enterprise"``. When ``"prototype"``, the prompt asks
+            the LLM for exactly 1 domain so trivial projects (snake
+            game, todo app, etc.) don't get split into multiple
+            domains. This honors the prototype-mode contract of
+            "speed over granularity" — see bug #649 root cause 3.
+            ``None`` or any non-prototype value falls back to the
+            size-based floor below.
 
         Returns
         -------
@@ -1744,10 +1765,20 @@ Return ONLY the JSON object. Do not include commentary.
 
         features_text = "\n\n".join(feature_list)
 
-        # Determine target number of domains based on project size
+        # Determine target number of domains based on project size.
+        #
+        # Bug #649 root cause 3: prototype mode now forces a single
+        # domain so trivial projects (≤5 features) don't get split
+        # into "Game Physics" + "Game Presentation" for a 50-line
+        # snake game. For non-prototype small projects the floor was
+        # lowered from "2-3" to "1-3" so the LLM can still return 1
+        # when the project genuinely fits one domain — without
+        # preventing 2-3 when warranted.
         num_features = len(functional_requirements)
-        if num_features <= 5:
-            target_domains = "2-3"
+        if complexity_mode == "prototype":
+            target_domains = "1"
+        elif num_features <= 5:
+            target_domains = "1-3"
         elif num_features <= 15:
             target_domains = "3-5"
         elif num_features <= 30:
@@ -1999,8 +2030,12 @@ Create design artifacts such as:
         # Get complexity mode from constraints (passed from create_project)
         complexity_mode = constraints.complexity_mode
 
-        # STEP 1: Discover domains from functional requirements
-        domains = await self._discover_domains(functional_requirements)
+        # STEP 1: Discover domains from functional requirements.
+        # Bug #649 root cause 3: forward ``complexity_mode`` so prototype
+        # projects collapse to a single domain (no over-decomposition).
+        domains = await self._discover_domains(
+            functional_requirements, complexity_mode=complexity_mode
+        )
         logger.info(f"Discovered {len(domains)} domains: {list(domains.keys())}")
 
         # STEP 2: Create bundled design tasks (one per domain)

--- a/src/integrations/composition_synthesis.py
+++ b/src/integrations/composition_synthesis.py
@@ -75,11 +75,19 @@ def _build_composition_description(project_name: str) -> str:
       downstream tools can verify wiring happened
     - Require ``log_artifact`` for the wired file (file-level surface
       for the structured-decision metadata)
+    - Mandate a build-verification gate (bug #649 root cause 2): the
+      composed product must actually build before the task is
+      reported complete.  Marcus says WHAT must be true (build exits
+      0, dev server probe returns 2xx); the agent picks HOW to
+      satisfy.  This is Invariant #2 v2 applied at the composition
+      task — verification belongs to Marcus, agents own only the
+      implementation HOW.
 
     Bright-line guard: the description must NOT name a specific entry
     point file (e.g., ``"the entry point is App.tsx"``).  Multiple
     examples are listed; the agent picks which applies to their
-    scaffold.
+    scaffold.  Similarly the build-verification step lists multiple
+    stack-keyed commands so Marcus does not prescribe one.
     """
     return (
         f"Wire {project_name}'s implementation domains into a working "
@@ -95,8 +103,35 @@ def _build_composition_description(project_name: str) -> str:
         f"the wiring approach (DI container, direct mounting, etc.).\n"
         f"3. Call log_artifact for the entry-point file you modified "
         f"so downstream verification can locate it.\n"
-        f"4. Verify the composed product runs (smoke test the "
-        f"composition root)."
+        f"4. MANDATORY BUILD VERIFICATION (bug #649 root cause 2): "
+        f"Before reporting this task at 100%, run a build command "
+        f"appropriate to the project's stated tech stack and confirm "
+        f"it exits 0.  Examples (pick the one that matches your "
+        f"scaffold's package manifest — do not run all of them):\n"
+        f"   - JavaScript/TypeScript with Vite/Webpack: ``npm run "
+        f"build``\n"
+        f"   - Python project with build module: ``python -m build``\n"
+        f"   - Rust: ``cargo build``\n"
+        f"   - Other stacks: the equivalent command for the build "
+        f"tool your scaffold actually uses.\n"
+        f"   If the build fails with unresolved imports, missing "
+        f"modules, or path-alias mismatches (the verify-snake-3 "
+        f"failure mode), FIX the imports before reporting done.  "
+        f"Reconcile competing config files (e.g., do not leave both "
+        f"vite.config.js and vite.config.ts in the project when only "
+        f"one is in use).\n"
+        f"5. MANDATORY DEV-SERVER PROBE when applicable: For "
+        f"projects with a runnable dev server (vite, webpack-dev-"
+        f"server, python http.server, etc.), boot the server in the "
+        f"background, ``curl -f`` the root URL to confirm 2xx, then "
+        f"kill the server.  Composition is not done if the running "
+        f"app fails to boot or returns 5xx.\n"
+        f"6. DO NOT MARK THIS TASK COMPLETE on a broken build.  If "
+        f"the build or dev-server probe cannot pass after a "
+        f"reasonable fix attempt, report a blocker instead — the "
+        f"smoke gate downstream will reject the project anyway, and "
+        f"reporting complete-with-broken-build is the failure mode "
+        f"bug #649 was filed to prevent."
     )
 
 

--- a/src/integrations/nlp_tools.py
+++ b/src/integrations/nlp_tools.py
@@ -1273,9 +1273,13 @@ class NaturalLanguageProjectCreator(NaturalLanguageTaskCreator):
             "2. Shared Components: reusable UI or logic components (Card, "
             "Button, API client) — needed when ≥2 domains will use the "
             "same component.\n"
-            "3. Tech Foundation: shared configuration (TypeScript config, "
-            "routing, test harness) — needed when agents would duplicate "
-            "this setup independently.\n\n"
+            "3. Tech Foundation: shared build/tooling configuration "
+            "matching the project's stated tech stack (e.g., the build "
+            "tool config, router setup, test harness for whatever "
+            "language the spec asks for) — needed when agents would "
+            "duplicate this setup independently. Do NOT assume "
+            "TypeScript; honor the language the spec actually states "
+            "(bug #649 root cause 1).\n\n"
             "Be CONSERVATIVE. Return foundation tasks ONLY when agents "
             "would DEFINITELY produce incompatible implementations without "
             "them.  When uncertain, return an empty list.\n\n"
@@ -3955,30 +3959,52 @@ for the following project.
 Generate ONLY the shared build/tooling infrastructure. The implementing \
 agents decide everything about the application code.
 
-ALLOWED files (generate these):
-- Package manifest (package.json, pyproject.toml, Cargo.toml, etc.)
-- Build configuration (tsconfig, vite.config, eslint config, etc.)
-- Entry point (main.tsx, main.py, main.rs — minimal, just mounts app)
-- App shell (App.tsx or equivalent — imports components, no styling logic)
+LANGUAGE / TECH-STACK CONSTRAINTS (bug #649 root cause 1):
+Read the project description above for any explicit language, framework, \
+or "no <X>" constraint (e.g., "vanilla JavaScript", "plain Python", \
+"no TypeScript", "Flask only"). HONOR THOSE CONSTRAINTS EXACTLY:
+- If the spec says "vanilla JavaScript", produce .js files and do NOT \
+generate tsconfig.json, main.tsx, App.tsx, or any TypeScript artifact.
+- If the spec says "plain Python", do not introduce frameworks or \
+type-checking config the spec did not ask for.
+- Pick file extensions and config filenames to match the stated stack. \
+The architecture document above is authoritative for the tech stack \
+choice — follow it instead of any example below.
+
+ALLOWED files (generate these — file names/extensions match stated stack):
+- Package manifest (e.g., package.json, pyproject.toml, Cargo.toml)
+- Build configuration (e.g., vite.config.js / vite.config.ts / \
+pyproject build settings — pick the form that matches the language)
+- Entry point (e.g., main.js, main.ts, index.js, main.py — pick the \
+extension that matches the language stated in the spec)
+- App shell (the entry module wires up components; for vanilla-JS \
+projects this is just main.js, not App.tsx)
 - Tooling config (.gitignore, .env.example)
 - ONE placeholder file per implementation task (see below)
 
 FORBIDDEN — do NOT generate these:
-- TypeScript interfaces, types, or data model definitions
+- Type definitions or data-model files (those are the agents' work)
 - Utility functions, helpers, or service implementations
 - CSS files, stylesheets, or design tokens
 - Test files or test configuration
 - Any file with more than 3 lines of actual code (configs excepted)
+- Files in a language the spec did NOT ask for (no .ts when the spec \
+says vanilla JS; no Python config when the spec says JavaScript)
 
-Placeholder files must contain EXACTLY one comment line:
+Placeholder files must contain EXACTLY one comment line using the \
+language's native comment syntax (// for JS/TS, # for Python, etc.):
 // TimeWidget — implementation task for agent
 
-The .gitignore MUST include: node_modules/, dist/, *.js (in src/), \
-.env, and build artifacts appropriate for the project type.
+The .gitignore MUST include the build artifacts appropriate for the \
+project's stated tech stack (e.g., node_modules/ and dist/ for JS/TS, \
+__pycache__/ and *.pyc for Python). Do NOT add "*.js in src/" to the \
+gitignore when the project's source language IS JavaScript — that \
+would ignore the user's actual source files.
 
-Respond with ONLY a JSON array of files. No markdown fencing:
+Respond with ONLY a JSON array of files. No markdown fencing.
+Example shape (your actual extensions must match the stated stack):
 [{{"path": "package.json", "content": "..."}}, \
-{{"path": "src/main.tsx", "content": "..."}}]
+{{"path": "src/<entry-file>", "content": "..."}}]
 """
 
 

--- a/src/marcus_mcp/coordinator/spec_coverage_augmenter.py
+++ b/src/marcus_mcp/coordinator/spec_coverage_augmenter.py
@@ -42,14 +42,28 @@ class SpecCoverageAugmenter:
 
     Satisfies the
     :class:`~src.marcus_mcp.coordinator.graph_augmentation.GraphAugmenter`
-    Protocol.  Stateless — constructed without arguments; pulls the
-    spec text from ``prd_analysis.original_description`` at call time.
+    Protocol.  Pulls the spec text from
+    ``prd_analysis.original_description`` at call time.
 
     Attributes
     ----------
     name : str
         Stable identifier ``"spec_coverage"`` used as the telemetry
         key in the chain's namespaced result dict.
+
+    Parameters
+    ----------
+    complexity_mode : Optional[str]
+        Project complexity mode (``"prototype"`` / ``"standard"`` /
+        ``"enterprise"``).  When ``"prototype"``, :meth:`augment`
+        short-circuits to a no-op — spec_coverage's keyword-based
+        gap-fill produces redundant tasks on trivial projects (see
+        bug #649 root cause 4: the verify-snake-3 run synthesized
+        "Implement Web Browser Playability" as a duplicate of
+        "Implement Game Presentation and Rendering System"), and
+        contract-first decomposition + outcome coverage already
+        cover the spec for those projects.  ``None`` or any
+        non-prototype value preserves the legacy behavior.
 
     Notes
     -----
@@ -61,13 +75,17 @@ class SpecCoverageAugmenter:
 
     Lifetime expectation
     --------------------
-    Stateless.  Constructed per-call inside
-    ``parse_prd_to_tasks`` / ``decompose_by_contract``.  See the
-    matching note on :class:`OutcomeCoverageAugmenter` — the same
-    tripwire applies if state is ever added.
+    Constructed per-call inside
+    ``parse_prd_to_tasks`` / ``decompose_by_contract`` via
+    :meth:`AdvancedPRDParser._build_augmenter_chain`.  Holds
+    ``complexity_mode`` for the duration of one decomposition; the
+    chain is rebuilt for each project so the state is per-run.
     """
 
     name: str = "spec_coverage"
+
+    def __init__(self, *, complexity_mode: Optional[str] = None) -> None:
+        self._complexity_mode = complexity_mode
 
     async def augment(
         self,
@@ -101,6 +119,16 @@ class SpecCoverageAugmenter:
             ``telemetry`` is empty when no gaps were filled, otherwise
             ``{"spec_gap_count": N, "spec_gap_features": [...names]}``.
         """
+        # Bug #649 root cause 4: prototype mode skips spec_coverage
+        # entirely.  The keyword-based gap-fill produces noise on
+        # trivial projects (it synthesized "Implement Web Browser
+        # Playability" duplicating the rendering task on snake), and
+        # outcome coverage + contract-first decomposition already
+        # cover the spec for prototype projects.  Non-prototype modes
+        # keep the existing behavior.
+        if self._complexity_mode == "prototype":
+            return AugmentationResult(augmented_tasks=list(tasks))
+
         spec = prd_analysis.original_description or ""
         if not spec:
             return AugmentationResult(augmented_tasks=list(tasks))

--- a/src/marcus_mcp/tools/task.py
+++ b/src/marcus_mcp/tools/task.py
@@ -18,6 +18,10 @@ from typing import Any, Dict, List, Optional
 
 from src.core.ai_powered_task_assignment import find_optimal_task_for_agent_ai_powered
 from src.core.models import Priority, Task, TaskAssignment, TaskStatus
+from src.integrations.product_smoke import (
+    VerificationSpec,
+    verify_verification_specs,
+)
 from src.logging.agent_events import log_agent_event
 from src.logging.conversation_logger import conversation_logger, log_thinking
 from src.marcus_mcp.utils import serialize_for_mcp
@@ -241,6 +245,313 @@ def _is_integration_task(task: Task) -> bool:
         return "type:integration" in labels
     except TypeError:
         return False
+
+
+def _is_composition_task(task: Task) -> bool:
+    """Detect whether a task is a Marcus-synthesized composition task.
+
+    Composition tasks are produced by
+    :func:`src.integrations.composition_synthesis.build_composition_task`
+    when a multi-domain contract-first project needs an explicit
+    entry-point wiring step.  They carry the ``"composition"`` label
+    and ``source_type == "composition_synthesis"``.
+
+    Detection accepts either signal so kanban round-trips that strip
+    labels (preserving ``source_type`` in ``source_context``) still
+    surface as composition tasks.  Mirror of the existing
+    ``_has_existing_composition_task`` detection in
+    ``src/integrations/composition_synthesis.py``.
+
+    Parameters
+    ----------
+    task : Task
+        Task to inspect.
+
+    Returns
+    -------
+    bool
+        True if the task is a composition task.
+
+    Notes
+    -----
+    Bug #649 root cause 2: the composer agent previously marked
+    itself done without verifying the composed product built.  The
+    text-only instruction in the composition task description was
+    not enough — agents under retry pressure rationalized
+    done-with-broken-build.  This detector gates the **enforcement**
+    path: :func:`_run_composer_smoke_gate` runs only when this
+    returns True.
+    """
+    labels = getattr(task, "labels", None) or []
+    try:
+        if "composition" in labels:
+            return True
+    except TypeError:
+        pass
+    return getattr(task, "source_type", None) == "composition_synthesis"
+
+
+def _detect_composer_build_specs(
+    project_root: "Any",  # pathlib.Path; quoted to avoid top-import churn
+) -> List[VerificationSpec]:
+    """Detect the project's build command(s) from its package manifest files.
+
+    Mechanical detection (no LLM, no hardcoded language ontology):
+    each branch maps a file-presence signal to the universally-known
+    build command for that toolchain.  ``package.json`` means Node,
+    ``pyproject.toml`` means Python, etc. — facts about the
+    ecosystem, not a Marcus opinion.
+
+    Permissive by design: when nothing matches (e.g., a static
+    HTML-only project), returns an empty list and the composer gate
+    treats it as a pass.  The downstream integration verification
+    smoke gate remains the broad catch-all.
+
+    Per Invariant #2 v2 (CLAUDE.md MULTIAGENCY_PROCLAMATION):
+    Marcus authors the verification command (this function); the
+    agent owns implementation HOW (which bundler config, which
+    import-fix approach).  Two agents handed the same composition
+    task can still satisfy ``npm run build`` in legitimately
+    different ways.
+
+    Parameters
+    ----------
+    project_root : Path
+        Composed implementation directory.  The function reads
+        well-known manifest filenames from this directory only — it
+        does not recurse, does not run subprocesses, and does not
+        call the LLM.
+
+    Returns
+    -------
+    List[VerificationSpec]
+        Zero or more specs the composer gate should run.  Each spec
+        carries a stable ``signal_id`` (``"composition_build"`` or
+        ``"composition_compile"``) so failures point to a clear
+        rejection reason.  Order is unspecified.
+    """
+    import json as _json
+    from pathlib import Path as _Path
+
+    pr: _Path = project_root
+    specs: List[VerificationSpec] = []
+
+    # Node.js / TypeScript: package.json with scripts.build
+    package_json = pr / "package.json"
+    if package_json.exists():
+        try:
+            data = _json.loads(package_json.read_text())
+        except (OSError, ValueError):
+            data = None
+        if isinstance(data, dict):
+            scripts = data.get("scripts")
+            if isinstance(scripts, dict) and "build" in scripts:
+                specs.append(
+                    VerificationSpec(
+                        signal_id="composition_build",
+                        command="npm install --silent && npm run build",
+                        description=(
+                            "Composer gate: project build succeeds "
+                            "(Marcus-authored verification)"
+                        ),
+                    )
+                )
+
+    # Python: pyproject.toml present -> compile all .py files via
+    # stdlib compileall.  We do NOT use ``python -m build`` because
+    # the ``build`` package may not be installed; compileall is a
+    # stdlib import and catches the syntax-level breakage the
+    # composer gate cares about.
+    if (pr / "pyproject.toml").exists():
+        specs.append(
+            VerificationSpec(
+                signal_id="composition_compile",
+                command="python -m compileall -q .",
+                description=(
+                    "Composer gate: Python sources compile "
+                    "(Marcus-authored verification)"
+                ),
+            )
+        )
+
+    # Rust: Cargo.toml
+    if (pr / "Cargo.toml").exists():
+        specs.append(
+            VerificationSpec(
+                signal_id="composition_build",
+                command="cargo build --quiet",
+                description=(
+                    "Composer gate: Rust project builds "
+                    "(Marcus-authored verification)"
+                ),
+            )
+        )
+
+    # Go: go.mod
+    if (pr / "go.mod").exists():
+        specs.append(
+            VerificationSpec(
+                signal_id="composition_build",
+                command="go build ./...",
+                description=(
+                    "Composer gate: Go project builds " "(Marcus-authored verification)"
+                ),
+            )
+        )
+
+    return specs
+
+
+async def _run_composer_smoke_gate(
+    *,
+    task: Task,
+    agent_id: str,
+    state: "Any",
+) -> Optional[Dict[str, Any]]:
+    """Enforce Marcus-authored build verification on composition tasks.
+
+    Runs at completion time for tasks where :func:`_is_composition_task`
+    returns True.  Detects the project's build tooling from package
+    manifest files (mechanical, no LLM) and runs the universal
+    build command for whichever toolchain is present.  On non-zero
+    exit, returns a rejection response that the caller returns
+    directly to the agent — the composer task is NOT marked done.
+
+    Permissive on infrastructure gaps
+    ---------------------------------
+    Unlike the integration smoke gate which hard-rejects on missing
+    project_root (every integration task MUST be verifiable),
+    the composer gate passes (returns None) when:
+
+    - Marcus cannot resolve the workspace state's ``project_root``
+    - The project root exists but contains no recognized package
+      manifest
+
+    In both cases the downstream integration verification still
+    runs and acts as the catch-all.  Composer gate's job is only to
+    REJECT when a build is configured and DEFINITELY fails.
+
+    Parameters
+    ----------
+    task : Task
+        Composition task being completed.
+    agent_id : str
+        Agent reporting completion (surfaced in rejection payload).
+    state : Any
+        Marcus server state (provides ``kanban_client`` for
+        workspace state lookup).
+
+    Returns
+    -------
+    Optional[Dict[str, Any]]
+        ``None`` if the gate passed (no build configured, or build
+        succeeded).  A rejection dict if the configured build
+        command exited non-zero.
+
+    Notes
+    -----
+    Bug #649 root cause 2: the verify-snake-3 run (2026-05-24)
+    shipped a broken Vite import (``@/physics/engine`` unresolvable)
+    because the composer agent marked itself done without running
+    a build.  This gate makes that failure mode impossible —
+    Marcus runs the build as a subprocess and rejects on exit != 0.
+    """
+    from pathlib import Path as _Path
+
+    # Resolve project_root via workspace state (same primitive the
+    # integration smoke gate uses).  Failure to resolve is
+    # permissive — the integration smoke gate downstream remains the
+    # hard enforcement layer.
+    project_root: Optional[str] = None
+    if hasattr(state, "kanban_client") and state.kanban_client:
+        try:
+            ws_state = state.kanban_client._load_workspace_state()
+            if ws_state and "project_root" in ws_state:
+                project_root = ws_state["project_root"]
+        except Exception as ws_err:  # pragma: no cover - defensive log
+            logger.warning(
+                "COMPOSER SMOKE GATE: workspace-state load failed for "
+                "%s: %s.  Skipping composer gate (integration "
+                "verification remains the catch-all).",
+                task.id,
+                ws_err,
+            )
+            return None
+
+    if not project_root:
+        logger.info(
+            "COMPOSER SMOKE GATE: no project_root resolved for %s; "
+            "skipping composer gate.",
+            task.id,
+        )
+        return None
+
+    project_root_path = _Path(project_root)
+    if not project_root_path.is_dir():
+        logger.info(
+            "COMPOSER SMOKE GATE: project_root %r is not a directory; "
+            "skipping composer gate for %s.",
+            project_root,
+            task.id,
+        )
+        return None
+
+    specs = _detect_composer_build_specs(project_root_path)
+    if not specs:
+        logger.info(
+            "COMPOSER SMOKE GATE: no build manifest detected at %s; "
+            "skipping composer gate for %s.",
+            project_root_path,
+            task.id,
+        )
+        return None
+
+    logger.info(
+        "COMPOSER SMOKE GATE: running %d Marcus-authored build spec(s) "
+        "for composition task %s at %s",
+        len(specs),
+        task.id,
+        project_root_path,
+    )
+    result = await verify_verification_specs(specs=specs, cwd=project_root_path)
+    if result.success:
+        logger.info(
+            "COMPOSER SMOKE GATE: all %d build spec(s) passed for %s",
+            len(specs),
+            task.id,
+        )
+        return None
+
+    # Rejection: surface the specific build that failed so the
+    # composer agent can fix imports / config rather than guessing.
+    failure_summary = getattr(result, "failure_summary", "") or (
+        "Composition build failed."
+    )
+    logger.warning(
+        "COMPOSER SMOKE GATE: build FAILED for %s — %s.  Rejecting " "completion.",
+        task.id,
+        failure_summary,
+    )
+    return {
+        "success": False,
+        "status": "composer_smoke_failed",
+        "agent_id": agent_id,
+        "task_id": task.id,
+        "failure_summary": failure_summary,
+        "blocker": (
+            f"Composer build verification failed: {failure_summary}. "
+            "Fix the underlying build problem (typically unresolved "
+            "imports, missing modules, or conflicting build configs "
+            "such as both vite.config.js and vite.config.ts) and "
+            "re-report completion."
+        ),
+        "message": (
+            "Marcus rejected this composition-task completion because "
+            "the project does not build.  This is bug #649 root "
+            "cause 2's enforcement layer — composition tasks cannot "
+            "be reported done with a broken build."
+        ),
+    }
 
 
 def _missing_verifications_for_required_outcomes_response(
@@ -3031,6 +3342,48 @@ async def report_task_progress(
                         f"for task {task_id}: {smoke_err}"
                     )
                     logger.exception("Smoke verification exception details:")
+
+            # COMPOSER SMOKE GATE (bug #649 root cause 2 enforcement
+            # layer).  Composition tasks are Marcus-synthesized
+            # wiring tasks (``build_composition_task`` in
+            # ``src/integrations/composition_synthesis.py``).  The
+            # text-only instruction in the composition task
+            # description ("DO NOT MARK THIS TASK COMPLETE on a
+            # broken build") is not enforcement — under retry
+            # pressure agents rationalized done-with-broken-build.
+            # This gate makes that failure mode impossible: Marcus
+            # detects the project's build tooling mechanically from
+            # package manifest files in the composed implementation
+            # directory and runs the universal build command as a
+            # subprocess.  On non-zero exit, the composer task is
+            # rejected and the agent must fix the underlying build
+            # problem.  Per Invariant #2 v2 (CLAUDE.md
+            # MULTIAGENCY_PROCLAMATION): verification belongs to
+            # Marcus's setup-time pipeline, not the agent's
+            # discretion.  See ``_run_composer_smoke_gate`` for the
+            # detection + subprocess logic, and the docstring there
+            # for the permissive-on-infrastructure-gap rationale
+            # (the integration smoke gate downstream remains the
+            # hard catch-all).
+            if task is not None and _is_composition_task(task):
+                try:
+                    composer_response = await _run_composer_smoke_gate(
+                        task=task,
+                        agent_id=agent_id,
+                        state=state,
+                    )
+                    if composer_response is not None:
+                        return composer_response
+                except Exception as composer_err:
+                    # Same fall-through policy as the integration
+                    # gate above — infrastructure failures don't
+                    # block completion (integration verification
+                    # is the broad catch-all).
+                    logger.error(
+                        f"Composer smoke verification system error "
+                        f"for task {task_id}: {composer_err}"
+                    )
+                    logger.exception("Composer smoke verification exception details:")
 
         _timer.mark("validation")
 

--- a/tests/unit/ai/test_bundled_domain_designs.py
+++ b/tests/unit/ai/test_bundled_domain_designs.py
@@ -152,10 +152,109 @@ class TestBundledDomainDiscovery:
         # Act
         await parser._discover_domains(small_requirements)
 
-        # Assert - Should suggest 2-3 domains for small projects
+        # Assert - Should suggest 1-3 domains for small projects.
+        #
+        # Bug #649 root cause 3: the previous floor of "2-3" forced
+        # trivial projects (snake game, etc.) into ≥2 domains, which
+        # cascaded into over-decomposition (11 tasks for 50-line snake).
+        # Lowering the floor to "1-3" lets the LLM return 1 domain when
+        # the project genuinely fits one — without preventing it from
+        # returning 2-3 when warranted.
         parser.llm_client.analyze.assert_called_once()
         call_args = parser.llm_client.analyze.call_args.kwargs["prompt"]
-        assert "2-3" in call_args  # Target domain count for small projects
+        assert "1-3" in call_args  # Target domain count for small projects
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_discover_domains_prototype_mode_forces_single_domain(
+        self, parser, sample_functional_requirements
+    ):
+        """Test that complexity_mode='prototype' forces target=1 domain.
+
+        Bug #649 root cause 3: ``should_decompose`` correctly skips
+        further per-task decomposition in prototype mode, but
+        ``_discover_domains`` was called unconditionally — so trivial
+        projects still got split into multiple domains, defeating the
+        prototype-mode promise of "speed over granularity."
+
+        With the fix, prototype mode forces ``target_domains="1"`` in
+        the LLM prompt so the model returns a single cohesive domain
+        for the whole feature set.
+        """
+        # Arrange
+        parser.llm_client.analyze.return_value = json.dumps(
+            {
+                "domains": [
+                    {
+                        "name": "Snake Game",
+                        "feature_ids": [
+                            req["id"] for req in sample_functional_requirements
+                        ],
+                        "rationale": "Single trivial-project domain",
+                    }
+                ]
+            }
+        )
+
+        # Act
+        await parser._discover_domains(
+            sample_functional_requirements,
+            complexity_mode="prototype",
+        )
+
+        # Assert - Prompt asks for exactly 1 domain.
+        parser.llm_client.analyze.assert_called_once()
+        call_args = parser.llm_client.analyze.call_args.kwargs["prompt"]
+        assert "1" in call_args.split("Return JSON with")[1].split("domains")[0]
+        # And the prompt MUST NOT carry the multi-domain floor language.
+        assert "2-3" not in call_args
+        assert "3-5" not in call_args
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_discover_domains_non_prototype_unchanged_for_medium(self, parser):
+        """Standard/enterprise complexity preserves the existing 4-7 floor
+        for medium projects (16-30 features).
+
+        Regression guard: the fix for bug #649 root cause 3 must only
+        change behavior for prototype mode and small projects — medium
+        and large projects retain the same target_domains buckets.
+        """
+        # Arrange - 20 features so we hit the "4-7" bucket
+        medium_requirements = [
+            {
+                "id": f"feature_{i}",
+                "name": f"Feature {i}",
+                "description": f"Description {i}",
+                "affected_components": ["frontend"],
+                "complexity": "simple",
+            }
+            for i in range(20)
+        ]
+        parser.llm_client.analyze.return_value = json.dumps(
+            {
+                "domains": [
+                    {
+                        "name": f"Domain{i}",
+                        "feature_ids": [
+                            f"feature_{j}" for j in range(i * 4, (i + 1) * 4)
+                        ],
+                        "rationale": f"Domain {i}",
+                    }
+                    for i in range(5)
+                ]
+            }
+        )
+
+        # Act
+        await parser._discover_domains(
+            medium_requirements,
+            complexity_mode="standard",
+        )
+
+        # Assert - Medium-project floor (4-7) unchanged.
+        call_args = parser.llm_client.analyze.call_args.kwargs["prompt"]
+        assert "4-7" in call_args
 
     @pytest.mark.unit
     @pytest.mark.asyncio

--- a/tests/unit/coordinator/test_spec_coverage_augmenter.py
+++ b/tests/unit/coordinator/test_spec_coverage_augmenter.py
@@ -492,3 +492,105 @@ class TestStage4PostSafetyCheckCallSiteRemoved:
             "nlp_tools.py must not import check_spec_coverage post-Stage-4 — "
             "the augmenter chain handles spec coverage now."
         )
+
+
+# ---------------------------------------------------------------------------
+# Prototype-mode skip (bug #649 root cause 4)
+# ---------------------------------------------------------------------------
+
+
+class TestPrototypeModeSkip:
+    """``complexity_mode='prototype'`` short-circuits the augmenter.
+
+    Background — bug #649 root cause 4
+    -----------------------------------
+    On the verify-snake-3 run (2026-05-24), ``SpecCoverageAugmenter``
+    synthesized "Implement Web Browser Playability" as a gap-fill
+    because the spec phrase "playable in a web browser" wasn't matched
+    against any existing task by ``check_spec_coverage``'s keyword
+    scan.  The synthesized task duplicated "Implement Game Presentation
+    and Rendering System" — pure over-decomposition.
+
+    For prototype projects (snake game, todo app, single-file demos),
+    the contract-first decomposer + outcome coverage already cover the
+    spec.  Spec_coverage's redundant gap-fills produce noise.  The
+    short-circuit accepted here: when ``complexity_mode='prototype'``,
+    no spec_coverage gap-fill runs at all.
+    """
+
+    @pytest.mark.asyncio
+    async def test_prototype_mode_returns_input_tasks_unchanged(self) -> None:
+        """No LLM call, no synthesized tasks — pure pass-through."""
+        from src.marcus_mcp.coordinator.spec_coverage_augmenter import (
+            SpecCoverageAugmenter,
+        )
+
+        with patch(
+            "src.marcus_mcp.coordinator.spec_coverage_augmenter." "check_spec_coverage",
+            new_callable=AsyncMock,
+        ) as mock_check:
+            augmenter = SpecCoverageAugmenter(complexity_mode="prototype")
+            tasks = [_make_task("t1"), _make_task("t2")]
+            result = await augmenter.augment(
+                prd_analysis=_make_prd_analysis("build a snake game"),
+                tasks=tasks,
+            )
+
+        # Coverage check never ran.
+        mock_check.assert_not_awaited()
+        # Tasks come back unchanged; no synthesized ids; no telemetry.
+        assert result.augmented_tasks == tasks
+        assert result.synthesized_ids == []
+        assert result.telemetry == {}
+
+    @pytest.mark.asyncio
+    async def test_standard_mode_unchanged_behavior(self) -> None:
+        """Non-prototype mode still calls ``check_spec_coverage``.
+
+        Regression guard: only prototype mode short-circuits.  Standard
+        and enterprise modes (the previous default) keep the existing
+        behavior so the fix is opt-in via complexity_mode.
+        """
+        from src.marcus_mcp.coordinator.spec_coverage_augmenter import (
+            SpecCoverageAugmenter,
+        )
+
+        with patch(
+            "src.marcus_mcp.coordinator.spec_coverage_augmenter." "check_spec_coverage",
+            new_callable=AsyncMock,
+            return_value=[],
+        ) as mock_check:
+            augmenter = SpecCoverageAugmenter(complexity_mode="standard")
+            await augmenter.augment(
+                prd_analysis=_make_prd_analysis("build a weather app"),
+                tasks=[_make_task("t1")],
+            )
+
+        mock_check.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_default_complexity_mode_preserves_legacy_behavior(self) -> None:
+        """Construction without ``complexity_mode`` keeps the old default.
+
+        Pre-bug-#649 callers constructed ``SpecCoverageAugmenter()`` with
+        no arguments.  The new keyword-only ``complexity_mode`` must
+        default to ``None`` and behave identically to standard mode for
+        backwards compatibility — only when an explicit ``"prototype"``
+        is passed does the short-circuit engage.
+        """
+        from src.marcus_mcp.coordinator.spec_coverage_augmenter import (
+            SpecCoverageAugmenter,
+        )
+
+        with patch(
+            "src.marcus_mcp.coordinator.spec_coverage_augmenter." "check_spec_coverage",
+            new_callable=AsyncMock,
+            return_value=[],
+        ) as mock_check:
+            augmenter = SpecCoverageAugmenter()  # No complexity_mode
+            await augmenter.augment(
+                prd_analysis=_make_prd_analysis("build a thing"),
+                tasks=[_make_task("t1")],
+            )
+
+        mock_check.assert_awaited_once()

--- a/tests/unit/integrations/test_composition_task_synthesis.py
+++ b/tests/unit/integrations/test_composition_task_synthesis.py
@@ -473,3 +473,131 @@ class TestCompositionIdempotency:
             impl_tasks=[existing_composition, _impl_task("t1")],
         )
         assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Bug #649 root cause 2 — mandatory build verification gate
+# ---------------------------------------------------------------------------
+
+
+class TestBuildVerificationGate:
+    """Composition task description must require a real build check.
+
+    Background — bug #649 root cause 2
+    -----------------------------------
+    The verify-snake-3 run (2026-05-24) shipped a broken Vite import
+    (``@/physics/engine`` unresolvable) because the composer agent
+    merged worktree files and marked its task done without verifying
+    the result built.  The integration verification smoke gate
+    eventually got bypassed when later retries used weak
+    ``start_command`` values until one returned exit 0.
+
+    The fix: the composition task description (Marcus-authored)
+    explicitly requires a build-verification command appropriate to
+    the project's stated tech stack, and forbids marking complete on
+    a broken build.  Marcus says WHAT must be true (build exit 0);
+    agent decides HOW (which bundler, which flags).  Per Invariant
+    #2 v2 (CLAUDE.md), verification belongs to Marcus's setup-time
+    pipeline; this is the composition-task expression of that rule.
+    """
+
+    def test_description_mandates_build_verification(self) -> None:
+        """Description names a mandatory build-verification step.
+
+        Pre-fix the description had a vague "smoke test the
+        composition root" bullet that left the agent free to skip the
+        check.  Post-fix the description uses MANDATORY phrasing so
+        the agent cannot interpret it as optional.
+        """
+        from src.integrations.composition_synthesis import (
+            build_composition_task,
+        )
+
+        task = build_composition_task(
+            project_name="snake-game",
+            impl_tasks=[_impl_task("t1"), _impl_task("t2")],
+        )
+        assert task is not None
+        # The description must contain MANDATORY-style framing for the
+        # build step.  Accept any of "MANDATORY", "REQUIRED", or
+        # "must" near the build check so phrasing can evolve.
+        desc = task.description
+        assert "build verification" in desc.lower() or "mandatory build" in desc.lower()
+
+    def test_description_lists_per_stack_build_commands(self) -> None:
+        """Description gives concrete per-stack build-command examples.
+
+        Marcus does not pick THE command — the agent picks the form
+        matching the scaffold.  Multiple examples are named so the
+        agent reads them as a menu, not a prescription.  This is
+        coordination per Invariant #2 v2: Marcus says "your build
+        must succeed"; the agent decides HOW to satisfy that for
+        their stack.
+        """
+        from src.integrations.composition_synthesis import (
+            build_composition_task,
+        )
+
+        task = build_composition_task(
+            project_name="x",
+            impl_tasks=[_impl_task("t1"), _impl_task("t2")],
+        )
+        assert task is not None
+        desc_lower = task.description.lower()
+        # At minimum two of the canonical stacks must be named so
+        # the agent does not read it as "Marcus picked npm".
+        stacks_named = sum(
+            keyword in desc_lower
+            for keyword in ("npm run build", "python -m build", "cargo build")
+        )
+        assert stacks_named >= 2, (
+            "Description must list >=2 stack-specific build commands "
+            "so the agent does not read a single example as the "
+            "canonical command"
+        )
+
+    def test_description_forbids_marking_complete_on_broken_build(self) -> None:
+        """Description must explicitly forbid done-on-broken-build.
+
+        Without an explicit prohibition the agent under retry
+        pressure may report the task complete by reasoning "I tried
+        to fix the build, close enough."  The text bans that
+        interpretation outright.
+        """
+        from src.integrations.composition_synthesis import (
+            build_composition_task,
+        )
+
+        task = build_composition_task(
+            project_name="x",
+            impl_tasks=[_impl_task("t1"), _impl_task("t2")],
+        )
+        assert task is not None
+        desc_lower = task.description.lower()
+        # Some phrase ruling out broken-build acceptance.
+        assert (
+            "broken build" in desc_lower
+            or "do not mark this task complete" in desc_lower
+            or "blocker" in desc_lower
+        )
+
+    def test_description_requires_dev_server_probe_when_applicable(self) -> None:
+        """Server-mode projects must boot + curl the running app.
+
+        The verify-snake-3 failure mode: the agent ran a weak
+        verification that did not actually launch the dev server.
+        Marcus now names "boot dev server + curl" as the canonical
+        probe so vague verification gets rejected by the description
+        itself.
+        """
+        from src.integrations.composition_synthesis import (
+            build_composition_task,
+        )
+
+        task = build_composition_task(
+            project_name="x",
+            impl_tasks=[_impl_task("t1"), _impl_task("t2")],
+        )
+        assert task is not None
+        desc_lower = task.description.lower()
+        assert "dev server" in desc_lower or "curl" in desc_lower

--- a/tests/unit/integrations/test_scaffold_prompt_language_agnostic.py
+++ b/tests/unit/integrations/test_scaffold_prompt_language_agnostic.py
@@ -1,0 +1,180 @@
+"""Unit tests for bug #649 root cause 1 — scaffold prompt must be language-agnostic.
+
+Background
+----------
+Bug #649 root cause 1: the ``_SCAFFOLD_PROMPT`` template at
+``src/integrations/nlp_tools.py`` previously hardcoded TypeScript file
+extensions and config names in its allowed-files list and example
+output (``main.tsx``, ``App.tsx``, ``tsconfig.json``).  Large language
+models follow concrete examples; the scaffold LLM produced
+TypeScript artifacts even when the project description explicitly
+asked for vanilla JavaScript (the verify-snake-3 failure mode).
+
+These tests pin the post-fix shape of the prompt: hardcoded
+TypeScript examples are removed, an explicit "honor stated language
+constraints" instruction is present, and the example output is
+parameterized rather than naming ``main.tsx`` outright.
+
+The shared-foundation prompt at ``_synthesize_shared_foundation``
+underwent the same fix; this file covers both.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+# ---------------------------------------------------------------------------
+# _SCAFFOLD_PROMPT — language-agnostic structure
+# ---------------------------------------------------------------------------
+
+
+class TestScaffoldPromptLanguageAgnostic:
+    """The scaffold prompt must not bias the LLM toward TypeScript.
+
+    Verifies the static structure of the ``_SCAFFOLD_PROMPT`` module
+    constant rather than mocking an end-to-end run.  Static-text
+    assertions are sufficient because the LLM's bias was driven by
+    the example text — fix the example, fix the bias.
+    """
+
+    @pytest.fixture
+    def prompt(self) -> str:
+        """The scaffold prompt template as a string."""
+        from src.integrations.nlp_tools import _SCAFFOLD_PROMPT
+
+        return _SCAFFOLD_PROMPT
+
+    def test_no_hardcoded_main_tsx_in_example_output(self, prompt: str) -> None:
+        """The example output must not name ``main.tsx`` outright.
+
+        Pre-fix, the example output ended with
+        ``{"path": "src/main.tsx", "content": "..."}`` which the LLM
+        copied for vanilla-JS specs.  The fix replaces it with a
+        parameterized placeholder so the LLM picks an extension
+        matching the stated stack.
+        """
+        # The literal example output line must be gone.
+        assert '"path": "src/main.tsx"' not in prompt
+        # And the entry-point bullet must not list main.tsx as the
+        # first/primary example before main.js / main.py.
+        assert "main.tsx," not in prompt.split("Entry point")[1].split("\n")[0]
+
+    def test_no_hardcoded_app_tsx_as_app_shell(self, prompt: str) -> None:
+        """The app-shell bullet must not name ``App.tsx`` as the canonical form."""
+        # "App.tsx or equivalent" framing biased TS as the canonical
+        # shell.  Post-fix the bullet describes the role
+        # language-agnostically.
+        assert "App.tsx or equivalent" not in prompt
+
+    def test_no_hardcoded_tsconfig_in_build_config(self, prompt: str) -> None:
+        """The build-config bullet must not list ``tsconfig`` as the lead example.
+
+        Pre-fix: "Build configuration (tsconfig, vite.config, ...)".
+        Post-fix: bullet uses language-neutral examples or names the
+        TS form only conditionally on language match.
+        """
+        # The pre-fix lead-with-tsconfig framing is gone.
+        assert "Build configuration (tsconfig," not in prompt
+
+    def test_explicit_honor_stated_language_instruction(self, prompt: str) -> None:
+        """The prompt must explicitly tell the LLM to honor the spec's language.
+
+        Without this instruction the LLM defaults to whatever the
+        examples suggest (TypeScript pre-fix).  With the instruction,
+        the LLM treats "vanilla JavaScript" in the spec as a hard
+        constraint.
+        """
+        # Lowercase compare so wording can evolve without breaking the test.
+        prompt_lower = prompt.lower()
+        assert "vanilla javascript" in prompt_lower or "honor" in prompt_lower
+        # Specifically: must name "vanilla javascript" as the canonical
+        # opt-out example so the LLM recognizes the phrase from the spec.
+        assert "vanilla javascript" in prompt_lower
+
+    def test_forbids_files_in_unrequested_language(self, prompt: str) -> None:
+        """The forbidden-files list must mention not producing files in
+        a language the spec did not ask for.
+
+        Pre-fix the forbidden list only banned "TypeScript interfaces"
+        as a code-density concern, not as a language constraint.
+        Post-fix it bans cross-language drift outright.
+        """
+        prompt_lower = prompt.lower()
+        # Some phrasing equivalent to "no .ts files when spec says vanilla JS"
+        # must be present.
+        assert ".ts" in prompt_lower and "vanilla" in prompt_lower
+
+    def test_gitignore_guidance_does_not_block_js_in_src(self, prompt: str) -> None:
+        """The .gitignore guidance must not block ``*.js`` in ``src/``
+        unconditionally.
+
+        Pre-fix the prompt said ``"*.js (in src/)"`` must be in
+        gitignore — which is correct for a TypeScript project (build
+        output) but wrong for a vanilla-JS project where .js files
+        ARE the source.
+        """
+        # The unconditional "*.js (in src/)" instruction must be gone.
+        assert "*.js (in src/)" not in prompt
+
+
+# ---------------------------------------------------------------------------
+# _synthesize_shared_foundation prompt — language-agnostic Tech Foundation
+# ---------------------------------------------------------------------------
+
+
+class TestSharedFoundationPromptLanguageAgnostic:
+    """The foundation prompt must not bias the LLM toward TypeScript.
+
+    Verifies the prompt structure inside
+    ``_synthesize_shared_foundation`` by reading the method source.
+    A full call-and-capture test would require constructing a
+    NaturalLanguageProjectCreator and mocking the LLM — overkill for
+    a static text-shape assertion.
+    """
+
+    @pytest.fixture
+    def method_source(self) -> str:
+        """Return the source of ``_synthesize_shared_foundation`` as text."""
+        import inspect
+
+        from src.integrations.nlp_tools import NaturalLanguageProjectCreator
+
+        return inspect.getsource(
+            NaturalLanguageProjectCreator._synthesize_shared_foundation
+        )
+
+    def test_tech_foundation_bullet_no_longer_says_typescript_config(
+        self, method_source: str
+    ) -> None:
+        """The Tech Foundation example must not say "TypeScript config".
+
+        Pre-fix: ``"Tech Foundation: shared configuration (TypeScript
+        config, routing, test harness)"``.  The TypeScript-as-example
+        biased the LLM to recommend TS-foundation tasks even for
+        non-TS projects.
+        """
+        # The exact pre-fix string must be gone.
+        assert "TypeScript config, " not in method_source
+
+    def test_tech_foundation_prompt_acknowledges_language_constraint(
+        self, method_source: str
+    ) -> None:
+        """The Tech Foundation prompt must instruct the LLM to honor
+        the spec's stated language.
+
+        Post-fix the prompt names the language constraint as
+        authoritative (e.g., "honor the language the spec actually
+        states") so the LLM does not default to TypeScript when the
+        spec asked for vanilla JavaScript.
+        """
+        # Wording can evolve; we accept any phrase that names
+        # language honoring or constraint matching.
+        lower = method_source.lower()
+        assert (
+            "honor the language" in lower
+            or "language the spec" in lower
+            or "stated tech stack" in lower
+        )

--- a/tests/unit/marcus_mcp/test_composer_smoke_gate.py
+++ b/tests/unit/marcus_mcp/test_composer_smoke_gate.py
@@ -1,0 +1,362 @@
+"""Unit tests for the composer smoke gate (bug #649 root cause 2 — enforcement).
+
+Background
+----------
+PR #650's first attempt at fixing bug #649 root cause 2 added a
+text-only instruction to the composition task description ("DO NOT
+MARK THIS TASK COMPLETE on a broken build").  That was a step but
+not a gate — if the composer agent reported the task done anyway,
+no Marcus layer rejected it.  The Kaia review of PR #650 surfaced
+this as the gap.
+
+This module's tests pin the **enforcement layer**: Marcus detects
+the project's build tooling from the implementation directory
+(mechanically, no LLM, no hardcoded language ontology) and runs the
+universal build command for whichever package manifest is present.
+On non-zero exit, the composition task is rejected.
+
+Detection rules:
+
+- ``package.json`` with ``scripts.build`` -> ``npm install && npm run build``
+- ``pyproject.toml`` -> ``python -m compileall -q .``
+  (compileall is in the stdlib; avoids requiring the ``build`` package)
+- ``Cargo.toml`` -> ``cargo build --quiet``
+- ``go.mod`` -> ``go build ./...``
+- Nothing matches -> empty list (permissive pass; no build to verify)
+
+Per Invariant #2 v2 (CLAUDE.md MULTIAGENCY_PROCLAMATION): Marcus
+authors the verification command; the agent owns implementation.
+The detection function maps a file-presence signal to the
+universally-known build command for that toolchain — not a
+prescriptive ontology, just the mechanical fact that ``package.json``
+means Node.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+# ---------------------------------------------------------------------------
+# _is_composition_task — task-type detection
+# ---------------------------------------------------------------------------
+
+
+class TestIsCompositionTask:
+    """``_is_composition_task`` recognizes Marcus-synthesized composition tasks."""
+
+    def _task(self, *, labels=None, source_type=None) -> MagicMock:
+        """Minimal task stub with the attributes the detector reads."""
+        task = MagicMock()
+        task.labels = labels
+        task.source_type = source_type
+        return task
+
+    def test_detects_via_composition_label(self) -> None:
+        """Tasks with ``composition`` in labels are composition tasks."""
+        from src.marcus_mcp.tools.task import _is_composition_task
+
+        task = self._task(labels=["composition", "marcus_synthesized"])
+        assert _is_composition_task(task) is True
+
+    def test_detects_via_source_type(self) -> None:
+        """Tasks with ``source_type='composition_synthesis'`` are composition tasks.
+
+        Survives kanban round-trips that strip labels but preserve
+        source_type (matches the existing detection at
+        ``composition_synthesis.py:_has_existing_composition_task``).
+        """
+        from src.marcus_mcp.tools.task import _is_composition_task
+
+        task = self._task(labels=[], source_type="composition_synthesis")
+        assert _is_composition_task(task) is True
+
+    def test_rejects_integration_task(self) -> None:
+        """Integration tasks are not composition tasks (distinct gates)."""
+        from src.marcus_mcp.tools.task import _is_composition_task
+
+        task = self._task(labels=["type:integration", "integration"])
+        assert _is_composition_task(task) is False
+
+    def test_rejects_implementation_task(self) -> None:
+        """Plain implementation tasks are not composition tasks."""
+        from src.marcus_mcp.tools.task import _is_composition_task
+
+        task = self._task(labels=["implementation"])
+        assert _is_composition_task(task) is False
+
+    def test_handles_missing_labels(self) -> None:
+        """No labels and no source_type returns False (no crash)."""
+        from src.marcus_mcp.tools.task import _is_composition_task
+
+        task = self._task(labels=None, source_type=None)
+        assert _is_composition_task(task) is False
+
+
+# ---------------------------------------------------------------------------
+# _detect_composer_build_specs — mechanical build-command detection
+# ---------------------------------------------------------------------------
+
+
+class TestDetectComposerBuildSpecs:
+    """Mechanical detection from package manifest files in the project root."""
+
+    def test_node_with_scripts_build_returns_npm_spec(self, tmp_path: Path) -> None:
+        """package.json with ``scripts.build`` -> npm install && npm run build."""
+        from src.marcus_mcp.tools.task import _detect_composer_build_specs
+
+        (tmp_path / "package.json").write_text(
+            json.dumps(
+                {
+                    "name": "verify-snake-4",
+                    "scripts": {"dev": "vite", "build": "vite build"},
+                }
+            )
+        )
+        specs = _detect_composer_build_specs(tmp_path)
+        assert len(specs) == 1
+        spec = specs[0]
+        assert "npm" in spec.command
+        assert "run build" in spec.command
+        assert spec.signal_id  # non-empty
+
+    def test_node_without_scripts_build_returns_empty(self, tmp_path: Path) -> None:
+        """package.json with no ``scripts.build`` -> no spec (no build configured).
+
+        Permissive default: if there's nothing to build (a pure
+        static HTML+JS project may have package.json only for
+        devDeps), the gate passes rather than fabricating a fake
+        check.
+        """
+        from src.marcus_mcp.tools.task import _detect_composer_build_specs
+
+        (tmp_path / "package.json").write_text(
+            json.dumps({"name": "x", "scripts": {"start": "node main.js"}})
+        )
+        specs = _detect_composer_build_specs(tmp_path)
+        assert specs == []
+
+    def test_node_with_malformed_package_json_returns_empty(
+        self, tmp_path: Path
+    ) -> None:
+        """A corrupt package.json is treated as absent — gate stays permissive.
+
+        Marcus should not fail to load on agent-side corruption; the
+        ordinary smoke pipeline downstream catches truly broken
+        projects.  Composer gate's job is only to reject when build
+        is definitely broken.
+        """
+        from src.marcus_mcp.tools.task import _detect_composer_build_specs
+
+        (tmp_path / "package.json").write_text("this is not json {{{")
+        specs = _detect_composer_build_specs(tmp_path)
+        assert specs == []
+
+    def test_python_with_pyproject_returns_compileall_spec(
+        self, tmp_path: Path
+    ) -> None:
+        """pyproject.toml present -> python -m compileall.
+
+        Using ``compileall`` (stdlib) rather than ``python -m build``
+        because the latter requires the ``build`` package which may
+        not be installed.  Syntax-level compile is the minimum
+        signal that the assembled Python project is at least
+        parseable.
+        """
+        from src.marcus_mcp.tools.task import _detect_composer_build_specs
+
+        (tmp_path / "pyproject.toml").write_text(
+            "[build-system]\nrequires = ['hatchling']\n"
+        )
+        specs = _detect_composer_build_specs(tmp_path)
+        assert len(specs) == 1
+        assert "compileall" in specs[0].command
+
+    def test_rust_cargo_toml_returns_cargo_build_spec(self, tmp_path: Path) -> None:
+        """Cargo.toml -> cargo build."""
+        from src.marcus_mcp.tools.task import _detect_composer_build_specs
+
+        (tmp_path / "Cargo.toml").write_text(
+            "[package]\nname = 'x'\nversion = '0.1.0'\n"
+        )
+        specs = _detect_composer_build_specs(tmp_path)
+        assert len(specs) == 1
+        assert "cargo build" in specs[0].command
+
+    def test_go_mod_returns_go_build_spec(self, tmp_path: Path) -> None:
+        """go.mod -> go build ./..."""
+        from src.marcus_mcp.tools.task import _detect_composer_build_specs
+
+        (tmp_path / "go.mod").write_text("module x\n\ngo 1.21\n")
+        specs = _detect_composer_build_specs(tmp_path)
+        assert len(specs) == 1
+        assert "go build" in specs[0].command
+
+    def test_empty_project_returns_empty(self, tmp_path: Path) -> None:
+        """Empty project -> empty list (nothing to verify, permissive pass)."""
+        from src.marcus_mcp.tools.task import _detect_composer_build_specs
+
+        specs = _detect_composer_build_specs(tmp_path)
+        assert specs == []
+
+    def test_polyglot_project_returns_all_applicable_specs(
+        self, tmp_path: Path
+    ) -> None:
+        """Multiple manifests present -> all applicable specs.
+
+        Polyglot projects (rare but real — e.g. a JS frontend with a
+        Python backend) should have ALL their build commands run.
+        The gate either accepts all or rejects on the first failure.
+        """
+        from src.marcus_mcp.tools.task import _detect_composer_build_specs
+
+        (tmp_path / "package.json").write_text(
+            json.dumps({"scripts": {"build": "vite build"}})
+        )
+        (tmp_path / "pyproject.toml").write_text("[build-system]\nrequires = []\n")
+        specs = _detect_composer_build_specs(tmp_path)
+        assert len(specs) == 2
+        commands = {s.command for s in specs}
+        assert any("npm" in c for c in commands)
+        assert any("compileall" in c for c in commands)
+
+
+# ---------------------------------------------------------------------------
+# _run_composer_smoke_gate — full gate behavior
+# ---------------------------------------------------------------------------
+
+
+class TestRunComposerSmokeGate:
+    """Composition completion gate — Marcus-authored, subprocess-enforced."""
+
+    def _state(self, project_root: Path) -> MagicMock:
+        """Mock Marcus state with workspace state pointing at ``project_root``."""
+        state = MagicMock()
+        kanban = MagicMock()
+        kanban._load_workspace_state = MagicMock(
+            return_value={"project_root": str(project_root)}
+        )
+        state.kanban_client = kanban
+        return state
+
+    def _composition_task(self) -> MagicMock:
+        task = MagicMock()
+        task.id = "composition_test"
+        task.name = "Compose verify-snake-4 entry point"
+        task.labels = ["composition", "marcus_synthesized"]
+        task.source_type = "composition_synthesis"
+        return task
+
+    @pytest.mark.asyncio
+    async def test_passes_when_no_build_configured(self, tmp_path: Path) -> None:
+        """Empty project -> no specs -> gate passes (returns None).
+
+        Permissive pass when there's nothing to verify — the
+        composition root may legitimately be a pure static HTML
+        project with no build step.
+        """
+        from src.marcus_mcp.tools.task import _run_composer_smoke_gate
+
+        state = self._state(tmp_path)
+        result = await _run_composer_smoke_gate(
+            task=self._composition_task(), agent_id="agent_1", state=state
+        )
+        assert result is None  # Gate passed
+
+    @pytest.mark.asyncio
+    async def test_passes_when_subprocess_succeeds(self, tmp_path: Path) -> None:
+        """Detected build that exits 0 -> gate passes."""
+        from src.marcus_mcp.tools.task import _run_composer_smoke_gate
+
+        (tmp_path / "package.json").write_text(
+            json.dumps({"scripts": {"build": "echo ok"}})
+        )
+
+        success_result = MagicMock()
+        success_result.success = True
+        success_result.failure_summary = ""
+
+        state = self._state(tmp_path)
+        with patch(
+            "src.marcus_mcp.tools.task.verify_verification_specs",
+            new_callable=AsyncMock,
+            return_value=success_result,
+        ) as mock_verify:
+            result = await _run_composer_smoke_gate(
+                task=self._composition_task(),
+                agent_id="agent_1",
+                state=state,
+            )
+
+        assert result is None  # Gate passed
+        mock_verify.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_rejects_when_subprocess_fails(self, tmp_path: Path) -> None:
+        """Detected build that exits non-zero -> gate rejects.
+
+        This is the verify-snake-3 failure mode the fix targets:
+        composer agent reported done, but ``npm run build`` would
+        have failed with the @/physics/engine resolution error.
+        Pre-fix nothing rejected.  Post-fix Marcus subprocess-runs
+        the build and rejects.
+        """
+        from src.marcus_mcp.tools.task import _run_composer_smoke_gate
+
+        (tmp_path / "package.json").write_text(
+            json.dumps({"scripts": {"build": "vite build"}})
+        )
+
+        failure_result = MagicMock()
+        failure_result.success = False
+        failure_result.failure_summary = (
+            "build failed: cannot resolve import @/physics/engine"
+        )
+
+        state = self._state(tmp_path)
+        with patch(
+            "src.marcus_mcp.tools.task.verify_verification_specs",
+            new_callable=AsyncMock,
+            return_value=failure_result,
+        ):
+            result = await _run_composer_smoke_gate(
+                task=self._composition_task(),
+                agent_id="agent_1",
+                state=state,
+            )
+
+        assert result is not None
+        assert result["success"] is False
+        # Rejection carries enough info for the agent to fix the
+        # underlying problem rather than retrying blindly.
+        assert "build" in result.get("blocker", "").lower()
+        assert result["task_id"] == "composition_test"
+
+    @pytest.mark.asyncio
+    async def test_logs_when_no_project_root_resolved(self) -> None:
+        """Missing workspace state -> permissive pass with a warning log.
+
+        Unlike the integration smoke gate (which hard-rejects on
+        missing project_root because every integration task MUST be
+        verifiable), the composer gate is best-effort: when Marcus
+        cannot locate the implementation directory, the downstream
+        integration verification catches anything still broken.
+        Composer-gate failure-to-load should not block completion
+        on a configuration glitch.
+        """
+        from src.marcus_mcp.tools.task import _run_composer_smoke_gate
+
+        state = MagicMock()
+        state.kanban_client = None  # No workspace state
+
+        result = await _run_composer_smoke_gate(
+            task=self._composition_task(), agent_id="agent_1", state=state
+        )
+        # Permissive: no rejection, downstream gate is the catch-all.
+        assert result is None


### PR DESCRIPTION
## Why

Marcus is the system that splits a project description into tasks for AI coding agents. Today, on **trivial specs** like "build a snake game in vanilla JavaScript," it currently produces over-engineered, wrong-language, broken-build output:

- 11 tasks for a 50-line snake game (over-decomposition)
- TypeScript files for a vanilla-JS spec (tech-stack drift)
- Broken build accepted as done (composer ships without verifying)

This PR fixes the trivial-spec **reliability floor** so trivial specs at least produce correctly-shaped, language-honoring, locally-buildable output. **This is floor cleanup, not a complete reliability fix** — see the "Honest scope" section below.

Full failure-mode write-up: #649. Foundational orchestration follow-ups: #651, #652, #206.

## What changed

Four commits visible in `git log`:

### Commit `1330ae9b` — Roots 3+4: prototype-mode short-circuits
- `_discover_domains` (`src/ai/advanced/prd/advanced_parser.py`) accepts `complexity_mode` and forces `target_domains="1"` for prototype mode. Non-prototype small projects get `"1-3"` (was `"2-3"`).
- `SpecCoverageAugmenter` accepts `complexity_mode` and short-circuits to a no-op in prototype mode.
- `_build_augmenter_chain` forwards `constraints.complexity_mode` at both call sites.

### Commit `906c2fff` — Root 1: scaffold + foundation prompts honor stated tech stack
- `_SCAFFOLD_PROMPT` no longer hardcodes `main.tsx`/`App.tsx`/`tsconfig` as canonical examples. Language-agnostic descriptions + explicit "honor stated language constraints" instruction.
- `_synthesize_shared_foundation` prompt: "TypeScript config" → language-neutral phrasing.
- No regex-based spec extractor; LLM-driven extraction stays in the existing PRD analysis path.

### Commit `0a4fade2` — Root 2 (text instruction): composer description mandates build verification
- Composition task description names MANDATORY build verification with per-stack examples (`npm run build`, `python -m build`, `cargo build`), dev-server probe when applicable, and explicit prohibition on done-with-broken-build.
- This commit is **text-only** — see commit `9031f1c9` below for the enforcement layer.

### Commit `9031f1c9` — Root 2 (enforcement): composer smoke gate
- `_is_composition_task(task)` detects composition tasks by `composition` label or `source_type=="composition_synthesis"`.
- `_detect_composer_build_specs(project_root)` — mechanical detection from package manifest files (no LLM, no hardcoded language ontology).
- `_run_composer_smoke_gate(...)` — runs detected specs via `verify_verification_specs` subprocess primitive; rejects on non-zero exit.
- Wired into `report_task_progress` alongside the existing integration smoke gate trigger.

## Honest scope (read this before merging)

The composer smoke gate (commit `9031f1c9`) is **partially effective** by itself. It correctly validates that the project's build commands exit 0 in `project_root` — but at the moment the gate runs, `project_root` may NOT yet contain the completing agent's work (their work is on their worktree branch). The gate validates "does main currently build?" rather than "does this agent's deliverable produce a working main?"

The verify-snake-4 acceptance run (test66, 2026-05-24) surfaced a much deeper foundational bug:

- **5 of 10 agents had merge conflicts** that silently dropped their work
- The composer's commit (`722505a`: "build verified, 62/62 tests passing") **never reached HEAD** because the merge to main failed and Marcus marked the task DONE in kanban anyway
- The integration verifier's full renderer implementation (`c713450`) was also dropped the same way
- Final HEAD contains scaffolding + early agents' work + README — missing the composer and integration verifier work

This is the **kanban/filesystem divergence** bug filed as #651. The gate from `9031f1c9` is downstream of that bug; until it's fixed, the gate's effectiveness is capped by the merge-success rate of agent branches.

## Follow-up work (must land before claiming trivial-spec reliability)

Three issues all pulled forward to **v0.3.9 milestone**:

- **#651** — Marcus marks tasks DONE when worktree merge to main fails (filesystem/kanban divergence). The foundational orchestration bug. ~2 days of work.
- **#652** — Smoke gates inspect `project_root` instead of the agent's worktree where work actually lives. Fixes the gate-scoping issue described above. ~2-3 days of work.
- **#206** — Baton Arbitration: resource-level write locking declared at decomposition time so two tasks never write to the same file in parallel. The PROPER prevention. Pulled from v0.7.0 to v0.3.9 per Larry's 2026-05-24 decision. ~1-2 weeks of work for MVP.

## What this PR is and is not

**This PR is:** the trivial-spec floor cleanup (over-decomposition, tech-stack drift, broken-build acceptance). Each fix passes the Invariant #2 v2 bright-line test (Marcus says WHAT must be true; agent decides HOW).

**This PR is NOT:** the foundational orchestration fix. PR #650's gates assume kanban truth matches filesystem truth — an assumption #651 will repair, and that #206 will prevent from breaking in the first place.

**Bright-line check per fix:** all 4 root causes pass — two agents handed the same task can still produce legitimately different output within the new constraints.

## Test plan

### Automated (green on this branch)

- [x] `pytest tests/unit/ai/test_bundled_domain_designs.py` — domain floor
- [x] `pytest tests/unit/coordinator/test_spec_coverage_augmenter.py` — prototype-mode skip
- [x] `pytest tests/unit/integrations/test_scaffold_prompt_language_agnostic.py` — scaffold + foundation prompts
- [x] `pytest tests/unit/integrations/test_composition_task_synthesis.py::TestBuildVerificationGate` — composer description
- [x] `pytest tests/unit/marcus_mcp/test_composer_smoke_gate.py` — composer gate enforcement
- [x] 946 unit tests pass across touched directories
- [x] mypy clean

### End-to-end (run before merge or as part of v0.3.9 acceptance)

- [x] **verify-snake-4** ran on 2026-05-24 (test66). Result: prototype-mode short-circuits worked (1 domain, 12 tasks vs verify-snake-3's 11 — still high; the merge-conflict bug masked the over-decomposition fix's full effect). **Surfaced #651 as expected from empirical validation.** Documented in test66 retro.
- [ ] **verify-snake-5** (after #651 + #652 land): same spec; expected to produce ≤5 tasks, vanilla JS only, working build, no orphaned branches.
- [ ] **verify-todo-1** and **verify-tictactoe-1**: alternate trivial specs.

## Related

- Closes #649
- Surfaces (and is partially blocked by) #651, #652
- Pulls #206 forward to v0.3.9
- Builds on Invariant #2 v2 (#639)
- Addresses parts of #636, #637, #638
- PR #642 (contract verifier soft rollout) remains on hold

🤖 Generated with [Claude Code](https://claude.com/claude-code)