### PR TITLE
fix(#659): anchor scaffold paths to implementation tasks

### DIFF
--- a/src/integrations/nlp_tools.py
+++ b/src/integrations/nlp_tools.py
@@ -14,7 +14,7 @@ import os
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 # Add src to path
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "src"))
@@ -4001,10 +4001,21 @@ __pycache__/ and *.pyc for Python). Do NOT add "*.js in src/" to the \
 gitignore when the project's source language IS JavaScript — that \
 would ignore the user's actual source files.
 
+TASK ANCHORING (issue #659): for each placeholder file you generate \
+for an implementation task, you MUST include a ``task_name`` field \
+that EXACTLY matches the task name from the Implementation Tasks \
+list above (e.g., ``"Implement Game Core Engine"``). This binds the \
+placeholder to its owning task so Marcus can surface the path to the \
+implementing agent. Files that are NOT per-task placeholders (config, \
+manifests, entry points, .gitignore) MUST omit the ``task_name`` \
+field — they are shared infrastructure, not owned by any single task.
+
 Respond with ONLY a JSON array of files. No markdown fencing.
 Example shape (your actual extensions must match the stated stack):
 [{{"path": "package.json", "content": "..."}}, \
-{{"path": "src/<entry-file>", "content": "..."}}]
+{{"path": "src/<entry-file>", "content": "..."}}, \
+{{"path": "src/<placeholder>", "content": "// ...", \
+"task_name": "Implement <FeatureName>"}}]
 """
 
 
@@ -4014,7 +4025,7 @@ async def _generate_project_scaffold(
     project_name: str,
     project_root: str,
     design_content: Dict[str, Dict[str, Any]],
-) -> bool:
+) -> Tuple[bool, Dict[str, str]]:
     """
     Generate project scaffold and write to disk on main.
 
@@ -4022,6 +4033,18 @@ async def _generate_project_scaffold(
     shared infrastructure files (package manifest, config, entry
     point) and empty placeholder files per implementation task.
     Written to project_root so worktrees inherit them.
+
+    Issue #659 — task anchoring
+    ---------------------------
+    Each per-task placeholder the LLM emits now carries a
+    ``task_name`` field binding it to the owning implementation
+    task. The returned mapping ``{task_name: scaffold_path}`` lets
+    the caller persist the scaffold path on the corresponding
+    kanban task's ``source_context``. Agents then read this
+    anchor from their task instructions instead of inventing a
+    sibling path and orphaning the scaffold (the
+    ``src/core/gameEngine.js`` failure observed in
+    ``snake-baton-1``).
 
     Parameters
     ----------
@@ -4038,8 +4061,15 @@ async def _generate_project_scaffold(
 
     Returns
     -------
-    bool
-        True if scaffold was generated successfully.
+    Tuple[bool, Dict[str, str]]
+        ``(success, task_to_path)`` where ``success`` is True iff
+        the scaffold wrote at least one file and ``task_to_path``
+        maps each implementation task name the LLM bound to a
+        placeholder file → that placeholder's relative path
+        within ``project_root``. Config/entry-point files are
+        absent from the mapping (they have no owning task). The
+        mapping is empty when scaffold generation is skipped or
+        all placeholders were rejected.
 
     See: https://github.com/lwgray/marcus/issues/300
     """
@@ -4049,6 +4079,9 @@ async def _generate_project_scaffold(
     from src.ai.providers.llm_abstraction import LLMAbstraction
 
     project_root_path = Path(project_root)
+    # #659: filled in below from LLM output; returned to caller so
+    # the scaffold path can be persisted on the owning task.
+    task_to_path: Dict[str, str] = {}
 
     # Get the architecture doc content from design_content
     arch_content = ""
@@ -4064,7 +4097,7 @@ async def _generate_project_scaffold(
         logger.warning(
             "[scaffold] No architecture doc found — " "skipping scaffold generation"
         )
-        return False
+        return False, task_to_path
 
     # Build implementation task list
     impl_tasks = [
@@ -4081,7 +4114,7 @@ async def _generate_project_scaffold(
         logger.warning(
             "[scaffold] No implementation tasks found — " "skipping scaffold generation"
         )
-        return False
+        return False, task_to_path
 
     llm = LLMAbstraction()
 
@@ -4102,7 +4135,7 @@ async def _generate_project_scaffold(
 
         if not response:
             logger.warning("[scaffold] Empty LLM response")
-            return False
+            return False, task_to_path
 
         # Parse JSON array of files
         from src.utils.json_parser import clean_json_response
@@ -4112,7 +4145,7 @@ async def _generate_project_scaffold(
 
         if not isinstance(files, list):
             logger.warning("[scaffold] Expected JSON array")
-            return False
+            return False, task_to_path
 
         # Filter out over-generated files (GH-307)
         # Config files can be any length. Non-config files must be
@@ -4137,6 +4170,12 @@ async def _generate_project_scaffold(
             "vite.config.ts",
             "vite.config.js",
         }
+
+        # Build the set of impl task names so we can validate the
+        # LLM-emitted ``task_name`` field (#659). Anything not in this
+        # set is silently dropped from the mapping — the scaffold file
+        # still gets written, but no task ends up anchored to it.
+        impl_task_names = {getattr(t, "name", "") for t in impl_tasks}
 
         # Write each file to disk
         written = 0
@@ -4173,6 +4212,32 @@ async def _generate_project_scaffold(
             full_path.write_text(fcontent, encoding="utf-8")
             written += 1
 
+            # #659: bind the placeholder to its owning implementation
+            # task so the caller can stamp ``scaffold_path`` on the
+            # task's ``source_context``. Only honor ``task_name`` when
+            # it names a real impl task — defensive against the LLM
+            # inventing a name (or attaching it to a config file).
+            raw_task_name = f.get("task_name")
+            if (
+                raw_task_name
+                and isinstance(raw_task_name, str)
+                and raw_task_name in impl_task_names
+                and not is_config
+            ):
+                if raw_task_name in task_to_path:
+                    # Two placeholders bound to the same task — keep
+                    # the first one, warn so we can investigate the
+                    # prompt drift if it recurs.
+                    logger.warning(
+                        "[scaffold] task '%s' bound to multiple "
+                        "placeholders: keeping %s, ignoring %s",
+                        raw_task_name,
+                        task_to_path[raw_task_name],
+                        fpath,
+                    )
+                else:
+                    task_to_path[raw_task_name] = fpath
+
         if rejected > 0:
             logger.info(f"[scaffold] Rejected {rejected} over-generated " f"file(s)")
 
@@ -4203,11 +4268,11 @@ async def _generate_project_scaffold(
         else:
             logger.warning(f"[scaffold] Commit failed: " f"{result.stderr.decode()}")
 
-        return written > 0
+        return written > 0, task_to_path
 
     except Exception as e:
         logger.warning(f"[scaffold] Failed: {e}")
-        return False
+        return False, task_to_path
 
 
 async def _register_design_via_mcp(
@@ -4667,13 +4732,61 @@ async def _run_design_phase_body(
 
     # Scaffold generation — best effort, non-fatal on failure
     try:
-        await _generate_project_scaffold(
+        scaffold_ok, scaffold_task_to_path = await _generate_project_scaffold(
             tasks=safe_tasks,
             project_description=description,
             project_name=project_name,
             project_root=project_root,
             design_content=design_content,
         )
+
+        # #659: persist the scaffold path on the owning task's
+        # ``source_context`` so the agent prompt (Layer 1.3 in
+        # ``build_tiered_instructions``) can show it as the canonical
+        # implementation address. Without this, agents pick a sibling
+        # path by accident — the ``src/core/gameEngine.js`` orphan
+        # observed in ``snake-baton-1`` (commit 0ddc6c0 wrote at
+        # ``src/game/gameEngine.js`` while the scaffold sat at
+        # ``src/core/gameEngine.js``).
+        #
+        # ``safe_tasks`` and ``created_tasks`` are index-aligned by
+        # construction (same ``zip`` invariant used for the design-DONE
+        # update above), so we match the LLM-emitted ``task_name``
+        # against the ORIGINAL task name and use the kanban-side task
+        # ID to issue the update.
+        if scaffold_ok and scaffold_task_to_path:
+            name_to_kanban_id = {
+                orig.name: ct.id for ct, orig in zip(created_tasks, safe_tasks)
+            }
+            for task_name, scaffold_path in scaffold_task_to_path.items():
+                kanban_id = name_to_kanban_id.get(task_name)
+                if not kanban_id:
+                    logger.warning(
+                        "[scaffold] LLM bound placeholder to task "
+                        "'%s' but no kanban task matches that name; "
+                        "skipping anchor",
+                        task_name,
+                    )
+                    continue
+                try:
+                    await kanban_client.update_task(
+                        kanban_id,
+                        {"source_context": {"scaffold_path": scaffold_path}},
+                    )
+                    logger.info(
+                        "[scaffold] Anchored task '%s' (%s) to %s",
+                        task_name,
+                        kanban_id,
+                        scaffold_path,
+                    )
+                except Exception as anchor_err:
+                    logger.warning(
+                        "[scaffold] Failed to anchor task '%s' to %s: %s",
+                        task_name,
+                        scaffold_path,
+                        anchor_err,
+                    )
+
         logger.info("[scaffold] Background generation complete")
     except Exception as e:
         logger.warning(f"[scaffold] Background generation failed (non-fatal): {e}")

--- a/src/integrations/nlp_tools.py
+++ b/src/integrations/nlp_tools.py
@@ -4754,13 +4754,23 @@ async def _run_design_phase_body(
         # update above), so we match the LLM-emitted ``task_name``
         # against the ORIGINAL task name and use the kanban-side task
         # ID to issue the update.
+        # Cross-provider persistence: SQLite merges ``source_context``
+        # into its JSON column; Planka / GitHub / Linear don't have a
+        # ``source_context`` column and would otherwise silently drop
+        # the anchor. The single ``update_task`` call below also writes
+        # a ``MARCUS_SCAFFOLD_PATH`` marker into the description,
+        # mirroring the ``MARCUS_CONTRACT_FIRST`` pattern. Every
+        # provider's ``update_task`` round-trips description.
+        # ``_resolve_scaffold_path`` in ``task.py`` parses the marker
+        # as the fallback path source when ``source_context`` is empty
+        # — cross-provider parity intact.
         if scaffold_ok and scaffold_task_to_path:
-            name_to_kanban_id = {
-                orig.name: ct.id for ct, orig in zip(created_tasks, safe_tasks)
+            name_to_pair = {
+                orig.name: (ct.id, orig) for ct, orig in zip(created_tasks, safe_tasks)
             }
             for task_name, scaffold_path in scaffold_task_to_path.items():
-                kanban_id = name_to_kanban_id.get(task_name)
-                if not kanban_id:
+                pair = name_to_pair.get(task_name)
+                if not pair:
                     logger.warning(
                         "[scaffold] LLM bound placeholder to task "
                         "'%s' but no kanban task matches that name; "
@@ -4768,10 +4778,25 @@ async def _run_design_phase_body(
                         task_name,
                     )
                     continue
+                kanban_id, orig_task = pair
+                # Idempotent marker append: skip when the marker is
+                # already present so re-invocation doesn't multiply
+                # the comment.
+                existing_desc = getattr(orig_task, "description", "") or ""
+                if "<!-- MARCUS_SCAFFOLD_PATH:" in existing_desc:
+                    new_desc = existing_desc
+                else:
+                    marker = f"<!-- MARCUS_SCAFFOLD_PATH: {scaffold_path} -->"
+                    new_desc = (
+                        f"{existing_desc}\n\n{marker}" if existing_desc else marker
+                    )
                 try:
                     await kanban_client.update_task(
                         kanban_id,
-                        {"source_context": {"scaffold_path": scaffold_path}},
+                        {
+                            "description": new_desc,
+                            "source_context": {"scaffold_path": scaffold_path},
+                        },
                     )
                     logger.info(
                         "[scaffold] Anchored task '%s' (%s) to %s",

--- a/src/integrations/providers/sqlite_kanban.py
+++ b/src/integrations/providers/sqlite_kanban.py
@@ -684,6 +684,47 @@ class SQLiteKanban(KanbanInterface):
                             now_iso,
                         ),
                     )
+                elif key == "source_context":
+                    # Merge into existing source_context JSON, not
+                    # replace. Codex P1 on PR #660: prior to this
+                    # branch, update_task silently ignored
+                    # source_context entirely so the #659 scaffold
+                    # anchor never landed on the row. Read-modify-write
+                    # under the same connection keeps the merge atomic.
+                    # Callers passing a dict (e.g. ``{"scaffold_path":
+                    # "..."}``) merge their keys in; ``None`` clears
+                    # the field; an empty dict ``{}`` is a no-op.
+                    if value is None:
+                        set_clauses.append("source_context = ?")
+                        params.append(None)
+                    elif isinstance(value, dict):
+                        if not value:
+                            # Empty dict — no-op so we don't churn
+                            # updated_at when there's nothing to merge.
+                            continue
+                        row = conn.execute(
+                            "SELECT source_context FROM tasks " "WHERE id = ?",
+                            (task_id,),
+                        ).fetchone()
+                        existing_json = row["source_context"] if row else None
+                        existing_ctx: Dict[str, Any] = {}
+                        if existing_json:
+                            try:
+                                parsed = json.loads(existing_json)
+                                if isinstance(parsed, dict):
+                                    existing_ctx = parsed
+                            except (json.JSONDecodeError, TypeError):
+                                # Corrupt row — overwrite rather than
+                                # silently preserve unparseable state.
+                                existing_ctx = {}
+                        merged = {**existing_ctx, **value}
+                        set_clauses.append("source_context = ?")
+                        params.append(
+                            json.dumps(
+                                merged,
+                                default=_json_default,
+                            )
+                        )
 
             params.append(task_id)
             # Safe: set_clauses only contains hardcoded column names

--- a/src/marcus_mcp/tools/task.py
+++ b/src/marcus_mcp/tools/task.py
@@ -1355,6 +1355,30 @@ def build_tiered_instructions(
                 "writing code. Conform to them at the boundary; design "
                 "everything else yourself."
             )
+
+        # #659: scaffold-path anchor. When Marcus's pre-fork scaffold
+        # generated a placeholder file for this task, surface the
+        # exact path so the agent fills the scaffold instead of
+        # inventing a sibling path (the ``src/core/gameEngine.js``
+        # orphan failure observed in ``snake-baton-1`` — the engine
+        # agent wrote at ``src/game/gameEngine.js`` because nothing
+        # told them ``src/core/gameEngine.js`` was their file).
+        # Source: persisted on the task's ``source_context`` at
+        # scaffold-generation time in
+        # ``_generate_project_scaffold`` (``nlp_tools.py``).
+        scaffold_path_raw = ""
+        if isinstance(task.source_context, dict):
+            scaffold_path_raw = str(task.source_context.get("scaffold_path", "") or "")
+        if scaffold_path_raw:
+            contract_notice += (
+                f"\n\n📂 IMPLEMENTATION FILE: {scaffold_path_raw}\n"
+                f"Marcus pre-created a placeholder at this path. Fill "
+                f"it with your implementation — do NOT create a "
+                f"sibling file elsewhere. Other agents will import "
+                f"from this exact path. If the file is missing when "
+                f"you start, the scaffold step may have failed; "
+                f"create the file at this path."
+            )
         # GH-356: surface scope_annotation semantics so agents know
         # how to interpret the field on each dependency artifact.
         contract_notice += (

--- a/src/marcus_mcp/tools/task.py
+++ b/src/marcus_mcp/tools/task.py
@@ -1177,6 +1177,46 @@ def _parse_contract_metadata(task: Task) -> Dict[str, str]:
     }
 
 
+def _resolve_scaffold_path(task: Task) -> str:
+    """Return the scaffold anchor path for ``task``, or empty string.
+
+    Priority order, mirroring the contract-metadata resolver above so
+    the path survives any kanban provider:
+
+    1. ``task.source_context["scaffold_path"]`` — set by SQLite's
+       ``update_task`` source_context-merge code (#660). The default
+       SQLite provider persists this directly.
+    2. ``MARCUS_SCAFFOLD_PATH`` marker in the task description —
+       fallback for non-SQLite providers (Planka, GitHub, Linear)
+       that round-trip the description verbatim but don't have a
+       native ``source_context`` column. Same approach
+       ``_parse_contract_metadata`` uses for contract data.
+
+    Returns an empty string when neither source carries a path —
+    legacy / pre-#659 tasks render normally without the anchor section.
+    """
+    source_context = getattr(task, "source_context", None) or {}
+    if isinstance(source_context, dict):
+        sc_path = source_context.get("scaffold_path")
+        if sc_path:
+            return str(sc_path).strip()
+
+    description = getattr(task, "description", "") or ""
+    marker_start = description.find("<!-- MARCUS_SCAFFOLD_PATH:")
+    if marker_start == -1:
+        return ""
+    marker_end = description.find("-->", marker_start)
+    if marker_end == -1:
+        return ""
+
+    marker_body = description[marker_start:marker_end]
+    # Marker body shape: ``<!-- MARCUS_SCAFFOLD_PATH: src/foo.js``
+    # Strip the prefix and any whitespace.
+    prefix = "<!-- MARCUS_SCAFFOLD_PATH:"
+    raw = marker_body[len(prefix) :].strip()
+    return raw
+
+
 def build_tiered_instructions(
     base_instructions: str,
     task: Task,
@@ -1360,15 +1400,12 @@ def build_tiered_instructions(
         # generated a placeholder file for this task, surface the
         # exact path so the agent fills the scaffold instead of
         # inventing a sibling path (the ``src/core/gameEngine.js``
-        # orphan failure observed in ``snake-baton-1`` — the engine
-        # agent wrote at ``src/game/gameEngine.js`` because nothing
-        # told them ``src/core/gameEngine.js`` was their file).
-        # Source: persisted on the task's ``source_context`` at
-        # scaffold-generation time in
-        # ``_generate_project_scaffold`` (``nlp_tools.py``).
-        scaffold_path_raw = ""
-        if isinstance(task.source_context, dict):
-            scaffold_path_raw = str(task.source_context.get("scaffold_path", "") or "")
+        # orphan failure observed in ``snake-baton-1``). The
+        # ``_resolve_scaffold_path`` helper checks ``source_context``
+        # first (SQLite provider has a native column) then falls back
+        # to the ``MARCUS_SCAFFOLD_PATH`` description marker that
+        # round-trips through Planka / GitHub / Linear providers.
+        scaffold_path_raw = _resolve_scaffold_path(task)
         if scaffold_path_raw:
             contract_notice += (
                 f"\n\n📂 IMPLEMENTATION FILE: {scaffold_path_raw}\n"

--- a/tests/unit/integrations/test_design_autocomplete.py
+++ b/tests/unit/integrations/test_design_autocomplete.py
@@ -574,6 +574,7 @@ class TestRunDesignPhaseHandoff:
             patch(
                 "src.integrations.nlp_tools._generate_project_scaffold",
                 new_callable=AsyncMock,
+                return_value=(True, {}),
             ),
         ):
             mock_gen.return_value = mock_design_content
@@ -659,6 +660,7 @@ class TestRunDesignPhaseHandoff:
             patch(
                 "src.integrations.nlp_tools._generate_project_scaffold",
                 new_callable=AsyncMock,
+                return_value=(True, {}),
             ),
         ):
             mock_gen.return_value = mock_design_content
@@ -742,6 +744,7 @@ class TestRunDesignPhaseHandoff:
             patch(
                 "src.integrations.nlp_tools._generate_project_scaffold",
                 new_callable=AsyncMock,
+                return_value=(True, {}),
             ),
         ):
             mock_gen.side_effect = RuntimeError("LLM timeout")
@@ -781,6 +784,7 @@ class TestRunDesignPhaseHandoff:
             patch(
                 "src.integrations.nlp_tools._generate_project_scaffold",
                 new_callable=AsyncMock,
+                return_value=(True, {}),
             ),
         ):
             mock_gen.return_value = {}
@@ -828,6 +832,7 @@ class TestRunDesignPhaseHandoff:
             patch(
                 "src.integrations.nlp_tools._generate_project_scaffold",
                 new_callable=AsyncMock,
+                return_value=(True, {}),
             ) as mock_scaffold,
         ):
             mock_gen.return_value = mock_design_content
@@ -894,6 +899,7 @@ class TestRunDesignPhaseHandoff:
             patch(
                 "src.integrations.nlp_tools._generate_project_scaffold",
                 new_callable=AsyncMock,
+                return_value=(True, {}),
             ) as mock_scaffold,
         ):
             mock_gen.return_value = mock_design_content
@@ -953,6 +959,7 @@ class TestRunDesignPhaseHandoff:
             patch(
                 "src.integrations.nlp_tools._generate_project_scaffold",
                 new_callable=AsyncMock,
+                return_value=(True, {}),
             ),
         ):
             mock_gen.return_value = mock_design_content
@@ -1019,6 +1026,7 @@ class TestRunDesignPhaseHandoff:
             patch(
                 "src.integrations.nlp_tools._generate_project_scaffold",
                 new_callable=AsyncMock,
+                return_value=(True, {}),
             ),
         ):
             mock_gen.return_value = mock_design_content
@@ -1164,6 +1172,7 @@ class TestRunDesignPhasePreGeneratedContent:
             patch(
                 "src.integrations.nlp_tools._generate_project_scaffold",
                 new_callable=AsyncMock,
+                return_value=(True, {}),
             ),
         ):
             await _run_design_phase(
@@ -1218,6 +1227,7 @@ class TestRunDesignPhasePreGeneratedContent:
             patch(
                 "src.integrations.nlp_tools._generate_project_scaffold",
                 new_callable=AsyncMock,
+                return_value=(True, {}),
             ),
         ):
             mock_log_artifact.return_value = {
@@ -1279,6 +1289,7 @@ class TestRunDesignPhasePreGeneratedContent:
             patch(
                 "src.integrations.nlp_tools._generate_project_scaffold",
                 new_callable=AsyncMock,
+                return_value=(True, {}),
             ),
         ):
             await _run_design_phase(
@@ -1375,6 +1386,7 @@ class TestRunDesignPhaseCostAttribution:
                 patch(
                     "src.integrations.nlp_tools._generate_project_scaffold",
                     new_callable=AsyncMock,
+                    return_value=(True, {}),
                 ),
             ):
                 await _run_design_phase(
@@ -1423,6 +1435,7 @@ class TestRunDesignPhaseCostAttribution:
             patch(
                 "src.integrations.nlp_tools._generate_project_scaffold",
                 new_callable=AsyncMock,
+                return_value=(True, {}),
             ),
         ):
             # Should not raise — the isinstance guard prevents the
@@ -1509,6 +1522,7 @@ class TestRunDesignPhaseCostAttribution:
                 patch(
                     "src.integrations.nlp_tools._generate_project_scaffold",
                     new_callable=AsyncMock,
+                    return_value=(True, {}),
                 ),
             ):
                 await _run_design_phase(

--- a/tests/unit/integrations/test_scaffold_anchoring.py
+++ b/tests/unit/integrations/test_scaffold_anchoring.py
@@ -1,0 +1,326 @@
+"""
+Unit tests for scaffold anchoring (issue #659).
+
+When Marcus generates a project scaffold pre-fork, each implementation
+task receives a placeholder file at a canonical path (e.g.,
+``src/core/gameEngine.js`` for the "Implement Game Core Engine" task).
+Without an explicit anchor in the agent's task instructions, agents
+sometimes invent sibling paths (the ``src/game/gameEngine.js`` orphan
+observed in ``snake-baton-1``), leaving the scaffold as dead code on
+disk and creating import ambiguity downstream.
+
+These tests verify two behaviors:
+
+1. ``_generate_project_scaffold`` returns a ``{task_name → path}``
+   mapping for every placeholder the LLM bound to an implementation
+   task. Config files (manifests, entry points, .gitignore) are
+   absent from the mapping because they have no owning task.
+
+2. ``build_tiered_instructions`` surfaces the persisted
+   ``scaffold_path`` from ``task.source_context`` in the
+   IMPLEMENTATION FILE section of the agent's task instructions.
+"""
+
+import json
+from typing import Any, Optional
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from src.core.models import (
+    Priority,
+    Task,
+    TaskStatus,
+)
+from src.integrations.nlp_tools import _generate_project_scaffold
+from src.marcus_mcp.tools.task import build_tiered_instructions
+
+pytestmark = pytest.mark.unit
+
+
+def _make_task(name: str, source_context: Optional[dict[str, Any]] = None) -> Task:
+    """Construct a minimal Task instance for the tests below."""
+    from datetime import datetime, timezone
+
+    now = datetime.now(timezone.utc)
+    return Task(
+        id=f"task_{name.lower().replace(' ', '_')}",
+        name=name,
+        description="",
+        status=TaskStatus.TODO,
+        priority=Priority.MEDIUM,
+        assigned_to=None,
+        created_at=now,
+        updated_at=now,
+        due_date=None,
+        estimated_hours=2.0,
+        labels=["implementation"],
+        source_context=source_context or {},
+        responsibility="implements " + name,
+    )
+
+
+class TestScaffoldReturnsAnchorMapping:
+    """``_generate_project_scaffold`` returns ``task_name → scaffold_path``."""
+
+    @pytest.mark.asyncio
+    async def test_returns_mapping_for_each_bound_placeholder(self, tmp_path) -> None:
+        """Each placeholder with a valid ``task_name`` lands in the mapping.
+
+        Mirrors the snake-baton-1 shape: two implementation tasks, one
+        placeholder per task. The LLM is mocked to emit the canonical
+        JSON the prompt asks for.
+        """
+        tasks = [
+            _make_task("Implement Game Core Engine"),
+            _make_task("Implement Game Presentation and Feedback System"),
+        ]
+        design_content = {
+            "Design Game Core Engine": {
+                "artifacts": [
+                    {
+                        "artifact_type": "architecture",
+                        "content": "# arch doc",
+                    }
+                ]
+            }
+        }
+        llm_response = json.dumps(
+            [
+                {"path": "package.json", "content": "{}"},
+                {
+                    "path": "src/core/gameEngine.js",
+                    "content": "// game engine placeholder",
+                    "task_name": "Implement Game Core Engine",
+                },
+                {
+                    "path": "src/presentation/renderer.js",
+                    "content": "// renderer placeholder",
+                    "task_name": "Implement Game Presentation and Feedback System",
+                },
+            ]
+        )
+
+        with patch(
+            "src.ai.providers.llm_abstraction.LLMAbstraction.analyze",
+            new_callable=AsyncMock,
+            return_value=llm_response,
+        ):
+            success, task_to_path = await _generate_project_scaffold(
+                tasks=tasks,
+                project_description="Snake game in vanilla JS",
+                project_name="snake",
+                project_root=str(tmp_path),
+                design_content=design_content,
+            )
+
+        assert success is True
+        assert task_to_path == {
+            "Implement Game Core Engine": "src/core/gameEngine.js",
+            "Implement Game Presentation and Feedback System": (
+                "src/presentation/renderer.js"
+            ),
+        }
+
+    @pytest.mark.asyncio
+    async def test_config_files_excluded_from_mapping(self, tmp_path) -> None:
+        """Files without a ``task_name`` (configs / entry points) skip the mapping.
+
+        ``package.json``, ``vite.config.js``, ``index.html``, and the
+        entry-point ``main.js`` are shared infrastructure — no single
+        task owns them, so they MUST NOT appear in the anchor mapping.
+        """
+        tasks = [_make_task("Implement Game Core Engine")]
+        design_content = {
+            "Design Game Core Engine": {
+                "artifacts": [{"artifact_type": "architecture", "content": "doc"}]
+            }
+        }
+        llm_response = json.dumps(
+            [
+                {"path": "package.json", "content": "{}"},
+                {"path": "vite.config.js", "content": "export default {}"},
+                {"path": "index.html", "content": "<!doctype html>"},
+                {"path": "src/main.js", "content": "// entry"},
+                {
+                    "path": "src/core/gameEngine.js",
+                    "content": "// engine",
+                    "task_name": "Implement Game Core Engine",
+                },
+            ]
+        )
+
+        with patch(
+            "src.ai.providers.llm_abstraction.LLMAbstraction.analyze",
+            new_callable=AsyncMock,
+            return_value=llm_response,
+        ):
+            _, task_to_path = await _generate_project_scaffold(
+                tasks=tasks,
+                project_description="snake",
+                project_name="snake",
+                project_root=str(tmp_path),
+                design_content=design_content,
+            )
+
+        # Only the explicitly-bound placeholder appears.
+        assert task_to_path == {"Implement Game Core Engine": "src/core/gameEngine.js"}
+
+    @pytest.mark.asyncio
+    async def test_unknown_task_name_is_ignored(self, tmp_path) -> None:
+        """A ``task_name`` not matching any impl task is silently dropped.
+
+        Defensive against LLM hallucination — if the model emits a
+        ``task_name`` that doesn't correspond to a real task, we'd
+        rather write the scaffold file and skip the anchor than write
+        a phantom anchor that misleads downstream code.
+        """
+        tasks = [_make_task("Implement Game Core Engine")]
+        design_content = {
+            "Design X": {
+                "artifacts": [{"artifact_type": "architecture", "content": "doc"}]
+            }
+        }
+        llm_response = json.dumps(
+            [
+                {
+                    "path": "src/foo.js",
+                    "content": "// foo",
+                    "task_name": "Implement Some Task That Does Not Exist",
+                },
+            ]
+        )
+
+        with patch(
+            "src.ai.providers.llm_abstraction.LLMAbstraction.analyze",
+            new_callable=AsyncMock,
+            return_value=llm_response,
+        ):
+            _, task_to_path = await _generate_project_scaffold(
+                tasks=tasks,
+                project_description="x",
+                project_name="x",
+                project_root=str(tmp_path),
+                design_content=design_content,
+            )
+
+        assert task_to_path == {}
+
+    @pytest.mark.asyncio
+    async def test_duplicate_task_name_keeps_first(self, tmp_path) -> None:
+        """When the LLM binds two files to the same task, only the first wins.
+
+        Multiple placeholders per task is a prompt-drift symptom we
+        log but don't fail on. The mapping is task → ONE path; the
+        first one the writer sees stays.
+        """
+        tasks = [_make_task("Implement Game Core Engine")]
+        design_content = {
+            "Design X": {
+                "artifacts": [{"artifact_type": "architecture", "content": "doc"}]
+            }
+        }
+        llm_response = json.dumps(
+            [
+                {
+                    "path": "src/core/gameEngine.js",
+                    "content": "// first",
+                    "task_name": "Implement Game Core Engine",
+                },
+                {
+                    "path": "src/engine/index.js",
+                    "content": "// second",
+                    "task_name": "Implement Game Core Engine",
+                },
+            ]
+        )
+
+        with patch(
+            "src.ai.providers.llm_abstraction.LLMAbstraction.analyze",
+            new_callable=AsyncMock,
+            return_value=llm_response,
+        ):
+            _, task_to_path = await _generate_project_scaffold(
+                tasks=tasks,
+                project_description="x",
+                project_name="x",
+                project_root=str(tmp_path),
+                design_content=design_content,
+            )
+
+        # First write wins; both files still land on disk, but only
+        # the first is anchored.
+        assert task_to_path == {"Implement Game Core Engine": "src/core/gameEngine.js"}
+
+
+class TestAgentInstructionsSurfaceScaffoldPath:
+    """``build_tiered_instructions`` surfaces ``scaffold_path`` to the agent."""
+
+    def test_implementation_file_section_appears_when_path_set(self) -> None:
+        """A task with ``source_context.scaffold_path`` gets an anchor section.
+
+        The instructions must explicitly name the path so the agent
+        fills the scaffold rather than picking a sibling path.
+        """
+        task = _make_task(
+            "Implement Game Core Engine",
+            source_context={
+                "scaffold_path": "src/core/gameEngine.js",
+                "contract_file": "docs/architecture/engine.md",
+            },
+        )
+
+        instructions = build_tiered_instructions(
+            base_instructions="Build the engine.",
+            task=task,
+            context_data=None,
+            dependency_awareness=None,
+            predictions=None,
+            state=None,
+        )
+
+        assert "IMPLEMENTATION FILE: src/core/gameEngine.js" in instructions
+        assert "do NOT create a sibling file" in instructions
+
+    def test_no_anchor_section_when_path_missing(self) -> None:
+        """Without ``scaffold_path``, no IMPLEMENTATION FILE section appears.
+
+        Legacy tasks created before #659 won't have the field;
+        instructions must still render cleanly without it.
+        """
+        task = _make_task(
+            "Implement Game Core Engine",
+            source_context={"contract_file": "docs/architecture/engine.md"},
+        )
+
+        instructions = build_tiered_instructions(
+            base_instructions="Build the engine.",
+            task=task,
+            context_data=None,
+            dependency_awareness=None,
+            predictions=None,
+            state=None,
+        )
+
+        assert "IMPLEMENTATION FILE:" not in instructions
+
+    def test_empty_scaffold_path_treated_as_missing(self) -> None:
+        """``scaffold_path = ""`` should not render an empty anchor section."""
+        task = _make_task(
+            "Implement Game Core Engine",
+            source_context={
+                "scaffold_path": "",
+                "contract_file": "docs/architecture/engine.md",
+            },
+        )
+
+        instructions = build_tiered_instructions(
+            base_instructions="Build the engine.",
+            task=task,
+            context_data=None,
+            dependency_awareness=None,
+            predictions=None,
+            state=None,
+        )
+
+        assert "IMPLEMENTATION FILE:" not in instructions

--- a/tests/unit/integrations/test_scaffold_anchoring.py
+++ b/tests/unit/integrations/test_scaffold_anchoring.py
@@ -324,3 +324,92 @@ class TestAgentInstructionsSurfaceScaffoldPath:
         )
 
         assert "IMPLEMENTATION FILE:" not in instructions
+
+    def test_falls_back_to_description_marker_for_non_sqlite(self) -> None:
+        """Non-SQLite providers carry the anchor via a description marker.
+
+        Planka, GitHub, and Linear don't have a ``source_context``
+        column. The anchor survives in the task description as a
+        ``<!-- MARCUS_SCAFFOLD_PATH: ... -->`` marker, mirroring the
+        ``MARCUS_CONTRACT_FIRST`` pattern. ``_resolve_scaffold_path``
+        parses the marker as the fallback path source.
+        """
+        task = _make_task(
+            "Implement Game Core Engine",
+            source_context={
+                "contract_file": "docs/architecture/engine.md",
+                # No scaffold_path here — simulates a Planka-backed
+                # task that never persisted the JSON column.
+            },
+        )
+        # Description carries the marker, the way the
+        # cross-provider write path leaves it.
+        task.description = (
+            "Build the engine.\n\n"
+            "<!-- MARCUS_SCAFFOLD_PATH: src/core/gameEngine.js -->"
+        )
+
+        instructions = build_tiered_instructions(
+            base_instructions="Build the engine.",
+            task=task,
+            context_data=None,
+            dependency_awareness=None,
+            predictions=None,
+            state=None,
+        )
+
+        assert "IMPLEMENTATION FILE: src/core/gameEngine.js" in instructions
+
+    def test_source_context_wins_over_description_marker(self) -> None:
+        """When both are present, ``source_context`` is the source of truth.
+
+        SQLite carries the path in its JSON column; the description
+        marker is the cross-provider fallback. If both somehow
+        disagree (e.g., the description marker is stale and the JSON
+        column was updated), the JSON column is authoritative for
+        the IMPLEMENTATION FILE section.
+
+        Note: the description (including its marker) appears verbatim
+        in Layer 0's mandatory workflow listing. That's expected —
+        the marker IS a description-borne signal in non-SQLite
+        providers. What matters is which path the structured anchor
+        section names.
+        """
+        task = _make_task(
+            "Implement Game Core Engine",
+            source_context={"scaffold_path": "src/core/gameEngine.js"},
+        )
+        task.description = "<!-- MARCUS_SCAFFOLD_PATH: src/old/stale_path.js -->"
+
+        instructions = build_tiered_instructions(
+            base_instructions="Build the engine.",
+            task=task,
+            context_data=None,
+            dependency_awareness=None,
+            predictions=None,
+            state=None,
+        )
+
+        # The structured anchor section names the source_context path.
+        assert "IMPLEMENTATION FILE: src/core/gameEngine.js" in instructions
+        # The structured section does NOT name the stale marker path.
+        assert "IMPLEMENTATION FILE: src/old/stale_path.js" not in instructions
+
+    def test_malformed_marker_does_not_render_section(self) -> None:
+        """A marker without a closing ``-->`` is silently ignored."""
+        task = _make_task(
+            "Implement Game Core Engine",
+            source_context={},
+        )
+        task.description = "<!-- MARCUS_SCAFFOLD_PATH: src/core/gameEngine.js"
+
+        instructions = build_tiered_instructions(
+            base_instructions="Build the engine.",
+            task=task,
+            context_data=None,
+            dependency_awareness=None,
+            predictions=None,
+            state=None,
+        )
+
+        assert "IMPLEMENTATION FILE:" not in instructions

--- a/tests/unit/integrations/test_sqlite_kanban.py
+++ b/tests/unit/integrations/test_sqlite_kanban.py
@@ -692,6 +692,111 @@ class TestSQLiteKanbanUpdateTask:
         assert updated.status == TaskStatus.TODO
         assert updated.assigned_to is None
 
+    @pytest.mark.asyncio
+    async def test_update_task_source_context_merges_into_existing(
+        self, connected_kanban: SQLiteKanban
+    ) -> None:
+        """Codex P1 on PR #660: ``source_context`` updates MUST merge.
+
+        Without merging, an anchoring update like ``{"scaffold_path":
+        "src/core/gameEngine.js"}`` would clobber the ``contract_file``
+        and ``responsibility`` fields the decomposer wrote at task
+        creation. Verify both old and new keys survive after the
+        merge.
+        """
+        data = _sample_task_data()
+        data["source_context"] = {
+            "contract_file": "docs/arch/engine.md",
+            "responsibility": "owns engine contract",
+        }
+        task = await connected_kanban.create_task(data)
+
+        # Anchor the scaffold path — must NOT lose contract_file /
+        # responsibility.
+        updated = await connected_kanban.update_task(
+            task.id,
+            {"source_context": {"scaffold_path": "src/core/gameEngine.js"}},
+        )
+        assert updated is not None
+        assert updated.source_context == {
+            "contract_file": "docs/arch/engine.md",
+            "responsibility": "owns engine contract",
+            "scaffold_path": "src/core/gameEngine.js",
+        }
+
+    @pytest.mark.asyncio
+    async def test_update_task_source_context_new_value_overrides_existing(
+        self, connected_kanban: SQLiteKanban
+    ) -> None:
+        """New value for an existing key wins (standard dict merge semantics)."""
+        data = _sample_task_data()
+        data["source_context"] = {"scaffold_path": "src/old/path.js"}
+        task = await connected_kanban.create_task(data)
+
+        updated = await connected_kanban.update_task(
+            task.id,
+            {"source_context": {"scaffold_path": "src/new/path.js"}},
+        )
+        assert updated is not None
+        assert updated.source_context == {"scaffold_path": "src/new/path.js"}
+
+    @pytest.mark.asyncio
+    async def test_update_task_source_context_empty_dict_is_no_op(
+        self, connected_kanban: SQLiteKanban
+    ) -> None:
+        """An empty ``source_context`` dict must not erase the existing value.
+
+        Codex catch: ``{"source_context": {}}`` previously fell through
+        the entire elif chain silently. Now it explicitly no-ops on the
+        column so updated_at doesn't churn either.
+        """
+        data = _sample_task_data()
+        data["source_context"] = {"contract_file": "docs/arch.md"}
+        task = await connected_kanban.create_task(data)
+
+        updated = await connected_kanban.update_task(
+            task.id,
+            {"source_context": {}},
+        )
+        assert updated is not None
+        assert updated.source_context == {"contract_file": "docs/arch.md"}
+
+    @pytest.mark.asyncio
+    async def test_update_task_source_context_none_clears_field(
+        self, connected_kanban: SQLiteKanban
+    ) -> None:
+        """``source_context = None`` is the explicit "drop everything" signal."""
+        data = _sample_task_data()
+        data["source_context"] = {"contract_file": "docs/arch.md"}
+        task = await connected_kanban.create_task(data)
+
+        updated = await connected_kanban.update_task(
+            task.id,
+            {"source_context": None},
+        )
+        assert updated is not None
+        # The model normalizes a cleared source_context to either
+        # None or an empty dict depending on the deserializer. Either
+        # form is acceptable; what matters is that the prior keys
+        # are gone.
+        assert not updated.source_context
+
+    @pytest.mark.asyncio
+    async def test_update_task_source_context_merges_when_no_prior(
+        self, connected_kanban: SQLiteKanban
+    ) -> None:
+        """A task created without source_context can still be anchored later."""
+        data = _sample_task_data()
+        # No source_context at create time.
+        task = await connected_kanban.create_task(data)
+
+        updated = await connected_kanban.update_task(
+            task.id,
+            {"source_context": {"scaffold_path": "src/core/engine.js"}},
+        )
+        assert updated is not None
+        assert updated.source_context == {"scaffold_path": "src/core/engine.js"}
+
 
 # ============================================================
 # Phase 4: Comments + Progress + Blockers + Metrics


### PR DESCRIPTION
## What is this system, briefly

Marcus is a coordination platform for multi-agent software builds. Before agents spawn, Marcus generates a project **scaffold** — a small set of placeholder files (one per implementation task) that establish the canonical file layout. Implementing agents are expected to *fill* those placeholders with their actual code.

This PR fixes a real coordination failure where some agents find the scaffold and fill it, while others ignore it and invent their own paths. Closes #659.

## Why (the user-visible problem)

In `snake-baton-1` (2026-05-25, `~/experiments/test74`), Marcus generated three scaffold placeholders at:

- `src/main.js`
- `src/presentation/renderer.js`
- `src/core/gameEngine.js`

Two of the three agents found the scaffold and worked there:

| Scaffold file | Final state | Outcome |
|---|---|---|
| `src/main.js` | extended to 136 lines | scaffold filled ✓ |
| `src/presentation/renderer.js` | extended to 157 lines | scaffold filled ✓ |
| `src/core/gameEngine.js` | **untouched, still 1 line** | **orphaned — agent wrote at `src/game/gameEngine.js` instead** |

The engine agent shipped 176 lines at `src/game/gameEngine.js`. Marcus's scaffold at `src/core/gameEngine.js` is now permanent dead code on disk. The composition step imported from the agent's invented path; at scale this creates real chaos (half the agents importing from invented paths, half from scaffolds, dead code accumulating).

**This is not a delivery bug.** All scaffold files are visible in every agent's worktree (they `git ls`). It's an **anchoring bug**: nothing in the agent's task instructions tells them *"your implementation lives at `src/core/gameEngine.js`."* They have to guess from the task name + spec. The renderer agent got lucky picking `src/presentation/renderer.js` (lexical match to "Game Presentation"). The engine agent guessed wrong.

## What changed

Four small changes that bind each placeholder to its owning task at scaffold-generation time and surface that anchor to the agent.

### 1. Scaffold LLM prompt (`src/integrations/nlp_tools.py`)

`_SCAFFOLD_PROMPT` now instructs the LLM to emit a `task_name` field on each per-task placeholder file:

```jsonc
[
  {"path": "package.json", "content": "..."},                         // no task_name (config)
  {"path": "src/core/gameEngine.js",                                  // per-task placeholder
   "content": "// placeholder",
   "task_name": "Implement Game Core Engine"}
]
```

Config files (manifests, entry points, `.gitignore`) **must omit** `task_name` — they are shared infrastructure, owned by no single task.

### 2. `_generate_project_scaffold` returns the anchor mapping

Signature changed from `-> bool` to `-> Tuple[bool, Dict[str, str]]`. The second element is `{task_name → scaffold_path}` for each placeholder the LLM bound to a real implementation task.

Defensive against LLM hallucination:

- An unknown `task_name` (not in `impl_tasks`) is silently dropped.
- A duplicate `task_name` keeps the first path and warns.
- Config files never appear in the mapping even if the LLM emits a `task_name` for them.

### 3. Caller persists the anchor on the kanban task (`_run_design_phase`)

Right after the scaffold call, the caller walks `(task_name → scaffold_path)` and updates each corresponding kanban task's `source_context["scaffold_path"]` via `kanban_client.update_task`. `safe_tasks` and `created_tasks` are index-aligned (same invariant used for the design-DONE update), so we look up the kanban id by original task name.

### 4. Agent instructions surface the anchor (`build_tiered_instructions`)

When the task carries `source_context.scaffold_path`, the CONTRACT RESPONSIBILITY layer now appends:

```
📂 IMPLEMENTATION FILE: src/core/gameEngine.js
Marcus pre-created a placeholder at this path. Fill it with your
implementation — do NOT create a sibling file elsewhere. Other agents
will import from this exact path. If the file is missing when you
start, the scaffold step may have failed; create the file at this
path.
```

This is the load-bearing instruction — without it the agent can `ls` and see the scaffold, but has no anchor that tells them which placeholder is *theirs*.

## Bright-line check (Multi-Agency Proclamation)

Marcus naming the canonical file path is **coordination, not control** — it's the public import address downstream agents will use. Same reasoning we accepted for `declared_files` in #658.

Agent still owns HOW the file is filled (class vs function, libraries, helpers, internal structure, error handling, naming inside the module). Two agents handed *"Fill `src/core/gameEngine.js` with the GameEngine class"* can still produce legitimately different implementations.

The Bright Line Test: "Could an agent, given the same board state, choose to do something meaningfully different from what Marcus suggests?" **YES** — the implementation strategy inside the file remains the agent's call.

## Worked example (snake-baton-1 with this fix)

Before this PR:

```
scaffold writes:    src/core/gameEngine.js  (placeholder, 1 line)
agent receives:     "Implement Game Core Engine" with no path anchor
agent writes:       src/game/gameEngine.js   (176 lines)
result:             two engine files; the scaffold is dead code
```

After this PR:

```
scaffold writes:    src/core/gameEngine.js  (placeholder, 1 line)
agent receives:     task instructions include
                    "IMPLEMENTATION FILE: src/core/gameEngine.js
                     Fill this path. Do NOT create a sibling file."
agent writes:       src/core/gameEngine.js   (filled with real code)
result:             one engine file at the canonical path
```

## Where to look in the code first

| File | Purpose |
|---|---|
| `src/integrations/nlp_tools.py:3945` | `_SCAFFOLD_PROMPT` — the LLM prompt asking for `task_name` per placeholder |
| `src/integrations/nlp_tools.py:4011` | `_generate_project_scaffold` — now returns the anchor mapping |
| `src/integrations/nlp_tools.py:~4730` | Caller in `_run_design_phase` — persists `scaffold_path` on each task |
| `src/marcus_mcp/tools/task.py:~1370` | `build_tiered_instructions` — surfaces the IMPLEMENTATION FILE section |
| `tests/unit/integrations/test_scaffold_anchoring.py` | 7 new unit tests covering mapping behavior + instruction surfacing |

## Glossary

| Term | Meaning |
|---|---|
| **Scaffold** | A small set of placeholder files Marcus writes pre-fork to establish canonical file layout. One placeholder per implementation task. Committed to `main` so each worktree inherits it. |
| **Anchor** | The persisted `task.source_context["scaffold_path"]` that binds an implementation task to its scaffold file. Surfaced in the agent's task instructions. |
| **Orphan** | A scaffold file no agent filled — left as a 1-line placeholder forever (the failure this PR fixes). |
| **`task_name` field** | A new JSON field in the scaffold LLM output that names the implementation task each placeholder belongs to. |
| **Bright-line test** | The check Marcus uses to distinguish coordination from control: "Could an agent, given the same board state, choose to do something meaningfully different from what Marcus suggests?" YES = coordination, build it. |

## How to verify it works

1. Run the new unit tests:
   ```bash
   python -m pytest tests/unit/integrations/test_scaffold_anchoring.py -v
   ```
   Expected: 7 tests pass.
2. Run the existing test_design_autocomplete suite (uses mocks of `_generate_project_scaffold`):
   ```bash
   python -m pytest tests/unit/integrations/test_design_autocomplete.py -q
   ```
   Expected: 25 tests pass.
3. Broader regression sweep:
   ```bash
   python -m pytest tests/unit/integrations/ tests/unit/marcus_mcp/ -q
   ```
   Expected: 799 pass, 38 skipped, 0 fail.
4. Mypy:
   ```bash
   python -m mypy src/integrations/nlp_tools.py src/marcus_mcp/tools/task.py
   ```
   Expected: clean.
5. **Manual E2E (post-merge):** run any prototype-mode project with two implementation tasks. Then check:
   - Each implementation task's `source_context` has a `scaffold_path` field (via `sqlite3 ~/dev/marcus/data/kanban.db "SELECT name, json_extract(source_context, '$.scaffold_path') FROM tasks WHERE project_id = '<id>';"`)
   - When an agent picks up the task, the response surfaces `IMPLEMENTATION FILE: <path>` in instructions.
   - After agents finish, every scaffold path on `main` is non-trivial.
   - No sibling files at competing paths implementing the same contract.

## Test plan

- [x] 4 unit tests for the scaffold mapping (`TestScaffoldReturnsAnchorMapping`)
- [x] 3 unit tests for instruction surfacing (`TestAgentInstructionsSurfaceScaffoldPath`)
- [x] 25 existing `test_design_autocomplete` tests still pass (mocks updated to return the tuple shape)
- [x] 799 unit tests pass across `tests/unit/integrations` + `tests/unit/marcus_mcp` (no regression)
- [x] Mypy clean on the two modified source files + the new test file
- [ ] Manual end-to-end run on a multi-task prototype project (post-merge)

## Related

- #659 — parent issue (filed in this same conversation with the corrected diagnosis: anchoring bug, not delivery bug)
- #658 — file lock registry MVP (analogous "Marcus names the canonical path" decision for write-locks; established the bright-line precedent this PR builds on)
- #650 — `fix(#649): trivial-spec baseline` (introduced tech-stack honoring and the composer build gate; complementary to this PR for prototype-mode runs)
- #607 — decomposition redesign series (context for the recent push to make Marcus's coordination contracts more explicit)
- Companion problem (not in this PR): SpecCoverage refactor to fold gap-fill into `completion_criteria` instead of synthesizing new tasks — separate PR pending Kaia review of routing precedence

🤖 Generated with [Claude Code](https://claude.com/claude-code)