### PR TITLE
fix(#666): restore SpecCoverage with LLM semantic coverage, on every complexity mode

### DIFF
--- a/src/ai/advanced/prd/advanced_parser.py
+++ b/src/ai/advanced/prd/advanced_parser.py
@@ -667,10 +667,10 @@ class AdvancedPRDParser:
         Parameters
         ----------
         complexity_mode : Optional[str]
-            Forwarded to :class:`SpecCoverageAugmenter` so prototype
-            projects skip spec_coverage's redundant keyword-based
-            gap-fill (bug #649 root cause 4).  ``None`` preserves the
-            legacy behavior for non-prototype runs.
+            Forwarded to :class:`SpecCoverageAugmenter`, where it is now a
+            no-op: issue #666 removed the prototype skip so spec_coverage
+            runs on every mode.  Retained for call-site compatibility and
+            removable in a follow-up.
 
         Returns
         -------

--- a/src/cost_tracking/operations.py
+++ b/src/cost_tracking/operations.py
@@ -137,6 +137,17 @@ OPERATIONS: Dict[str, Operation] = {
         ),
         "category": "decomposition",
     },
+    "spec_coverage_confirm": {
+        "label": "Spec coverage confirm",
+        "description": (
+            "Semantic coverage judgment (issue #666): given the extracted "
+            "spec features and the current task list, the LLM decides which "
+            "features no task actually delivers, so only genuine gaps are "
+            "synthesized into tasks. Replaces the keyword coverage scan, "
+            "which mismatched on shared/absent words."
+        ),
+        "category": "decomposition",
+    },
     "outcome_gap_fill": {
         "label": "Outcome gap fill",
         "description": (

--- a/src/integrations/spec_coverage.py
+++ b/src/integrations/spec_coverage.py
@@ -15,9 +15,11 @@ the component. Epictetus rated Completeness 2.0/5 (D).
 
 Design
 ------
-1. extract_spec_features  — LLM call to pull feature phrases from spec.
-2. find_uncovered_features — keyword match against task names/descriptions.
-3. check_spec_coverage    — orchestrates 1+2 and returns gap Task objects.
+1. extract_spec_features   — LLM call to pull feature phrases from spec.
+2. _llm_confirm_uncovered  — LLM semantic-coverage judgment: which features
+   does no task actually deliver? (issue #666). The ``find_uncovered_features``
+   keyword scan is kept only as a non-fatal fallback when this call fails.
+3. check_spec_coverage     — orchestrates 1+2 and returns gap Task objects.
 
 Gap tasks are labeled ``spec_gap`` so Cato and agents can distinguish them
 from normal decomposed tasks. They are inserted into safe_tasks before
@@ -28,7 +30,7 @@ import json
 import logging
 import uuid
 from datetime import datetime, timezone
-from typing import Any, List
+from typing import Any, List, Optional
 
 from src.core.models import Priority, Task, TaskStatus
 
@@ -164,6 +166,97 @@ def find_uncovered_features(
     return uncovered
 
 
+async def _llm_confirm_uncovered(
+    features: List[str],
+    tasks: List[Task],
+) -> Optional[List[str]]:
+    """Use one LLM call to find spec features that no task actually delivers.
+
+    Keyword matching (:func:`find_uncovered_features`) judges coverage by
+    whether a feature's words appear as substrings in the task text, which
+    is wrong in both directions: a shared generic word ("game") marks
+    "game restart" covered even when no task restarts the game (the #666
+    false negative — the snake game shipped without restart), and a feature
+    with no shared word ("browser playability") is marked uncovered even
+    when a "rendering" task delivers it (the #637 false positive — a
+    spurious build). Because every uncovered feature becomes a full agent
+    build, this judgment must be semantic, not lexical. It is
+    domain-agnostic: it reads whatever tasks exist and asks, per feature,
+    whether any task delivers it.
+
+    Parameters
+    ----------
+    features : List[str]
+        Feature phrases extracted from the spec.
+    tasks : List[Task]
+        Current task list to judge coverage against.
+
+    Returns
+    -------
+    Optional[List[str]]
+        The features no task delivers (a subset of ``features``), or
+        ``None`` on any failure so the caller can fall back to the keyword
+        scan and the pipeline stays non-fatal.
+    """
+    if not features:
+        return []
+
+    from src.ai.providers.llm_abstraction import LLMAbstraction
+
+    llm = LLMAbstraction()
+
+    class _Ctx:
+        max_tokens = 1024
+
+    def _task_line(t: Task) -> str:
+        line = f"- {t.name}: {t.description}"
+        # Include criteria so a feature that outcome coverage already rolled
+        # into a task's completion/acceptance criteria (#607/#611) is seen as
+        # covered here -- prevents a duplicate-task double-fire (#665/#666).
+        criteria = list(getattr(t, "acceptance_criteria", None) or []) + list(
+            getattr(t, "completion_criteria", None) or []
+        )
+        if criteria:
+            line += "\n    delivers: " + "; ".join(str(c) for c in criteria)
+        return line
+
+    task_lines = "\n".join(_task_line(t) for t in tasks)
+    feature_lines = "\n".join(f"- {f}" for f in features)
+    prompt = (
+        "You are reviewing whether a software project's task list covers "
+        "every feature its specification promises.\n\n"
+        "FEATURES (from the spec):\n"
+        f"{feature_lines}\n\n"
+        "TASKS (the planned work):\n"
+        f"{task_lines or '(no tasks)'}\n\n"
+        "For each feature, decide whether at least one task would, when "
+        "completed, actually deliver it. Judge by meaning, not by shared "
+        "words: a task can cover a feature with entirely different wording, "
+        "and merely sharing a word does not mean it delivers the feature. "
+        "Return ONLY a JSON array of the feature strings that NO task "
+        "delivers, copied verbatim from the FEATURES list. Return [] if "
+        'every feature is delivered.\nExample: ["game restart", "export csv"]'
+    )
+
+    try:
+        raw = str(await llm.analyze(prompt, _Ctx(), operation="spec_coverage_confirm"))
+        start = raw.find("[")
+        end = raw.rfind("]") + 1
+        if start == -1 or end == 0:
+            logger.warning("[spec_coverage] coverage LLM response missing JSON array")
+            return None
+        parsed: Any = json.loads(raw[start:end])
+        if not isinstance(parsed, list):
+            return None
+        # Only keep features that were actually in the input — guards
+        # against the model inventing or paraphrasing strings.
+        feature_set = set(features)
+        return [str(f) for f in parsed if str(f) in feature_set]
+    except Exception as exc:
+        logger.warning(f"[spec_coverage] _llm_confirm_uncovered failed: {exc}")
+        return None
+
+
 async def check_spec_coverage(
     description: str,
     tasks: List[Task],
@@ -203,7 +296,17 @@ async def check_spec_coverage(
             )
             return []
 
-        uncovered = find_uncovered_features(features, tasks)
+        uncovered = await _llm_confirm_uncovered(features, tasks)
+        if uncovered is None:
+            # LLM coverage check unavailable — fall back to the keyword scan
+            # so the pipeline stays non-fatal (less precise, but a missing
+            # safety net is worse than a coarse one).
+            logger.warning(
+                "[spec_coverage] LLM coverage check unavailable; "
+                "falling back to keyword scan"
+            )
+            uncovered = find_uncovered_features(features, tasks)
+
         if not uncovered:
             logger.info(
                 f"[spec_coverage] All {len(features)} spec features have coverage"

--- a/src/marcus_mcp/coordinator/spec_coverage_augmenter.py
+++ b/src/marcus_mcp/coordinator/spec_coverage_augmenter.py
@@ -54,16 +54,12 @@ class SpecCoverageAugmenter:
     Parameters
     ----------
     complexity_mode : Optional[str]
-        Project complexity mode (``"prototype"`` / ``"standard"`` /
-        ``"enterprise"``).  When ``"prototype"``, :meth:`augment`
-        short-circuits to a no-op — spec_coverage's keyword-based
-        gap-fill produces redundant tasks on trivial projects (see
-        bug #649 root cause 4: the verify-snake-3 run synthesized
-        "Implement Web Browser Playability" as a duplicate of
-        "Implement Game Presentation and Rendering System"), and
-        contract-first decomposition + outcome coverage already
-        cover the spec for those projects.  ``None`` or any
-        non-prototype value preserves the legacy behavior.
+        Retained as a no-op for chain-construction compatibility
+        (issue #666).  It formerly short-circuited spec_coverage on
+        ``"prototype"`` runs, but that silenced the safety net and let
+        genuinely-dropped outcomes ship (the snake game with no restart).
+        spec_coverage now runs on every mode; this argument no longer
+        affects behavior and can be removed in a follow-up.
 
     Notes
     -----
@@ -119,16 +115,12 @@ class SpecCoverageAugmenter:
             ``telemetry`` is empty when no gaps were filled, otherwise
             ``{"spec_gap_count": N, "spec_gap_features": [...names]}``.
         """
-        # Bug #649 root cause 4: prototype mode skips spec_coverage
-        # entirely.  The keyword-based gap-fill produces noise on
-        # trivial projects (it synthesized "Implement Web Browser
-        # Playability" duplicating the rendering task on snake), and
-        # outcome coverage + contract-first decomposition already
-        # cover the spec for prototype projects.  Non-prototype modes
-        # keep the existing behavior.
-        if self._complexity_mode == "prototype":
-            return AugmentationResult(augmented_tasks=list(tasks))
-
+        # Issue #666: spec_coverage runs on EVERY complexity mode. The
+        # former prototype short-circuit silenced the safety net on
+        # prototype runs, so genuinely-dropped outcomes (e.g. the snake
+        # game's restart) were never caught and shipped missing.
+        # ``complexity_mode`` is retained as a no-op for chain-construction
+        # compatibility (see __init__ docstring).
         spec = prd_analysis.original_description or ""
         if not spec:
             return AugmentationResult(augmented_tasks=list(tasks))

--- a/tests/unit/coordinator/test_spec_coverage_augmenter.py
+++ b/tests/unit/coordinator/test_spec_coverage_augmenter.py
@@ -499,35 +499,29 @@ class TestStage4PostSafetyCheckCallSiteRemoved:
 # ---------------------------------------------------------------------------
 
 
-class TestPrototypeModeSkip:
-    """``complexity_mode='prototype'`` short-circuits the augmenter.
+class TestPrototypeModeNoLongerSkips:
+    """Issue #666: spec_coverage now runs on EVERY complexity mode.
 
-    Background — bug #649 root cause 4
-    -----------------------------------
-    On the verify-snake-3 run (2026-05-24), ``SpecCoverageAugmenter``
-    synthesized "Implement Web Browser Playability" as a gap-fill
-    because the spec phrase "playable in a web browser" wasn't matched
-    against any existing task by ``check_spec_coverage``'s keyword
-    scan.  The synthesized task duplicated "Implement Game Presentation
-    and Rendering System" — pure over-decomposition.
-
-    For prototype projects (snake game, todo app, single-file demos),
-    the contract-first decomposer + outcome coverage already cover the
-    spec.  Spec_coverage's redundant gap-fills produce noise.  The
-    short-circuit accepted here: when ``complexity_mode='prototype'``,
-    no spec_coverage gap-fill runs at all.
+    The old prototype short-circuit (bug #649 root cause 4) silenced
+    spec_coverage on prototype runs to cut a redundant-task/cost problem.
+    But a *dropped* outcome (e.g. the snake game's restart) is
+    mode-independent, and skipping the whole pass meant genuine gaps were
+    never caught — the snake game shipped without restart (#666). The skip
+    is removed. ``complexity_mode`` is retained as a no-op for chain
+    construction compatibility and no longer affects behavior.
     """
 
     @pytest.mark.asyncio
-    async def test_prototype_mode_returns_input_tasks_unchanged(self) -> None:
-        """No LLM call, no synthesized tasks — pure pass-through."""
+    async def test_prototype_mode_runs_spec_coverage(self) -> None:
+        """Prototype mode now RUNS the coverage check (no short-circuit)."""
         from src.marcus_mcp.coordinator.spec_coverage_augmenter import (
             SpecCoverageAugmenter,
         )
 
         with patch(
-            "src.marcus_mcp.coordinator.spec_coverage_augmenter." "check_spec_coverage",
+            "src.marcus_mcp.coordinator.spec_coverage_augmenter.check_spec_coverage",
             new_callable=AsyncMock,
+            return_value=[],
         ) as mock_check:
             augmenter = SpecCoverageAugmenter(complexity_mode="prototype")
             tasks = [_make_task("t1"), _make_task("t2")]
@@ -536,9 +530,9 @@ class TestPrototypeModeSkip:
                 tasks=tasks,
             )
 
-        # Coverage check never ran.
-        mock_check.assert_not_awaited()
-        # Tasks come back unchanged; no synthesized ids; no telemetry.
+        # Coverage check now runs even on prototype (no skip).
+        mock_check.assert_awaited_once()
+        # No gaps found -> passthrough unchanged.
         assert result.augmented_tasks == tasks
         assert result.synthesized_ids == []
         assert result.telemetry == {}

--- a/tests/unit/integrations/test_spec_coverage.py
+++ b/tests/unit/integrations/test_spec_coverage.py
@@ -293,3 +293,185 @@ class TestCheckSpecCoverage:
         assert len(gap_tasks) >= 1
         desc = gap_tasks[0].description.lower()
         assert "spec" in desc or "coverage" in desc or "missing" in desc
+
+
+class TestLlmConfirmUncovered:
+    """Issue #666: the LLM semantic-coverage check that replaces keyword
+    guessing — judges, per feature, whether any task actually delivers it.
+    """
+
+    @pytest.mark.asyncio
+    async def test_returns_features_the_llm_marks_uncovered(self) -> None:
+        """Returns exactly the features the LLM judges no task delivers."""
+        from src.integrations.spec_coverage import _llm_confirm_uncovered
+
+        tasks = [_make_task("Game Engine", "core loop and rendering")]
+        with patch("src.ai.providers.llm_abstraction.LLMAbstraction") as mock_llm:
+            mock_llm.return_value.analyze = AsyncMock(return_value='["game restart"]')
+            out = await _llm_confirm_uncovered(["game restart", "move snake"], tasks)
+        assert out == ["game restart"]
+
+    @pytest.mark.asyncio
+    async def test_filters_out_features_not_in_input(self) -> None:
+        """Guards against the LLM inventing feature strings."""
+        from src.integrations.spec_coverage import _llm_confirm_uncovered
+
+        with patch("src.ai.providers.llm_abstraction.LLMAbstraction") as mock_llm:
+            mock_llm.return_value.analyze = AsyncMock(
+                return_value='["hallucinated", "real one"]'
+            )
+            out = await _llm_confirm_uncovered(["real one"], [_make_task("t")])
+        assert out == ["real one"]
+
+    @pytest.mark.asyncio
+    async def test_returns_none_on_unparseable_response(self) -> None:
+        """A non-JSON response yields None so the caller can fall back."""
+        from src.integrations.spec_coverage import _llm_confirm_uncovered
+
+        with patch("src.ai.providers.llm_abstraction.LLMAbstraction") as mock_llm:
+            mock_llm.return_value.analyze = AsyncMock(return_value="not json at all")
+            out = await _llm_confirm_uncovered(["x"], [_make_task("t")])
+        assert out is None
+
+    @pytest.mark.asyncio
+    async def test_returns_none_on_exception(self) -> None:
+        """Any LLM error yields None (non-fatal — caller falls back)."""
+        from src.integrations.spec_coverage import _llm_confirm_uncovered
+
+        with patch("src.ai.providers.llm_abstraction.LLMAbstraction") as mock_llm:
+            mock_llm.return_value.analyze = AsyncMock(side_effect=RuntimeError("boom"))
+            out = await _llm_confirm_uncovered(["x"], [_make_task("t")])
+        assert out is None
+
+    @pytest.mark.asyncio
+    async def test_prompt_includes_task_criteria(self) -> None:
+        """The coverage prompt includes completion/acceptance criteria, so a
+        feature outcome coverage rolled into a task's criteria (#607/#611) is
+        seen as covered — preventing a duplicate-task double-fire with #665.
+        """
+        from src.integrations.spec_coverage import _llm_confirm_uncovered
+
+        task = _make_task("Tech Foundation", "vite project scaffold")
+        task.completion_criteria = [
+            "Implementation must cover: keyboard input handler for arrows"
+        ]
+        captured: dict[str, str] = {}
+
+        async def _fake_analyze(prompt: str, ctx: object, operation: str = "") -> str:
+            captured["prompt"] = prompt
+            return "[]"
+
+        with patch("src.ai.providers.llm_abstraction.LLMAbstraction") as mock_llm:
+            mock_llm.return_value.analyze = AsyncMock(side_effect=_fake_analyze)
+            await _llm_confirm_uncovered(["keyboard input"], [task])
+
+        assert "keyboard input handler for arrows" in captured["prompt"]
+
+
+class TestCheckSpecCoverageSemantic:
+    """Issue #666: check_spec_coverage uses semantic coverage, with the
+    keyword scan retained only as a fallback when the LLM call fails.
+    """
+
+    @pytest.mark.asyncio
+    async def test_synthesizes_gap_the_keyword_scan_would_miss(self) -> None:
+        """The snake-restart regression: 'game restart' is marked covered by
+        the keyword scan (the word 'game' matches a task) yet no task does
+        restart — semantic coverage catches it and synthesizes a task.
+        """
+        tasks = [_make_task("Game Mechanics", "snake movement and growth")]
+        # Prove the keyword scan MISSES it (the false negative behind #666):
+        assert find_uncovered_features(["game restart"], tasks) == []
+        with (
+            patch(
+                "src.integrations.spec_coverage.extract_spec_features",
+                new_callable=AsyncMock,
+                return_value=["game restart"],
+            ),
+            patch(
+                "src.integrations.spec_coverage._llm_confirm_uncovered",
+                new_callable=AsyncMock,
+                return_value=["game restart"],
+            ),
+        ):
+            gaps = await check_spec_coverage("snake game with restart", tasks)
+        assert len(gaps) == 1
+        assert gaps[0].name == "Implement Game Restart"
+        assert "spec_gap" in gaps[0].labels
+
+    @pytest.mark.asyncio
+    async def test_no_spurious_task_when_semantically_covered(self) -> None:
+        """The #637 regression: a feature a task DOES deliver is not
+        duplicated, even though the keyword scan would flag it (no shared
+        word with the covering task).
+        """
+        tasks = [
+            _make_task(
+                "Game Presentation and Rendering System",
+                "draws the playfield to an html canvas each frame",
+            )
+        ]
+        # Keyword scan WOULD flag it (false positive -> spurious build):
+        assert find_uncovered_features(["browser playability"], tasks) == [
+            "browser playability"
+        ]
+        with (
+            patch(
+                "src.integrations.spec_coverage.extract_spec_features",
+                new_callable=AsyncMock,
+                return_value=["browser playability"],
+            ),
+            patch(
+                "src.integrations.spec_coverage._llm_confirm_uncovered",
+                new_callable=AsyncMock,
+                return_value=[],
+            ),
+        ):
+            gaps = await check_spec_coverage("playable in a browser", tasks)
+        assert gaps == []
+
+    @pytest.mark.asyncio
+    async def test_domain_agnostic_non_game_gap(self) -> None:
+        """Not game-specific: a SaaS 'password reset' gap is synthesized the
+        same way, proving the logic carries no domain assumptions.
+        """
+        tasks = [_make_task("User Login", "email and password authentication")]
+        with (
+            patch(
+                "src.integrations.spec_coverage.extract_spec_features",
+                new_callable=AsyncMock,
+                return_value=["password reset"],
+            ),
+            patch(
+                "src.integrations.spec_coverage._llm_confirm_uncovered",
+                new_callable=AsyncMock,
+                return_value=["password reset"],
+            ),
+        ):
+            gaps = await check_spec_coverage("saas app with login and reset", tasks)
+        assert len(gaps) == 1
+        assert gaps[0].name == "Implement Password Reset"
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_keyword_when_semantic_check_unavailable(
+        self,
+    ) -> None:
+        """When the LLM coverage check errors (returns None), the keyword
+        scan is the fallback so the pipeline stays non-fatal.
+        """
+        tasks = [_make_task("Login", "auth")]
+        with (
+            patch(
+                "src.integrations.spec_coverage.extract_spec_features",
+                new_callable=AsyncMock,
+                return_value=["data export"],
+            ),
+            patch(
+                "src.integrations.spec_coverage._llm_confirm_uncovered",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
+        ):
+            gaps = await check_spec_coverage("app with data export", tasks)
+        assert len(gaps) == 1
+        assert gaps[0].name == "Implement Data Export"


### PR DESCRIPTION
## What this is, briefly

Marcus turns a project spec into a graph of tasks that AI agents build. A setup-time pass called **`spec_coverage`** is a safety net: it checks that every feature the spec promises has a task, and synthesizes a task for any that's missing.

## Why (the bug)

On prototype runs, the snake game **shipped with no restart** even though the spec asked for it (#666). Two compounding causes:

1. **PR #650 skipped `spec_coverage` entirely on prototype runs** (to save an LLM call). So the net was simply off — a dropped feature was never caught.
2. **Even with the skip removed, the coverage check itself would still miss it.** `find_uncovered_features` marks a feature *covered* if **any** of its words appears as a substring anywhere in the task text (`spec_coverage.py:162`). The feature `"game restart"` was marked covered just because the word **"game"** appears in some task — `restart` was never flagged. The same leniency invents *spurious* tasks the other way (`"browser playability"` flagged uncovered when a "rendering" task delivers it — #637).

A keyword scan is wrong in both directions: it misses real gaps (false negative → missing feature) and invents fake ones (false positive → wasted agent build). And every synthesized task is a **full agent build** — dollars and minutes — so precision matters far more than the ~$0.0007 detection call.

## What changed

- **Replaced the keyword coverage check with one LLM *semantic* coverage call** (`_llm_confirm_uncovered`): given the spec features and the current task list — **including each task's completion/acceptance criteria** — it judges, per feature, whether any task actually delivers it. This catches the restart gap and stops the spurious-task false positive.
- **The keyword scan (`find_uncovered_features`) is kept only as a non-fatal fallback** when the LLM call errors (returns `None`), preserving the module's "never stall the pipeline" contract.
- **Removed the prototype short-circuit** in `SpecCoverageAugmenter` — `spec_coverage` now runs on every complexity mode, because a *dropped* outcome is mode-independent (the outcome extractor is identical across modes). `complexity_mode` is retained as a documented no-op (removable in a follow-up).
- Gaps are synthesized as **standalone tasks** (not re-hosted onto an existing task — that's the #665 misrouting we explicitly avoided). Feeding criteria into the prompt prevents a **double-fire** with `outcome_coverage`'s rollup.
- Registered the `spec_coverage_confirm` LLM op in cost-tracking (so its cost is labeled in Cato), and corrected a stale docstring.

## Domain-agnostic by design

Nothing in the code or prompt is game-specific — it reads whatever tasks exist and asks "does any task deliver feature X?" A regression test proves it with a non-game SaaS gap (`password reset`).

## Where to look

| File | Change |
|---|---|
| `src/integrations/spec_coverage.py` | `_llm_confirm_uncovered` (semantic coverage); `check_spec_coverage` uses it with keyword fallback; prompt includes task criteria |
| `src/marcus_mcp/coordinator/spec_coverage_augmenter.py` | removed the prototype skip; `complexity_mode` now a no-op |
| `src/cost_tracking/operations.py` | registered `spec_coverage_confirm` |
| `src/ai/advanced/prd/advanced_parser.py` | corrected stale `complexity_mode` docstring |

## Test plan

- [x] `pytest -m unit` — full suite green (2,238 passed; the one failure is the known sandbox-only `claude`-in-temp-path artifact, unrelated)
- [x] `mypy` on changed files — clean
- [x] 10 new tests: snake-restart regression (proves the keyword scan *would* miss it), no-spurious-task (#637), domain-agnostic SaaS gap, keyword fallback on LLM error, criteria-included-in-prompt (anti double-fire), and `_llm_confirm_uncovered` parse/None cases
- [x] Adversarially reviewed for cross-component effects — **Cato renders `spec_gap` as a plain "work" card** (`aggregator.py:_classify_display_role`), so running on prototype only adds normal cards; no special handling to break

## Related

- #666 (this), #637 (spurious duplicate gap tasks — fixed by precision), #665 (gap misrouting — avoided by synthesizing standalone tasks), #650 (the prototype skip this reverses)
- Follow-ups (non-blocking): remove the now-no-op `complexity_mode` param; both flagged in code comments