### PR TITLE
feat(#651): auto-recover BLOCKED-by-merge-conflict tasks via worktree rebase (Option A)

### DIFF
--- a/src/marcus_mcp/tools/task.py
+++ b/src/marcus_mcp/tools/task.py
@@ -1897,6 +1897,30 @@ async def request_next_task(agent_id: str, state: Any) -> Any:
         optimal_task = await find_optimal_task_for_agent(agent_id, state)
         _mark("task_selection")
 
+        # Bug #651 follow-up — before declaring "no task ready" and
+        # letting the runner spawn another ephemeral agent that will
+        # rediscover the same state, sweep any BLOCKED-by-merge-conflict
+        # tasks and try to recover them via rebase.  If recovery
+        # unblocks a downstream task, the CURRENT agent can claim it
+        # instead of forcing a fresh spawn-poll cycle.
+        #
+        # Eliminates verify-snake-8's spawn-thrash failure mode where
+        # 49 ephemeral agents spawned chasing an unrecoverable BLOCKED
+        # task before the 20-min stall watchdog fired (~$25-50 wasted
+        # spawn cost from one recoverable conflict).
+        if not optimal_task:
+            recovered_count = await _sweep_blocked_merge_conflicts(state)
+            if recovered_count > 0:
+                logger.info(
+                    "[recovery] sweep recovered %d task(s); refreshing state "
+                    "and re-selecting for agent %s",
+                    recovered_count,
+                    agent_id,
+                )
+                await state.refresh_project_state()
+                optimal_task = await find_optimal_task_for_agent(agent_id, state)
+                _mark("task_selection_after_recovery")
+
         if optimal_task:
             try:
                 # Get implementation context if using GitHub
@@ -2845,6 +2869,250 @@ def _apply_merge_failure_to_update_data(
             "visible rather than silently dropped (bug #651)."
         ),
     }
+
+
+async def _attempt_merge_recovery(
+    *,
+    task: Task,
+    state: Any,
+) -> Optional[Dict[str, Any]]:
+    """Recover a BLOCKED-by-merge-conflict task via worktree rebase.
+
+    Bug #651 follow-up.  PR #653 marked tasks BLOCKED on merge fail
+    (closed the kanban/filesystem divergence) but left them
+    unrecoverable.  verify-snake-8 (test71, 2026-05-25) hit one
+    such conflict and the runner spawned 49 ephemeral agents
+    chasing the unclaimed downstream task before the 20-minute
+    stall watchdog gave up — roughly $25-50 of wasted spawn cost.
+
+    Most "conflicts" in DAG-based parallel work are stale-base
+    false conflicts: another agent merged main while this agent's
+    worktree was on the old base; the actual code changes don't
+    overlap.  Rebase resolves these mechanically.  Real content
+    conflicts (overlapping line edits) abort the rebase and leave
+    the task BLOCKED for human intervention.
+
+    Recovery flow:
+
+    1. Read ``source_context.merge_conflict`` from the BLOCKED task.
+    2. Resolve the worktree path
+       (``<project_root>/../worktrees/<agent_id>``, the Marcus
+       convention set by ``spawn_agents.py``).
+    3. Run ``git rebase main`` in the worktree.
+    4. On clean rebase: ``git checkout main`` in the main repo,
+       ``git merge --ff-only <branch>``, transition task to DONE
+       on the kanban, clear ``merge_conflict`` from source_context.
+    5. On rebase conflict: ``git rebase --abort`` to clean state;
+       leave task BLOCKED; return None.
+
+    Parameters
+    ----------
+    task : Task
+        The BLOCKED task whose source_context carries the
+        ``merge_conflict`` record from
+        :func:`_apply_merge_failure_to_update_data`.
+    state : Any
+        Marcus server state.  ``kanban_client._load_workspace_state()``
+        provides the ``project_root``; ``kanban_client.update_task``
+        applies the BLOCKED→DONE transition on success.
+
+    Returns
+    -------
+    Optional[Dict[str, Any]]
+        Success dict ``{"success": True, "task_id": ...,
+        "method": "rebase"}`` when the task recovered.  ``None`` for
+        any failure path.  Callers treat ``None`` as "task stays
+        BLOCKED."
+
+    Notes
+    -----
+    Bright-line: Marcus rebasing the agent's branch onto main is
+    environment shaping, not HOW dictation.  Same primitive as
+    ``git pull --rebase`` that any developer runs daily.
+    """
+    import subprocess as _sp
+    from pathlib import Path as _Path
+
+    ctx = task.source_context or {}
+    merge_conflict = ctx.get("merge_conflict")
+    if not isinstance(merge_conflict, dict):
+        return None
+
+    agent_id = merge_conflict.get("agent_id")
+    branch = merge_conflict.get("branch") or (
+        f"marcus/{agent_id}" if agent_id else None
+    )
+    if not agent_id or not branch:
+        return None
+
+    project_root: Optional[str] = None
+    if hasattr(state, "kanban_client") and state.kanban_client:
+        load_state = getattr(state.kanban_client, "_load_workspace_state", None)
+        if callable(load_state):
+            try:
+                ws = load_state()
+                if isinstance(ws, dict):
+                    project_root = ws.get("project_root")
+            except Exception:
+                project_root = None
+    if not project_root:
+        return None
+
+    repo = _Path(project_root)
+    if not repo.is_dir():
+        return None
+
+    worktree = repo.parent / "worktrees" / agent_id
+    if not worktree.is_dir():
+        logger.info(
+            "[recovery] %s: worktree %s missing; cannot auto-recover",
+            task.id,
+            worktree,
+        )
+        return None
+
+    logger.info(
+        "[recovery] %s: attempting rebase of %s onto main in %s",
+        task.id,
+        branch,
+        worktree,
+    )
+    try:
+        rebase = _sp.run(
+            ["git", "rebase", "main"],
+            cwd=worktree,
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+    except (_sp.SubprocessError, OSError) as exc:
+        logger.warning("[recovery] %s: rebase subprocess error: %s", task.id, exc)
+        return None
+
+    if rebase.returncode != 0:
+        logger.warning(
+            "[recovery] %s: rebase failed (real content conflict?): %s",
+            task.id,
+            rebase.stderr.strip() if rebase.stderr else "(no stderr)",
+        )
+        try:
+            _sp.run(
+                ["git", "rebase", "--abort"],
+                cwd=worktree,
+                capture_output=True,
+                timeout=30,
+            )
+        except (_sp.SubprocessError, OSError):
+            pass
+        return None
+
+    try:
+        _sp.run(
+            ["git", "checkout", "main"],
+            cwd=repo,
+            check=True,
+            capture_output=True,
+            timeout=30,
+        )
+        _sp.run(
+            ["git", "reset", "--hard", "HEAD"],
+            cwd=repo,
+            capture_output=True,
+            timeout=30,
+        )
+        merge = _sp.run(
+            ["git", "merge", "--ff-only", branch],
+            cwd=repo,
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+        if merge.returncode != 0:
+            logger.warning(
+                "[recovery] %s: post-rebase fast-forward failed: %s",
+                task.id,
+                merge.stderr.strip() if merge.stderr else "(no stderr)",
+            )
+            return None
+    except (_sp.SubprocessError, OSError) as exc:
+        logger.warning("[recovery] %s: post-rebase merge error: %s", task.id, exc)
+        return None
+
+    new_ctx = dict(ctx)
+    new_ctx.pop("merge_conflict", None)
+    update_data: Dict[str, Any] = {
+        "status": TaskStatus.DONE,
+        "completed_at": datetime.now(timezone.utc).isoformat(),
+        "source_context": new_ctx,
+    }
+    try:
+        await state.kanban_client.update_task(task.id, update_data)
+    except Exception as exc:
+        logger.warning(
+            "[recovery] %s: kanban update failed after rebase+merge: %s",
+            task.id,
+            exc,
+        )
+        return None
+
+    logger.info(
+        "[recovery] %s: recovered via rebase; branch %s merged to main",
+        task.id,
+        branch,
+    )
+    return {
+        "success": True,
+        "task_id": task.id,
+        "branch": branch,
+        "method": "rebase",
+    }
+
+
+async def _sweep_blocked_merge_conflicts(state: Any) -> int:
+    """Sweep BLOCKED-by-merge-conflict tasks and attempt recovery on each.
+
+    Called from :func:`request_next_task` before returning
+    ``no_task_ready``.  Iterates :attr:`state.project_tasks`, picks
+    out tasks that are BLOCKED with a ``merge_conflict`` record in
+    ``source_context``, and runs :func:`_attempt_merge_recovery` on
+    each.  Returns the count of successfully recovered tasks so
+    the caller can decide whether to refresh project state and
+    retry task selection.
+
+    Bug #651 follow-up — eliminates verify-snake-8's spawn-thrash
+    failure mode where 49 ephemeral agents spawned chasing an
+    unrecoverable BLOCKED task before the 20-min stall watchdog
+    fired.
+
+    Parameters
+    ----------
+    state : Any
+        Marcus server state.  Needs ``project_tasks`` and
+        ``kanban_client``.
+
+    Returns
+    -------
+    int
+        Number of BLOCKED tasks recovered to DONE.
+    """
+    project_tasks = getattr(state, "project_tasks", None) or []
+    recovered = 0
+    for task in project_tasks:
+        if getattr(task, "status", None) != TaskStatus.BLOCKED:
+            continue
+        ctx = getattr(task, "source_context", None) or {}
+        if not isinstance(ctx, dict) or "merge_conflict" not in ctx:
+            continue
+        try:
+            result = await _attempt_merge_recovery(task=task, state=state)
+        except (
+            Exception
+        ) as exc:  # noqa: BLE001 - never let one bad task block the sweep
+            logger.warning("[recovery] sweep: unexpected error on %s: %s", task.id, exc)
+            continue
+        if result and result.get("success"):
+            recovered += 1
+    return recovered
 
 
 async def _merge_agent_branch_to_main(

--- a/tests/unit/marcus_mcp/test_merge_conflict_recovery.py
+++ b/tests/unit/marcus_mcp/test_merge_conflict_recovery.py
@@ -1,0 +1,396 @@
+"""Unit tests for merge-conflict recovery (#651 follow-up, Option A).
+
+Background
+----------
+PR #653 marked tasks BLOCKED on merge failure (closed the
+kanban/filesystem divergence) but didn't recover them.  verify-snake-8
+(test71, 2026-05-25) hit a single content conflict that left task
+``f76f890d`` BLOCKED; the runner then spawned 49 ephemeral agents
+chasing the unclaimed downstream task before the 20-minute stall
+watchdog gave up.  Roughly $25-50 of wasted spawn cost from one
+recoverable conflict.
+
+This module implements **auto-recovery via rebase**: when a task is
+BLOCKED with ``source_context.merge_conflict``, Marcus reads the
+agent_id, locates the worktree (still on disk under
+``<experiment_dir>/worktrees/<agent_id>``), runs ``git rebase main``
+in the worktree, and on success fast-forwards main to the rebased
+branch and transitions the task to DONE.
+
+Most "conflicts" in DAG-based parallel work are stale-base false
+conflicts: another agent merged main while this agent's worktree
+was on the old base; the actual code changes don't overlap.
+Rebase resolves these mechanically.  Real content conflicts
+(where two agents' changes overlap on the same lines) abort the
+rebase; the task stays BLOCKED for human intervention.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from src.core.models import Priority, Task, TaskStatus
+
+pytestmark = pytest.mark.unit
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_blocked_task(
+    *,
+    task_id: str = "task_recovered",
+    agent_id: str = "agent_X",
+    branch: str | None = None,
+    name: str = "Implement feature",
+) -> Task:
+    """Build a Task in BLOCKED state with merge_conflict source_context.
+
+    Mirrors what ``_apply_merge_failure_to_update_data`` stamps onto
+    a task when its merge fails.
+    """
+    now = datetime.now(timezone.utc)
+    return Task(
+        id=task_id,
+        name=name,
+        description="...",
+        status=TaskStatus.BLOCKED,
+        priority=Priority.HIGH,
+        assigned_to=None,
+        created_at=now,
+        updated_at=now,
+        due_date=None,
+        estimated_hours=1.0,
+        source_context={
+            "merge_conflict": {
+                "agent_id": agent_id,
+                "branch": branch or f"marcus/{agent_id}",
+                "conflict_stderr": "merge failed: ...",
+                "blocked_at": now.isoformat(),
+            }
+        },
+    )
+
+
+def _setup_recoverable_repo(tmp_path: Path) -> Path:
+    """Build a tmp git project where rebase resolves cleanly.
+
+    Layout::
+
+        tmp_path/
+          implementation/   (main repo on 'main')
+            base.txt        (committed on main)
+            mainonly.txt    (committed on main AFTER agent branched)
+          worktrees/
+            agent_X/        (worktree on 'marcus/agent_X')
+              base.txt
+              agent_X.txt   (committed on the agent's branch)
+
+    The agent's branch was created from an OLDER main (before
+    ``mainonly.txt`` was added).  Rebase should cleanly replay the
+    agent's commit on top of current main.
+    """
+    impl = tmp_path / "implementation"
+    impl.mkdir()
+    wtree_parent = tmp_path / "worktrees"
+    wtree_parent.mkdir()
+
+    def git(cwd: Path, *args: str) -> None:
+        subprocess.run(
+            ["git", *args],
+            cwd=cwd,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+
+    # Initialize repo, identity, base commit on main.
+    git(impl, "init", "--initial-branch=main")
+    git(impl, "config", "user.email", "test@marcus.test")
+    git(impl, "config", "user.name", "Test")
+    (impl / "base.txt").write_text("base\n")
+    git(impl, "add", ".")
+    git(impl, "commit", "-m", "scaffold")
+
+    # Create agent branch from this point — BEFORE the next main commit.
+    git(impl, "branch", "marcus/agent_X")
+
+    # Advance main with a new file (different file from agent's work).
+    (impl / "mainonly.txt").write_text("from main\n")
+    git(impl, "add", "mainonly.txt")
+    git(impl, "commit", "-m", "main advances after agent branched")
+
+    # Create the agent's worktree from their branch.
+    wt = wtree_parent / "agent_X"
+    git(impl, "worktree", "add", str(wt), "marcus/agent_X")
+
+    # Agent commits their own file on the branch (different from mainonly.txt).
+    (wt / "agent_X.txt").write_text("agent X work\n")
+    git(wt, "add", "agent_X.txt")
+    git(wt, "commit", "-m", "feat(agent_X): add file")
+
+    return impl
+
+
+def _setup_unrecoverable_repo(tmp_path: Path) -> Path:
+    """Build a tmp git project where rebase has a real content conflict.
+
+    Both main and the agent's branch modify the SAME LINE of
+    ``conflict.txt``; rebase fails and must abort.
+    """
+    impl = tmp_path / "implementation"
+    impl.mkdir()
+    wtree_parent = tmp_path / "worktrees"
+    wtree_parent.mkdir()
+
+    def git(cwd: Path, *args: str) -> None:
+        subprocess.run(
+            ["git", *args],
+            cwd=cwd,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+
+    git(impl, "init", "--initial-branch=main")
+    git(impl, "config", "user.email", "test@marcus.test")
+    git(impl, "config", "user.name", "Test")
+    (impl / "conflict.txt").write_text("original line\n")
+    git(impl, "add", ".")
+    git(impl, "commit", "-m", "scaffold")
+
+    git(impl, "branch", "marcus/agent_X")
+
+    # Main modifies the contested file.
+    (impl / "conflict.txt").write_text("main's version\n")
+    git(impl, "add", "conflict.txt")
+    git(impl, "commit", "-m", "main modifies conflict.txt")
+
+    wt = wtree_parent / "agent_X"
+    git(impl, "worktree", "add", str(wt), "marcus/agent_X")
+
+    # Agent also modifies the contested file (same line) on their branch.
+    (wt / "conflict.txt").write_text("agent's version\n")
+    git(wt, "add", "conflict.txt")
+    git(wt, "commit", "-m", "feat(agent_X): modify conflict.txt")
+
+    return impl
+
+
+def _make_state(impl: Path, *, blocked_task: Task) -> MagicMock:
+    """Marcus state mock with the inputs the recovery helper reads."""
+    state = MagicMock()
+    state.kanban_client = MagicMock()
+    state.kanban_client._load_workspace_state = MagicMock(
+        return_value={"project_root": str(impl)}
+    )
+    state.kanban_client.update_task = AsyncMock(return_value={"success": True})
+    state.project_tasks = [blocked_task]
+    return state
+
+
+# ---------------------------------------------------------------------------
+# _attempt_merge_recovery — happy path
+# ---------------------------------------------------------------------------
+
+
+class TestAttemptMergeRecoveryHappyPath:
+    """Stale-base false-conflict recoveries (the common case)."""
+
+    @pytest.mark.asyncio
+    async def test_rebase_succeeds_merges_branch_returns_success(
+        self, tmp_path
+    ) -> None:
+        """When the rebase is clean, the branch lands in main and the task
+        recovers.
+
+        Verifies the end-to-end path: rebase succeeds, fast-forward
+        merge lands the agent's commit in main, ``kanban_client.update_task``
+        is called with status=DONE, and the helper returns a success dict.
+        """
+        from src.marcus_mcp.tools.task import _attempt_merge_recovery
+
+        impl = _setup_recoverable_repo(tmp_path)
+        task = _make_blocked_task()
+        state = _make_state(impl, blocked_task=task)
+
+        result = await _attempt_merge_recovery(task=task, state=state)
+
+        # Helper reports success
+        assert result is not None
+        assert result["success"] is True
+        assert result["task_id"] == task.id
+
+        # The agent's file is now in main (rebase replayed cleanly,
+        # fast-forward merge succeeded).
+        assert (impl / "agent_X.txt").exists()
+        assert (impl / "agent_X.txt").read_text() == "agent X work\n"
+        # And main's own file is still there.
+        assert (impl / "mainonly.txt").exists()
+
+        # The task was transitioned to DONE on the kanban.
+        state.kanban_client.update_task.assert_awaited_once()
+        kanban_call = state.kanban_client.update_task.call_args
+        update_data = (
+            kanban_call.args[1]
+            if len(kanban_call.args) > 1
+            else kanban_call.kwargs["update_data"]
+        )
+        assert update_data["status"] == TaskStatus.DONE
+
+    @pytest.mark.asyncio
+    async def test_recovery_clears_merge_conflict_from_source_context(
+        self, tmp_path
+    ) -> None:
+        """On success the ``source_context.merge_conflict`` record is removed.
+
+        Otherwise the task would look like it still has a merge
+        conflict even after recovery — downstream tooling (recovery
+        sweepers, dashboards) would misclassify it.
+        """
+        from src.marcus_mcp.tools.task import _attempt_merge_recovery
+
+        impl = _setup_recoverable_repo(tmp_path)
+        task = _make_blocked_task()
+        state = _make_state(impl, blocked_task=task)
+
+        await _attempt_merge_recovery(task=task, state=state)
+
+        # Inspect the update_data passed to update_task.
+        kanban_call = state.kanban_client.update_task.call_args
+        update_data = (
+            kanban_call.args[1]
+            if len(kanban_call.args) > 1
+            else kanban_call.kwargs["update_data"]
+        )
+        # source_context still exists (other fields may have been set)
+        # but the merge_conflict entry must be gone.
+        ctx = update_data.get("source_context", {})
+        assert "merge_conflict" not in ctx
+
+
+# ---------------------------------------------------------------------------
+# _attempt_merge_recovery — failure path
+# ---------------------------------------------------------------------------
+
+
+class TestAttemptMergeRecoveryRealConflict:
+    """When rebase has real content conflicts, leave the task BLOCKED."""
+
+    @pytest.mark.asyncio
+    async def test_real_content_conflict_aborts_rebase_returns_none(
+        self, tmp_path
+    ) -> None:
+        """The rebase aborts on overlapping line changes; the task stays
+        BLOCKED so a human (or future MCP recovery tool) can resolve.
+
+        Critical: the worktree must NOT be left in a half-rebase state.
+        ``git rebase --abort`` cleans it up regardless of how this
+        function exits.
+        """
+        from src.marcus_mcp.tools.task import _attempt_merge_recovery
+
+        impl = _setup_unrecoverable_repo(tmp_path)
+        task = _make_blocked_task()
+        state = _make_state(impl, blocked_task=task)
+
+        result = await _attempt_merge_recovery(task=task, state=state)
+
+        # Helper reports recovery failed (None or success=False).
+        assert result is None or result.get("success") is False
+
+        # No kanban transition to DONE — task stays BLOCKED.
+        if state.kanban_client.update_task.called:
+            kanban_call = state.kanban_client.update_task.call_args
+            update_data = (
+                kanban_call.args[1]
+                if len(kanban_call.args) > 1
+                else kanban_call.kwargs.get("update_data", {})
+            )
+            assert update_data.get("status") != TaskStatus.DONE
+
+        # Worktree is back to a clean state (no rebase in progress).
+        wt = tmp_path / "worktrees" / "agent_X"
+        rebase_dir = wt / ".git" / "rebase-merge"
+        rebase_apply = wt / ".git" / "rebase-apply"
+        # Neither rebase-state directory should remain.
+        assert not rebase_dir.exists()
+        assert not rebase_apply.exists()
+
+
+# ---------------------------------------------------------------------------
+# _attempt_merge_recovery — edge cases (defensive)
+# ---------------------------------------------------------------------------
+
+
+class TestAttemptMergeRecoveryDefensive:
+    """No-op gracefully when inputs are missing or malformed."""
+
+    @pytest.mark.asyncio
+    async def test_no_merge_conflict_in_source_context_returns_none(
+        self,
+    ) -> None:
+        """Task without merge_conflict source_context is a no-op.
+
+        Defensive: the helper might be called speculatively on any
+        BLOCKED task; only those marked by ``_apply_merge_failure_to_
+        update_data`` should be attempted.
+        """
+        from src.marcus_mcp.tools.task import _attempt_merge_recovery
+
+        now = datetime.now(timezone.utc)
+        task = Task(
+            id="task_X",
+            name="X",
+            description="...",
+            status=TaskStatus.BLOCKED,
+            priority=Priority.HIGH,
+            assigned_to=None,
+            created_at=now,
+            updated_at=now,
+            due_date=None,
+            estimated_hours=1.0,
+            source_context=None,  # No merge_conflict record
+        )
+        state = MagicMock()
+        state.kanban_client = MagicMock()
+
+        result = await _attempt_merge_recovery(task=task, state=state)
+
+        assert result is None
+        state.kanban_client.update_task.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_missing_worktree_returns_none(self, tmp_path) -> None:
+        """If the worktree directory was cleaned up, recovery is impossible.
+
+        Could happen across Marcus restarts or if the experiment runner
+        teardown removed the worktrees.  Return None so the task stays
+        BLOCKED; a human can investigate.
+        """
+        from src.marcus_mcp.tools.task import _attempt_merge_recovery
+
+        # Repo exists but no worktree directory for agent_X.
+        impl = tmp_path / "implementation"
+        impl.mkdir()
+        subprocess.run(
+            ["git", "init", "--initial-branch=main"],
+            cwd=impl,
+            check=True,
+            capture_output=True,
+        )
+
+        task = _make_blocked_task()
+        state = _make_state(impl, blocked_task=task)
+
+        result = await _attempt_merge_recovery(task=task, state=state)
+
+        assert result is None


### PR DESCRIPTION
## Why

PR #653 marked tasks BLOCKED on merge failure but left them **unrecoverable**. verify-snake-8 (test71, 2026-05-25) hit one such conflict and the runner spawned **49 ephemeral agents** before the 20-min stall watchdog gave up — roughly **\$25-50 of wasted spawn cost** from one recoverable conflict. On a commercial customer's API key the wasted spend could be \$200-500 per stall event.

This PR implements **Option A** from Larry's 2026-05-25 decision: auto-recovery via worktree rebase. The proper architectural prevention (#206 baton arbitration) is the next sprint of work; this is the safety net that ships fast.

Most conflicts in DAG-based parallel work are **stale-base false conflicts**. Rebase resolves these mechanically. Real content conflicts abort the rebase and leave the task BLOCKED.

## What changed

**`_attempt_merge_recovery(task, state)`** in `src/marcus_mcp/tools/task.py`:
1. Reads `source_context.merge_conflict` (set by PR #653's helper)
2. Resolves worktree path: `<project_root>/../worktrees/<agent_id>`
3. `git rebase main` in the worktree
4. On clean rebase: checkout main + defensive reset + `git merge --ff-only <branch>` + kanban → DONE + clear `merge_conflict` from source_context
5. On rebase conflict: `git rebase --abort` to clean state; leave BLOCKED; return None

**`_sweep_blocked_merge_conflicts(state)`** iterates `state.project_tasks` and runs recovery on each BLOCKED+merge_conflict task.

**Wired into `request_next_task`**: when no `optimal_task` found, sweep fires before returning `no_task_ready`. If recovery unblocks downstream tasks, refresh state + re-select for the current agent. Eliminates the spawn-thrash cycle.

## Bright-line check

Marcus rebasing the agent's branch onto main is environment shaping, not HOW dictation. Same primitive as `git pull --rebase`. Agent's code unchanged; Marcus just integrates cleanly against advanced main. **Passes Invariant #2.**

## Test plan

### Automated (green)

- [x] 5 new tests in `tests/unit/marcus_mcp/test_merge_conflict_recovery.py` using real `tmp_path` git repos
- [x] 408 unit tests pass across `tests/unit/marcus_mcp` + `tests/unit/mcp`
- [x] `mypy src/marcus_mcp/tools/task.py` — clean

### End-to-end (reviewer to run)

- [ ] Re-run a spec that triggers a conflict (verify-snake-8 setup). Expected: conflict happens, task briefly BLOCKED, next poll's sweep recovers via rebase, task → DONE, downstream unblocks, run completes. Spawn count <10, not 49.

## Empirical motivation

From verify-snake-8 (test71) runner log:

```
[02:19:16] start
[03:14:52]   spawned agent_unicorn_1_41    ← spawn #41 chasing the blocked task
[03:15:27]   spawned agent_unicorn_2_42
... 8 more spawns ...
[03:19:15] STALL: no task-count change for 20 min — tearing down
[03:20:15] run finished — spawned 49 ephemeral agents
```

This PR eliminates that failure mode.

## What this PR does NOT do

- Prevent conflicts (that's #206 baton arbitration, next sprint)
- Handle real content conflicts automatically (leaves task BLOCKED for human)
- Address the L6 cliff "games don't work" problem (PR #642 / behavioral verification)

## Related

- PR #653 — safety net this builds on (BLOCKED on merge fail, defensive reset, memory honesty)
- PR #655 — cache TTL bump
- #206 — Baton Arbitration (prevention, next sprint)
- #654 — behavioral verification gap (separate L6 cliff concern)

🤖 Generated with [Claude Code](https://claude.com/claude-code)