### PR TITLE
fix: derive project_info.json path server-side so a dropped agent field can't strand a run

### DIFF
--- a/src/marcus_mcp/tools/nlp.py
+++ b/src/marcus_mcp/tools/nlp.py
@@ -479,6 +479,42 @@ async def create_project(
     return result
 
 
+def _resolve_project_info_path(options: Dict[str, Any]) -> Optional[str]:
+    """Resolve where Marcus writes ``project_info.json`` for the runner.
+
+    The experiment runner waits for ``<experiment_dir>/project_info.json``
+    as its go-signal and instructs the project-creator agent to pass
+    ``project_info_path`` in the ``create_project`` options. A
+    lower-fidelity agent can drop that single field from a long options
+    object; when it does, Marcus has no path, silently skips the write,
+    and the runner times out without ever spawning a work agent (the
+    snake-pr673 / test92 failure).
+
+    To make the handshake independent of agent fidelity, fall back to
+    deriving the path from ``project_root`` (which survives reliably): the
+    runner sets ``project_root == <experiment_dir>/implementation``, so the
+    info file sits one level up.
+
+    Parameters
+    ----------
+    options : Dict[str, Any]
+        The ``create_project`` options dict.
+
+    Returns
+    -------
+    Optional[str]
+        The resolved path, or ``None`` when neither ``project_info_path``
+        nor ``project_root`` is usable (caller then skips the write).
+    """
+    explicit = options.get("project_info_path")
+    if explicit:
+        return str(explicit)
+    project_root = options.get("project_root")
+    if project_root:
+        return str(Path(project_root).parent / "project_info.json")
+    return None
+
+
 async def _create_project_inner(
     description: str, project_name: str, options: Optional[Dict[str, Any]], state: Any
 ) -> Dict[str, Any]:
@@ -1233,7 +1269,7 @@ async def _create_project_inner(
         # recommended_agents without a second MCP HTTP session (which was
         # racy — the session could time out before Marcus was ready).
         if result.get("success") and isinstance(options, dict):
-            info_path_str = options.get("project_info_path")
+            info_path_str = _resolve_project_info_path(options)
             if info_path_str:
                 import json as _json
                 from pathlib import Path as _Path

--- a/tests/unit/marcus_mcp/test_resolve_project_info_path.py
+++ b/tests/unit/marcus_mcp/test_resolve_project_info_path.py
@@ -1,0 +1,62 @@
+"""
+Unit tests for ``_resolve_project_info_path`` (project-creation handshake).
+
+The experiment runner waits for ``<experiment_dir>/project_info.json`` as its
+go-signal and instructs the project-creator agent to pass
+``project_info_path`` in the ``create_project`` options
+(``spawn_agents.py`` injects it). A lower-fidelity agent (e.g. Haiku) can
+drop that one field from a long options object, leaving Marcus with no path
+-- so it silently skips the write, the runner times out at 600s, and the run
+never spawns a work agent.
+
+The fix derives the path from ``project_root`` (which survives reliably)
+when ``project_info_path`` is absent, so a dropped field can no longer
+strand the run. The runner sets ``project_root == <experiment_dir>/
+implementation``, so the info file sits one level up.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from src.marcus_mcp.tools.nlp import _resolve_project_info_path
+
+pytestmark = pytest.mark.unit
+
+
+class TestResolveProjectInfoPath:
+    """Resolve the project_info.json write path independent of agent fidelity."""
+
+    def test_explicit_path_is_used_verbatim(self) -> None:
+        """An explicit ``project_info_path`` is returned unchanged."""
+        opts = {
+            "project_info_path": "/runs/x/project_info.json",
+            "project_root": "/runs/x/implementation",
+        }
+        assert _resolve_project_info_path(opts) == "/runs/x/project_info.json"
+
+    def test_derived_from_project_root_when_path_missing(self) -> None:
+        """With no explicit path, derive it from ``project_root`` one level up."""
+        opts = {"project_root": "/Users/me/experiments/test92/implementation"}
+        assert _resolve_project_info_path(opts) == str(
+            Path("/Users/me/experiments/test92") / "project_info.json"
+        )
+
+    def test_explicit_path_takes_precedence_over_project_root(self) -> None:
+        """When both are present, the explicit path wins."""
+        opts = {
+            "project_info_path": "/custom/pi.json",
+            "project_root": "/runs/x/implementation",
+        }
+        assert _resolve_project_info_path(opts) == "/custom/pi.json"
+
+    def test_none_when_neither_present(self) -> None:
+        """No path and no project_root yields ``None`` (caller skips the write)."""
+        assert _resolve_project_info_path({}) is None
+
+    def test_none_when_both_empty_strings(self) -> None:
+        """Falsy values are treated as absent."""
+        assert (
+            _resolve_project_info_path({"project_info_path": "", "project_root": ""})
+            is None
+        )


### PR DESCRIPTION
## What this is, briefly

Marcus is an AI agent coordinator. The experiment **runner** (`dev-tools/experiments/runners/`) launches a project: a **project-creator agent** calls the `create_project` MCP tool, Marcus builds the task graph, and the runner then spawns **work agents** to build the project. The runner's go-signal is a file, `project_info.json`, that Marcus writes after creating the project.

## Why (what broke)

On a real run (`test92` / `snake-pr673-1`), the project was created correctly — 14 tasks, contracts, scaffold committed — but **the run hung and no work agent ever spawned.** Root cause, traced end-to-end:

1. The runner injects `project_info_path` into the `create_project` options and tells the creator agent to pass it (`spawn_agents.py:404-405`).
2. Marcus writes `project_info.json` **only when `options["project_info_path"]` is present** (`src/marcus_mcp/tools/nlp.py`). If absent, it silently skips — no log, no error.
3. The creator agent ran on **Haiku** and **dropped `project_info_path`** from a 7-field options object. Verified from the agent's actual tool call: options contained `complexity, provider, mode, decomposer, tech_stack, project_root` — `project_info_path` absent.
4. No path → no file → the runner waited 600s for `project_info.json`, timed out, and exited. No work agent spawned. (No task was ever claimed, so there was also no lease to expire — the stall was *before* any Marcus interaction.)

**Marcus's server code was correct.** This was agent fidelity: a weaker model omitted one field. A stronger model lowers the odds but doesn't eliminate them — the go-signal shouldn't depend on an agent re-echoing a redundant path.

## What changed

New pure helper `_resolve_project_info_path(options)` in `src/marcus_mcp/tools/nlp.py`:

- Returns an explicit `project_info_path` if present (unchanged behavior, back-compatible).
- Otherwise **derives** it from `project_root`: the runner sets `project_root == <experiment_dir>/implementation` (`spawn_agents.py:361,371`) and waits for `<experiment_dir>/project_info.json` (`spawn_agents.py:397`), so the file is `Path(project_root).parent / "project_info.json"`.

`create_project`'s write-block now calls the helper instead of reading `project_info_path` directly. A dropped field can no longer strand a run on any model.

## Worked example

`project_root = /Users/.../experiments/test92/implementation` → derived info path = `/Users/.../experiments/test92/project_info.json` — exactly the file the runner's wait-loop (`spawn_agents.py:263`) polls. In the failed run, `project_root` *did* survive the agent's options reconstruction; only `project_info_path` was dropped. Deriving from the field that survived closes the gap.

## Where to look

| File | Purpose |
|---|---|
| `src/marcus_mcp/tools/nlp.py` `_resolve_project_info_path` | new helper (explicit path, else derive from project_root) |
| `src/marcus_mcp/tools/nlp.py` `_create_project_inner` write-block | now calls the helper |
| `dev-tools/experiments/runners/spawn_agents.py` (361/371/397/263) | where the runner sets project_root and waits for the file |

## Test plan

- [x] `pytest -m unit` — full suite green (2,235 passed; the 1 failure is a pre-existing sandbox-only artifact — a test asserting `claude` is absent from a built command, tripped by this machine's `/tmp/claude-501/...` temp dir — unrelated to this change)
- [x] `mypy src/marcus_mcp/tools/nlp.py` — clean
- [x] New helper tests: explicit path verbatim; derive from project_root; explicit precedence; None when neither; None on empty strings
- [ ] Reviewer: confirm the runner's expected path equals `project_root.parent/project_info.json` for all harnesses (claude/codex/gemini)
- [ ] Optional: a real `/marcus` run with a Haiku creator now produces `project_info.json` and spawns a work agent

## Related

- The `test92` / `snake-pr673-1` run failure (project created, runner timed out at 600s)
- A stronger `--model` for the creator is a complementary *mitigation*; this change is the *durable* fix (handshake no longer depends on agent fidelity)