### PR TITLE
feat(#683 Cause 1): outcome-aware feature filter — cap by complexity tier, never drop a core feature

### DIFF
--- a/src/ai/advanced/prd/advanced_parser.py
+++ b/src/ai/advanced/prd/advanced_parser.py
@@ -9,7 +9,7 @@ import json
 import logging
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
-from typing import Any, Dict, List, Optional, Sequence, Tuple
+from typing import Any, Dict, List, Optional, Sequence, Set, Tuple
 
 from src.ai.advanced.prd.outcome_extractor import (
     UserOutcome,
@@ -2280,12 +2280,44 @@ Create design artifacts such as:
         project_size = (constraints.quality_requirements or {}).get(
             "project_size", "medium"
         )
+
+        # #683 Cause 1: determine which features are CORE (serve an
+        # in-scope user outcome) via one LLM call, so the filter keeps
+        # them and trims only scope-creep — instead of dropping by list
+        # position. Gated on outcome coverage (which provides the
+        # outcomes). On flag-off / no outcomes / LLM error we pass
+        # ``None``: the filter still caps by the complexity tier
+        # (deterministic, far better than the old team_size cut) and #683
+        # Cause 2 backstops any core feature that slips through.
+        protected_ids: Optional[Set[str]] = None
+        from src.config.outcome_coverage_config import is_outcome_coverage_enabled
+
+        if is_outcome_coverage_enabled() and analysis.user_outcomes:
+            try:
+                from src.marcus_mcp.coordinator.outcome_coverage import (
+                    map_core_feature_ids_with_llm,
+                )
+
+                protected_ids = await map_core_feature_ids_with_llm(
+                    requirements=analysis.functional_requirements,
+                    outcomes=analysis.user_outcomes,
+                    llm_client=self.llm_client,
+                )
+            except Exception as exc:  # noqa: BLE001 — graceful degradation
+                logger.warning(
+                    "#683 Cause 1: core-feature mapping failed; falling "
+                    "back to tier-cap filtering without core protection: %s",
+                    exc,
+                )
+                protected_ids = None
+
         functional_requirements = self._filter_requirements_by_size(
             analysis.functional_requirements,
             project_size,
             constraints.team_size,
             # Pass original PRD for specificity detection
             analysis.original_description,
+            protected_ids,
         )
 
         # Get complexity mode from constraints (passed from create_project)
@@ -5187,6 +5219,7 @@ explanation."""
         project_size: str,
         team_size: int,
         prd_content: str,
+        protected_ids: Optional[Set[str]] = None,
     ) -> List[Dict[str, Any]]:
         """
         Filter functional requirements based on project size and team capacity.
@@ -5261,27 +5294,59 @@ explanation."""
             f"filtering for project_size={project_size}"
         )
 
-        # Map to new 3-option system (with legacy support)
-        if project_size in ["prototype", "mvp"]:
-            # Prototype: only keep the most essential 1-2 requirements
-            filtered = requirements[:2]
-        elif project_size in ["standard", "small", "medium"]:
-            # Standard: limit based on team size (typically 3-5 features)
-            max_reqs = min(len(requirements), max(3, team_size))
-            filtered = requirements[:max_reqs]
-        else:
-            # Enterprise/Large: include all requirements
-            filtered = requirements
+        # #683 Cause 1: cap by the project's complexity tier, NOT team
+        # size. ``project_size`` IS the complexity mode; team size governs
+        # parallelism, not scope. The old ``requirements[:max(3, team_size)]``
+        # cut a "medium" project (whose own expected range is 8-15) down to
+        # 3 by list position, silently dropping core features (the snake
+        # collision / game-over / restart loss in #683). The cap is the
+        # upper bound of the tier's expected feature range.
+        tier_caps = {
+            "prototype": 5,
+            "mvp": 5,
+            "small": 10,
+            "standard": 15,
+            "medium": 15,
+            "enterprise": 30,
+            "large": 30,
+        }
+        cap = tier_caps.get(project_size, 15)
+
+        # #683 Cause 1: never drop a CORE feature (one that serves an
+        # in-scope user outcome, per the LLM mapping the caller passes in).
+        # Keep all protected requirements first; fill the rest of the cap
+        # with non-core features in order; trim only genuine scope-creep.
+        protected = protected_ids or set()
+
+        def _rid(req: Dict[str, Any]) -> str:
+            return str(req.get("id") or req.get("name") or "unknown")
+
+        core = [r for r in requirements if _rid(r) in protected]
+        non_core = [r for r in requirements if _rid(r) not in protected]
+
+        # Core features are never dropped, even if they alone exceed the
+        # cap (correctness floor — Cause 2 would otherwise have to rebuild
+        # them). Non-core fills whatever capacity remains.
+        remaining = max(0, cap - len(core))
+        filtered = core + non_core[:remaining]
+        # Preserve original ordering for stability/readability.
+        kept_ids = {_rid(r) for r in filtered}
+        filtered = [r for r in requirements if _rid(r) in kept_ids]
 
         if len(filtered) < original_count:
-            filtered_ids = [
-                req.get("id", req.get("name", "unknown")) for req in filtered
-            ]
-            dropped_ids = [id for id in original_ids if id not in filtered_ids]
+            filtered_ids = [_rid(r) for r in filtered]
+            dropped_ids = [i for i in original_ids if i not in filtered_ids]
             logger.warning(
                 f"Filtered {original_count} -> {len(filtered)} "
-                f"(size={project_size}, team={team_size}). "
+                f"(size={project_size}, cap={cap}, "
+                f"core_protected={len(core)}). "
                 f"Kept: {filtered_ids}, Dropped: {dropped_ids}"
+            )
+        if len(core) > cap:
+            logger.warning(
+                f"#683 Cause 1: {len(core)} core feature(s) exceed the "
+                f"{project_size} cap of {cap}; keeping all core features "
+                f"(scope floor) — consider a larger project_size."
             )
 
         return filtered

--- a/src/ai/advanced/prd/advanced_parser.py
+++ b/src/ai/advanced/prd/advanced_parser.py
@@ -2304,12 +2304,23 @@ Create design artifacts such as:
                     llm_client=self.llm_client,
                 )
             except Exception as exc:  # noqa: BLE001 — graceful degradation
+                # Codex P2 on PR #688: a transient mapping failure must NOT
+                # reintroduce the outcome-dropping behavior this fixes. With
+                # outcome coverage ON, the safe fallback is to protect ALL
+                # current requirements (treat every feature as core) so an
+                # over-cap list can't trim a real feature by list position.
+                # The deterministic tier cap still applies; #683 Cause 2
+                # backstops anything genuinely beyond it.
                 logger.warning(
-                    "#683 Cause 1: core-feature mapping failed; falling "
-                    "back to tier-cap filtering without core protection: %s",
+                    "#683 Cause 1: core-feature mapping failed; protecting "
+                    "all requirements so none are dropped by position: %s",
                     exc,
                 )
-                protected_ids = None
+                protected_ids = {
+                    str(r.get("id") or r.get("name") or "")
+                    for r in analysis.functional_requirements
+                    if (r.get("id") or r.get("name"))
+                }
 
         functional_requirements = self._filter_requirements_by_size(
             analysis.functional_requirements,

--- a/src/cost_tracking/operations.py
+++ b/src/cost_tracking/operations.py
@@ -84,6 +84,15 @@ OPERATIONS: Dict[str, Operation] = {
         ),
         "category": "decomposition",
     },
+    "core_feature_mapping": {
+        "label": "Core feature mapping",
+        "description": (
+            "Maps AI-generated functional requirements to in-scope user "
+            "outcomes so the capacity filter keeps core features and trims "
+            "only scope-creep (#683 Cause 1)."
+        ),
+        "category": "decomposition",
+    },
     "generate_contracts": {
         "label": "Generate contracts",
         "description": (

--- a/src/marcus_mcp/coordinator/outcome_coverage.py
+++ b/src/marcus_mcp/coordinator/outcome_coverage.py
@@ -502,6 +502,116 @@ async def compute_coverage_with_llm(
     return coverage
 
 
+_CORE_FEATURE_PROMPT = """\
+You are reviewing the feature list a planner generated for a software \
+project, deciding which features are CORE (required for the product to \
+satisfy what the user asked for) versus scope-creep the planner added on \
+its own.
+
+A feature is CORE when it is needed to deliver at least one of the \
+user-visible outcomes below. A feature is NON-CORE when no listed outcome \
+depends on it (nice-to-have, gold-plating, or tangential).
+
+User-visible outcomes (the ground truth of what the product must do):
+{outcomes_block}
+
+Features the planner generated:
+{features_block}
+
+For each feature id, decide whether it is core. Judge by MEANING, not \
+shared words — a feature and an outcome can use the same nouns yet be \
+unrelated, and can be related with no shared words.
+
+Return strict JSON, no preamble, no markdown fences:
+
+{{
+  "core_feature_ids": ["<id of each CORE feature>"]
+}}
+"""
+
+
+async def map_core_feature_ids_with_llm(
+    *,
+    requirements: List[Dict[str, Any]],
+    outcomes: Iterable[UserOutcome],
+    llm_client: Any,
+    max_tokens: int = 1500,
+) -> Set[str]:
+    """Return the ids of functional requirements that serve an in-scope outcome.
+
+    Issue #683 Cause 1. One batched LLM call decides which AI-generated
+    features are CORE (needed for an in-scope user outcome) so the
+    capacity filter can keep them and trim only genuine scope-creep —
+    instead of dropping features by list position. Uses semantic mapping,
+    not keyword overlap (which fails both directions on shared domain
+    nouns; see :func:`keyword_overlap_mapper`'s own warning).
+
+    Cost is attributed to the ``core_feature_mapping`` operation
+    (registered in ``src/cost_tracking/operations.py``) via
+    :func:`safe_structured_call`.
+
+    The requirement id is ``req["id"]`` when present, else ``req["name"]``
+    — the same identity the filter logs as Kept/Dropped.
+
+    Graceful degradation contract: callers must treat any raised
+    exception as "protect everything" (return all ids) so a mapping
+    failure never drops a required feature. This function itself returns
+    only the ids the LLM marked core; the all-ids fallback lives in the
+    caller alongside its flag/empty checks.
+
+    Returns
+    -------
+    set of str
+        Requirement ids judged core. Unknown ids in the response are
+        dropped; out-of-scope outcomes are never sent.
+
+    Raises
+    ------
+    ValueError
+        On malformed JSON or a missing ``core_feature_ids`` key.
+    """
+
+    def _req_id(req: Dict[str, Any]) -> str:
+        return str(req.get("id") or req.get("name") or "")
+
+    in_scope = [o for o in outcomes if o.scope == "in_scope"]
+    valid_ids = {_req_id(r) for r in requirements if _req_id(r)}
+    # No outcomes to protect against, or no identifiable requirements →
+    # caller should keep everything; signal that by returning all ids.
+    if not in_scope or not valid_ids:
+        return set(valid_ids)
+
+    outcomes_block = "\n".join(
+        f"- {o.id}: {o.action} (signal: {o.success_signal})" for o in in_scope
+    )
+    features_block = "\n".join(
+        f"- {_req_id(r)}: {r.get('name', '')} — {r.get('description', '')}"
+        for r in requirements
+        if _req_id(r)
+    )
+    prompt = _CORE_FEATURE_PROMPT.format(
+        outcomes_block=outcomes_block, features_block=features_block
+    )
+
+    from src.utils.structured_llm import safe_structured_call
+
+    try:
+        payload = await safe_structured_call(
+            llm=llm_client,
+            prompt=prompt,
+            operation="core_feature_mapping",
+            initial_max_tokens=max_tokens,
+        )
+    except (ValueError, json.JSONDecodeError) as exc:
+        raise ValueError(f"Core-feature mapping: malformed JSON: {exc}") from exc
+
+    raw = payload.get("core_feature_ids")
+    if not isinstance(raw, list):
+        raise ValueError("Core-feature mapping: response missing 'core_feature_ids'")
+
+    return {rid for rid in raw if isinstance(rid, str) and rid in valid_ids}
+
+
 _GAP_FILL_PROMPT_HEADER = """\
 The following user-visible outcomes are required by the specification
 but the current task graph does not cover them.  Generate the minimum

--- a/tests/unit/ai/test_advanced_parser_unit.py
+++ b/tests/unit/ai/test_advanced_parser_unit.py
@@ -66,3 +66,15 @@ class TestFilterRequirementsBySizeCause1:
         )
         ids = [r["id"] for r in out]
         assert ids == sorted(ids, key=lambda x: int(x[1:]))
+
+    def test_all_ids_protected_keeps_everything_over_cap(self) -> None:
+        """Codex P2 (#688): the mapping-failure fallback protects ALL ids, so
+        an over-cap list keeps every requirement — nothing is dropped by
+        position. This is the property the except-branch fallback relies on."""
+        parser = self._parser()
+        reqs = self._reqs(25)  # 25 > medium cap 15
+        protected = {r["id"] for r in reqs}  # fallback = protect everything
+        out = parser._filter_requirements_by_size(
+            reqs, "medium", 3, "build something", protected
+        )
+        assert len(out) == 25, "all-ids fallback must drop nothing"

--- a/tests/unit/ai/test_advanced_parser_unit.py
+++ b/tests/unit/ai/test_advanced_parser_unit.py
@@ -1,0 +1,68 @@
+"""Unit tests for AdvancedPRDParser helpers (#683 Cause 1).
+
+Covers ``_filter_requirements_by_size``: the capacity filter must cap by
+the complexity TIER (not team size) and must never drop a CORE feature
+(one the caller marks as serving an in-scope user outcome).
+"""
+
+import pytest
+
+from src.ai.advanced.prd.advanced_parser import AdvancedPRDParser
+
+pytestmark = pytest.mark.unit
+
+
+class TestFilterRequirementsBySizeCause1:
+    """#683 Cause 1: cap by complexity tier (not team size) and never drop a
+    core (outcome-bearing) feature."""
+
+    def _parser(self) -> AdvancedPRDParser:
+        return AdvancedPRDParser()
+
+    def _reqs(self, n: int):
+        return [
+            {"id": f"f{i}", "name": f"Feature {i}", "description": "d"}
+            for i in range(n)
+        ]
+
+    def test_medium_keeps_all_when_under_tier_cap(self) -> None:
+        """6 features in a medium project are all kept (tier cap 15), not cut
+        to 3 by team_size — the snake-run regression."""
+        parser = self._parser()
+        out = parser._filter_requirements_by_size(
+            self._reqs(6), "medium", 3, "build a snake game"
+        )
+        assert len(out) == 6
+
+    def test_over_cap_trims_non_core_keeps_core(self) -> None:
+        """20 features, medium (cap 15): core features survive; scope-creep is
+        trimmed to fit, never a core feature."""
+        parser = self._parser()
+        protected = {"f17", "f18", "f19"}  # core features late in the list
+        out = parser._filter_requirements_by_size(
+            self._reqs(20), "medium", 3, "build something", protected
+        )
+        kept = {r["id"] for r in out}
+        assert len(out) == 15
+        assert protected.issubset(kept), "core features must never be dropped"
+
+    def test_core_exceeding_cap_all_kept(self) -> None:
+        """If core features alone exceed the cap, all are kept (scope floor)."""
+        parser = self._parser()
+        protected = {f"f{i}" for i in range(17)}  # 17 core > cap 15
+        out = parser._filter_requirements_by_size(
+            self._reqs(18), "medium", 3, "build something", protected
+        )
+        kept = {r["id"] for r in out}
+        assert protected.issubset(kept)
+        assert len(out) >= 17
+
+    def test_preserves_original_order(self) -> None:
+        """Kept features retain their original order."""
+        parser = self._parser()
+        protected = {"f10"}
+        out = parser._filter_requirements_by_size(
+            self._reqs(20), "medium", 3, "build something", protected
+        )
+        ids = [r["id"] for r in out]
+        assert ids == sorted(ids, key=lambda x: int(x[1:]))

--- a/tests/unit/ai/test_advanced_parser_unit.py
+++ b/tests/unit/ai/test_advanced_parser_unit.py
@@ -17,7 +17,11 @@ class TestFilterRequirementsBySizeCause1:
     core (outcome-bearing) feature."""
 
     def _parser(self) -> AdvancedPRDParser:
-        return AdvancedPRDParser()
+        # _filter_requirements_by_size is a pure method (uses only its args
+        # + _detect_prompt_specificity, no __init__ state). Bypass __init__
+        # via __new__ so the test needs no LLM provider / API key — keeps it
+        # a true unit test and CI-safe with no config_marcus.json.
+        return AdvancedPRDParser.__new__(AdvancedPRDParser)
 
     def _reqs(self, n: int):
         return [

--- a/tests/unit/ai/test_advanced_prd_parser.py
+++ b/tests/unit/ai/test_advanced_prd_parser.py
@@ -545,13 +545,16 @@ class TestAdvancedPRDParserTaskGeneration:
             prd_analysis, mock_constraints
         )
 
-        # Should have all functional epics
+        # Should have all functional epics. #683: all 4 functional reqs are
+        # kept (tier cap, not team_size), so 4 functional + 1 NFR + 1 infra =
+        # 6. Previously team_size cut 'validation', giving 5.
         assert (
-            len(hierarchy) == 5
-        )  # 3 functional + 1 NFR + 1 infra (validation is filtered)
+            len(hierarchy) == 6
+        )  # 4 functional + 1 NFR + 1 infra (nothing filtered by team_size)
         assert "epic_crud_operations" in hierarchy
         assert "epic_todo_properties" in hierarchy
         assert "epic_user_auth" in hierarchy
+        assert "epic_validation" in hierarchy
 
         # Issue #607 step 3: design + implement only (no Test task) -> 2 tasks each.
         assert len(hierarchy["epic_crud_operations"]) == 2

--- a/tests/unit/ai/test_advanced_prd_parser.py
+++ b/tests/unit/ai/test_advanced_prd_parser.py
@@ -1088,8 +1088,14 @@ class TestRequirementFiltering:
 
     @pytest.mark.unit
     @pytest.mark.asyncio
-    async def test_guided_requirements_filtered_by_team_size(self, parser):
-        """Test that AI-generated requirements are filtered by team capacity"""
+    async def test_guided_requirements_capped_by_tier_not_team_size(self, parser):
+        """AI-generated requirements are capped by complexity tier, not team size.
+
+        #683: team_size governs parallelism, not scope. The old behavior cut
+        the list to team_size (dropping required features by list position);
+        now the cap is the complexity tier's expected feature count (standard
+        = 15), so a 5-item guided list is kept whole.
+        """
         # Arrange
         requirements = [
             {"id": "req1", "name": "Feature 1"},
@@ -1117,9 +1123,10 @@ class TestRequirementFiltering:
                 prd_content=prd_content,
             )
 
-        # Assert - Filtered to team_size (3)
-        assert len(result) == 3
-        assert result == requirements[:3]
+        # Assert - all 5 kept: under the standard tier cap (15); team_size no
+        # longer reduces scope (#683).
+        assert len(result) == 5
+        assert result == requirements
 
     @pytest.mark.unit
     @pytest.mark.asyncio

--- a/tests/unit/ai/test_prd_parser_robustness.py
+++ b/tests/unit/ai/test_prd_parser_robustness.py
@@ -227,14 +227,15 @@ class TestPRDParserRobustness:
 
         hierarchy = await parser._generate_task_hierarchy(analysis, mock_constraints)
 
-        # Should have 3 functional epics + 1 NFR + 1 infra (empty req is filtered out)
-        assert len(hierarchy) == 5
+        # #683: all 4 functional reqs are kept (capped by tier, not team_size),
+        # so 4 functional + 1 NFR + 1 infra = 6. The old count of 5 was the
+        # team_size cut dropping the 4th req — not "empty req filtered out".
+        assert len(hierarchy) == 6
 
         # Check epic IDs are properly generated
         assert "epic_crud_operations" in hierarchy
         assert "epic_user_authentication" in hierarchy
         assert "epic_data_validation" in hierarchy
-        # Note: Empty requirements are filtered out, not converted to fallback epics
         assert "epic_non_functional" in hierarchy
         assert "epic_infrastructure" in hierarchy
 

--- a/tests/unit/coordinator/test_gotcha_enumeration.py
+++ b/tests/unit/coordinator/test_gotcha_enumeration.py
@@ -280,3 +280,72 @@ class TestImplementationTaskPlacement:
         by_id = {t.id: t for t in enriched}
         assert by_id["test_x"].acceptance_criteria == []
         assert f"{GOTCHA_CRITERION_PREFIX}g" in by_id["impl_x"].acceptance_criteria
+
+
+class TestMapCoreFeatureIds:
+    """#683 Cause 1: map AI features to in-scope outcomes (semantic, via LLM)."""
+
+    @pytest.mark.asyncio
+    async def test_returns_core_ids_from_llm(self):
+        from src.marcus_mcp.coordinator.outcome_coverage import (
+            map_core_feature_ids_with_llm,
+        )
+
+        reqs = [
+            {"id": "f_move", "name": "Movement", "description": "steer snake"},
+            {"id": "f_theme", "name": "Dark theme", "description": "color scheme"},
+        ]
+        outcomes = [_outcome("o_play", "user plays snake", "snake moves")]
+        llm = _llm(json.dumps({"core_feature_ids": ["f_move"]}))
+
+        core = await map_core_feature_ids_with_llm(
+            requirements=reqs, outcomes=outcomes, llm_client=llm
+        )
+        assert core == {"f_move"}
+
+    @pytest.mark.asyncio
+    async def test_unknown_ids_dropped(self):
+        from src.marcus_mcp.coordinator.outcome_coverage import (
+            map_core_feature_ids_with_llm,
+        )
+
+        reqs = [{"id": "f_move", "name": "Movement", "description": "d"}]
+        outcomes = [_outcome("o", "x", "y")]
+        llm = _llm(json.dumps({"core_feature_ids": ["f_move", "hallucinated"]}))
+
+        core = await map_core_feature_ids_with_llm(
+            requirements=reqs, outcomes=outcomes, llm_client=llm
+        )
+        assert core == {"f_move"}
+
+    @pytest.mark.asyncio
+    async def test_no_in_scope_outcomes_returns_all_ids(self):
+        """No in-scope outcomes → caller should keep everything; helper
+        returns all ids and makes no LLM call."""
+        from src.marcus_mcp.coordinator.outcome_coverage import (
+            map_core_feature_ids_with_llm,
+        )
+
+        reqs = [{"id": "f1", "name": "A", "description": "d"}]
+        outcomes = [_outcome("o", "x", "y", scope="out_of_scope")]
+        llm = _llm(json.dumps({"core_feature_ids": []}))
+
+        core = await map_core_feature_ids_with_llm(
+            requirements=reqs, outcomes=outcomes, llm_client=llm
+        )
+        assert core == {"f1"}
+        llm.analyze.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_malformed_response_raises(self):
+        from src.marcus_mcp.coordinator.outcome_coverage import (
+            map_core_feature_ids_with_llm,
+        )
+
+        reqs = [{"id": "f1", "name": "A", "description": "d"}]
+        outcomes = [_outcome("o", "x", "y")]
+        llm = _llm(json.dumps({"wrong_key": []}))
+        with pytest.raises(ValueError):
+            await map_core_feature_ids_with_llm(
+                requirements=reqs, outcomes=outcomes, llm_client=llm
+            )


### PR DESCRIPTION
## What is this system, briefly

**Marcus** turns a plain-English project spec into a graph of tasks for AI agents to build. Before building the task graph it asks an AI to brainstorm the project's **features** (functional requirements), then a **capacity filter** trims that list. A **user outcome** is something the finished product must do ("the snake dies when it hits a wall").

## Why

Issue **#683**, Cause 1: the capacity filter dropped **required** features. It did `requirements[:max(3, team_size)]` — keep the first N **by list position**, blind to importance. With the default `team_size=3`, a "medium" project (whose own expected range is **8–15** features) was cut to **3**. On a real Snake run it dropped `collision_detection`, `game_over_screen`, and `grid_rendering` — so no tasks were created to build them and the game would ship unplayable.

Two root problems: (1) `team_size` was used to limit **scope** when it should only affect **parallelism**; (2) trimming was by list order, with no notion of which features are core.

## What changed

`_filter_requirements_by_size` in `src/ai/advanced/prd/advanced_parser.py`:

1. **Cap by the complexity tier, not team size.** `project_size` *is* the complexity mode; the cap is now that tier's expected upper bound (prototype 5, medium/standard 15, enterprise 30). This alone fixes the Snake case deterministically — 6 features ≤ 15, nothing dropped, **no LLM needed for the common case**.
2. **Never drop a core feature.** A new setup-time LLM call, `map_core_feature_ids_with_llm` (`src/marcus_mcp/coordinator/outcome_coverage.py`), maps AI features to in-scope user outcomes **semantically** — not keyword overlap, which fails both directions on shared domain nouns (its own `keyword_overlap_mapper` docstring warns against it). Core features (those serving an in-scope outcome) are kept first; only genuine non-outcome scope-creep is trimmed to fit the cap; core is kept even if it alone exceeds the cap (a scope floor).

**Cost tracking:** the new call is registered as the `core_feature_mapping` operation in `src/cost_tracking/operations.py` and tagged via `safe_structured_call`, so its tokens are attributed in the per-project cost breakdown — this resolves **#686**.

**Graceful degradation:** flag-off / no outcomes / LLM error → `protected_ids=None`; the filter still applies the deterministic tier cap (far better than the old team_size cut), and **#683 Cause 2** (gap-fill synthesizing impl tasks) backstops anything trimmed.

### Glossary
- **functional requirement / feature** — a unit of work the AI proposes from the spec.
- **user outcome** — a user-visible thing the product must do; the ground truth of required scope.
- **core feature** — one that serves at least one in-scope user outcome.
- **complexity tier / project_size** — prototype / standard(medium) / enterprise; sets the feature-count cap.
- **capacity filter** — `_filter_requirements_by_size`, trims the feature list.

### Bright-line check (MAS invariant)
Deciding which features become tasks is environment design — Marcus structuring the board. It says nothing about HOW an agent implements a feature. Passes.

## Worked example (real Snake run)

| | Before | After |
|---|---|---|
| Filter log | `Filtered 6 -> 3, Dropped: [collision, game_over, grid]` | (no drop) `AI-guided requirements (6 items)` |
| Tasks | 7, with 4 orphaned outcomes | 13, **0 orphans** |
| Gotchas | dropped | 20, all on implementation tasks |

## Test plan

- [x] `pytest tests/unit/ai/test_advanced_parser_unit.py` — 5 new filter tests (tier cap keeps all under cap; over-cap trims non-core but keeps core; core>cap all kept; order preserved)
- [x] `pytest tests/unit/coordinator/test_gotcha_enumeration.py` — 4 new mapping tests (core ids, unknown-id drop, no-in-scope→all-ids+no-call, malformed→raise)
- [x] `pytest tests/unit/coordinator/ tests/unit/ai/test_advanced_parser_unit.py tests/unit/config/` — 488 pass
- [x] `mypy` clean on all changed files
- [x] Real-LLM snake run: 6/6 features kept (was 6→3), 0 orphan warnings
- [ ] Reviewer: run `python scripts/dump_gotcha_criteria.py` (needs `ANTHROPIC_API_KEY`)

## Related

- Completes **#683** with Cause 2 (PR #687, merged). Cause 1 is the cost-preserving suspenders; Cause 2 is the hard backstop.
- Resolves **#686** (cost-center wiring for the new LLM call).
- Decision: Simon `cd836dd9` (semantic LLM mapping over keyword text-matching, per Kaia review). Builds on #664/#680.

🤖 Generated with [Claude Code](https://claude.com/claude-code)