### PR TITLE
fix(runner): fast-fail spawn-thrash when no task completes

### DIFF
--- a/dev-tools/experiments/runners/spawn_agents.py
+++ b/dev-tools/experiments/runners/spawn_agents.py
@@ -39,6 +39,7 @@ if _RUNNERS_PARENT not in sys.path:
 from runners.harness import HARNESSES, Harness, get_harness  # noqa: E402
 from runners.marcus_client import MarcusMCPClient  # noqa: E402
 from runners.spawn_controller import (  # noqa: E402
+    SpawnThrashDetector,
     StallWatchdog,
     compute_spawn_count,
     experiment_lifecycle_state,
@@ -324,6 +325,15 @@ class ExperimentConfig:
         # in project_options) so it is not forwarded to Marcus's
         # create_project, which would reject the unknown key.
         self.stall_timeout_minutes = int(self.config.get("stall_timeout_minutes", 20))
+
+        # Spawn-thrash fast-fail: tears down after this many consecutive
+        # polls of (to_spawn > 0 AND completed unchanged). Catches the
+        # failure mode where a BLOCKED task gates every claimable
+        # downstream task — the runner would otherwise keep spawning
+        # ephemeral agents that immediately exit, burning ~$0.50–$1.00
+        # per agent until the 20-minute stall watchdog fires. 5 polls at
+        # the default 30s cadence = a 2.5-minute fail-fast. 0 disables.
+        self.spawn_thrash_polls = int(self.config.get("spawn_thrash_polls", 5))
 
         # Agent harness selection (GH issue: codex harness support).
         # ``claude`` (default) spawns Anthropic's claude CLI in each pane;
@@ -1882,9 +1892,13 @@ echo "=========================================="
             max(1, (stall_minutes * 60) // poll_seconds) if stall_minutes > 0 else 0
         )
         watchdog = StallWatchdog(stall_polls=stall_polls)
+        thrash_polls = self.config.spawn_thrash_polls
+        thrash_detector = SpawnThrashDetector(thrash_polls=thrash_polls)
         _emit(
             f"poll every {poll_seconds}s; stall watchdog at "
-            f"{stall_minutes} min ({stall_polls} unchanged polls)"
+            f"{stall_minutes} min ({stall_polls} unchanged polls); "
+            f"spawn-thrash fast-fail at {thrash_polls} polls "
+            f"(~{(thrash_polls * poll_seconds) // 60} min)"
         )
 
         worker_pane_ids: List[str] = []
@@ -1996,6 +2010,16 @@ echo "=========================================="
                             f"{stall_minutes} min — tearing down"
                         )
                         self._teardown("stalled")
+                        break
+
+                    if thrash_detector.observe(done, to_spawn):
+                        _emit(
+                            f"SPAWN-THRASH: spawned agents for "
+                            f"{thrash_polls} polls with no task "
+                            f"completing — likely BLOCKED dependency "
+                            f"gating downstream work; tearing down"
+                        )
+                        self._teardown("spawn_thrash")
                         break
 
                 except Exception as exc:  # noqa: BLE001

--- a/dev-tools/experiments/runners/spawn_controller.py
+++ b/dev-tools/experiments/runners/spawn_controller.py
@@ -161,3 +161,100 @@ class StallWatchdog:
             self._last = current
             self._unchanged = 0
         return self._unchanged >= self._stall_polls
+
+
+class SpawnThrashDetector:
+    """
+    Detect spawn-thrash: agents keep spawning but no task ever completes.
+
+    The :class:`StallWatchdog` only fires when *everything* stops changing
+    (``completed``, ``in_progress``, and ``blocked`` all flat) for many
+    minutes — a coarse signal designed to catch wedged runs. It does not
+    catch a much more expensive failure mode where the runner keeps
+    spawning ephemeral agents that immediately exit because no task is
+    actually claimable (every unclaimed task is gated by a BLOCKED
+    dependency, or claim races leave the agent with nothing to do). On
+    paper the task counts are "changing" — ``in_progress`` flickers up
+    and back down each cycle — so the stall watchdog never fires. In
+    practice the run burns one ephemeral agent worth of cost per poll
+    (≈ $0.50–$1.00) until the 20-minute stall timeout finally bites,
+    by which point 30–50 agents have been spawned for nothing.
+
+    The thrash signature is much sharper than "everything is flat":
+
+    - ``to_spawn > 0`` (the runner is actively spawning this poll)
+    - ``completed`` did NOT increase since the previous poll
+
+    Each poll the runner reports both numbers to :meth:`observe`. Each
+    poll matching the signature increments an internal counter; any poll
+    that completes a task — or any poll where the runner spawned nothing
+    — resets it. After ``thrash_polls`` matching polls in a row the
+    detector reports thrash and the runner tears the experiment down.
+
+    Why a separate detector instead of tightening :class:`StallWatchdog`
+    ------------------------------------------------------------------
+    StallWatchdog watches a different question: "has the run stopped
+    making any kind of progress?" That has to be a slow signal because
+    a long-running task can leave the tuple flat for minutes on
+    purpose. Spawn-thrash is the opposite — the runner is *not* idle,
+    it is actively burning money on doomed agents — and can be detected
+    quickly without the false-positive risk that would come from
+    speeding up StallWatchdog.
+
+    Parameters
+    ----------
+    thrash_polls : int
+        Consecutive idle-spawn polls (to_spawn > 0 AND completed
+        unchanged) that constitute a thrash. ``0`` disables the
+        detector entirely.
+    """
+
+    def __init__(self, thrash_polls: int) -> None:
+        self._thrash_polls = thrash_polls
+        self._last_completed: Optional[int] = None
+        self._idle_spawn_polls = 0
+
+    def observe(self, completed: int, to_spawn: int) -> bool:
+        """
+        Record one poll and report whether the run is spawn-thrashing.
+
+        Parameters
+        ----------
+        completed : int
+            Tasks completed so far this run (cumulative).
+        to_spawn : int
+            Number of ephemeral agents the runner is spawning this
+            poll (the output of :func:`compute_spawn_count`).
+
+        Returns
+        -------
+        bool
+            True once ``thrash_polls`` consecutive polls have spawned
+            agents without any task completing; always False when the
+            detector is disabled.
+        """
+        if self._thrash_polls <= 0:
+            return False
+
+        # Initialize baseline on the first observation. The first poll
+        # cannot itself be a thrash — we need at least one prior poll
+        # to compare ``completed`` against — so it only sets the baseline.
+        if self._last_completed is None:
+            self._last_completed = completed
+            return False
+
+        if completed > self._last_completed:
+            # A task completed — real progress, reset the counter.
+            self._last_completed = completed
+            self._idle_spawn_polls = 0
+            return False
+
+        if to_spawn > 0:
+            # No progress AND we spawned this poll — thrash candidate.
+            self._idle_spawn_polls += 1
+        # If to_spawn == 0 we are not burning money this poll; hold
+        # the counter where it is rather than incrementing, so a brief
+        # quiescent period during a slow task does not falsely trip
+        # the detector — but also does not reset it, because the
+        # thrash may resume next poll.
+        return self._idle_spawn_polls >= self._thrash_polls

--- a/tests/unit/experiments/test_spawn_controller.py
+++ b/tests/unit/experiments/test_spawn_controller.py
@@ -14,6 +14,7 @@ import pytest
 
 # conftest.py puts dev-tools/experiments/ on sys.path so `runners` imports.
 from runners.spawn_controller import (
+    SpawnThrashDetector,
     StallWatchdog,
     compute_spawn_count,
     experiment_lifecycle_state,
@@ -146,6 +147,112 @@ class TestStallWatchdog:
         wd = StallWatchdog(stall_polls=0)
         for _ in range(20):
             assert wd.update(0, 0, 0) is False
+
+
+class TestSpawnThrashDetector:
+    """
+    SpawnThrashDetector flags runs that spawn agents but complete no tasks.
+
+    Failure mode it catches (real incidents on test66, test71, test73):
+    a BLOCKED task gates every claimable downstream task, so the runner
+    keeps trying to fill the desired-agent count with ephemeral agents
+    that immediately exit. ``completed`` stays flat while the runner
+    burns one agent's worth of cost per poll. StallWatchdog cannot
+    catch this — the tuple it watches keeps flickering — and only
+    fires after 20 minutes, by which point 30–50 agents have been
+    wasted.
+    """
+
+    def test_fires_after_n_idle_spawn_polls(self) -> None:
+        """to_spawn>0 and completed flat for thrash_polls in a row -> fire."""
+        det = SpawnThrashDetector(thrash_polls=3)
+        # First observation is baseline only — never fires.
+        assert det.observe(completed=5, to_spawn=2) is False
+        # Three more polls: still spawning, still no completions.
+        assert det.observe(completed=5, to_spawn=2) is False  # idle x1
+        assert det.observe(completed=5, to_spawn=2) is False  # idle x2
+        assert det.observe(completed=5, to_spawn=2) is True  # idle x3 -> fire
+
+    def test_completion_resets_the_counter(self) -> None:
+        """Any task completing during the streak resets thrash detection."""
+        det = SpawnThrashDetector(thrash_polls=2)
+        det.observe(completed=3, to_spawn=2)  # baseline
+        assert det.observe(completed=3, to_spawn=2) is False  # idle x1
+        # An agent finishes — progress, reset.
+        assert det.observe(completed=4, to_spawn=2) is False
+        assert det.observe(completed=4, to_spawn=2) is False  # idle x1 again
+        assert det.observe(completed=4, to_spawn=2) is True  # idle x2 -> fire
+
+    def test_zero_spawn_poll_does_not_advance_counter(self) -> None:
+        """A poll with to_spawn=0 is not burning money — don't count it.
+
+        Holding the counter (rather than resetting) preserves the
+        signal: the thrash may resume next poll once unclaimed grows
+        again, and we should not have to start counting over.
+        """
+        det = SpawnThrashDetector(thrash_polls=3)
+        det.observe(completed=5, to_spawn=1)  # baseline
+        assert det.observe(completed=5, to_spawn=1) is False  # idle x1
+        assert det.observe(completed=5, to_spawn=1) is False  # idle x2
+        # A poll where we did NOT spawn — counter held, not incremented.
+        assert det.observe(completed=5, to_spawn=0) is False  # held at 2
+        # Spawning resumes — one more idle-spawn poll trips the trigger.
+        assert det.observe(completed=5, to_spawn=1) is True  # idle x3 -> fire
+
+    def test_zero_thrash_polls_disables_the_detector(self) -> None:
+        """thrash_polls=0 means the detector never fires."""
+        det = SpawnThrashDetector(thrash_polls=0)
+        for _ in range(50):
+            assert det.observe(completed=0, to_spawn=10) is False
+
+    def test_first_observation_never_fires(self) -> None:
+        """No prior poll to compare against — first observation is baseline."""
+        det = SpawnThrashDetector(thrash_polls=1)
+        # Even with the most aggressive threshold (1), the first poll
+        # cannot fire because there is no last_completed yet.
+        assert det.observe(completed=0, to_spawn=99) is False
+
+    def test_progress_after_fire_threshold_does_not_unfire(self) -> None:
+        """Once thrash is reported, the runner is expected to tear down.
+
+        We do not need the detector to keep reporting True after the
+        first fire; one True is enough to trigger teardown. But if it
+        is called again before teardown completes, completion should
+        still reset the counter so a subsequent re-arm is possible
+        (defensive, for future re-use).
+        """
+        det = SpawnThrashDetector(thrash_polls=2)
+        det.observe(completed=0, to_spawn=1)  # baseline
+        det.observe(completed=0, to_spawn=1)  # idle x1
+        assert det.observe(completed=0, to_spawn=1) is True  # fire
+        # Completion lands — counter resets, detector is quiet again.
+        assert det.observe(completed=1, to_spawn=1) is False
+        assert det.observe(completed=1, to_spawn=1) is False  # idle x1
+
+    def test_realistic_thrash_scenario_test73(self) -> None:
+        """Reproduce verify-snake-10 (test73) signature: BLOCKED dep, spawn-thrash.
+
+        Baseline: ``completed=4``, then for the next ~10 polls the
+        runner spawns 1–3 agents each cycle because Marcus reports
+        ``desired>in_flight`` and ``unclaimed>0``, but every spawned
+        agent receives "no task" (the only unclaimed work is gated by
+        the BLOCKED merge-conflict task) and exits. With thrash_polls=5
+        the detector should fire on the 6th observation — capping
+        wasted spawns at ~5 instead of letting the 20-minute stall
+        watchdog count to 38+.
+        """
+        det = SpawnThrashDetector(thrash_polls=5)
+        # Cumulative completed plateaus at 4 — exactly the test73 trace.
+        observations = [
+            (4, 2),  # baseline
+            (4, 2),  # idle x1
+            (4, 3),  # idle x2
+            (4, 1),  # idle x3
+            (4, 2),  # idle x4
+            (4, 2),  # idle x5 -> fire here
+        ]
+        results = [det.observe(c, s) for c, s in observations]
+        assert results == [False, False, False, False, False, True]
 
 
 class TestExperimentLifecycleState:


### PR DESCRIPTION
## What is this system, briefly

Marcus is a coordination platform for multi-agent software builds. The
**experiment runner** (the long-running script in
`dev-tools/experiments/runners/spawn_agents.py`) is the program that
actually drives a Marcus run: it polls Marcus every ~30 seconds and
spawns short-lived "ephemeral" agents — each does exactly one task
and exits — to fill the agent count Marcus asks for. This PR fixes
a failure mode in the runner that can quietly burn tens of dollars
per run.

## Why (the user-visible problem)

When a task gets marked **BLOCKED** in Marcus — for example because an
agent's worktree merge to `main` failed with a real content conflict
that the auto-rebase recovery added in PR #656 cannot resolve — every
downstream task that depends on it stays unclaimed forever. Marcus
still reports `desired_agent_count > in_flight_tasks`, so the runner
keeps spawning agents that immediately receive "no task ready" and
exit. Each wasted agent costs roughly **$0.50–$1.00** in tokens.

The existing safety net is a **stall watchdog** that fires only after
20 minutes of zero change to the `(completed, in_progress, blocked)`
task-count tuple. Under spawn-thrash, that tuple keeps flickering
(`in_progress` goes up by one when the agent claims, back down when
it exits) — so the watchdog never trips. Real recent incidents:

| Run | Spawn count before teardown | Estimated waste |
|---|---|---|
| test71 (verify-snake-8) | 49 agents over 20 minutes | $25–$50 |
| test73 (verify-snake-10) | 38 agents before manual kill | $19–$38 |

If this happened on a user's API key in a hosted Marcus deployment,
one bad project could rack up real money before anyone noticed.

## What changed

### New: `SpawnThrashDetector` (in `dev-tools/experiments/runners/spawn_controller.py`)

A second watchdog that runs alongside `StallWatchdog`. Each poll the
runner reports two numbers:

- `completed`: cumulative tasks completed this run
- `to_spawn`: number of agents the runner is spawning this poll
  (the output of `compute_spawn_count`)

The detector counts **consecutive polls where `to_spawn > 0` AND
`completed` did not increase**. When the count reaches `thrash_polls`
(default 5), the detector reports thrash and the runner tears the
session down with the new `spawn_thrash` exit reason.

Behavior details:

- Any task completing during the streak resets the counter to zero.
- A poll where the runner spawned nothing (`to_spawn == 0`) holds the
  counter where it is — a slow task is not thrash, but the thrash may
  resume once the runner spawns again, and we should not have to
  start counting from scratch.
- The first observation only sets the baseline (we need a prior poll
  to compare `completed` against), so the detector never fires on
  the very first poll.
- `thrash_polls = 0` disables the detector entirely.

### Wired into the runner main loop (`spawn_agents.py`)

The detector is constructed alongside the stall watchdog and consulted
every poll, immediately after the existing stall-watchdog check.

### Config

A new top-level config key `spawn_thrash_polls` (default `5`) is
read in `ExperimentSpawner.__init__`. At the default 30-second poll
cadence this is a **2.5-minute fast-fail**. Worst-case waste under
the new threshold: ~5 agents per incident instead of the 30–50 we
have been seeing — a **6–10x improvement**.

## Why a separate detector (vs. tightening StallWatchdog)

`StallWatchdog` answers "has the whole run stopped making any kind of
progress?" — that has to be a slow signal because a long-running task
can legitimately leave the tuple flat for many minutes. Speeding it
up would cause false positives on slow tasks.

`SpawnThrashDetector` answers a sharper question — "is the runner
actively burning money on doomed agents?" — and can be detected
quickly without that risk because the signal includes the spawning
behavior itself, not just whether the counts moved.

## Worked numerical example

At default `spawn_thrash_polls = 5` and `control_poll_seconds = 30`:

- **Detection window**: 5 polls × 30 s = 150 s = 2.5 minutes
- **Max spawns during detection**: bounded by `desired_agent_count`;
  for a typical 10-agent run, ≤ 5 spawns (one or two per poll)
- **Max wasted cost**: 5 spawns × $1/spawn = **~$5 per thrash incident**
- **Compared to today**: 30–50 spawns × $1/spawn = **$30–$50 per incident**

## Where to look in the code first

| File | Purpose |
|---|---|
| `dev-tools/experiments/runners/spawn_controller.py` | New `SpawnThrashDetector` class (pure decision logic, no I/O) |
| `dev-tools/experiments/runners/spawn_agents.py` | Wires the detector into the polling loop; adds `spawn_thrash_polls` config key |
| `tests/unit/experiments/test_spawn_controller.py` | 7 new unit tests in `TestSpawnThrashDetector` |

## Glossary

| Term | Meaning |
|---|---|
| **Ephemeral agent** | A worker process that claims one Marcus task, completes it, and exits. The runner spawns a new one for the next task instead of reusing the process. |
| **Spawn-thrash** | The runner keeps spawning ephemeral agents that immediately exit because no task is actually claimable. Identified by `completed` flat while `to_spawn > 0`. |
| **BLOCKED task** | A Marcus task marked unworkable (e.g., a merge to `main` failed). Downstream tasks that depend on it stay unclaimed. |
| **Stall watchdog** | The existing 20-minute timer that tears down a run when `(completed, in_progress, blocked)` stops changing. Does NOT catch spawn-thrash because the tuple keeps flickering. |
| **`to_spawn`** | The output of `compute_spawn_count(desired, in_flight, unclaimed)` — how many agents the runner will start this poll. |

## How to verify it works

1. Run the new unit tests:
   ```bash
   python -m pytest tests/unit/experiments/test_spawn_controller.py -v
   ```
   Expected: all 21 tests pass, including 7 in `TestSpawnThrashDetector`.
2. Run the spawn_agents unit suite to confirm no regression:
   ```bash
   python -m pytest tests/unit/experiments/test_spawn_agents.py -q
   ```
   Expected: 90 tests pass.
3. Mypy:
   ```bash
   python -m mypy dev-tools/experiments/runners/spawn_controller.py \
                  dev-tools/experiments/runners/spawn_agents.py
   ```
   Expected: `Success: no issues found in 2 source files`.
4. Optional end-to-end (when one is convenient): run a project that
   reliably produces a real content merge conflict. The runner should
   emit `SPAWN-THRASH: spawned agents for 5 polls with no task
   completing` and tear down after ~2.5 minutes instead of waiting
   20 minutes.

## Test plan

- [x] Unit: `SpawnThrashDetector` fires after N idle-spawn polls
- [x] Unit: completion resets the counter
- [x] Unit: `to_spawn == 0` holds the counter without incrementing
- [x] Unit: `thrash_polls == 0` disables the detector
- [x] Unit: first observation never fires (baseline-only)
- [x] Unit: post-fire re-arm via completion
- [x] Unit: realistic test73 trace (`completed` plateau at 4)
- [x] All 90 existing `spawn_agents` unit tests still pass
- [x] Mypy clean on both modified files
- [ ] Manual: trigger a real BLOCKED-task scenario, observe `spawn_thrash` teardown in ~2.5 min

## Related

- Issue #206 — file-level baton arbitration (gated on this PR by user request: a coordination bug there must not be able to spawn 50 agents)
- PR #656 — `feat(#651): auto-recover BLOCKED-by-merge-conflict tasks via rebase` (Option A — fixes the 80% stale-base case; real content conflicts still produce BLOCKED tasks that this detector now catches in 2.5 min)
- PR #653 — `fix(#651): mark task BLOCKED when worktree merge to main fails` (root cause of the BLOCKED-task scenarios that surface spawn-thrash)
- PR #655 — foundation contract cache TTL bump (unrelated; mentioned for context on the run-cost work stream)

🤖 Generated with [Claude Code](https://claude.com/claude-code)