### PR TITLE
docs(create_project): document 'decomposer' option to restore contract_first routing

### DIFF
--- a/src/marcus_mcp/tools/nlp.py
+++ b/src/marcus_mcp/tools/nlp.py
@@ -527,6 +527,18 @@ async def _create_project_inner(
         - tech_stack (List[str]): Technologies to use (e.g., ["React", "Python"])
         - deadline (str): Project deadline in YYYY-MM-DD format
         - tags (List[str]): Tags for project organization
+        - decomposer (str): Task decomposition strategy. One of:
+            - "contract_first" — generates domain contracts before
+              decomposition; each task owns a contract interface.
+              Recommended for projects where agents must coordinate
+              against shared interfaces (most multi-agent runs).
+              Requires ``project_root``.
+            - "feature_based" (default) — shapes tasks directly from
+              functional requirements. Faster to plan; weaker
+              coordination signal. Falls back here automatically if
+              ``contract_first`` is selected but ``project_root`` is
+              absent or contract generation fails.
+          Overrides the ``MARCUS_DECOMPOSER`` environment variable.
 
         Runner Integration:
         - project_info_path (str): Absolute path where Marcus should write


### PR DESCRIPTION
## What is Marcus, briefly

Marcus is a coordination platform for multi-agent software builds. The ``create_project`` MCP tool accepts an ``options`` dict that controls how the project is decomposed into tasks. One of those options — ``decomposer`` — chooses between two decomposition strategies: ``contract_first`` (richer coordination) and ``feature_based`` (faster but weaker coordination).

This PR is a 12-line documentation fix that addresses a 5-week-old latent regression: ``decomposer`` works in code but has never been listed in the tool's documented options. Claude CLI sessions that read the tool's docstring sometimes drop it. As a result, projects requesting ``contract_first`` are silently routed through ``feature_based``, producing weaker tasks with no contracts and no domain ownership.

## The bug, in one paragraph

The runner reads ``config.yaml`` (which has ``decomposer: contract_first``), serializes ``project_options`` to JSON, and embeds the JSON inside a natural-language prompt sent to a Claude CLI session. The Claude session then constructs an ``mcp__marcus__create_project`` tool call. When Claude reads the tool's signature and docstring, it sees no documented ``decomposer`` field. Some sessions preserve unknown options dict keys verbatim; others quietly drop them as undocumented noise. Same runner, same YAML, different decomposer reaching Marcus.

## Evidence from the cost db (real-world failure observed today)

Two ``snake-scaffold-2`` runs created from identical configs (both with ``decomposer: contract_first`` in YAML):

| Run | Started | Recorded decomposer |
|---|---|---|
| ``snake-baton-1`` | 2026-05-26 02:21 UTC | ``contract_first`` ✓ |
| ``snake-scaffold-2`` v2 | 2026-05-26 21:06 UTC | **``feature_based`` ✗** |

The v2 run resulted in tasks with ``source_type=nlp_project``, no ``contract_file``, no interface contracts in ``docs/architecture/``, and 0 task→file anchors — agents had nothing to coordinate against. This was the proximate cause of the user-visible *"snake game has broken across the last 6 runs"* symptom we've been chasing for two weeks.

## Why this regression has been latent for 5 weeks

The decomposer routing landed in commit ``1bee7336`` (Release v0.3.4, 2026-04-17). ``decomposer`` was never added to ``create_project``'s docstring options list at that time. The Project Settings list (lines 519–530 of ``src/marcus_mcp/tools/nlp.py``) was last touched ``2025-10-05`` — 8 months ago. So this has been a latent gap the whole time. Most runs got lucky because the Claude session happened to be charitable about preserving the options dict shape.

## What changed

12 lines added to the ``create_project`` docstring under Project Settings:

```python
- decomposer (str): Task decomposition strategy. One of:
    - "contract_first" — generates domain contracts before
      decomposition; each task owns a contract interface.
      Recommended for projects where agents must coordinate
      against shared interfaces (most multi-agent runs).
      Requires ``project_root``.
    - "feature_based" (default) — shapes tasks directly from
      functional requirements. Faster to plan; weaker
      coordination signal. Falls back here automatically if
      ``contract_first`` is selected but ``project_root`` is
      absent or contract generation fails.
  Overrides the ``MARCUS_DECOMPOSER`` environment variable.
```

**No code logic changes.** Pure documentation. MCP clients (Claude CLI sessions) now see ``decomposer`` as a documented part of the tool contract and reliably pass it through.

## Bright-line check (Multi-Agency Proclamation)

Documentation. No agent behavior change. Trivially safe under all three invariants.

## Where to look in the code first

| File | Lines | Purpose |
|---|---|---|
| ``src/marcus_mcp/tools/nlp.py`` | 519–530 | The Project Settings options list — where ``decomposer`` now appears |
| ``src/config/decomposer_config.py`` | full file | Existing implementation (unchanged) — the routing logic this option drives |

## How to verify it works

1. Existing unit tests still pass:
   ```bash
   python -m pytest tests/unit/config/test_decomposer_config.py \
                    tests/unit/marcus_mcp/test_create_project_run_recording.py \
                    tests/unit/marcus_mcp/test_create_project_serialization.py
   ```
   Expected: 31 tests pass.
2. Mypy clean:
   ```bash
   python -m mypy src/marcus_mcp/tools/nlp.py
   ```
3. **End-to-end (the actual test of this fix):** rerun a snake-game project. Check the cost db immediately after ``create_project`` returns:
   ```bash
   sqlite3 ~/.marcus/costs.db \
     "SELECT project_name, decomposer FROM runs ORDER BY started_at DESC LIMIT 1;"
   ```
   Expected: ``decomposer=contract_first``, not ``feature_based``.

## Test plan

- [x] Existing 31 unit tests pass (no regression)
- [x] Mypy clean
- [ ] Manual: rerun snake-game with ``decomposer: contract_first`` in config; verify the cost db records ``contract_first``, the tasks have ``source_type=contract_first`` and a non-empty ``contract_file`` in ``source_context``, and agents complete the work without the orphan / merge-conflict failure modes observed across the last six runs.

## Related

- 1bee7336 — the commit that introduced decomposer routing (2026-04-17, 5 weeks ago) without documenting it
- PR #650 — trivial-spec baseline (2026-05-24): not the cause of this specific regression, but suspect for adjacent failures (tech-stack honoring, spec-coverage skip in prototype mode) we may address separately if needed after this fix
- PR #660 / PR #661 / Issue #659 — the scaffold-anchoring work we shipped this week, which was treating a symptom of this routing failure rather than the cause. PR #661 (anchoring safety net) should probably be closed as "wrong direction" once this fix demonstrates that ``contract_first`` reliably runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)