### PR TITLE
fix(#667): trim orphaned subtasks from Marcus's in-memory working set (non-destructive; protects Cato)

### DIFF
--- a/src/marcus_mcp/server.py
+++ b/src/marcus_mcp/server.py
@@ -14,7 +14,7 @@ import signal
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Set, Union
+from typing import Any, Dict, List, Optional, Set, Tuple, Union
 
 from src.telemetry import get_telemetry_client, print_first_run_notice_if_needed
 
@@ -49,6 +49,7 @@ from src.core.events import Events  # noqa: E402
 from src.core.models import (  # noqa: E402
     ProjectState,
     RiskLevel,
+    Task,
     TaskAssignment,
     TaskStatus,
     WorkerStatus,
@@ -73,6 +74,48 @@ from src.marcus_mcp.handlers import handle_tool_call  # noqa: E402
 from src.marcus_mcp.tool_groups import get_tools_for_endpoint  # noqa: E402
 from src.monitoring.assignment_monitor import AssignmentMonitor  # noqa: E402
 from src.monitoring.project_monitor import ProjectMonitor  # noqa: E402
+
+
+def _carry_forward_active_subtasks(
+    project_tasks: Optional[List[Task]], parent_ids: Set[str]
+) -> Tuple[List[Task], int]:
+    """Select which in-memory subtasks survive a project-state refresh.
+
+    Only subtasks whose parent is still on the board (``parent_ids``) are
+    carried forward in Marcus's in-memory working set. Orphaned subtasks
+    (parent removed, or left over from another project in a long-lived
+    server process) are dropped from the working set so they stop bloating
+    memory and churning the dependency-inference cache signature on the
+    ``request_next_task`` hot path (issue #667).
+
+    This trims the in-memory list ONLY. The durable record in
+    ``data/marcus_state/subtasks.json`` -- which Cato reads directly as its
+    subtask data source -- is never modified here. Issue #672 tracks moving
+    subtask storage into the database so Cato consumes a contract rather
+    than Marcus's private file.
+
+    Parameters
+    ----------
+    project_tasks : Optional[List[Task]]
+        Current in-memory task list (parents and subtasks), or None.
+    parent_ids : Set[str]
+        IDs of parent tasks present on the board this refresh.
+
+    Returns
+    -------
+    Tuple[List[Task], int]
+        ``(kept_subtasks, dropped_orphan_count)``.
+    """
+    kept: List[Task] = []
+    dropped = 0
+    for task in project_tasks or []:
+        if not getattr(task, "is_subtask", False):
+            continue
+        if getattr(task, "parent_task_id", None) in parent_ids:
+            kept.append(task)
+        else:
+            dropped += 1
+    return kept, dropped
 
 
 class MarcusServer:
@@ -1015,21 +1058,44 @@ class MarcusServer:
                         f"{len(parent_tasks)} parent tasks"
                     )
                 else:
-                    # After migration: preserve subtasks, update parents
-                    # Extract existing subtasks
-                    existing_subtasks = []
-                    if self.project_tasks:
-                        for task in self.project_tasks:
-                            if getattr(task, "is_subtask", False):
-                                existing_subtasks.append(task)
+                    # After migration: preserve subtasks, update parents.
+                    #
+                    # Issue #667 (Option 2, non-destructive): only carry
+                    # forward subtasks whose parent is still on the board.
+                    # Orphaned subtasks (parent removed, or left over from a
+                    # different project in a long-lived server process)
+                    # otherwise accumulate in this in-memory working set,
+                    # growing memory and -- because this list is fed to
+                    # ``Context.analyze_dependencies`` on the
+                    # ``request_next_task`` hot path -- churning the
+                    # dependency-cache signature, which triggers surprise
+                    # LLM inference calls.
+                    #
+                    # We trim the in-memory list ONLY. The durable record in
+                    # ``data/marcus_state/subtasks.json`` is left untouched:
+                    # Cato reads that file directly as its subtask data
+                    # source, so deleting from it would blank Cato's views.
+                    # Issue #672 tracks the proper fix (move subtask storage
+                    # into the DB so Cato reads a contract, not this file).
+                    parent_ids = {t.id for t in parent_tasks}
+                    existing_subtasks, dropped_orphans = _carry_forward_active_subtasks(
+                        self.project_tasks, parent_ids
+                    )
 
                     # Combine refreshed parents with preserved subtasks
                     self.project_tasks = parent_tasks + existing_subtasks
 
-                    logger.info(
+                    msg = (
                         f"Refreshed {len(parent_tasks)} parent tasks, "
                         f"preserved {len(existing_subtasks)} subtasks"
                     )
+                    if dropped_orphans:
+                        msg += (
+                            f", dropped {dropped_orphans} orphaned subtasks "
+                            f"from the in-memory working set "
+                            f"(subtasks.json unchanged)"
+                        )
+                    logger.info(msg)
 
                 # v0.3.8.post1: invalidate the foundation-contract cache
                 # whenever project_tasks is reassigned from kanban —

--- a/src/marcus_mcp/server.py
+++ b/src/marcus_mcp/server.py
@@ -94,6 +94,13 @@ def _carry_forward_active_subtasks(
     subtask storage into the database so Cato consumes a contract rather
     than Marcus's private file.
 
+    A transient empty ``parent_ids`` (the board fetch returned no tasks --
+    the Planka provider does this on error) is treated as "no information"
+    rather than "every parent is gone": all existing subtasks are preserved
+    and nothing is dropped. Otherwise a single failed refresh would orphan
+    every subtask, and the one-time migration guard would never re-add them
+    (Codex P1 on PR #673).
+
     Parameters
     ----------
     project_tasks : Optional[List[Task]]
@@ -106,11 +113,16 @@ def _carry_forward_active_subtasks(
     Tuple[List[Task], int]
         ``(kept_subtasks, dropped_orphan_count)``.
     """
+    subtasks = [t for t in (project_tasks or []) if getattr(t, "is_subtask", False)]
+    # Empty parent set == the board fetch returned nothing this refresh,
+    # almost always transient (Planka returns [] when get_all_tasks raises).
+    # Preserve all subtasks rather than orphan-GC them, or one failed
+    # refresh strands every subtask until restart (Codex P1 on PR #673).
+    if not parent_ids:
+        return subtasks, 0
     kept: List[Task] = []
     dropped = 0
-    for task in project_tasks or []:
-        if not getattr(task, "is_subtask", False):
-            continue
+    for task in subtasks:
         if getattr(task, "parent_task_id", None) in parent_ids:
             kept.append(task)
         else:

--- a/tests/unit/marcus_mcp/test_subtask_carry_forward.py
+++ b/tests/unit/marcus_mcp/test_subtask_carry_forward.py
@@ -1,0 +1,80 @@
+"""
+Unit tests for ``_carry_forward_active_subtasks`` (issue #667, Option 2).
+
+When ``refresh_project_state`` rebuilds Marcus's in-memory task list, it
+must carry forward only the subtasks whose parent is still on the board.
+Orphaned subtasks (parent gone, or left over from another project in a
+long-lived server process) are dropped from the in-memory working set so
+they stop bloating memory and churning the dependency-inference cache
+signature on the ``request_next_task`` hot path.
+
+This helper trims the in-memory list ONLY — the durable record in
+``data/marcus_state/subtasks.json`` (which Cato reads directly as its
+subtask data source) is never touched. See issue #672 for the proper
+fix (move subtask storage into the database).
+"""
+
+from datetime import datetime, timezone
+from typing import Optional
+
+import pytest
+
+from src.core.models import Priority, Task, TaskStatus
+from src.marcus_mcp.server import _carry_forward_active_subtasks
+
+pytestmark = pytest.mark.unit
+
+
+def _task(
+    task_id: str, *, is_subtask: bool = False, parent_task_id: Optional[str] = None
+) -> Task:
+    """Build a minimal Task, optionally flagged as a subtask."""
+    return Task(
+        id=task_id,
+        name=task_id,
+        description="",
+        status=TaskStatus.TODO,
+        priority=Priority.MEDIUM,
+        estimated_hours=1.0,
+        dependencies=[],
+        labels=[],
+        assigned_to=None,
+        created_at=datetime.now(timezone.utc),
+        updated_at=datetime.now(timezone.utc),
+        due_date=None,
+        is_subtask=is_subtask,
+        parent_task_id=parent_task_id,
+    )
+
+
+class TestCarryForwardActiveSubtasks:
+    """Only subtasks with a live parent survive; the file is never touched."""
+
+    def test_keeps_subtasks_whose_parent_is_on_the_board(self) -> None:
+        """A subtask whose parent id is in ``parent_ids`` is carried forward."""
+        sub = _task("p1_sub_1", is_subtask=True, parent_task_id="p1")
+        kept, dropped = _carry_forward_active_subtasks([sub], {"p1"})
+        assert kept == [sub]
+        assert dropped == 0
+
+    def test_drops_orphaned_subtasks_whose_parent_is_gone(self) -> None:
+        """A subtask whose parent is no longer on the board is dropped (counted)."""
+        live = _task("p1_sub_1", is_subtask=True, parent_task_id="p1")
+        orphan = _task("old_sub_1", is_subtask=True, parent_task_id="old-parent")
+        kept, dropped = _carry_forward_active_subtasks([live, orphan], {"p1"})
+        assert kept == [live]
+        assert dropped == 1
+
+    def test_ignores_non_subtasks(self) -> None:
+        """Parents (non-subtasks) are not returned — the caller re-adds them."""
+        parent = _task("p1", is_subtask=False)
+        sub = _task("p1_sub_1", is_subtask=True, parent_task_id="p1")
+        kept, dropped = _carry_forward_active_subtasks([parent, sub], {"p1"})
+        assert kept == [sub]
+        assert dropped == 0
+
+    def test_handles_none_task_list(self) -> None:
+        """A ``None`` task list yields no kept subtasks and no drops."""
+        kept, dropped = _carry_forward_active_subtasks(None, {"p1"})
+        assert kept == []
+        assert dropped == 0

--- a/tests/unit/marcus_mcp/test_subtask_carry_forward.py
+++ b/tests/unit/marcus_mcp/test_subtask_carry_forward.py
@@ -78,3 +78,18 @@ class TestCarryForwardActiveSubtasks:
         kept, dropped = _carry_forward_active_subtasks(None, {"p1"})
         assert kept == []
         assert dropped == 0
+
+    def test_empty_parent_set_preserves_all_subtasks(self) -> None:
+        """A transient empty board fetch must NOT orphan-GC subtasks.
+
+        When ``get_all_tasks`` returns ``[]`` on error (the Planka provider
+        does this), ``parent_ids`` is empty. Treating that as "every parent
+        is gone" would drop every subtask, and the one-time migration guard
+        would never re-add them -- stranding agents until restart. An empty
+        parent set must therefore preserve all subtasks (Codex P1, PR #673).
+        """
+        s1 = _task("p1_sub_1", is_subtask=True, parent_task_id="p1")
+        s2 = _task("p2_sub_1", is_subtask=True, parent_task_id="p2")
+        kept, dropped = _carry_forward_active_subtasks([s1, s2], set())
+        assert kept == [s1, s2]
+        assert dropped == 0


### PR DESCRIPTION
## What this system is, briefly

**Marcus** is an AI agent coordinator: it breaks a project into a graph of tasks on a shared "kanban" board (a database of work items) and lets independent AI agents pull tasks one at a time and build. **Cato** is a separate observability dashboard that reads Marcus's data and shows what's happening.

## Why (user-visible motivation)

On long or repeatedly-recovered runs, Marcus's in-memory task list (`project_tasks`) kept accumulating leftover **subtasks** (the smaller steps a big task is split into). Two problems followed:

1. **Memory grew unbounded** over time.
2. **Surprise LLM calls / "credit balance too low" errors.** Every extra task changed the "signature" of the task graph, which busted a cache and made Marcus fire LLM dependency-inference calls during the `request_next_task` polling loop — the calls that showed up in #667 as `credit balance too low` errors in a place nobody expected API usage.

A first attempt fixed this by *deleting* subtasks — but **Cato reads Marcus's subtask file (`data/marcus_state/subtasks.json`) directly as its own data source**, so deleting would have silently blanked Cato's subtask views. This PR takes the non-destructive route instead.

## What changed

- New pure helper `_carry_forward_active_subtasks(project_tasks, parent_ids)` in `src/marcus_mcp/server.py`.
- `refresh_project_state` now uses it: when rebuilding `project_tasks`, it carries forward only subtasks whose **parent is still on the board**, dropping orphaned ones (parent removed, or left over from a different project) from the **in-memory list only**.
- **Nothing is deleted from disk.** `data/marcus_state/subtasks.json` (what Cato reads) is never touched here — Cato keeps all its data.
- 4 new unit tests in `tests/unit/marcus_mcp/test_subtask_carry_forward.py`.

## Worked example with numbers

A run had ~4,283 subtasks across 868 parents accumulated in memory and on disk. With this change, only the current project's still-on-the-board subtasks stay in the in-memory working set (tens, not thousands), so the dependency-cache signature stops churning and the surprise calls stop. The on-disk file is untouched, so Cato still renders subtasks normally.

## What this does NOT do (scope)

- It does not remove the cross-app coupling (Cato reading Marcus's private file). The proper fix — moving subtask storage into the database so Cato reads a contract — is tracked in **#672**, with a step-by-step conversion from this stopgap.
- It does not address whether the Marcus server's API key is depleted/misconfigured (a separate possible cause behind the credit-balance errors).

## Where to look in the code first

| File | Purpose |
|---|---|
| `src/marcus_mcp/server.py` `_carry_forward_active_subtasks` | the new pure helper (keep vs drop) |
| `src/marcus_mcp/server.py` `refresh_project_state` | calls the helper when rebuilding `project_tasks` |
| `tests/unit/marcus_mcp/test_subtask_carry_forward.py` | the 4 unit tests |

## Test plan

- [x] `pytest -m unit` — full suite green (2,229 passed; the single failure is a pre-existing sandbox-only artifact unrelated to this change: a test asserting the string `claude` is absent from a built command, which trips only because this machine's temp dir is named `/tmp/claude-501/...`)
- [x] `mypy src/marcus_mcp/server.py` — clean
- [x] New helper tests: keep live-parent subtask; drop orphan (counted); ignore non-subtasks; handle `None`
- [ ] Reviewer: confirm `data/marcus_state/subtasks.json` is never written by this path (Cato safety)
- [ ] Reviewer: confirm no behavior change for the normal single-project case (parents stay on the board, so their subtasks are all kept)

## Related

- #667 — umbrella (lease/spawn runaway + the credit-balance errors)
- #668 — validation window + transactional late-accept (merged; fixed the recovery loop that was the other churn driver)
- #672 — Option 1: move subtask storage into the DB (the proper decoupling; includes the conversion path from this PR)
- #671 — completion-path subtask GC (superseded; deletion only safe once #672 lands)
- Cato coupling incident — Simon concern `aa830cdb`, decision `189e130b`