### PR TITLE
fix(experiments): give the spawn-thrash detector a real progress signal

### DIFF
--- a/dev-tools/experiments/runners/spawn_agents.py
+++ b/dev-tools/experiments/runners/spawn_agents.py
@@ -1985,13 +1985,19 @@ echo "=========================================="
                     # "Real progress" signal for the spawn-thrash detector:
                     # a monotonic, cumulative tally of the signals an agent
                     # emits while genuinely working a task — completions
-                    # plus logged work (context requests, artifacts,
-                    # decisions, blockers). It rises on real work and stays
-                    # flat on claim-and-exit churn; unlike in_progress it
-                    # never flickers back down, so it cannot mask thrash.
-                    # See SpawnThrashDetector.observe.
+                    # plus the report_task_progress heartbeat (25/50/75%)
+                    # and logged work (context requests, artifacts,
+                    # decisions, blockers). progress_updates is the earliest
+                    # of these: it fires as soon as a claimed agent reports,
+                    # well before the first artifact lands, closing the
+                    # claim->first-artifact gap that would otherwise let the
+                    # detector fast-fail a healthy run. It rises on real work
+                    # and stays flat on claim-and-exit churn; unlike
+                    # in_progress it never flickers back down, so it cannot
+                    # mask thrash. See SpawnThrashDetector.observe.
                     activity = (
                         done
+                        + int(status.get("progress_updates", 0))
                         + int(status.get("context_requests", 0))
                         + int(status.get("artifacts_created", 0))
                         + int(status.get("decisions_logged", 0))

--- a/dev-tools/experiments/runners/spawn_agents.py
+++ b/dev-tools/experiments/runners/spawn_agents.py
@@ -1982,6 +1982,21 @@ echo "=========================================="
                     total = int(status.get("total_tasks", 0))
                     in_progress = int(status.get("in_progress_tasks", 0))
                     blocked = int(status.get("blocked_tasks", 0))
+                    # "Real progress" signal for the spawn-thrash detector:
+                    # a monotonic, cumulative tally of the signals an agent
+                    # emits while genuinely working a task — completions
+                    # plus logged work (context requests, artifacts,
+                    # decisions, blockers). It rises on real work and stays
+                    # flat on claim-and-exit churn; unlike in_progress it
+                    # never flickers back down, so it cannot mask thrash.
+                    # See SpawnThrashDetector.observe.
+                    activity = (
+                        done
+                        + int(status.get("context_requests", 0))
+                        + int(status.get("artifacts_created", 0))
+                        + int(status.get("decisions_logged", 0))
+                        + int(status.get("blockers_reported", 0))
+                    )
                     _emit(
                         f"tasks {done}/{total} done "
                         f"({in_progress} in-progress, {blocked} blocked) | "
@@ -2012,12 +2027,17 @@ echo "=========================================="
                         self._teardown("stalled")
                         break
 
-                    if thrash_detector.observe(done, to_spawn):
+                    if thrash_detector.observe(activity, to_spawn):
                         _emit(
-                            f"SPAWN-THRASH: spawned agents for "
-                            f"{thrash_polls} polls with no task "
-                            f"completing — likely BLOCKED dependency "
-                            f"gating downstream work; tearing down"
+                            f"SPAWN-THRASH: spawned an agent on each of the "
+                            f"last {thrash_polls} polls but saw no forward "
+                            f"progress — {done} completed, {in_progress} "
+                            f"in-progress, and no agent logged any work "
+                            f"(get_task_context / log_artifact / "
+                            f"log_decision). Agents are starting but not "
+                            f"claiming or working: likely deferred MCP tools, "
+                            f"a skill mismatch, or every unclaimed task gated "
+                            f"by a BLOCKED dependency. Tearing down."
                         )
                         self._teardown("spawn_thrash")
                         break

--- a/dev-tools/experiments/runners/spawn_controller.py
+++ b/dev-tools/experiments/runners/spawn_controller.py
@@ -183,13 +183,16 @@ class SpawnThrashDetector:
     The thrash signature is much sharper than "everything is flat":
 
     - ``to_spawn > 0`` (the runner is actively spawning this poll)
-    - ``completed`` did NOT increase since the previous poll
+    - no *real progress* since the previous poll, where progress is a
+      monotonic tally of the signals an agent emits while genuinely
+      working a task (completions plus logged work — context requests,
+      artifacts, decisions, blockers). See :meth:`observe`.
 
     Each poll the runner reports both numbers to :meth:`observe`. Each
     poll matching the signature increments an internal counter; any poll
-    that completes a task — or any poll where the runner spawned nothing
-    — resets it. After ``thrash_polls`` matching polls in a row the
-    detector reports thrash and the runner tears the experiment down.
+    that shows real progress — or any poll where the runner spawned
+    nothing — resets it. After ``thrash_polls`` matching polls in a row
+    the detector reports thrash and the runner tears the experiment down.
 
     Why a separate detector instead of tightening :class:`StallWatchdog`
     ------------------------------------------------------------------
@@ -211,17 +214,30 @@ class SpawnThrashDetector:
 
     def __init__(self, thrash_polls: int) -> None:
         self._thrash_polls = thrash_polls
-        self._last_completed: Optional[int] = None
+        self._last_activity: Optional[int] = None
         self._idle_spawn_polls = 0
 
-    def observe(self, completed: int, to_spawn: int) -> bool:
+    def observe(self, activity: int, to_spawn: int) -> bool:
         """
         Record one poll and report whether the run is spawn-thrashing.
 
         Parameters
         ----------
-        completed : int
-            Tasks completed so far this run (cumulative).
+        activity : int
+            A monotonic, cumulative "real progress" counter the caller
+            assembles from the signals an agent emits while actually
+            working a task — completed tasks plus logged work
+            (``get_task_context`` requests, ``log_artifact`` /
+            ``log_decision`` calls, ``report_blocker`` calls). Any
+            increase since the previous poll proves an agent is making
+            forward progress, so the thrash counter resets.
+
+            Why not ``in_progress``: that count *flickers* (0→1→0) during
+            genuine thrash — an agent claims a task, fails to make
+            progress, exits, the lease is recovered — so resetting on it
+            would mask the very failure this detector exists to catch.
+            The work-output counters are cumulative and only ever rise:
+            they move on real work and stay flat on claim-and-exit churn.
         to_spawn : int
             Number of ephemeral agents the runner is spawning this
             poll (the output of :func:`compute_spawn_count`).
@@ -230,7 +246,7 @@ class SpawnThrashDetector:
         -------
         bool
             True once ``thrash_polls`` consecutive polls have spawned
-            agents without any task completing; always False when the
+            agents without any real progress; always False when the
             detector is disabled.
         """
         if self._thrash_polls <= 0:
@@ -238,14 +254,14 @@ class SpawnThrashDetector:
 
         # Initialize baseline on the first observation. The first poll
         # cannot itself be a thrash — we need at least one prior poll
-        # to compare ``completed`` against — so it only sets the baseline.
-        if self._last_completed is None:
-            self._last_completed = completed
+        # to compare ``activity`` against — so it only sets the baseline.
+        if self._last_activity is None:
+            self._last_activity = activity
             return False
 
-        if completed > self._last_completed:
-            # A task completed — real progress, reset the counter.
-            self._last_completed = completed
+        if activity > self._last_activity:
+            # Real forward progress — reset the counter.
+            self._last_activity = activity
             self._idle_spawn_polls = 0
             return False
 

--- a/src/experiments/live_experiment_monitor.py
+++ b/src/experiments/live_experiment_monitor.py
@@ -96,6 +96,7 @@ class LiveExperimentMonitor:
         self.artifacts_created = 0
         self.decisions_logged = 0
         self.context_requests = 0
+        self.progress_updates = 0
 
         # Previous completed-task count, used to derive per-interval velocity
         self._last_completed_count = 0
@@ -227,6 +228,7 @@ class LiveExperimentMonitor:
             "total_artifacts": float(self.artifacts_created),
             "total_decisions": float(self.decisions_logged),
             "total_context_requests": float(self.context_requests),
+            "total_progress_updates": float(self.progress_updates),
         }
 
         # Generate summary
@@ -556,6 +558,29 @@ class LiveExperimentMonitor:
 
         logger.debug(f"Recorded context request: {agent_id} for {task_id}")
 
+    def record_progress(
+        self,
+        agent_id: str,
+        task_id: str,
+        progress: int = 0,
+        status: str = "in_progress",
+    ) -> None:
+        """Record a task-progress heartbeat (a report_task_progress call).
+
+        Counts every progress report — including intermediate 25/50/75%
+        updates — as a sign the agent is alive and working its claimed
+        task. The runner's spawn-thrash detector reads this (via
+        ``progress_updates`` in :meth:`get_status`) so it does not tear
+        down a healthy-but-slow run that is advancing without a
+        completion yet.
+        """
+        self.progress_updates += 1
+
+        logger.debug(
+            f"Recorded progress update: {agent_id} on {task_id} "
+            f"({progress}% {status})"
+        )
+
     async def get_status(self) -> Dict[str, Any]:
         """
         Get current experiment status.
@@ -598,6 +623,7 @@ class LiveExperimentMonitor:
             "artifacts_created": self.artifacts_created,
             "decisions_logged": self.decisions_logged,
             "context_requests": self.context_requests,
+            "progress_updates": self.progress_updates,
         }
 
         # Ground truth from the kanban backend. This is what
@@ -657,6 +683,7 @@ Condition Metrics:
 - Artifacts Created: {self.artifacts_created}
 - Decisions Logged: {self.decisions_logged}
 - Context Requests: {self.context_requests}
+- Progress Updates: {self.progress_updates}
 
 Top Agents by Completions:
 """

--- a/src/marcus_mcp/tools/context.py
+++ b/src/marcus_mcp/tools/context.py
@@ -181,6 +181,16 @@ async def get_task_context(task_id: str, state: Any) -> Dict[str, Any]:
         },
     )
 
+    # Record in the active experiment if one is running (mirrors
+    # log_decision above). Without this, context_requests stays 0 and the
+    # runner's spawn-thrash detector cannot see a claimed agent pulling
+    # context as a sign of forward progress.
+    from src.experiments.live_experiment_monitor import get_active_monitor
+
+    _monitor = get_active_monitor()
+    if _monitor and _monitor.is_running:
+        _monitor.record_context_request(agent_id=agent_id, task_id=task_id)
+
     try:
         # Check if this is a subtask
         if hasattr(state, "subtask_manager") and state.subtask_manager:

--- a/src/marcus_mcp/tools/task.py
+++ b/src/marcus_mcp/tools/task.py
@@ -3732,6 +3732,22 @@ async def report_task_progress(
         },
     )
 
+    # Record the progress heartbeat in the active experiment monitor so
+    # the runner's spawn-thrash detector sees a claimed task advancing
+    # (report_task_progress at 25/50/75%) as real progress, not only
+    # completions. Counted on every report — a report arriving at all
+    # proves the agent is alive and working its task.
+    from src.experiments.live_experiment_monitor import get_active_monitor
+
+    _progress_monitor = get_active_monitor()
+    if _progress_monitor and _progress_monitor.is_running:
+        _progress_monitor.record_progress(
+            agent_id=agent_id,
+            task_id=task_id,
+            progress=progress,
+            status=status,
+        )
+
     # Escalation flag — set when the retry ceiling is hit during
     # validation. The task is routed through the normal completion
     # path (kanban update, lease cleanup, branch merge) but the

--- a/tests/unit/experiments/test_live_experiment_monitor.py
+++ b/tests/unit/experiments/test_live_experiment_monitor.py
@@ -43,7 +43,42 @@ def _make_monitor(kanban_client: Any = None) -> LiveExperimentMonitor:
     monitor.artifacts_created = 0
     monitor.decisions_logged = 0
     monitor.context_requests = 0
+    monitor.progress_updates = 0
     return monitor
+
+
+class TestProgressHeartbeat:
+    """record_progress + progress_updates surface the report_task_progress
+    heartbeat (PR #704 review).
+
+    The spawn-thrash detector reads ``progress_updates`` so a claimed
+    agent reporting 25/50/75% counts as forward progress before any task
+    completes — closing the claim->first-artifact gap that could
+    otherwise fast-fail a healthy run.
+    """
+
+    def test_record_progress_increments_counter(self) -> None:
+        """Each report_task_progress call bumps the counter."""
+        monitor = _make_monitor()
+        assert monitor.progress_updates == 0
+        monitor.record_progress(agent_id="a1", task_id="t1", progress=25)
+        monitor.record_progress(agent_id="a1", task_id="t1", progress=50)
+        assert monitor.progress_updates == 2
+
+    @pytest.mark.asyncio
+    async def test_get_status_exposes_progress_updates(self) -> None:
+        """get_status surfaces progress_updates for the runner to read."""
+        monitor = _make_monitor()
+        monitor.record_progress(agent_id="a1", task_id="t1", progress=75)
+        status = await monitor.get_status()
+        assert status["progress_updates"] == 1
+
+    def test_record_context_request_increments_counter(self) -> None:
+        """record_context_request (now wired into get_task_context) counts."""
+        monitor = _make_monitor()
+        assert monitor.context_requests == 0
+        monitor.record_context_request(agent_id="a1", task_id="t1")
+        assert monitor.context_requests == 1
 
 
 class TestGetStatusKanbanTruth:

--- a/tests/unit/experiments/test_spawn_controller.py
+++ b/tests/unit/experiments/test_spawn_controller.py
@@ -151,37 +151,64 @@ class TestStallWatchdog:
 
 class TestSpawnThrashDetector:
     """
-    SpawnThrashDetector flags runs that spawn agents but complete no tasks.
+    SpawnThrashDetector flags runs that spawn agents but make no progress.
 
     Failure mode it catches (real incidents on test66, test71, test73):
     a BLOCKED task gates every claimable downstream task, so the runner
     keeps trying to fill the desired-agent count with ephemeral agents
-    that immediately exit. ``completed`` stays flat while the runner
-    burns one agent's worth of cost per poll. StallWatchdog cannot
-    catch this — the tuple it watches keeps flickering — and only
-    fires after 20 minutes, by which point 30–50 agents have been
-    wasted.
+    that immediately exit. The ``activity`` tally (completions plus
+    logged agent work — context requests, artifacts, decisions,
+    blockers) stays flat while the runner burns one agent's worth of
+    cost per poll. StallWatchdog cannot catch this — the tuple it
+    watches keeps flickering — and only fires after 20 minutes, by which
+    point 30–50 agents have been wasted.
+
+    The detector takes a single monotonic ``activity`` int; deciding
+    *which* signals compose it lives at the call site (spawn_agents.py).
+    ``in_progress`` is deliberately excluded there — it flickers 0→1→0
+    on claim-and-exit churn and would mask the thrash.
     """
 
     def test_fires_after_n_idle_spawn_polls(self) -> None:
-        """to_spawn>0 and completed flat for thrash_polls in a row -> fire."""
+        """to_spawn>0 and activity flat for thrash_polls in a row -> fire."""
         det = SpawnThrashDetector(thrash_polls=3)
         # First observation is baseline only — never fires.
-        assert det.observe(completed=5, to_spawn=2) is False
+        assert det.observe(activity=5, to_spawn=2) is False
         # Three more polls: still spawning, still no completions.
-        assert det.observe(completed=5, to_spawn=2) is False  # idle x1
-        assert det.observe(completed=5, to_spawn=2) is False  # idle x2
-        assert det.observe(completed=5, to_spawn=2) is True  # idle x3 -> fire
+        assert det.observe(activity=5, to_spawn=2) is False  # idle x1
+        assert det.observe(activity=5, to_spawn=2) is False  # idle x2
+        assert det.observe(activity=5, to_spawn=2) is True  # idle x3 -> fire
 
     def test_completion_resets_the_counter(self) -> None:
         """Any task completing during the streak resets thrash detection."""
         det = SpawnThrashDetector(thrash_polls=2)
-        det.observe(completed=3, to_spawn=2)  # baseline
-        assert det.observe(completed=3, to_spawn=2) is False  # idle x1
+        det.observe(activity=3, to_spawn=2)  # baseline
+        assert det.observe(activity=3, to_spawn=2) is False  # idle x1
         # An agent finishes — progress, reset.
-        assert det.observe(completed=4, to_spawn=2) is False
-        assert det.observe(completed=4, to_spawn=2) is False  # idle x1 again
-        assert det.observe(completed=4, to_spawn=2) is True  # idle x2 -> fire
+        assert det.observe(activity=4, to_spawn=2) is False
+        assert det.observe(activity=4, to_spawn=2) is False  # idle x1 again
+        assert det.observe(activity=4, to_spawn=2) is True  # idle x2 -> fire
+
+    def test_logged_work_resets_without_a_completion(self) -> None:
+        """Mid-task progress (an agent logging work) resets the streak.
+
+        The whole point of broadening the signal from ``completed`` to a
+        cumulative ``activity`` tally: a single contract task can take
+        minutes to finish, and while it runs the agent claims the task
+        and logs context requests / artifacts / decisions. Those bumps
+        must reset the thrash counter so a healthy-but-slow run is not
+        torn down before its first completion.
+        """
+        det = SpawnThrashDetector(thrash_polls=3)
+        det.observe(activity=10, to_spawn=2)  # baseline, 0 completions yet
+        assert det.observe(activity=10, to_spawn=2) is False  # idle x1
+        assert det.observe(activity=10, to_spawn=2) is False  # idle x2
+        # No task completed, but an agent logged an artifact: the tally
+        # ticks up -> real progress -> reset, even though completed==0.
+        assert det.observe(activity=11, to_spawn=2) is False
+        assert det.observe(activity=11, to_spawn=2) is False  # idle x1
+        assert det.observe(activity=11, to_spawn=2) is False  # idle x2
+        assert det.observe(activity=11, to_spawn=2) is True  # idle x3 -> fire
 
     def test_zero_spawn_poll_does_not_advance_counter(self) -> None:
         """A poll with to_spawn=0 is not burning money — don't count it.
@@ -191,26 +218,26 @@ class TestSpawnThrashDetector:
         again, and we should not have to start counting over.
         """
         det = SpawnThrashDetector(thrash_polls=3)
-        det.observe(completed=5, to_spawn=1)  # baseline
-        assert det.observe(completed=5, to_spawn=1) is False  # idle x1
-        assert det.observe(completed=5, to_spawn=1) is False  # idle x2
+        det.observe(activity=5, to_spawn=1)  # baseline
+        assert det.observe(activity=5, to_spawn=1) is False  # idle x1
+        assert det.observe(activity=5, to_spawn=1) is False  # idle x2
         # A poll where we did NOT spawn — counter held, not incremented.
-        assert det.observe(completed=5, to_spawn=0) is False  # held at 2
+        assert det.observe(activity=5, to_spawn=0) is False  # held at 2
         # Spawning resumes — one more idle-spawn poll trips the trigger.
-        assert det.observe(completed=5, to_spawn=1) is True  # idle x3 -> fire
+        assert det.observe(activity=5, to_spawn=1) is True  # idle x3 -> fire
 
     def test_zero_thrash_polls_disables_the_detector(self) -> None:
         """thrash_polls=0 means the detector never fires."""
         det = SpawnThrashDetector(thrash_polls=0)
         for _ in range(50):
-            assert det.observe(completed=0, to_spawn=10) is False
+            assert det.observe(activity=0, to_spawn=10) is False
 
     def test_first_observation_never_fires(self) -> None:
         """No prior poll to compare against — first observation is baseline."""
         det = SpawnThrashDetector(thrash_polls=1)
         # Even with the most aggressive threshold (1), the first poll
         # cannot fire because there is no last_completed yet.
-        assert det.observe(completed=0, to_spawn=99) is False
+        assert det.observe(activity=0, to_spawn=99) is False
 
     def test_progress_after_fire_threshold_does_not_unfire(self) -> None:
         """Once thrash is reported, the runner is expected to tear down.
@@ -222,27 +249,27 @@ class TestSpawnThrashDetector:
         (defensive, for future re-use).
         """
         det = SpawnThrashDetector(thrash_polls=2)
-        det.observe(completed=0, to_spawn=1)  # baseline
-        det.observe(completed=0, to_spawn=1)  # idle x1
-        assert det.observe(completed=0, to_spawn=1) is True  # fire
+        det.observe(activity=0, to_spawn=1)  # baseline
+        det.observe(activity=0, to_spawn=1)  # idle x1
+        assert det.observe(activity=0, to_spawn=1) is True  # fire
         # Completion lands — counter resets, detector is quiet again.
-        assert det.observe(completed=1, to_spawn=1) is False
-        assert det.observe(completed=1, to_spawn=1) is False  # idle x1
+        assert det.observe(activity=1, to_spawn=1) is False
+        assert det.observe(activity=1, to_spawn=1) is False  # idle x1
 
     def test_realistic_thrash_scenario_test73(self) -> None:
         """Reproduce verify-snake-10 (test73) signature: BLOCKED dep, spawn-thrash.
 
-        Baseline: ``completed=4``, then for the next ~10 polls the
+        Baseline: ``activity=4``, then for the next ~10 polls the
         runner spawns 1–3 agents each cycle because Marcus reports
         ``desired>in_flight`` and ``unclaimed>0``, but every spawned
         agent receives "no task" (the only unclaimed work is gated by
-        the BLOCKED merge-conflict task) and exits. With thrash_polls=5
-        the detector should fire on the 6th observation — capping
-        wasted spawns at ~5 instead of letting the 20-minute stall
-        watchdog count to 38+.
+        the BLOCKED merge-conflict task) and exits — logging no work, so
+        the activity tally never moves. With thrash_polls=5 the detector
+        should fire on the 6th observation — capping wasted spawns at ~5
+        instead of letting the 20-minute stall watchdog count to 38+.
         """
         det = SpawnThrashDetector(thrash_polls=5)
-        # Cumulative completed plateaus at 4 — exactly the test73 trace.
+        # The activity tally plateaus at 4 — exactly the test73 trace.
         observations = [
             (4, 2),  # baseline
             (4, 2),  # idle x1


### PR DESCRIPTION
Fixes #703.

## Problem

`SpawnThrashDetector` reset its idle-spawn counter **only when `completed_tasks` increased**, so it was blind to an agent that had **claimed a task and was actively working it** (logging context/artifacts/decisions) but hadn't finished within the 5-poll (~2.5 min) fuse. A single `contract_first` task takes minutes, so the detector tore down healthy-but-slow runs and blamed a "BLOCKED dependency" that didn't exist.

## Fix

`observe()` now takes a monotonic, cumulative **`activity`** tally the runner assembles from the signals an agent emits while genuinely working:

```python
activity = done                                    # completed_tasks
         + context_requests + artifacts_created    # get_task_context / log_artifact
         + decisions_logged + blockers_reported    # log_decision / report_blocker
```

Any increase resets the thrash streak. **`in_progress` is deliberately excluded** — it flickers 0→1→0 on claim-and-exit churn (the lease lifecycle) and would mask the very thrash the detector exists to catch; the cumulative work counters only ever rise.

The `to_spawn == 0` hold behavior is unchanged, so this is purely *additive* protection: it can only *prevent* false teardowns, never suppress a real one (a genuinely doomed run logs no work → `activity` stays flat → still fires).

## Better teardown message

Before:
> `SPAWN-THRASH: spawned agents for 5 polls with no task completing — likely BLOCKED dependency gating downstream work; tearing down`

After:
> `SPAWN-THRASH: spawned an agent on each of the last 5 polls but saw no forward progress — 3 completed, 0 in-progress, and no agent logged any work (get_task_context / log_artifact / log_decision). Agents are starting but not claiming or working: likely deferred MCP tools, a skill mismatch, or every unclaimed task gated by a BLOCKED dependency. Tearing down.`

## Tests

`tests/unit/experiments/test_spawn_controller.py`: renamed the `observe()` keyword (`completed=`→`activity=`), refreshed docstrings, and added `test_logged_work_resets_without_a_completion` (a mid-task artifact log with zero completions resets the streak). **22 passed.**

## Note

Complements #702 (worker-side `--strict-mcp-config` fix). The lease-expiry system is the per-task recovery mechanism; this is the run-level cost-control backstop — see #703 for the full comparison and the future "expose lease-renewal freshness" option.

🤖 Generated with [Claude Code](https://claude.com/claude-code)