### PR TITLE
chore(ci): pin claude workflows to claude-sonnet-5 (action default model retired → 404)

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -37,8 +37,9 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 
-          # Optional: Specify model (defaults to Claude Sonnet 4, uncomment for Claude Opus 4)
-          # model: "claude-opus-4-20250514"
+          # Pin a current model explicitly — the action's built-in default
+          # (Claude Sonnet 4) was retired and now 404s, failing every review run.
+          model: "claude-sonnet-5"
 
           # Direct prompt for automated review (no @claude mention needed)
           direct_prompt: |

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -40,8 +40,9 @@ jobs:
           additional_permissions: |
             actions: read
 
-          # Optional: Specify model (defaults to Claude Sonnet 4, uncomment for Claude Opus 4)
-          # model: "claude-opus-4-20250514"
+          # Pin a current model explicitly — the action's built-in default
+          # (Claude Sonnet 4) was retired and now 404s, failing every run.
+          model: "claude-sonnet-5"
 
           # Optional: Customize the trigger phrase (default: @claude)
           # trigger_phrase: "/claude"


### PR DESCRIPTION
## What is this

Both Claude GitHub workflows (`claude-code-review.yml`, `claude.yml`) rely on the action's built-in default model. That default (`claude-sonnet-4-20250514`) has been retired by Anthropic, so every `claude-review` run now fails with `API Error: 404 not_found_error` before reviewing anything — first observed on PR #707, where all real checks passed but the review job died in 30s.

## What changed
One line in each workflow: pin `model: "claude-sonnet-5"` explicitly, replacing the commented-out suggestion that let the retired default apply.

## Test plan
- [ ] After merge, the next PR (or a re-run on #707/#708) shows claude-review completing instead of 404ing

Trivial-PR exemption applies (single-line config bump × 2 files: `.github/workflows/claude-code-review.yml`, `.github/workflows/claude.yml`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)