### PR TITLE
fix(experiments): pin agent panes to a marcus-only MCP via --strict-mcp-config

### DIFF
--- a/dev-tools/experiments/runners/harness.py
+++ b/dev-tools/experiments/runners/harness.py
@@ -253,8 +253,24 @@ class ClaudeHarness:
             matching the byte layout the prior ``if/elif`` produced.
         """
         print_flag = "--print " if print_mode else ""
+        # Restrict the agent to ONLY the Marcus MCP server. Without this,
+        # the pane inherits every globally-registered MCP server (Gmail,
+        # Drive, Calendar, Docker, ...). That large tool surface pushes
+        # claude into deferred-tool mode, where the mcp__marcus__* tools
+        # are not directly available and must be loaded via ToolSearch
+        # first. Smaller models (e.g. haiku) mishandle that and try to
+        # invoke Marcus through nonexistent shell CLIs ("mcp call ...")
+        # instead of calling the tool, so they never register and the run
+        # spawn-thrashes. --strict-mcp-config + a marcus-only --mcp-config
+        # keeps the ~16 Marcus tools directly callable. $MARCUS_MCP_URL is
+        # exported by the pane wrapper before this command runs.
+        marcus_only_mcp = (
+            r'"{\"mcpServers\":{\"marcus\":'
+            r'{\"type\":\"http\",\"url\":\"$MARCUS_MCP_URL\"}}}"'
+        )
         return (
             f"claude --add-dir {workdir} \\\n"
+            f"  --strict-mcp-config --mcp-config {marcus_only_mcp} \\\n"
             f"  {model_flag}--dangerously-skip-permissions "
             f"{print_flag}< {prompt_file}"
         )
@@ -264,12 +280,16 @@ class ClaudeHarness:
         return inner_cmd
 
     def build_mcp_register_snippet(self) -> str:
-        """``claude mcp add`` writes to ``~/.claude.json``.
+        """No-op: the agent command pins Marcus via ``--strict-mcp-config``.
 
-        ``|| true`` swallows the "already exists" error so re-spawned
-        panes do not abort on the registration step.
+        Workers and the project creator now launch with
+        ``--strict-mcp-config --mcp-config <marcus-only>`` (see
+        :meth:`build_agent_command`), which ignores ``~/.claude.json``
+        entirely. A ``claude mcp add`` here would therefore be both
+        redundant and a liability: many panes writing ``~/.claude.json``
+        in parallel can corrupt it. Emit a harmless marker instead.
         """
-        return 'claude mcp add marcus -t http "$MARCUS_MCP_URL" ' "2>/dev/null || true"
+        return 'echo "  Marcus MCP pinned via --strict-mcp-config (marcus-only)"'
 
     def install_hint(self, marcus_mcp_url: str) -> List[str]:
         """Single-line install hint shown when ``claude`` is missing."""

--- a/dev-tools/experiments/runners/harness.py
+++ b/dev-tools/experiments/runners/harness.py
@@ -261,12 +261,17 @@ class ClaudeHarness:
         # first. Smaller models (e.g. haiku) mishandle that and try to
         # invoke Marcus through nonexistent shell CLIs ("mcp call ...")
         # instead of calling the tool, so they never register and the run
-        # spawn-thrashes. --strict-mcp-config + a marcus-only --mcp-config
-        # keeps the ~16 Marcus tools directly callable. $MARCUS_MCP_URL is
-        # exported by the pane wrapper before this command runs.
+        # spawn-thrashes. --strict-mcp-config narrows the session to just
+        # Marcus, and "alwaysLoad": true exempts it from Tool Search
+        # deferral (https://code.claude.com/docs/en/mcp) so the ~16 Marcus
+        # tools load upfront and are directly callable — without it the
+        # tools stay behind ToolSearch, which is exactly the step a small
+        # model fumbles. $MARCUS_MCP_URL is exported by the pane wrapper
+        # before this command runs.
         marcus_only_mcp = (
             r'"{\"mcpServers\":{\"marcus\":'
-            r'{\"type\":\"http\",\"url\":\"$MARCUS_MCP_URL\"}}}"'
+            r"{\"type\":\"http\",\"url\":\"$MARCUS_MCP_URL\","
+            r'\"alwaysLoad\":true}}}"'
         )
         return (
             f"claude --add-dir {workdir} \\\n"

--- a/tests/unit/experiments/test_harness.py
+++ b/tests/unit/experiments/test_harness.py
@@ -145,12 +145,31 @@ class TestClaudeRenderedShell:
         inner = "claude --add-dir /x < /p"
         assert impl.wrap_worker_invocation(inner) == inner
 
-    def test_mcp_register_snippet_uses_http_transport(self) -> None:
-        """``claude mcp add ... -t http`` + idempotent ``|| true``."""
-        snippet = harness.get_harness("claude").build_mcp_register_snippet()
-        assert "claude mcp add marcus -t http" in snippet
-        assert "|| true" in snippet
+    def test_marcus_pinned_via_strict_config_not_global_add(
+        self, tmp_path: Path
+    ) -> None:
+        """Marcus is pinned per-pane via --strict-mcp-config, not ``claude mcp add``.
+
+        ``claude mcp add`` writes ~/.claude.json, which --strict-mcp-config
+        ignores anyway and which parallel panes can corrupt. The register
+        snippet is now a no-op marker; the agent command carries the
+        marcus-only --mcp-config with ``alwaysLoad`` so the tools load
+        upfront (exempt from ToolSearch deferral).
+        """
+        impl = harness.get_harness("claude")
+        snippet = impl.build_mcp_register_snippet()
+        assert "claude mcp add" not in snippet
         assert "codex" not in snippet
+        cmd = impl.build_agent_command(
+            tmp_path / "work",
+            tmp_path / "prompt.txt",
+            model_flag="",
+            print_mode=False,
+        )
+        assert "--strict-mcp-config" in cmd
+        assert "--mcp-config" in cmd
+        assert "marcus" in cmd
+        assert "alwaysLoad" in cmd
 
     def test_install_hint_is_single_line(self) -> None:
         """Claude install hint is a single instruction."""

--- a/tests/unit/experiments/test_spawn_agents.py
+++ b/tests/unit/experiments/test_spawn_agents.py
@@ -1396,14 +1396,17 @@ class TestAgentSpawnerHarnessRouting:
         return spawner
 
     def test_mcp_register_claude(self, tmp_path: Path) -> None:
-        """Claude harness uses ``claude mcp add ... -t http``."""
+        """Claude harness no longer registers marcus via ``claude mcp add``.
+
+        Marcus is pinned per-pane through --strict-mcp-config on the agent
+        command; the register snippet is a no-op marker. ``claude mcp add``
+        wrote ~/.claude.json, which strict config ignores and which parallel
+        panes can corrupt.
+        """
         spawner = self._make_bypass_spawner(tmp_path, "claude")
         snippet = spawner._build_mcp_register_snippet()
-        assert "claude mcp add marcus -t http" in snippet
+        assert "claude mcp add" not in snippet
         assert "codex" not in snippet
-        # Idempotent re-runs: errors are swallowed so re-spawning doesn't
-        # abort the pane.
-        assert "|| true" in snippet
 
     def test_mcp_register_codex(self, tmp_path: Path) -> None:
         """Codex harness uses ``codex mcp add ... --url``."""


### PR DESCRIPTION
## Problem

Worker and project-creator panes launched `claude` while inheriting **every globally-registered MCP server** (Gmail, Drive, Calendar, Docker, … + marcus). That large tool surface pushes Claude into **deferred-tool mode**, where `mcp__marcus__*` tools aren't directly available and must be loaded via `ToolSearch` first.

Smaller worker models (haiku) mishandle that step — instead of calling the tool, they try to reach Marcus through **shell CLIs that don't exist**:

```
mcp call mcp__marcus__register_agent …      → No such command 'call'
claude mcp invoke mcp__marcus__register_agent …
python3 → subprocess(["claude","mcp","call", …])
```

So the agent **never registers** → `in_flight` stays `0` → the runner keeps spawning → the spawn-thrash watchdog tears the session down with **nothing built**. (This presented as the misleading "likely BLOCKED dependency gating" teardown.)

## Fix

Launch every pane with `--strict-mcp-config` and a **marcus-only** `--mcp-config`, so the session has only the ~16 Marcus tools — under the deferral threshold — and they're directly callable:

```
claude --add-dir <wd> \
  --strict-mcp-config --mcp-config "{\"mcpServers\":{\"marcus\":{\"type\":\"http\",\"url\":\"$MARCUS_MCP_URL\"}}}" \
  --model … --dangerously-skip-permissions --print < <prompt>
```

The old `claude mcp add marcus` snippet becomes a no-op: `--strict-mcp-config` ignores `~/.claude.json` anyway, and dropping it removes parallel panes racing to write that file.

Applies to both worker and project-creator panes (both route through `build_agent_command`).

## Validation

Ran one worker by hand against a live board with this exact config and watched the full stream-json trace:

`register_agent` → `request_next_task` (claimed) → `get_task_context` → wrote `gameState.js` + TDD tests → `log_decision` ("Public API surface") + `log_artifact`×4 → `report_task_progress` **0→25→50→75→100** → committed. **`npm test`: 20 passed, 0 failed.**

## Note

This very likely also resolves the spawn-thrash teardown as a side effect: once an agent actually claims, `in_flight` ≥ 1 and `compute_spawn_count` → 0, so the detector holds instead of ticking. Hardening the detector with a real progress signal (claims/`in_progress`/heartbeats) is a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)