### PR TITLE
fix(#676): cap missing-verifications smoke-gate rejections to stop the gridlock loop

### DIFF
--- a/src/integrations/ai_analysis_engine.py
+++ b/src/integrations/ai_analysis_engine.py
@@ -747,12 +747,27 @@ Task Details:
             task_context=task_context,
         )
 
+        # Issue #676: differentiate the two failure modes so the log is
+        # attributable instead of a bare "AI blocker analysis failed:
+        # Expecting value". A transport/LLM error and a malformed (non-JSON)
+        # response are distinct problems; both fall back, but the cause
+        # should be visible. Behavior is unchanged (always falls back).
         try:
             response = await self._call_claude(prompt)
+        except Exception as e:
+            print(f"AI blocker analysis: LLM call failed: {e}", file=sys.stderr)
+            return self._generate_fallback_blocker_analysis(
+                description, severity, agent, task
+            )
+        try:
             result: Dict[str, Any] = json.loads(response)
             return result
-        except Exception as e:
-            print(f"AI blocker analysis failed: {e}", file=sys.stderr)
+        except (json.JSONDecodeError, TypeError) as e:
+            print(
+                f"AI blocker analysis: non-JSON LLM response ({e}); "
+                f"first 200 chars: {(response or '')[:200]!r}",
+                file=sys.stderr,
+            )
             return self._generate_fallback_blocker_analysis(
                 description, severity, agent, task
             )

--- a/src/marcus_mcp/tools/task.py
+++ b/src/marcus_mcp/tools/task.py
@@ -47,6 +47,82 @@ MAX_VALIDATION_RETRIES = 3
 _singleton_lock = threading.Lock()  # Thread-safe initialization
 
 
+# Smoke-gate missing-verifications retry ceiling (issue #676). The product
+# smoke gate rejects an integration completion that declares no
+# ``verifications`` for its in-scope outcomes. That rejection is retryable
+# (the agent can add verifications and re-report), but with NO ceiling an
+# agent that keeps re-sending the same incomplete report loops forever ->
+# lease expiry -> BLOCKED -> project gridlock (snake-pr667-5 hit 6 identical
+# rejections). After this many identical rejections the rejection is
+# converted to a TERMINAL escalation so the agent stops retrying and the
+# failure is surfaced with its remediation payload instead of looping.
+MAX_SMOKE_MISSING_VERIFICATION_ATTEMPTS = 2
+_smoke_missing_verification_attempts: Dict[str, int] = {}
+
+
+def _record_missing_verification_attempt(task_id: str) -> int:
+    """Increment and return the missing-verifications rejection count.
+
+    Parameters
+    ----------
+    task_id : str
+        The integration task being rejected for missing verifications.
+
+    Returns
+    -------
+    int
+        The cumulative number of missing-verifications rejections seen for
+        this task (1 on the first call).
+    """
+    count = _smoke_missing_verification_attempts.get(task_id, 0) + 1
+    _smoke_missing_verification_attempts[task_id] = count
+    return count
+
+
+def _clear_smoke_attempts(task_id: str) -> None:
+    """Reset the missing-verifications rejection count for a task."""
+    _smoke_missing_verification_attempts.pop(task_id, None)
+
+
+def _escalate_missing_verifications_response(
+    smoke_response: Dict[str, Any],
+) -> Dict[str, Any]:
+    """Convert a repeatable missing-verifications rejection into a terminal one.
+
+    After ``MAX_SMOKE_MISSING_VERIFICATION_ATTEMPTS`` identical rejections the
+    agent is plainly not going to add verifications by re-sending the same
+    call, so we stop the loop (issue #676): re-tag the rejection with a
+    distinct, non-retryable ``error`` plus ``terminal``/``escalated`` flags
+    while preserving the remediation payload (``blocker``,
+    ``missing_outcome_ids``) so the failure is actionable rather than a silent
+    gridlock. The input dict is not mutated.
+
+    Parameters
+    ----------
+    smoke_response : Dict[str, Any]
+        The ``verifications_required_but_missing`` rejection to escalate.
+
+    Returns
+    -------
+    Dict[str, Any]
+        A new dict tagged terminal/escalated, remediation fields intact.
+    """
+    escalated = dict(smoke_response)
+    escalated["status"] = "smoke_verification_escalated"
+    escalated["error"] = "verifications_required_escalated"
+    escalated["terminal"] = True
+    escalated["escalated"] = True
+    escalated["message"] = (
+        "Marcus has rejected this completion "
+        f"{MAX_SMOKE_MISSING_VERIFICATION_ATTEMPTS} times for the same "
+        "reason: no ``verifications`` for the task's required in-scope "
+        "outcomes. Do NOT retry the same call. This integration task is "
+        "escalated for remediation -- the outcome IDs that need coverage are "
+        "in ``missing_outcome_ids`` and the fix is in ``blocker``."
+    )
+    return escalated
+
+
 def clear_validation_retry(task_id: str) -> None:
     """Clear the validation retry history for a task.
 
@@ -65,6 +141,9 @@ def clear_validation_retry(task_id: str) -> None:
     if _retry_tracker is not None:
         _retry_tracker.clear_task(task_id)
         logger.debug("Cleared validation retry history for recovered task %s", task_id)
+    # Issue #676: also reset the smoke-gate missing-verifications counter so a
+    # recovered/reassigned task gets a fresh set of attempts.
+    _clear_smoke_attempts(task_id)
 
 
 async def get_project_board_context(state: Any) -> Dict[str, Optional[str]]:
@@ -4051,6 +4130,29 @@ async def report_task_progress(
                         verifications=verifications,
                     )
                     if smoke_response is not None:
+                        # Issue #676: a "verifications_required_but_missing"
+                        # rejection is retryable, but with no ceiling an agent
+                        # that keeps re-sending the same incomplete report
+                        # loops until lease expiry -> gridlock. After a small
+                        # number of identical rejections, escalate to a
+                        # terminal response so the agent stops and the failure
+                        # surfaces with its remediation payload.
+                        if (
+                            smoke_response.get("error")
+                            == "verifications_required_but_missing"
+                        ):
+                            attempts = _record_missing_verification_attempt(task_id)
+                            if attempts > MAX_SMOKE_MISSING_VERIFICATION_ATTEMPTS:
+                                logger.warning(
+                                    "Smoke gate: task %s rejected for missing "
+                                    "verifications %d times; escalating to a "
+                                    "terminal response (issue #676).",
+                                    task_id,
+                                    attempts,
+                                )
+                                return _escalate_missing_verifications_response(
+                                    smoke_response
+                                )
                         return smoke_response
                 except Exception as smoke_err:
                     # Smoke verification system error (not a smoke

--- a/src/marcus_mcp/tools/task.py
+++ b/src/marcus_mcp/tools/task.py
@@ -123,6 +123,75 @@ def _escalate_missing_verifications_response(
     return escalated
 
 
+async def _terminalize_escalated_smoke_task(
+    state: Any, task_id: str, agent_id: str, blocker: str
+) -> None:
+    """Move an escalated smoke-gate task to a terminal BOARD state.
+
+    Issue #676 (Codex P1 on PR #678): the escalation helper above only re-tags
+    the MCP *response* — no code in the repo consumes the
+    ``verifications_required_escalated`` / ``smoke_verification_escalated``
+    error to change kanban state.  So after the ceiling fires, an agent that
+    obeys "do NOT retry" simply stops calling back and the task stays
+    IN_PROGRESS with its lease held until timeout — the project idles on the
+    active task instead of surfacing a terminal board state immediately, which
+    is the exact gridlock #676 set out to end.
+
+    This mirrors ``report_blocker``: mark the kanban task BLOCKED and release
+    all coordination state (agent assignment + lease) so the board reflects the
+    terminal state at once and the agent's slot is freed.  Best-effort — any
+    failure is logged, never raised, so escalation reporting is never lost.
+
+    Parameters
+    ----------
+    state : Any
+        Marcus server state (``kanban_client``, ``lease_manager``, …).
+    task_id : str
+        The escalated task.
+    agent_id : str
+        Agent that held the task.
+    blocker : str
+        Blocker text recorded on the board.
+    """
+    try:
+        if getattr(state, "kanban_client", None):
+            await state.kanban_client.update_task(
+                task_id, {"status": TaskStatus.BLOCKED, "blocker": blocker}
+            )
+    except Exception as e:  # pragma: no cover - defensive
+        logger.warning(
+            "Smoke-gate escalation: failed to mark task %s BLOCKED: %s",
+            task_id,
+            e,
+        )
+
+    # Release coordination state — same decoupling as report_blocker (a
+    # terminal status must free the agent's slot independently of any
+    # correctness check, Simon decision 011b3fad).
+    try:
+        if getattr(state, "agent_status", None) and agent_id in state.agent_status:
+            state.agent_status[agent_id].current_tasks = []
+        if getattr(state, "agent_tasks", None) and agent_id in state.agent_tasks:
+            del state.agent_tasks[agent_id]
+        if getattr(state, "assignment_persistence", None):
+            await state.assignment_persistence.remove_assignment(agent_id)
+        if getattr(state, "lease_manager", None):
+            if task_id in state.lease_manager.active_leases:
+                del state.lease_manager.active_leases[task_id]
+                logger.info(
+                    "Released lease for escalated (terminal) task %s (agent %s)",
+                    task_id,
+                    agent_id,
+                )
+    except Exception as e:  # pragma: no cover - defensive
+        logger.warning(
+            "Smoke-gate escalation: failed to release coordination state "
+            "for task %s: %s",
+            task_id,
+            e,
+        )
+
+
 def clear_validation_retry(task_id: str) -> None:
     """Clear the validation retry history for a task.
 
@@ -4150,9 +4219,26 @@ async def report_task_progress(
                                     task_id,
                                     attempts,
                                 )
-                                return _escalate_missing_verifications_response(
+                                escalated = _escalate_missing_verifications_response(
                                     smoke_response
                                 )
+                                # Codex P1 on #678: actually terminalize the
+                                # board state + release the lease, so an agent
+                                # that obeys "do NOT retry" doesn't leave the
+                                # task IN_PROGRESS idling until lease timeout.
+                                await _terminalize_escalated_smoke_task(
+                                    state,
+                                    task_id,
+                                    agent_id,
+                                    str(
+                                        escalated.get("blocker")
+                                        or escalated.get("message")
+                                        or "Smoke gate escalated: required "
+                                        "verifications never declared."
+                                    ),
+                                )
+                                _clear_smoke_attempts(task_id)
+                                return escalated
                         return smoke_response
                 except Exception as smoke_err:
                     # Smoke verification system error (not a smoke

--- a/tests/unit/marcus_mcp/test_smoke_gate_escalation.py
+++ b/tests/unit/marcus_mcp/test_smoke_gate_escalation.py
@@ -13,13 +13,17 @@ number of identical attempts, so the agent stops retrying and the failure
 is surfaced (with the same remediation payload) instead of looping.
 """
 
+from unittest.mock import AsyncMock, Mock
+
 import pytest
 
+from src.core.models import TaskStatus
 from src.marcus_mcp.tools.task import (
     MAX_SMOKE_MISSING_VERIFICATION_ATTEMPTS,
     _clear_smoke_attempts,
     _escalate_missing_verifications_response,
     _record_missing_verification_attempt,
+    _terminalize_escalated_smoke_task,
 )
 
 pytestmark = pytest.mark.unit
@@ -110,3 +114,54 @@ class TestCeilingDecision:
         for _ in range(MAX_SMOKE_MISSING_VERIFICATION_ATTEMPTS + 1):
             last = _record_missing_verification_attempt("t-ceil2")
         assert last > MAX_SMOKE_MISSING_VERIFICATION_ATTEMPTS
+
+
+def _state_with_lease(task_id: str, agent_id: str) -> Mock:
+    """Build a Mock state holding a lease + assignment for the task."""
+    state = Mock()
+    state.kanban_client = Mock()
+    state.kanban_client.update_task = AsyncMock()
+    state.agent_status = {agent_id: Mock(current_tasks=[task_id])}
+    state.agent_tasks = {agent_id: Mock(task_id=task_id)}
+    state.assignment_persistence = Mock()
+    state.assignment_persistence.remove_assignment = AsyncMock()
+    state.lease_manager = Mock()
+    state.lease_manager.active_leases = {task_id: object()}
+    return state
+
+
+class TestTerminalizeEscalatedTask:
+    """Codex P1 (#678): escalation must terminalize the BOARD, not just the
+    MCP response — else the task idles IN_PROGRESS until lease timeout."""
+
+    @pytest.mark.asyncio
+    async def test_marks_task_blocked_on_board(self) -> None:
+        state = _state_with_lease("t-term", "agent-1")
+        await _terminalize_escalated_smoke_task(
+            state, "t-term", "agent-1", "required verifications never declared"
+        )
+        state.kanban_client.update_task.assert_awaited_once()
+        args = state.kanban_client.update_task.await_args
+        assert args.args[0] == "t-term"
+        assert args.args[1]["status"] == TaskStatus.BLOCKED
+        assert "blocker" in args.args[1]
+
+    @pytest.mark.asyncio
+    async def test_releases_lease_and_assignment(self) -> None:
+        state = _state_with_lease("t-term2", "agent-1")
+        await _terminalize_escalated_smoke_task(state, "t-term2", "agent-1", "blocker")
+        # lease released, assignment removed, agent slot freed
+        assert "t-term2" not in state.lease_manager.active_leases
+        assert "agent-1" not in state.agent_tasks
+        state.assignment_persistence.remove_assignment.assert_awaited_once_with(
+            "agent-1"
+        )
+
+    @pytest.mark.asyncio
+    async def test_board_failure_does_not_raise(self) -> None:
+        # Best-effort: a kanban failure must not lose the escalation.
+        state = _state_with_lease("t-term3", "agent-1")
+        state.kanban_client.update_task = AsyncMock(side_effect=RuntimeError("boom"))
+        await _terminalize_escalated_smoke_task(state, "t-term3", "agent-1", "blocker")
+        # still released the lease despite the board error
+        assert "t-term3" not in state.lease_manager.active_leases

--- a/tests/unit/marcus_mcp/test_smoke_gate_escalation.py
+++ b/tests/unit/marcus_mcp/test_smoke_gate_escalation.py
@@ -1,0 +1,112 @@
+"""
+Unit tests for the smoke-gate missing-verifications retry ceiling (issue #676).
+
+When an integration task carries in-scope outcomes but the agent reports
+completion without declaring ``verifications``, the product smoke gate
+rejects with ``error="verifications_required_but_missing"``. Before this
+fix that rejection had NO ceiling: the agent could re-send the same
+incomplete report forever, the gate rejected each time, and the run
+eventually froze into gridlock (snake-pr667-5: 6 identical rejections).
+
+The fix converts the rejection into a TERMINAL escalation after a small
+number of identical attempts, so the agent stops retrying and the failure
+is surfaced (with the same remediation payload) instead of looping.
+"""
+
+import pytest
+
+from src.marcus_mcp.tools.task import (
+    MAX_SMOKE_MISSING_VERIFICATION_ATTEMPTS,
+    _clear_smoke_attempts,
+    _escalate_missing_verifications_response,
+    _record_missing_verification_attempt,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _missing_verifications_rejection() -> dict:
+    """A representative missing-verifications rejection from the smoke gate."""
+    return {
+        "success": False,
+        "status": "smoke_verification_failed",
+        "error": "verifications_required_but_missing",
+        "agent_id": "agent-1",
+        "task_id": "task-int",
+        "blocker": "## Verifications required ...",
+        "missing_outcome_ids": ["outcome_play", "outcome_restart"],
+        "required_outcome_ids": ["outcome_play", "outcome_restart"],
+    }
+
+
+class TestMissingVerificationAttemptCounter:
+    """The per-task attempt counter increments and clears."""
+
+    def test_record_increments_per_task(self) -> None:
+        _clear_smoke_attempts("t-count")
+        assert _record_missing_verification_attempt("t-count") == 1
+        assert _record_missing_verification_attempt("t-count") == 2
+        assert _record_missing_verification_attempt("t-count") == 3
+
+    def test_counters_are_independent_per_task(self) -> None:
+        _clear_smoke_attempts("t-a")
+        _clear_smoke_attempts("t-b")
+        _record_missing_verification_attempt("t-a")
+        _record_missing_verification_attempt("t-a")
+        assert _record_missing_verification_attempt("t-b") == 1
+
+    def test_clear_resets_count(self) -> None:
+        _record_missing_verification_attempt("t-clear")
+        _clear_smoke_attempts("t-clear")
+        assert _record_missing_verification_attempt("t-clear") == 1
+
+
+class TestEscalationResponse:
+    """The terminal escalation preserves remediation but stops retries."""
+
+    def test_marks_terminal_and_escalated(self) -> None:
+        out = _escalate_missing_verifications_response(
+            _missing_verifications_rejection()
+        )
+        assert out["terminal"] is True
+        assert out["escalated"] is True
+        assert out["success"] is False
+
+    def test_uses_a_distinct_error_so_it_is_not_a_retry_signal(self) -> None:
+        out = _escalate_missing_verifications_response(
+            _missing_verifications_rejection()
+        )
+        # Must NOT keep the retryable error code, or the agent treats it as
+        # "fix and retry" rather than "stop, escalated".
+        assert out["error"] != "verifications_required_but_missing"
+        assert out["error"] == "verifications_required_escalated"
+
+    def test_preserves_remediation_payload(self) -> None:
+        out = _escalate_missing_verifications_response(
+            _missing_verifications_rejection()
+        )
+        assert out["missing_outcome_ids"] == ["outcome_play", "outcome_restart"]
+        assert "blocker" in out
+        # original is not mutated
+        src = _missing_verifications_rejection()
+        _escalate_missing_verifications_response(src)
+        assert src["error"] == "verifications_required_but_missing"
+
+
+class TestCeilingDecision:
+    """Attempts at/under the ceiling stay retryable; beyond it escalates."""
+
+    def test_first_attempts_under_ceiling(self) -> None:
+        _clear_smoke_attempts("t-ceil")
+        for i in range(1, MAX_SMOKE_MISSING_VERIFICATION_ATTEMPTS + 1):
+            assert (
+                _record_missing_verification_attempt("t-ceil")
+                <= MAX_SMOKE_MISSING_VERIFICATION_ATTEMPTS
+            )
+
+    def test_attempt_beyond_ceiling_triggers_escalation(self) -> None:
+        _clear_smoke_attempts("t-ceil2")
+        last = 0
+        for _ in range(MAX_SMOKE_MISSING_VERIFICATION_ATTEMPTS + 1):
+            last = _record_missing_verification_attempt("t-ceil2")
+        assert last > MAX_SMOKE_MISSING_VERIFICATION_ATTEMPTS


### PR DESCRIPTION
## What is this, briefly

Marcus coordinates AI coding agents. Every project ends with an **integration verification** task, gated by a **product smoke gate**. When that task carries in-scope user outcomes, the agent must declare per-outcome `verifications` at completion; a bare `start_command` is rejected.

## Why (the user-visible bug)

On the `snake-pr667-5` run, the project just… froze, idling until a 20-minute watchdog killed it. Under the hood: the integration agent reported "completed" **without** declaring `verifications`. The smoke gate rejected (`error: "verifications_required_but_missing"`). The agent re-sent the same incomplete report. Rejected again. **Six times.** That rejection had **no retry ceiling** — unlike the LLM validation gate, which caps at `MAX_VALIDATION_RETRIES`. The loop ran until the lease expired, the task went BLOCKED, everything depended on it, and the project gridlocked.

## What changed

1. **Retry ceiling (2) + terminal escalation** (`src/marcus_mcp/tools/task.py`). After 2 identical `verifications_required_but_missing` rejections, the rejection is converted into a **terminal escalation** — a distinct, non-retryable `error` (`verifications_required_escalated`) plus `terminal`/`escalated` flags — that **preserves the remediation payload** (`blocker`, `missing_outcome_ids`). The agent stops retrying; the failure surfaces with its fix instead of looping into gridlock.
   - The counter only counts the "declared **no** verifications at all" case. Once an agent declares any, it moves to the coverage-check path (different error), so partial progress isn't penalized.
   - The counter resets on task recovery/reassignment (in `clear_validation_retry`), so a fresh agent gets fresh attempts.
2. **De-silence the blocker-analysis parse** (`src/integrations/ai_analysis_engine.py`). The `"AI blocker analysis failed: Expecting value"` we saw was an undifferentiated catch. Split transport-failure vs non-JSON-response so the log is attributable (and the non-JSON case logs the response prefix). **Behavior unchanged** — it always falls back.

## Scope

This is the **minimal-safe slice** of the verification cluster. It stops the freeze; it does **not** yet change *what* verification proves. The larger **#677** redesign — Marcus authors a per-app-type outcome criterion (web=renders, pipeline=correct output, CLI=stdout, library=API), the agent reads the assembled code to produce evidence, the gate judges the evidence — is a separate PR (decision logged in Simon, reviewed by Kaia).

## Where to look

| File | Change |
|---|---|
| `src/marcus_mcp/tools/task.py` (helpers near `MAX_VALIDATION_RETRIES`; call site ~`if smoke_response is not None`) | ceiling + terminal escalation; counter reset in `clear_validation_retry` |
| `src/integrations/ai_analysis_engine.py` `analyze_blocker` | split transport vs non-JSON parse, attributable logs |
| `tests/unit/marcus_mcp/test_smoke_gate_escalation.py` | 8 new tests |

## Test plan

- [x] `pytest -m unit` — full suite green (2,252 passed; the one failure is the pre-existing sandbox-only `claude`-in-temp-path artifact, unrelated)
- [x] `mypy` on changed files — clean
- [x] 8 new tests: counter increments/clears, per-task independence, escalation response is terminal + non-retryable + preserves remediation + doesn't mutate input, ceiling boundary
- [ ] Reviewer: confirm the terminal escalation shape is one agents/runners treat as stop-not-retry

## Related

- #676 (this) — the gridlock dead-end
- #677 — what verification must *prove* (the bigger redesign; sibling)
- Mirrors the existing `MAX_VALIDATION_RETRIES` ceiling pattern in the same file
- Surfaced by the `snake-pr667-5` end-to-end run

## Deferred (follow-up, noted)

Explicitly marking the task BLOCKED + writing a remediation artifact file on escalation (vs the agent simply stopping on the terminal response) — and whether to re-enqueue a recovery agent with that artifact — is left for the #677 work, where the recovery path is in scope.