### PR TITLE
fix(#659): surface scaffold-path anchor on feature-based tasks too

### DIFF
--- a/src/marcus_mcp/tools/task.py
+++ b/src/marcus_mcp/tools/task.py
@@ -1416,26 +1416,6 @@ def build_tiered_instructions(
                 "everything else yourself."
             )
 
-        # #659: scaffold-path anchor. When Marcus's pre-fork scaffold
-        # generated a placeholder file for this task, surface the
-        # exact path so the agent fills the scaffold instead of
-        # inventing a sibling path (the ``src/core/gameEngine.js``
-        # orphan failure observed in ``snake-baton-1``). The
-        # ``_resolve_scaffold_path`` helper checks ``source_context``
-        # first (SQLite provider has a native column) then falls back
-        # to the ``MARCUS_SCAFFOLD_PATH`` description marker that
-        # round-trips through Planka / GitHub / Linear providers.
-        scaffold_path_raw = _resolve_scaffold_path(task)
-        if scaffold_path_raw:
-            contract_notice += (
-                f"\n\n📂 IMPLEMENTATION FILE: {scaffold_path_raw}\n"
-                f"Marcus pre-created a placeholder at this path. Fill "
-                f"it with your implementation — do NOT create a "
-                f"sibling file elsewhere. Other agents will import "
-                f"from this exact path. If the file is missing when "
-                f"you start, the scaffold step may have failed; "
-                f"create the file at this path."
-            )
         # Stay-in-scope boundary instruction. Without it, contract-first
         # impl agents routinely reach into shared infrastructure files
         # (entry points, manifests, build configs) to make their module
@@ -1507,6 +1487,35 @@ def build_tiered_instructions(
             "other agents might consume"
         )
         instructions_parts.append(contract_notice)
+
+    # Layer 1.35: Scaffold-path anchor (#659). When Marcus's pre-fork
+    # scaffold generated a placeholder file for this task, surface the
+    # exact path so the agent fills the scaffold instead of inventing a
+    # sibling path (the ``src/core/gameEngine.js`` orphan failure
+    # observed in ``snake-baton-1``). This is a STANDALONE layer, NOT
+    # gated on ``responsibility`` — scaffolds are generated for both the
+    # contract-first AND feature-based decomposition paths
+    # (``_run_design_phase`` runs whenever the project has design tasks
+    # and a project_root), but the anchor previously lived inside the
+    # contract-first ``if responsibility:`` block, so feature-based
+    # agents got the path persisted on their task yet never saw it —
+    # exactly the invent-your-own-path failure #659 is about, just on
+    # the other decomposer. ``_resolve_scaffold_path`` checks
+    # ``source_context`` first (SQLite has a native column) then the
+    # ``MARCUS_SCAFFOLD_PATH`` description marker that round-trips
+    # through Planka / GitHub / Linear. Naming the path is coordination
+    # (it is the public import address downstream agents use), not
+    # control — the agent still owns HOW the file is filled.
+    scaffold_path_raw = _resolve_scaffold_path(task)
+    if scaffold_path_raw:
+        instructions_parts.append(
+            f"\n\n📂 IMPLEMENTATION FILE: {scaffold_path_raw}\n"
+            f"Marcus pre-created a placeholder at this path. Fill it with "
+            f"your implementation — do NOT create a sibling file "
+            f"elsewhere. Other agents will import from this exact path. "
+            f"If the file is missing when you start, the scaffold step may "
+            f"have failed; create the file at this path."
+        )
 
     # Layer 1.4: Feature-based design artifact framing
     # Mirrors Layer 1.3 for the opposite decomposer mode.  When a

--- a/tests/unit/integrations/test_scaffold_anchoring.py
+++ b/tests/unit/integrations/test_scaffold_anchoring.py
@@ -282,6 +282,52 @@ class TestAgentInstructionsSurfaceScaffoldPath:
         assert "IMPLEMENTATION FILE: src/core/gameEngine.js" in instructions
         assert "do NOT create a sibling file" in instructions
 
+    def test_anchor_appears_for_feature_based_task_without_responsibility(
+        self,
+    ) -> None:
+        """Feature-based tasks (no ``responsibility``) also get the anchor.
+
+        Regression for #659: scaffolds are generated for both the
+        contract-first and feature-based decomposition paths, but the
+        anchor previously lived inside the contract-first
+        ``if responsibility:`` block — so a feature-based agent had the
+        path persisted on its task yet never saw it. The anchor is now a
+        standalone layer that fires for any task with a scaffold_path.
+        """
+        from datetime import datetime, timezone
+
+        now = datetime.now(timezone.utc)
+        # Built directly (not via _make_task) so responsibility is None,
+        # i.e. the contract-first layer does NOT fire.
+        task = Task(
+            id="task_feature_engine",
+            name="Implement Game Core Engine",
+            description="",
+            status=TaskStatus.TODO,
+            priority=Priority.MEDIUM,
+            assigned_to=None,
+            created_at=now,
+            updated_at=now,
+            due_date=None,
+            estimated_hours=2.0,
+            labels=["implementation"],
+            source_context={"scaffold_path": "src/core/gameEngine.js"},
+        )
+        assert not getattr(task, "responsibility", None)
+
+        instructions = build_tiered_instructions(
+            base_instructions="Build the engine.",
+            task=task,
+            context_data=None,
+            dependency_awareness=None,
+            predictions=None,
+            state=None,
+        )
+
+        # Anchor present even though the contract-first layer did not fire.
+        assert "IMPLEMENTATION FILE: src/core/gameEngine.js" in instructions
+        assert "CONTRACT RESPONSIBILITY" not in instructions
+
     def test_no_anchor_section_when_path_missing(self) -> None:
         """Without ``scaffold_path``, no IMPLEMENTATION FILE section appears.
 


### PR DESCRIPTION
## What is this system, briefly

Marcus breaks a project spec into tasks for independent AI agents. Before agents spawn, Marcus writes a **scaffold** — one placeholder file per implementation task — to establish the canonical file layout. Agents are meant to *fill* their placeholder, not invent a new path.

## Why

Issue #659 documented agents inventing their own file paths instead of filling the scaffold (the `src/core/gameEngine.js` orphan in `snake-baton-1`: Marcus's placeholder left as 1-line dead code while the agent wrote 176 lines at an invented `src/game/gameEngine.js`). Prior #659 work persisted the scaffold path on the task and added an agent-facing anchor — **but the anchor only fired for contract-first tasks.**

The anchor (`📂 IMPLEMENTATION FILE: <path>`) lived inside the contract-first `if responsibility:` block in `build_tiered_instructions`. Marcus generates scaffolds for **both** decomposition paths (`_run_design_phase` runs whenever the project has design tasks and a `project_root`). So on the **feature-based** path the scaffold path was persisted on the task (via `source_context["scaffold_path"]` + the `MARCUS_SCAFFOLD_PATH` description marker) but **never surfaced to the agent** — the exact invent-your-own-path failure #659 is about, just on the other decomposer.

## What changed

`src/marcus_mcp/tools/task.py`:
- Moved the scaffold-path anchor out of the contract-first block into a standalone **Layer 1.35** that fires for any task where `_resolve_scaffold_path(task)` is non-empty, regardless of `responsibility`.
- **Moved, not duplicated** — contract-first tasks still get the anchor exactly once (the existing contract-first surfacing tests in `test_scaffold_anchoring.py` and `test_contract_responsibility_prompt.py` still pass).

`tests/unit/integrations/test_scaffold_anchoring.py`:
- New regression test: a feature-based task (no `responsibility`) now gets the anchor and no spurious `CONTRACT RESPONSIBILITY` layer.

### Bright-line check (MAS invariant)
Naming the scaffold path is **coordination**, not control — it's the public import address downstream agents will use (same logic accepted for `declared_files` in #658). The agent still owns HOW the file is filled. Two agents given the same anchored task can produce legitimately different implementations.

## Test plan

- [x] `pytest tests/unit/integrations/test_scaffold_anchoring.py` — 11 pass (incl. new feature-based test)
- [x] `pytest tests/unit/mcp/test_contract_responsibility_prompt.py` — contract-first anchor still emits once
- [x] `pytest tests/unit/mcp/test_task_workflow_enforcement.py` — `_get_task_type` unaffected
- [x] `mypy src/marcus_mcp/tools/task.py` clean
- [ ] Reviewer: confirm a feature-based prototype run delivers `📂 IMPLEMENTATION FILE` in `request_next_task` instructions for scaffolded impl tasks

## Related

- Completes **#659** for the feature-based decomposition path (prior commits covered persistence, cross-provider marker, and contract-first surfacing).
- Sibling issue **#632** closed separately (already fixed by #635).

🤖 Generated with [Claude Code](https://claude.com/claude-code)